### PR TITLE
Remove delete button from operations list

### DIFF
--- a/app/OperationModal.js
+++ b/app/OperationModal.js
@@ -22,7 +22,7 @@ import { useAccounts } from './AccountsContext';
 import { useCategories } from './CategoriesContext';
 import { getLastAccessedAccount, setLastAccessedAccount } from './services/LastAccount';
 
-export default function OperationModal({ visible, onClose, operation, isNew }) {
+export default function OperationModal({ visible, onClose, operation, isNew, onDelete }) {
   const { colors } = useTheme();
   const { t } = useLocalization();
   const { addOperation, updateOperation, validateOperation } = useOperations();
@@ -109,6 +109,13 @@ export default function OperationModal({ visible, onClose, operation, isNew }) {
     setErrors({});
     onClose();
   }, [onClose]);
+
+  const handleDelete = useCallback(() => {
+    if (onDelete && operation) {
+      onDelete(operation);
+      onClose();
+    }
+  }, [onDelete, operation, onClose]);
 
   const openPicker = useCallback((type, data) => {
     Keyboard.dismiss();
@@ -304,6 +311,19 @@ export default function OperationModal({ visible, onClose, operation, isNew }) {
                     </Text>
                   </Pressable>
                 </View>
+
+                {/* Delete Button (only for editing) */}
+                {!isNew && onDelete && (
+                  <Pressable
+                    style={[styles.deleteButtonContainer, { backgroundColor: colors.card }]}
+                    onPress={handleDelete}
+                  >
+                    <Icon name="delete-outline" size={20} color={colors.delete || '#ff6b6b'} />
+                    <Text style={[styles.deleteButtonText, { color: colors.delete || '#ff6b6b' }]}>
+                      {t('delete_operation')}
+                    </Text>
+                  </Pressable>
+                )}
               </Pressable>
             </Pressable>
           </KeyboardAvoidingView>
@@ -560,5 +580,18 @@ const styles = StyleSheet.create({
   closeButtonText: {
     fontSize: 16,
     fontWeight: '600',
+  },
+  deleteButtonContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    marginTop: 8,
+    gap: 8,
+    minHeight: 48,
+  },
+  deleteButtonText: {
+    fontSize: 16,
+    fontWeight: '500',
   },
 });

--- a/app/OperationsScreen.js
+++ b/app/OperationsScreen.js
@@ -212,21 +212,10 @@ const OperationsScreen = () => {
               {formatDate(operation.date)}
             </Text>
           </View>
-
-          {/* Delete Button */}
-          <TouchableOpacity
-            onPress={() => handleDeleteOperation(operation)}
-            style={styles.deleteButton}
-            accessibilityRole="button"
-            accessibilityLabel={t('delete_operation_accessibility')}
-            accessibilityHint={t('delete_hint')}
-          >
-            <Icon name="delete-outline" size={22} color={colors.delete} accessible={false} />
-          </TouchableOpacity>
         </View>
       </TouchableOpacity>
     );
-  }, [colors, t, getCategoryInfo, getAccountName, handleEditOperation, handleDeleteOperation, formatDate, formatCurrency]);
+  }, [colors, t, getCategoryInfo, getAccountName, handleEditOperation, formatDate, formatCurrency]);
 
   if (operationsLoading || accountsLoading || categoriesLoading) {
     return (
@@ -283,6 +272,7 @@ const OperationsScreen = () => {
         onClose={() => setModalVisible(false)}
         operation={editingOperation}
         isNew={isNew}
+        onDelete={handleDeleteOperation}
       />
     </SafeAreaView>
   );
@@ -345,13 +335,6 @@ const styles = StyleSheet.create({
   },
   date: {
     fontSize: 12,
-  },
-  deleteButton: {
-    minWidth: 48,
-    minHeight: 48,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 4,
   },
   emptyContainer: {
     flex: 1,


### PR DESCRIPTION
- Remove delete button from operations list view
- Add delete button to edit operation modal (only shown when editing)
- Delete functionality now accessible through edit modal instead of list item
- Improves UX by reducing clutter in list view