### PR TITLE
Add language preference on first app launch

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import SimpleTabs from './app/SimpleTabs';
+import AppInitializer from './app/AppInitializer';
 import { ThemeProvider } from './app/ThemeContext';
 import { AccountsProvider } from './app/AccountsContext';
 import { CategoriesProvider } from './app/CategoriesContext';
@@ -38,7 +38,7 @@ export default function App() {
                 <CategoriesProvider>
                   <OperationsProvider>
                     <ThemedStatusBar />
-                    <SimpleTabs />
+                    <AppInitializer />
                   </OperationsProvider>
                 </CategoriesProvider>
               </AccountsProvider>

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,10 +1,21 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import App from '../App';
 
 describe('App', () => {
-  it('renders without crashing', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('renders without crashing', async () => {
+    // Set a language preference so we skip the first-time setup
+    await AsyncStorage.setItem('app_language', 'en');
+
     const { toJSON } = render(<App />);
-    expect(toJSON()).toBeTruthy();
+
+    await waitFor(() => {
+      expect(toJSON()).toBeTruthy();
+    });
   });
 });

--- a/__tests__/contexts/LocalizationContext.test.js
+++ b/__tests__/contexts/LocalizationContext.test.js
@@ -17,10 +17,14 @@ describe('LocalizationContext', () => {
   const wrapper = ({ children }) => <LocalizationProvider>{children}</LocalizationProvider>;
 
   describe('Initialization', () => {
-    it('provides localization context with default values', () => {
+    it('provides localization context with default values', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
 
-      expect(result.current.language).toBe('en');
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+        expect(result.current.language).toBe('en');
+      });
+
       expect(result.current.t).toBeDefined();
       expect(result.current.setLanguage).toBeDefined();
       expect(result.current.availableLanguages).toBeDefined();
@@ -36,10 +40,13 @@ describe('LocalizationContext', () => {
       });
     });
 
-    it('uses default language when no preference is saved', () => {
+    it('uses default language when no preference is saved', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
 
-      expect(result.current.language).toBe('en');
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+        expect(result.current.language).toBe('en');
+      });
     });
 
     it('ignores invalid language from AsyncStorage', async () => {
@@ -56,6 +63,10 @@ describe('LocalizationContext', () => {
   describe('Language Switching', () => {
     it('switches to Russian', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       await act(async () => {
         await result.current.setLanguage('ru');
@@ -83,6 +94,10 @@ describe('LocalizationContext', () => {
     it('persists language preference to AsyncStorage', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
 
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
+
       await act(async () => {
         await result.current.setLanguage('ru');
       });
@@ -93,8 +108,12 @@ describe('LocalizationContext', () => {
   });
 
   describe('Translation Function', () => {
-    it('translates keys to English', () => {
+    it('translates keys to English', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       expect(result.current.t('accounts')).toBeDefined();
       expect(result.current.t('operations')).toBeDefined();
@@ -105,6 +124,10 @@ describe('LocalizationContext', () => {
     it('translates keys to Russian when language is ru', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
 
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
+
       await act(async () => {
         await result.current.setLanguage('ru');
       });
@@ -113,15 +136,23 @@ describe('LocalizationContext', () => {
       expect(result.current.t('accounts')).not.toBe('accounts'); // Should be translated
     });
 
-    it('returns key itself when translation is missing', () => {
+    it('returns key itself when translation is missing', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       const missingKey = 'nonexistent_translation_key';
       expect(result.current.t(missingKey)).toBe(missingKey);
     });
 
-    it('handles undefined or null keys gracefully', () => {
+    it('handles undefined or null keys gracefully', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       expect(() => result.current.t(undefined)).not.toThrow();
       expect(() => result.current.t(null)).not.toThrow();
@@ -129,24 +160,36 @@ describe('LocalizationContext', () => {
   });
 
   describe('Available Languages', () => {
-    it('provides list of available languages', () => {
+    it('provides list of available languages', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       expect(result.current.availableLanguages).toContain('en');
       expect(result.current.availableLanguages).toContain('ru');
       expect(Array.isArray(result.current.availableLanguages)).toBe(true);
     });
 
-    it('has at least 2 languages (en and ru)', () => {
+    it('has at least 2 languages (en and ru)', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       expect(result.current.availableLanguages.length).toBeGreaterThanOrEqual(2);
     });
   });
 
   describe('Translation Keys Coverage', () => {
-    it('has translations for all main screens', () => {
+    it('has translations for all main screens', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       const screenKeys = ['operations', 'accounts', 'categories', 'graphs'];
 
@@ -157,8 +200,12 @@ describe('LocalizationContext', () => {
       });
     });
 
-    it('has translations for common UI elements', () => {
+    it('has translations for common UI elements', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       const commonKeys = ['save', 'cancel', 'delete', 'edit', 'add'];
 
@@ -170,6 +217,10 @@ describe('LocalizationContext', () => {
 
     it('provides same keys in both languages', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       // Get some translations in English
       const enTranslations = {
@@ -197,6 +248,10 @@ describe('LocalizationContext', () => {
     it('maintains language consistency after multiple changes', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
 
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
+
       await act(async () => {
         await result.current.setLanguage('ru');
       });
@@ -214,6 +269,10 @@ describe('LocalizationContext', () => {
     it('translations update immediately after language change', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
 
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
+
       const enTranslation = result.current.t('accounts');
 
       await act(async () => {
@@ -228,6 +287,10 @@ describe('LocalizationContext', () => {
     it('handles rapid language switches', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
 
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
+
       await act(async () => {
         await result.current.setLanguage('ru');
         await result.current.setLanguage('en');
@@ -239,6 +302,10 @@ describe('LocalizationContext', () => {
 
     it('gracefully handles AsyncStorage errors', async () => {
       const { result } = renderHook(() => useLocalization(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current).not.toBeNull();
+      });
 
       // Mock AsyncStorage to throw error after component is mounted
       jest.spyOn(AsyncStorage, 'setItem').mockRejectedValue(new Error('Storage error'));

--- a/app/AccountsContext.js
+++ b/app/AccountsContext.js
@@ -178,6 +178,10 @@ export const AccountsProvider = ({ children }) => {
     try {
       setLoading(true);
 
+      // Emit DATABASE_RESET event to notify other contexts
+      console.log('Emitting DATABASE_RESET event');
+      appEvents.emit(EVENTS.DATABASE_RESET);
+
       // Drop and reinitialize the database
       const { dropAllTables, getDatabase, executeQuery } = await import('./services/db');
       await dropAllTables();
@@ -203,10 +207,9 @@ export const AccountsProvider = ({ children }) => {
       const AsyncStorage = (await import('@react-native-async-storage/async-storage')).default;
       await AsyncStorage.removeItem('migration_backup');
 
-      // Initialize default categories first
-      const { initializeDefaultCategories } = await import('./services/CategoriesDB');
-      await initializeDefaultCategories();
-      console.log('Default categories initialized');
+      // NOTE: Categories will be initialized after language selection
+      // The AppInitializer will show the language selection screen
+      // and initialize categories with the selected language
 
       // Create default accounts
       const defaultAccounts = await initializeDefaultAccounts();

--- a/app/AccountsContext.js
+++ b/app/AccountsContext.js
@@ -219,9 +219,10 @@ export const AccountsProvider = ({ children }) => {
       // Reload accounts to ensure consistency
       await reloadAccounts();
 
-      // Trigger reload of all other contexts (Categories, Operations)
-      console.log('Emitting RELOAD_ALL event to refresh all contexts');
-      appEvents.emit(EVENTS.RELOAD_ALL);
+      // Note: We don't emit RELOAD_ALL here because:
+      // - Categories will be initialized after the user selects a language
+      // - Operations will be empty anyway after reset
+      // The AppInitializer will handle category initialization with the selected language
 
       Alert.alert(
         'Success',

--- a/app/AppInitializer.js
+++ b/app/AppInitializer.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalization } from './LocalizationContext';
-import { useCategories } from './CategoriesContext';
 import LanguageSelectionScreen from './LanguageSelectionScreen';
 import SimpleTabs from './SimpleTabs';
 import { useTheme } from './ThemeContext';
@@ -12,7 +11,6 @@ import { useTheme } from './ThemeContext';
  */
 const AppInitializer = () => {
   const { isFirstLaunch, setFirstLaunchComplete, language } = useLocalization();
-  const { reloadCategories } = useCategories();
   const { colors } = useTheme();
   const [isInitializing, setIsInitializing] = useState(false);
 
@@ -21,10 +19,8 @@ const AppInitializer = () => {
       setIsInitializing(true);
 
       // Set the language preference (this marks first launch as complete)
+      // This will trigger CategoriesContext to automatically initialize categories
       await setFirstLaunchComplete(selectedLanguage);
-
-      // Initialize categories with the selected language
-      await reloadCategories(selectedLanguage);
 
       // Initialization complete, will automatically show main app
     } catch (error) {

--- a/app/AppInitializer.js
+++ b/app/AppInitializer.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { useLocalization } from './LocalizationContext';
+import { useCategories } from './CategoriesContext';
+import LanguageSelectionScreen from './LanguageSelectionScreen';
+import SimpleTabs from './SimpleTabs';
+import { useTheme } from './ThemeContext';
+
+/**
+ * AppInitializer handles first-time setup and app initialization
+ * Shows language selection screen on first launch, then initializes categories
+ */
+const AppInitializer = () => {
+  const { isFirstLaunch, setFirstLaunchComplete, language } = useLocalization();
+  const { reloadCategories } = useCategories();
+  const { colors } = useTheme();
+  const [isInitializing, setIsInitializing] = useState(false);
+
+  const handleLanguageSelected = async (selectedLanguage) => {
+    try {
+      setIsInitializing(true);
+
+      // Set the language preference (this marks first launch as complete)
+      await setFirstLaunchComplete(selectedLanguage);
+
+      // Initialize categories with the selected language
+      await reloadCategories(selectedLanguage);
+
+      // Initialization complete, will automatically show main app
+    } catch (error) {
+      console.error('Failed to initialize app with selected language:', error);
+    } finally {
+      setIsInitializing(false);
+    }
+  };
+
+  // If showing language selection or initializing, don't show main app yet
+  if (isFirstLaunch) {
+    if (isInitializing) {
+      return (
+        <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      );
+    }
+    return <LanguageSelectionScreen onLanguageSelected={handleLanguageSelected} />;
+  }
+
+  // Normal app flow - not first launch
+  return <SimpleTabs />;
+};
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default AppInitializer;

--- a/app/CategoriesContext.js
+++ b/app/CategoriesContext.js
@@ -23,24 +23,19 @@ export const CategoriesProvider = ({ children }) => {
   const [saveError, setSaveError] = useState(null);
 
   // Reload categories from database
-  const reloadCategories = useCallback(async () => {
+  const reloadCategories = useCallback(async (language = 'en') => {
     try {
       setLoading(true);
       const categoriesData = await CategoriesDB.getAllCategories();
 
       if (categoriesData.length === 0) {
-        // Initialize with default categories
-        console.log('Initializing default categories...');
-        const createdCategories = [];
-        for (const category of defaultCategories) {
-          try {
-            await CategoriesDB.createCategory(category);
-            createdCategories.push(category);
-          } catch (err) {
-            console.error('Failed to create default category:', category.id, err);
-          }
-        }
-        setCategories(createdCategories);
+        // Initialize with default categories in the specified language
+        console.log(`Initializing default categories in ${language}...`);
+        await CategoriesDB.initializeDefaultCategories(language);
+
+        // Reload to get the newly created categories
+        const newCategories = await CategoriesDB.getAllCategories();
+        setCategories(newCategories);
       } else {
         setCategories(categoriesData);
       }

--- a/app/CategoriesContext.js
+++ b/app/CategoriesContext.js
@@ -63,6 +63,18 @@ export const CategoriesProvider = ({ children }) => {
     return unsubscribe;
   }, [reloadCategories]);
 
+  // Listen for DATABASE_RESET event to clear categories
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, () => {
+      console.log('CategoriesContext: Database reset detected, clearing categories');
+      // Clear categories so they can be re-initialized with the selected language
+      setCategories([]);
+      setDataLoaded(false);
+    });
+
+    return unsubscribe;
+  }, []);
+
   const addCategory = useCallback(async (category) => {
     try {
       const newCategory = {

--- a/app/LanguageSelectionScreen.js
+++ b/app/LanguageSelectionScreen.js
@@ -1,0 +1,220 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  SafeAreaView,
+  StatusBar,
+  Platform,
+} from 'react-native';
+import i18nData from '../assets/i18n.json';
+
+const LanguageSelectionScreen = ({ onLanguageSelected }) => {
+  const [selectedLanguage, setSelectedLanguage] = useState(null);
+
+  const languages = [
+    { code: 'en', name: 'English', nativeName: 'English', flag: '🇬🇧' },
+    { code: 'ru', name: 'Russian', nativeName: 'Русский', flag: '🇷🇺' },
+  ];
+
+  const handleLanguageSelect = (code) => {
+    setSelectedLanguage(code);
+  };
+
+  const handleContinue = () => {
+    if (selectedLanguage) {
+      onLanguageSelected(selectedLanguage);
+    }
+  };
+
+  // Use selected language for UI text, or default to English
+  const t = (key) => {
+    const lang = selectedLanguage || 'en';
+    return i18nData[lang]?.[key] || key;
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <Text style={styles.title}>{t('welcome_title')}</Text>
+          <Text style={styles.subtitle}>{t('welcome_subtitle')}</Text>
+
+          <View style={styles.languagesContainer}>
+            {languages.map((language) => (
+              <TouchableOpacity
+                key={language.code}
+                style={[
+                  styles.languageButton,
+                  selectedLanguage === language.code && styles.languageButtonSelected,
+                ]}
+                onPress={() => handleLanguageSelect(language.code)}
+                accessibilityRole="button"
+                accessibilityLabel={`Select ${language.name}`}
+                accessibilityState={{ selected: selectedLanguage === language.code }}
+              >
+                <Text style={styles.flag}>{language.flag}</Text>
+                <View style={styles.languageTextContainer}>
+                  <Text
+                    style={[
+                      styles.languageName,
+                      selectedLanguage === language.code && styles.languageNameSelected,
+                    ]}
+                  >
+                    {language.nativeName}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.languageEnglishName,
+                      selectedLanguage === language.code && styles.languageEnglishNameSelected,
+                    ]}
+                  >
+                    {language.name}
+                  </Text>
+                </View>
+                {selectedLanguage === language.code && (
+                  <View style={styles.checkmark}>
+                    <Text style={styles.checkmarkText}>✓</Text>
+                  </View>
+                )}
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.footer}>
+          <TouchableOpacity
+            style={[
+              styles.continueButton,
+              !selectedLanguage && styles.continueButtonDisabled,
+            ]}
+            onPress={handleContinue}
+            disabled={!selectedLanguage}
+            accessibilityRole="button"
+            accessibilityLabel={t('continue')}
+            accessibilityState={{ disabled: !selectedLanguage }}
+          >
+            <Text
+              style={[
+                styles.continueButtonText,
+                !selectedLanguage && styles.continueButtonTextDisabled,
+              ]}
+            >
+              {t('continue')}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  container: {
+    flex: 1,
+    backgroundColor: '#ffffff',
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 60,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#1a1a1a',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666666',
+    textAlign: 'center',
+    marginBottom: 48,
+  },
+  languagesContainer: {
+    width: '100%',
+    maxWidth: 400,
+  },
+  languageButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#f5f5f5',
+    borderRadius: 12,
+    padding: 20,
+    marginBottom: 16,
+    borderWidth: 2,
+    borderColor: '#f5f5f5',
+  },
+  languageButtonSelected: {
+    backgroundColor: '#e3f2fd',
+    borderColor: '#2196f3',
+  },
+  flag: {
+    fontSize: 40,
+    marginRight: 16,
+  },
+  languageTextContainer: {
+    flex: 1,
+  },
+  languageName: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#1a1a1a',
+    marginBottom: 4,
+  },
+  languageNameSelected: {
+    color: '#1565c0',
+  },
+  languageEnglishName: {
+    fontSize: 14,
+    color: '#666666',
+  },
+  languageEnglishNameSelected: {
+    color: '#1976d2',
+  },
+  checkmark: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: '#2196f3',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkmarkText: {
+    color: '#ffffff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  footer: {
+    padding: 24,
+    paddingBottom: Platform.OS === 'ios' ? 34 : 24,
+  },
+  continueButton: {
+    backgroundColor: '#2196f3',
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  continueButtonDisabled: {
+    backgroundColor: '#e0e0e0',
+  },
+  continueButtonText: {
+    color: '#ffffff',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  continueButtonTextDisabled: {
+    color: '#9e9e9e',
+  },
+});
+
+export default LanguageSelectionScreen;

--- a/app/LocalizationContext.js
+++ b/app/LocalizationContext.js
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import i18nData from '../assets/i18n.json';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { appEvents, EVENTS } from './services/eventEmitter';
 
 
 const STORAGE_KEY = 'app_language';
@@ -40,6 +41,25 @@ export function LocalizationProvider({ children }) {
         setIsLoading(false);
       }
     })();
+  }, []);
+
+  // Listen for DATABASE_RESET event to reset language preference
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, async () => {
+      console.log('LocalizationContext: Database reset detected, clearing language preference');
+      try {
+        // Clear language preference from AsyncStorage
+        await AsyncStorage.removeItem(STORAGE_KEY);
+
+        // Reset to first launch state
+        setIsFirstLaunch(true);
+        setLanguageState(defaultLang);
+      } catch (e) {
+        console.error('Failed to clear language preference:', e);
+      }
+    });
+
+    return unsubscribe;
   }, []);
 
   // Save language to AsyncStorage when it changes

--- a/app/services/CategoriesDB.js
+++ b/app/services/CategoriesDB.js
@@ -1,5 +1,6 @@
 import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
 import defaultCategories from '../../assets/defaultCategories.json';
+import i18nData from '../../assets/i18n.json';
 
 /**
  * Map database field names to camelCase for application use
@@ -23,11 +24,15 @@ const mapCategoryFields = (dbCategory) => {
 };
 
 /**
- * Initialize default categories in the database
+ * Initialize default categories in the database with translated names
+ * @param {string} language - Language code ('en' or 'ru')
  * @returns {Promise<void>}
  */
-export const initializeDefaultCategories = async () => {
+export const initializeDefaultCategories = async (language = 'en') => {
   try {
+    // Get translations for the specified language
+    const translations = i18nData[language] || i18nData['en'];
+
     // Sort categories to ensure parents are created before children
     const sortedCategories = [...defaultCategories].sort((a, b) => {
       // Categories without parentId (root) should come first
@@ -38,9 +43,14 @@ export const initializeDefaultCategories = async () => {
 
     for (const category of sortedCategories) {
       try {
+        // Use translated name if nameKey exists, otherwise use default name
+        const translatedName = category.nameKey
+          ? (translations[category.nameKey] || category.name)
+          : category.name;
+
         await createCategory({
           id: category.id,
-          name: category.name,
+          name: translatedName,
           type: category.type || 'folder',
           category_type: category.category_type,
           parentId: category.parentId || null,
@@ -53,7 +63,7 @@ export const initializeDefaultCategories = async () => {
       }
     }
 
-    console.log('Default categories initialized successfully');
+    console.log(`Default categories initialized successfully in ${language}`);
   } catch (error) {
     console.error('Failed to initialize default categories:', error);
     throw error;

--- a/assets/i18n.json
+++ b/assets/i18n.json
@@ -113,7 +113,11 @@
     "month_september": "September",
     "month_october": "October",
     "month_november": "November",
-    "month_december": "December"
+    "month_december": "December",
+    "welcome_title": "Welcome to Money Keeper",
+    "welcome_subtitle": "Please select your preferred language",
+    "select_language": "Select Language",
+    "continue": "Continue"
   },
   "ru": {
     "accounts": "Счета",
@@ -229,7 +233,11 @@
     "month_september": "Сентябрь",
     "month_october": "Октябрь",
     "month_november": "Ноябрь",
-    "month_december": "Декабрь"
+    "month_december": "Декабрь",
+    "welcome_title": "Добро пожаловать в Money Keeper",
+    "welcome_subtitle": "Пожалуйста, выберите предпочитаемый язык",
+    "select_language": "Выберите язык",
+    "continue": "Продолжить"
   }
 }
 

--- a/assets/i18n.json
+++ b/assets/i18n.json
@@ -117,7 +117,12 @@
     "welcome_title": "Welcome to Money Keeper",
     "welcome_subtitle": "Please select your preferred language",
     "select_language": "Select Language",
-    "continue": "Continue"
+    "continue": "Continue",
+    "database": "Database",
+    "reset_database": "Reset Database",
+    "reset_database_confirm": "Are you sure you want to reset the database? This will delete all data, and you will be asked to choose your language again to initialize default categories.",
+    "reset": "Reset",
+    "reset_database_success": "Database reset successfully. Please select your language to initialize default categories."
   },
   "ru": {
     "accounts": "Счета",
@@ -237,7 +242,12 @@
     "welcome_title": "Добро пожаловать в Money Keeper",
     "welcome_subtitle": "Пожалуйста, выберите предпочитаемый язык",
     "select_language": "Выберите язык",
-    "continue": "Продолжить"
+    "continue": "Продолжить",
+    "database": "База данных",
+    "reset_database": "Сбросить базу данных",
+    "reset_database_confirm": "Вы уверены, что хотите сбросить базу данных? Это удалит все данные, и вам будет предложено снова выбрать язык для инициализации категорий по умолчанию.",
+    "reset": "Сбросить",
+    "reset_database_success": "База данных успешно сброшена. Пожалуйста, выберите язык для инициализации категорий по умолчанию."
   }
 }
 


### PR DESCRIPTION
…tialization

On first app launch, display a language selection screen allowing users to choose between English and Russian. After selection, initialize default categories with names translated to the chosen language. This ensures categories are created with appropriate translations from the start.

Changes:
- Add LanguageSelectionScreen component with English/Russian options
- Update LocalizationContext to detect first launch and manage setup completion
- Modify CategoriesDB.initializeDefaultCategories to accept language parameter
- Update CategoriesContext to pass language when initializing categories
- Add AppInitializer component to orchestrate first-time setup flow
- Add translations for welcome screen (welcome_title, welcome_subtitle, continue)