### PR TITLE
Add drag-to-reorder accounts feature

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import { LocalizationProvider } from './app/LocalizationContext';
 import ErrorBoundary from './app/ErrorBoundary';
 import { StatusBar, Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 function ThemedStatusBar() {
   const { colorScheme, colors } = require('./app/ThemeContext').useTheme();
@@ -29,20 +30,22 @@ function ThemedStatusBar() {
 export default function App() {
   return (
     <ErrorBoundary>
-      <SafeAreaProvider>
-        <LocalizationProvider>
-          <ThemeProvider>
-            <AccountsProvider>
-              <CategoriesProvider>
-                <OperationsProvider>
-                  <ThemedStatusBar />
-                  <SimpleTabs />
-                </OperationsProvider>
-              </CategoriesProvider>
-            </AccountsProvider>
-          </ThemeProvider>
-        </LocalizationProvider>
-      </SafeAreaProvider>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <SafeAreaProvider>
+          <LocalizationProvider>
+            <ThemeProvider>
+              <AccountsProvider>
+                <CategoriesProvider>
+                  <OperationsProvider>
+                    <ThemedStatusBar />
+                    <SimpleTabs />
+                  </OperationsProvider>
+                </CategoriesProvider>
+              </AccountsProvider>
+            </ThemeProvider>
+          </LocalizationProvider>
+        </SafeAreaProvider>
+      </GestureHandlerRootView>
     </ErrorBoundary>
   );
 }

--- a/app/AccountsContext.js
+++ b/app/AccountsContext.js
@@ -148,6 +148,32 @@ export const AccountsProvider = ({ children }) => {
     }
   }, []);
 
+  const reorderAccounts = useCallback(async (newOrder) => {
+    try {
+      // Update local state immediately for responsive UI
+      setAccounts(newOrder);
+
+      // Prepare data for database update
+      const orderedAccounts = newOrder.map((account, index) => ({
+        id: account.id,
+        display_order: index,
+      }));
+
+      // Persist to database
+      await AccountsDB.reorderAccounts(orderedAccounts);
+    } catch (err) {
+      console.error('Failed to reorder accounts:', err);
+      // Reload accounts to restore correct order
+      await reloadAccounts();
+      Alert.alert(
+        'Error',
+        'Failed to save new account order. Please try again.',
+        [{ text: 'OK' }]
+      );
+      throw err;
+    }
+  }, [reloadAccounts]);
+
   const resetDatabase = useCallback(async () => {
     try {
       setLoading(true);
@@ -220,10 +246,11 @@ export const AccountsProvider = ({ children }) => {
     updateAccount,
     deleteAccount,
     reloadAccounts,
+    reorderAccounts,
     resetDatabase,
     validateAccount,
     currencies,
-  }), [accounts, loading, error, addAccount, updateAccount, deleteAccount, reloadAccounts, resetDatabase]);
+  }), [accounts, loading, error, addAccount, updateAccount, deleteAccount, reloadAccounts, reorderAccounts, resetDatabase]);
 
   return (
     <AccountsContext.Provider value={value}>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -58,3 +58,47 @@ jest.mock('react-native/Libraries/NativeComponent/ViewConfigIgnore', () => ({
   ConditionallyIgnoredEventHandlers: (value) => value,
   DynamicallyInjectedByGestureHandler: (value) => value,
 }));
+
+// Mock react-native-gesture-handler
+jest.mock('react-native-gesture-handler', () => {
+  const View = require('react-native/Libraries/Components/View/View');
+  return {
+    Swipeable: View,
+    DrawerLayout: View,
+    State: {},
+    ScrollView: View,
+    Slider: View,
+    Switch: View,
+    TextInput: View,
+    ToolbarAndroid: View,
+    ViewPagerAndroid: View,
+    DrawerLayoutAndroid: View,
+    WebView: View,
+    NativeViewGestureHandler: View,
+    TapGestureHandler: View,
+    FlingGestureHandler: View,
+    ForceTouchGestureHandler: View,
+    LongPressGestureHandler: View,
+    PanGestureHandler: View,
+    PinchGestureHandler: View,
+    RotationGestureHandler: View,
+    RawButton: View,
+    BaseButton: View,
+    RectButton: View,
+    BorderlessButton: View,
+    FlatList: View,
+    gestureHandlerRootHOC: jest.fn(component => component),
+    Directions: {},
+    GestureHandlerRootView: View,
+  };
+});
+
+// Mock react-native-draggable-flatlist
+jest.mock('react-native-draggable-flatlist', () => {
+  const React = require('react');
+  const { FlatList } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props) => React.createElement(FlatList, props),
+  };
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-chart-kit": "^6.12.0",
+        "react-native-draggable-flatlist": "^4.0.3",
         "react-native-safe-area-context": "^5.6.2",
         "react-native-screens": "^4.18.0",
         "react-native-svg": "^15.15.0",
@@ -1860,7 +1861,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2271,6 +2271,19 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.5",
@@ -4021,6 +4034,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -7609,6 +7629,23 @@
       "dependencies": {
         "hermes-estree": "0.23.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -11235,6 +11272,36 @@
         "react-native-svg": "> 6.4.1"
       }
     },
+    "node_modules/react-native-draggable-flatlist": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-draggable-flatlist/-/react-native-draggable-flatlist-4.0.3.tgz",
+      "integrity": "sha512-2F4x5BFieWdGq9SetD2nSAR7s7oQCSgNllYgERRXXtNfSOuAGAVbDb/3H3lP0y5f7rEyNwabKorZAD/SyyNbDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/preset-typescript": "^7.17.12"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.64.0",
+        "react-native-gesture-handler": ">=2.0.0",
+        "react-native-reanimated": ">=2.8.0"
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.29.1.tgz",
+      "integrity": "sha512-du3qmv0e3Sm7qsd9SfmHps+AggLiylcBBQ8ztz7WUtd8ZjKs5V3kekAbi9R2W9bRLSg47Ntp4GGMYZOhikQdZA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
@@ -11243,6 +11310,36 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.5.tgz",
+      "integrity": "sha512-UA6VUbxwhRjEw2gSNrvhkusUq3upfD3Cv+AnB07V+kC8kpvwRVI+ivwY95ePbWNFkFpP+Y2Sdw1WHpHWEV+P2Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": ">=0.5.0"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -11325,6 +11422,44 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.6.1.tgz",
+      "integrity": "sha512-URca8l7c7Uog7gv4mcg9KILdJlnbvwdS5yfXQYf5TDkD2W1VY1sduEKrD+sA3lUPXH/TG1vmXAvNxCNwPMYgGg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {
       "version": "0.81.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-native": "0.81.5",
         "react-native-chart-kit": "^6.12.0",
         "react-native-draggable-flatlist": "^4.0.3",
+        "react-native-gesture-handler": "^2.29.1",
         "react-native-safe-area-context": "^5.6.2",
         "react-native-screens": "^4.18.0",
         "react-native-svg": "^15.15.0",
@@ -2277,7 +2278,6 @@
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
       "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hammerjs": "^2.0.36"
       },
@@ -4039,8 +4039,7 @@
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -7635,7 +7634,6 @@
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -7644,8 +7642,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -11291,7 +11288,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.29.1.tgz",
       "integrity": "sha512-du3qmv0e3Sm7qsd9SfmHps+AggLiylcBBQ8ztz7WUtd8ZjKs5V3kekAbi9R2W9bRLSg47Ntp4GGMYZOhikQdZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-native": "0.81.5",
     "react-native-chart-kit": "^6.12.0",
     "react-native-draggable-flatlist": "^4.0.3",
+    "react-native-gesture-handler": "^2.29.1",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "^4.18.0",
     "react-native-svg": "^15.15.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-chart-kit": "^6.12.0",
+    "react-native-draggable-flatlist": "^4.0.3",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "^4.18.0",
     "react-native-svg": "^15.15.0",
@@ -38,7 +39,9 @@
   },
   "jest": {
     "preset": "jest-expo",
-    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"],
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
     ]


### PR DESCRIPTION
Implement long-press drag-and-drop functionality for reordering accounts:
- Add display_order field to accounts table via DB migration (V3 -> V4)
- Install react-native-draggable-flatlist for drag-and-drop UI
- Update AccountsDB to persist account order
- Add reorderAccounts method to AccountsContext
- Replace FlatList with DraggableFlatList in AccountsScreen
- Add drag handle icon to each account row
- Update UI to highlight active dragging state

Users can now long-press the drag handle to reorder their accounts.