### PR TITLE
Filter graph dates by available operations

### DIFF
--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -537,3 +537,27 @@ export const operationExists = async (id) => {
     throw error;
   }
 };
+
+/**
+ * Get distinct year/month combinations that have operations
+ * @returns {Promise<Array<{year: number, month: number}>>}
+ */
+export const getAvailableMonths = async () => {
+  try {
+    const results = await queryAll(
+      `SELECT DISTINCT
+         CAST(strftime('%Y', date) AS INTEGER) as year,
+         CAST(strftime('%m', date) AS INTEGER) as month
+       FROM operations
+       ORDER BY year DESC, month DESC`
+    );
+
+    return (results || []).map(row => ({
+      year: row.year,
+      month: row.month - 1 // Convert to 0-based month (0-11) for JavaScript Date
+    }));
+  } catch (error) {
+    console.error('Failed to get available months:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
Add getAvailableMonths function to OperationsDB to query distinct year/month combinations that have operations in the database. Update GraphsScreen to use this data to filter year and month picker options, ensuring users only see dates that contain actual transaction data. Automatically adjust selected month when changing years to maintain valid selection.