### PR TITLE
Refactor categories to remove subfolder type

### DIFF
--- a/app/CategoriesContext.js
+++ b/app/CategoriesContext.js
@@ -30,34 +30,16 @@ export const CategoriesProvider = ({ children }) => {
         if (categoriesData.length === 0) {
           // Initialize with default categories
           console.log('Initializing default categories...');
-          const mappedCategories = [];
+          const createdCategories = [];
           for (const category of defaultCategories) {
             try {
-              // Map the category type to match database schema
-              // defaultCategories uses: folder, subfolder, entry
-              // database expects: expense, income, folder
-              let dbType;
-              if (category.type === 'folder' || category.type === 'subfolder') {
-                dbType = 'folder';
-              } else if (category.type === 'entry') {
-                // Use categoryType (expense/income) for entries
-                dbType = category.categoryType;
-              } else {
-                dbType = category.type;
-              }
-
-              const mappedCategory = {
-                ...category,
-                type: dbType,
-              };
-
-              await CategoriesDB.createCategory(mappedCategory);
-              mappedCategories.push(mappedCategory);
+              await CategoriesDB.createCategory(category);
+              createdCategories.push(category);
             } catch (err) {
               console.error('Failed to create default category:', category.id, err);
             }
           }
-          setCategories(mappedCategories);
+          setCategories(createdCategories);
         } else {
           setCategories(categoriesData);
         }
@@ -187,11 +169,8 @@ export const CategoriesProvider = ({ children }) => {
     if (!category.name || category.name.trim() === '') {
       return 'Category name is required';
     }
-    if (!category.type) {
-      return 'Category type is required';
-    }
-    if (category.type !== 'folder' && !category.parentId) {
-      return 'Parent folder is required for subfolders and entries';
+    if (!category.category_type && !category.categoryType) {
+      return 'Category type (expense/income) is required';
     }
     if (!category.icon) {
       return 'Icon is required';

--- a/app/CategoriesScreen.js
+++ b/app/CategoriesScreen.js
@@ -45,13 +45,12 @@ const CategoriesScreen = () => {
   // Flatten the category tree based on expanded state
   const flattenedCategories = useMemo(() => {
     const flattened = [];
-    const rootCategories = categories.filter(cat => cat.type === 'folder');
+    const rootCategories = categories.filter(cat => !cat.parentId);
 
     const addWithChildren = (category, depth = 0) => {
       flattened.push({ ...category, depth });
 
-      const canExpand = category.type === 'folder' || category.type === 'subfolder';
-      if (canExpand && expandedIds.has(category.id)) {
+      if (expandedIds.has(category.id)) {
         const children = getChildren(category.id);
         children.forEach(child => addWithChildren(child, depth + 1));
       }
@@ -73,14 +72,14 @@ const CategoriesScreen = () => {
     const children = getChildren(category.id);
     const hasChildren = children.length > 0;
     const isExpanded = expandedIds.has(category.id);
-    const canExpand = category.type === 'folder' || category.type === 'subfolder';
     const indentWidth = depth * 20;
+    const categoryType = category.category_type || category.categoryType || 'expense';
 
     return (
       <TouchableOpacity
         style={[styles.categoryRow, { borderBottomColor: colors.border }]}
         onPress={() => {
-          if (canExpand && hasChildren) {
+          if (hasChildren) {
             toggleExpanded(category.id);
           } else {
             handleEditCategory(category);
@@ -88,12 +87,12 @@ const CategoriesScreen = () => {
         }}
         onLongPress={() => handleEditCategory(category)}
         accessibilityRole="button"
-        accessibilityLabel={`${category.nameKey ? t(category.nameKey) : category.name} category, ${category.type}`}
-        accessibilityHint={canExpand && hasChildren ? "Double tap to expand or collapse" : "Double tap to edit"}
+        accessibilityLabel={`${category.nameKey ? t(category.nameKey) : category.name} category, ${categoryType}`}
+        accessibilityHint={hasChildren ? "Double tap to expand or collapse" : "Double tap to edit"}
       >
         <View style={[styles.categoryContent, { paddingLeft: 16 + indentWidth }]}>
           {/* Expand/Collapse Icon */}
-          {canExpand && hasChildren ? (
+          {hasChildren ? (
             <TouchableOpacity
               onPress={() => toggleExpanded(category.id)}
               style={styles.expandButton}
@@ -126,13 +125,13 @@ const CategoriesScreen = () => {
             {category.nameKey ? t(category.nameKey) : category.name}
           </Text>
 
-          {/* Type Badge */}
+          {/* Category Type Badge */}
           <View
-            style={[styles.typeBadge, { backgroundColor: colors.secondary }]}
-            accessibilityLabel={`Type: ${category.type}`}
+            style={[styles.typeBadge, { backgroundColor: categoryType === 'expense' ? '#ff6b6b' : '#51cf66' }]}
+            accessibilityLabel={`Type: ${categoryType}`}
           >
-            <Text style={[styles.typeBadgeText, { color: colors.text }]}>
-              {category.type === 'folder' ? 'F' : category.type === 'subfolder' ? 'S' : 'E'}
+            <Text style={[styles.typeBadgeText, { color: '#fff' }]}>
+              {categoryType === 'expense' ? 'E' : 'I'}
             </Text>
           </View>
 

--- a/app/SettingsModal.js
+++ b/app/SettingsModal.js
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
+import { Modal, View, Text, Pressable, StyleSheet, Alert } from 'react-native';
 import { useTheme } from './ThemeContext';
 import { useLocalization } from './LocalizationContext';
+import { useAccounts } from './AccountsContext';
 
 const themeOptions = [
   { label: 'System', value: 'system' },
@@ -13,8 +14,31 @@ const themeOptions = [
 export default function SettingsModal({ visible, onClose }) {
   const { theme, setTheme, colorScheme, colors } = useTheme();
   const { t, language, setLanguage, availableLanguages } = useLocalization();
+  const { resetDatabase } = useAccounts();
   const [localSelection, setLocalSelection] = useState(theme);
   const [localLang, setLocalLang] = useState(language);
+
+  const handleResetDatabase = () => {
+    Alert.alert(
+      t('reset_database') || 'Reset Database',
+      t('reset_database_confirm') || 'Are you sure you want to reset the database? This will delete all data and create default accounts.',
+      [
+        { text: t('cancel') || 'Cancel', style: 'cancel' },
+        {
+          text: t('reset') || 'Reset',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await resetDatabase();
+              onClose();
+            } catch (error) {
+              // Error already handled in resetDatabase
+            }
+          },
+        },
+      ]
+    );
+  };
 
   useEffect(() => {
     if (visible) {
@@ -65,6 +89,19 @@ export default function SettingsModal({ visible, onClose }) {
               {localLang === lng && <Text style={{ color: colors.card, fontSize: 18 }}>✓</Text>}
             </Pressable>
           ))}
+
+          <Text style={[styles.subtitle, { color: colors.text, marginTop: 16 }]}>{t('database') || 'Database'}</Text>
+          <Pressable
+            style={({ pressed }) => [
+              styles.resetButton,
+              { backgroundColor: '#dc3545' },
+              pressed && { opacity: 0.8 },
+            ]}
+            onPress={handleResetDatabase}
+          >
+            <Text style={[styles.resetButtonText, { color: '#ffffff' }]}>{t('reset_database') || 'Reset Database'}</Text>
+          </Pressable>
+
           <View style={styles.modalButtonRow}>
             <Pressable style={[styles.modalButton, { backgroundColor: colors.secondary }]} onPress={onClose}>
               <Text style={[styles.closeText, { color: colors.text }]}>{t('cancel') || 'Cancel'}</Text>
@@ -153,5 +190,16 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 8,
     alignItems: 'center',
+  },
+  resetButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    marginBottom: 8,
+    alignItems: 'center',
+  },
+  resetButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
   },
 });

--- a/app/services/CategoriesDB.js
+++ b/app/services/CategoriesDB.js
@@ -35,19 +35,19 @@ export const getCategoryById = async (id) => {
 };
 
 /**
- * Get categories by type
- * @param {string} type - 'expense', 'income', or 'folder'
+ * Get categories by category_type (expense or income)
+ * @param {string} categoryType - 'expense' or 'income'
  * @returns {Promise<Array>}
  */
-export const getCategoriesByType = async (type) => {
+export const getCategoriesByCategoryType = async (categoryType) => {
   try {
     const categories = await queryAll(
-      'SELECT * FROM categories WHERE type = ? ORDER BY created_at ASC',
-      [type]
+      'SELECT * FROM categories WHERE category_type = ? ORDER BY created_at ASC',
+      [categoryType]
     );
     return categories || [];
   } catch (error) {
-    console.error('Failed to get categories by type:', error);
+    console.error('Failed to get categories by category_type:', error);
     throw error;
   }
 };
@@ -88,8 +88,9 @@ export const createCategory = async (category) => {
     const categoryData = {
       id: category.id,
       name: category.name,
-      type: category.type,
-      parent_id: category.parentId || null,
+      type: category.type || 'folder',
+      category_type: category.category_type || category.categoryType || 'expense',
+      parent_id: category.parentId || category.parent_id || null,
       icon: category.icon || null,
       color: category.color || null,
       created_at: now,
@@ -97,11 +98,12 @@ export const createCategory = async (category) => {
     };
 
     await executeQuery(
-      'INSERT INTO categories (id, name, type, parent_id, icon, color, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      'INSERT INTO categories (id, name, type, category_type, parent_id, icon, color, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
       [
         categoryData.id,
         categoryData.name,
         categoryData.type,
+        categoryData.category_type,
         categoryData.parent_id,
         categoryData.icon,
         categoryData.color,
@@ -137,6 +139,10 @@ export const updateCategory = async (id, updates) => {
     if (updates.type !== undefined) {
       fields.push('type = ?');
       values.push(updates.type);
+    }
+    if (updates.category_type !== undefined || updates.categoryType !== undefined) {
+      fields.push('category_type = ?');
+      values.push(updates.category_type || updates.categoryType);
     }
     if (updates.parentId !== undefined) {
       fields.push('parent_id = ?');

--- a/assets/defaultCategories.json
+++ b/assets/defaultCategories.json
@@ -1,290 +1,272 @@
 [
   {
-    "id": "expense-root",
-    "name": "Expenses",
-    "nameKey": "expense_categories",
-    "type": "folder",
-    "parentId": null,
-    "icon": "credit-card-outline",
-    "categoryType": "expense"
-  },
-  {
     "id": "expense-food",
     "name": "Food & Dining",
     "nameKey": "food_dining",
-    "type": "subfolder",
-    "parentId": "expense-root",
-    "icon": "food",
-    "categoryType": "expense"
+    "type": "folder",
+    "category_type": "expense",
+    "parentId": null,
+    "icon": "food"
   },
   {
     "id": "expense-food-restaurant",
     "name": "Restaurants",
     "nameKey": "restaurants",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-food",
-    "icon": "silverware-fork-knife",
-    "categoryType": "expense"
+    "icon": "silverware-fork-knife"
   },
   {
     "id": "expense-food-groceries",
     "name": "Groceries",
     "nameKey": "groceries",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-food",
-    "icon": "cart",
-    "categoryType": "expense"
+    "icon": "cart"
   },
   {
     "id": "expense-food-cafe",
     "name": "Cafe & Coffee",
     "nameKey": "cafe_coffee",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-food",
-    "icon": "coffee",
-    "categoryType": "expense"
+    "icon": "coffee"
   },
   {
     "id": "expense-transport",
     "name": "Transportation",
     "nameKey": "transportation",
-    "type": "subfolder",
-    "parentId": "expense-root",
-    "icon": "car",
-    "categoryType": "expense"
+    "type": "folder",
+    "category_type": "expense",
+    "parentId": null,
+    "icon": "car"
   },
   {
     "id": "expense-transport-fuel",
     "name": "Fuel",
     "nameKey": "fuel",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-transport",
-    "icon": "gas-station",
-    "categoryType": "expense"
+    "icon": "gas-station"
   },
   {
     "id": "expense-transport-public",
     "name": "Public Transport",
     "nameKey": "public_transport",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-transport",
-    "icon": "bus",
-    "categoryType": "expense"
+    "icon": "bus"
   },
   {
     "id": "expense-transport-taxi",
     "name": "Taxi & Rideshare",
     "nameKey": "taxi_rideshare",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-transport",
-    "icon": "taxi",
-    "categoryType": "expense"
+    "icon": "taxi"
   },
   {
     "id": "expense-shopping",
     "name": "Shopping",
     "nameKey": "shopping",
-    "type": "subfolder",
-    "parentId": "expense-root",
-    "icon": "shopping",
-    "categoryType": "expense"
+    "type": "folder",
+    "category_type": "expense",
+    "parentId": null,
+    "icon": "shopping"
   },
   {
     "id": "expense-shopping-clothing",
     "name": "Clothing",
     "nameKey": "clothing",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-shopping",
-    "icon": "hanger",
-    "categoryType": "expense"
+    "icon": "hanger"
   },
   {
     "id": "expense-shopping-electronics",
     "name": "Electronics",
     "nameKey": "electronics",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-shopping",
-    "icon": "laptop",
-    "categoryType": "expense"
+    "icon": "laptop"
   },
   {
     "id": "expense-shopping-other",
     "name": "Other Shopping",
     "nameKey": "other_shopping",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-shopping",
-    "icon": "cart-outline",
-    "categoryType": "expense"
+    "icon": "cart-outline"
   },
   {
     "id": "expense-bills",
     "name": "Bills & Utilities",
     "nameKey": "bills_utilities",
-    "type": "subfolder",
-    "parentId": "expense-root",
-    "icon": "file-document",
-    "categoryType": "expense"
+    "type": "folder",
+    "category_type": "expense",
+    "parentId": null,
+    "icon": "file-document"
   },
   {
     "id": "expense-bills-rent",
     "name": "Rent",
     "nameKey": "rent",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-bills",
-    "icon": "home",
-    "categoryType": "expense"
+    "icon": "home"
   },
   {
     "id": "expense-bills-electricity",
     "name": "Electricity",
     "nameKey": "electricity",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-bills",
-    "icon": "lightning-bolt",
-    "categoryType": "expense"
+    "icon": "lightning-bolt"
   },
   {
     "id": "expense-bills-water",
     "name": "Water",
     "nameKey": "water",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-bills",
-    "icon": "water",
-    "categoryType": "expense"
+    "icon": "water"
   },
   {
     "id": "expense-bills-internet",
     "name": "Internet & Phone",
     "nameKey": "internet_phone",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-bills",
-    "icon": "wifi",
-    "categoryType": "expense"
+    "icon": "wifi"
   },
   {
     "id": "expense-entertainment",
     "name": "Entertainment",
     "nameKey": "entertainment",
-    "type": "subfolder",
-    "parentId": "expense-root",
-    "icon": "movie",
-    "categoryType": "expense"
+    "type": "folder",
+    "category_type": "expense",
+    "parentId": null,
+    "icon": "movie"
   },
   {
     "id": "expense-entertainment-movies",
     "name": "Movies & Shows",
     "nameKey": "movies_shows",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-entertainment",
-    "icon": "movie-open",
-    "categoryType": "expense"
+    "icon": "movie-open"
   },
   {
     "id": "expense-entertainment-games",
     "name": "Games",
     "nameKey": "games",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-entertainment",
-    "icon": "gamepad-variant",
-    "categoryType": "expense"
+    "icon": "gamepad-variant"
   },
   {
     "id": "expense-entertainment-sports",
     "name": "Sports & Hobbies",
     "nameKey": "sports_hobbies",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-entertainment",
-    "icon": "basketball",
-    "categoryType": "expense"
+    "icon": "basketball"
   },
   {
     "id": "expense-health",
     "name": "Health & Fitness",
     "nameKey": "health_fitness",
-    "type": "subfolder",
-    "parentId": "expense-root",
-    "icon": "heart-pulse",
-    "categoryType": "expense"
+    "type": "folder",
+    "category_type": "expense",
+    "parentId": null,
+    "icon": "heart-pulse"
   },
   {
     "id": "expense-health-medical",
     "name": "Medical",
     "nameKey": "medical",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-health",
-    "icon": "hospital-box",
-    "categoryType": "expense"
+    "icon": "hospital-box"
   },
   {
     "id": "expense-health-pharmacy",
     "name": "Pharmacy",
     "nameKey": "pharmacy",
-    "type": "entry",
+    "type": "folder",
+    "category_type": "expense",
     "parentId": "expense-health",
-    "icon": "pill",
-    "categoryType": "expense"
+    "icon": "pill"
   },
   {
     "id": "expense-health-gym",
     "name": "Gym & Fitness",
     "nameKey": "gym_fitness",
-    "type": "entry",
-    "parentId": "expense-health",
-    "icon": "dumbbell",
-    "categoryType": "expense"
-  },
-  {
-    "id": "income-root",
-    "name": "Income",
-    "nameKey": "income_categories",
     "type": "folder",
-    "parentId": null,
-    "icon": "cash-multiple",
-    "categoryType": "income"
+    "category_type": "expense",
+    "parentId": "expense-health",
+    "icon": "dumbbell"
   },
   {
     "id": "income-salary",
     "name": "Salary",
     "nameKey": "salary",
-    "type": "entry",
-    "parentId": "income-root",
-    "icon": "briefcase",
-    "categoryType": "income"
+    "type": "folder",
+    "category_type": "income",
+    "parentId": null,
+    "icon": "briefcase"
   },
   {
     "id": "income-business",
     "name": "Business",
     "nameKey": "business",
-    "type": "entry",
-    "parentId": "income-root",
-    "icon": "domain",
-    "categoryType": "income"
+    "type": "folder",
+    "category_type": "income",
+    "parentId": null,
+    "icon": "domain"
   },
   {
     "id": "income-investments",
     "name": "Investments",
     "nameKey": "investments",
-    "type": "entry",
-    "parentId": "income-root",
-    "icon": "chart-line",
-    "categoryType": "income"
+    "type": "folder",
+    "category_type": "income",
+    "parentId": null,
+    "icon": "chart-line"
   },
   {
     "id": "income-gifts",
     "name": "Gifts",
     "nameKey": "gifts",
-    "type": "entry",
-    "parentId": "income-root",
-    "icon": "gift",
-    "categoryType": "income"
+    "type": "folder",
+    "category_type": "income",
+    "parentId": null,
+    "icon": "gift"
   },
   {
     "id": "income-other",
     "name": "Other Income",
     "nameKey": "other_income",
-    "type": "entry",
-    "parentId": "income-root",
-    "icon": "cash",
-    "categoryType": "income"
+    "type": "folder",
+    "category_type": "income",
+    "parentId": null,
+    "icon": "cash"
   }
 ]


### PR DESCRIPTION
… field

Major changes:
- Database schema: Changed categories to only use 'folder' type with a new 'category_type' field (expense/income)
- Removed three-tier hierarchy (folder/subfolder/entry) in favor of flexible folder structure
- All categories now have category_type property indicating expense or income
- Updated database migrations for both SQLite (native) and IndexedDB (web)
- Removed "Expenses" and "Income" root folders from default categories
- Simplified category UI: removed type picker, added clearer category type display
- Category badges now show E/I (expense/income) instead of F/S/E
- Updated validation to require category_type instead of hierarchical type

Files modified:
- app/services/db.js: Added V2 migration, updated schema with category_type
- app/services/db.web.js: Added V3 migration for IndexedDB
- app/services/CategoriesDB.js: Updated CRUD operations for category_type
- app/CategoriesContext.js: Removed type mapping, simplified validation
- app/CategoryModal.js: Removed subfolder/entry type selection, simplified UI
- app/CategoriesScreen.js: Updated display logic for new structure
- assets/defaultCategories.json: Restructured with folder-only types and category_type