### PR TITLE
Review and adjust UI for Material Design

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,8 @@ import ErrorBoundary from './app/ErrorBoundary';
 import { StatusBar, Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { PaperProvider } from 'react-native-paper';
+import { useMaterialTheme } from './app/useMaterialTheme';
 
 function ThemedStatusBar() {
   const { colorScheme, colors } = require('./app/ThemeContext').useTheme();
@@ -27,6 +29,17 @@ function ThemedStatusBar() {
   return <StatusBar translucent={false} />;
 }
 
+function AppContent() {
+  const paperTheme = useMaterialTheme();
+
+  return (
+    <PaperProvider theme={paperTheme}>
+      <ThemedStatusBar />
+      <SimpleTabs />
+    </PaperProvider>
+  );
+}
+
 export default function App() {
   return (
     <ErrorBoundary>
@@ -37,8 +50,7 @@ export default function App() {
               <AccountsProvider>
                 <CategoriesProvider>
                   <OperationsProvider>
-                    <ThemedStatusBar />
-                    <SimpleTabs />
+                    <AppContent />
                   </OperationsProvider>
                 </CategoriesProvider>
               </AccountsProvider>

--- a/app/AccountsScreen.js
+++ b/app/AccountsScreen.js
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo, memo, useRef } from 'react';
-import { View, Text, TextInput, Button, StyleSheet, TouchableOpacity, Modal, Pressable, Alert, KeyboardAvoidingView, Platform, ScrollView, Keyboard, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, Alert, KeyboardAvoidingView, Platform, ScrollView, Keyboard, FlatList } from 'react-native';
+import { Text, TextInput as PaperTextInput, Button, FAB, Portal, Modal, Card, TouchableRipple, ActivityIndicator } from 'react-native-paper';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 
@@ -13,34 +14,34 @@ const CurrencyPickerModal = memo(({ visible, onClose, currencies, colors, t, onS
     const [code, cur] = item;
 
     return (
-      <Pressable
+      <TouchableRipple
         onPress={() => onSelect(code)}
-        style={({ pressed }) => [
-          styles.pickerOption,
-          { borderColor: colors.border },
-          pressed && { backgroundColor: colors.selected }
-        ]}
+        style={styles.pickerOption}
+        rippleColor="rgba(0, 0, 0, .12)"
       >
-        <Text style={{ color: colors.text, fontSize: 18 }}>{cur.name} ({cur.symbol})</Text>
-      </Pressable>
+        <Text style={{ fontSize: 16 }}>{cur.name} ({cur.symbol})</Text>
+      </TouchableRipple>
     );
-  }, [colors.border, colors.text, colors.selected, onSelect]);
+  }, [onSelect]);
 
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
-      <Pressable style={styles.modalOverlay} onPress={onClose}>
-        <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-          <FlatList
-            data={Object.entries(currencies)}
-            keyExtractor={([code]) => code}
-            renderItem={renderCurrencyItem}
-          />
-          <Pressable style={styles.closeButton} onPress={onClose}>
-            <Text style={{ color: colors.primary }}>{t('close') || 'Close'}</Text>
-          </Pressable>
-        </Pressable>
-      </Pressable>
-    </Modal>
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onClose}
+        contentContainerStyle={[styles.pickerModalContent, { backgroundColor: colors.card }]}
+      >
+        <FlatList
+          data={Object.entries(currencies)}
+          keyExtractor={([code]) => code}
+          renderItem={renderCurrencyItem}
+          style={{ maxHeight: 400 }}
+        />
+        <Button mode="text" onPress={onClose} style={{ marginTop: 8 }}>
+          {t('close') || 'Close'}
+        </Button>
+      </Modal>
+    </Portal>
   );
 });
 
@@ -56,40 +57,47 @@ const AccountRow = memo(({ item, index, colors, onPress, t, drag, isActive }) =>
   }, [onPress, item.id]);
 
   return (
-    <View
+    <Card
+      mode="outlined"
       style={[
-        styles.accountRow,
-        { borderColor: colors.border, backgroundColor: rowBg },
+        styles.accountCard,
+        { backgroundColor: rowBg, borderColor: colors.border },
         isActive && { backgroundColor: colors.selected, opacity: 0.9 }
       ]}
     >
-      <TouchableOpacity
-        style={styles.accountContentWrapper}
-        onPress={handlePress}
-        accessibilityLabel={t('edit_account') || 'Edit Account'}
-        accessibilityRole="button"
-      >
-        <View style={styles.accountNameWrapper}>
-          <Text style={[styles.accountText, { color: colors.text }]} numberOfLines={1} ellipsizeMode="tail">
-            {item.name}
-          </Text>
-        </View>
-        <View style={styles.verticalDivider} />
-        <View style={styles.accountValueWrapper}>
-          <Text style={[styles.accountText, { color: colors.text, textAlign: 'right' }]} numberOfLines={1} ellipsizeMode="tail">
-            {item.balance} {item.currencySymbol}
-          </Text>
-        </View>
-      </TouchableOpacity>
-      <TouchableOpacity
-        onLongPress={drag}
-        style={styles.dragHandle}
-        accessibilityLabel={t('drag_to_reorder') || 'Long press to reorder'}
-        accessibilityRole="button"
-      >
-        <Icon name="drag-horizontal-variant" size={24} color={colors.mutedText} />
-      </TouchableOpacity>
-    </View>
+      <View style={styles.accountRow}>
+        <TouchableRipple
+          style={styles.accountContentWrapper}
+          onPress={handlePress}
+          rippleColor="rgba(0, 0, 0, .12)"
+          accessibilityLabel={t('edit_account') || 'Edit Account'}
+          accessibilityRole="button"
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}>
+            <View style={styles.accountNameWrapper}>
+              <Text variant="titleMedium" numberOfLines={1} ellipsizeMode="tail">
+                {item.name}
+              </Text>
+            </View>
+            <View style={styles.verticalDivider} />
+            <View style={styles.accountValueWrapper}>
+              <Text variant="titleMedium" style={{ textAlign: 'right' }} numberOfLines={1} ellipsizeMode="tail">
+                {item.balance} {item.currencySymbol}
+              </Text>
+            </View>
+          </View>
+        </TouchableRipple>
+        <TouchableRipple
+          onLongPress={drag}
+          style={styles.dragHandle}
+          rippleColor="rgba(0, 0, 0, .12)"
+          accessibilityLabel={t('drag_to_reorder') || 'Long press to reorder'}
+          accessibilityRole="button"
+        >
+          <Icon name="drag-horizontal-variant" size={24} color={colors.mutedText} />
+        </TouchableRipple>
+      </View>
+    </Card>
   );
 });
 
@@ -214,8 +222,8 @@ export default function AccountsScreen() {
   if (loading) {
     return (
       <View style={[styles.container, styles.loadingContainer, { backgroundColor: colors.background }]}>
-        <ActivityIndicator size="large" color={colors.primary} />
-        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+        <ActivityIndicator size="large" />
+        <Text variant="bodyLarge" style={{ marginTop: 12, color: colors.mutedText }}>
           {t('loading_accounts') || 'Loading accounts...'}
         </Text>
       </View>
@@ -225,7 +233,7 @@ export default function AccountsScreen() {
   if (error) {
     return (
       <View style={[styles.container, styles.errorContainer, { backgroundColor: colors.background }]}>
-        <Text style={[styles.errorText, { color: colors.delete }]}>
+        <Text variant="bodyLarge" style={{ color: colors.delete, textAlign: 'center' }}>
           {t('error_loading_accounts') || 'Failed to load accounts'}
         </Text>
       </View>
@@ -243,172 +251,127 @@ export default function AccountsScreen() {
         activationDistance={20}
         ListEmptyComponent={<Text style={{ color: colors.mutedText }}>{t('no_accounts') || 'No accounts yet.'}</Text>}
       />
-      <View style={styles.addButtonWrapper}>
-        <TouchableOpacity
-          style={[styles.addButton, { backgroundColor: colors.primary }]}
-          onPress={addAccountHandler}
-          activeOpacity={0.7}
-          accessibilityRole="button"
-          accessibilityLabel={t('add_account') || 'Add Account'}
-          accessibilityHint={t('add_account_hint') || 'Opens form to create a new account'}
+      <FAB
+        icon="plus"
+        label={t('add_account') || 'Add Account'}
+        style={styles.fab}
+        onPress={addAccountHandler}
+        accessibilityLabel={t('add_account') || 'Add Account'}
+        accessibilityHint={t('add_account_hint') || 'Opens form to create a new account'}
+      />
+      <Portal>
+        <Modal
+          visible={!!editingId}
+          onDismiss={handleCloseModal}
+          contentContainerStyle={[styles.modalContent, { backgroundColor: colors.card }]}
         >
-          <Icon name="plus" size={20} color="#fff" style={styles.addButtonIcon} />
-          <Text style={styles.addButtonText}>{t('add_account') || 'Add Account'}</Text>
-        </TouchableOpacity>
-      </View>
-      <Modal
-        visible={!!editingId}
-        animationType="slide"
-        transparent={true}
-        onRequestClose={handleCloseModal}
-      >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={{ flex: 1 }}
-        >
-          <Pressable style={styles.modalOverlay} onPress={handleCloseModal}>
-            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <ScrollView
-                style={{ flex: 1 }}
-                keyboardShouldPersistTaps="handled"
-                contentContainerStyle={{ paddingBottom: 20 }}
-              >
-                  <Text style={[styles.modalTitle, { color: colors.text }]}>{t('edit_account') || 'Edit Account'}</Text>
-                <TextInput
-                  style={[
-                    styles.input,
-                    errors.name && styles.inputError,
-                      { color: colors.text, backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }
-                  ]}
-                  value={editValues.name}
-                  onChangeText={handleNameChange}
-                  placeholder={t('account_name') || 'Account Name'}
-                    placeholderTextColor={colors.mutedText}
-                  autoFocus
-                  returnKeyType="next"
-                  onSubmitEditing={() => balanceInputRef.current?.focus()}
-                  blurOnSubmit={false}
-                />
-                {errors.name && <Text style={styles.error}>{errors.name}</Text>}
-                <TextInput
-                  ref={balanceInputRef}
-                  style={[
-                    styles.input,
-                    errors.balance && styles.inputError,
-                      { color: colors.text, backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }
-                  ]}
-                  value={editValues.balance}
-                  onChangeText={handleBalanceChange}
-                  placeholder={t('balance') || 'Balance'}
-                    placeholderTextColor={colors.mutedText}
-                  keyboardType="numeric"
-                  returnKeyType="done"
-                  onSubmitEditing={Keyboard.dismiss}
-                />
-                {errors.balance && <Text style={styles.error}>{errors.balance}</Text>}
-                  <View style={[styles.pickerWrapper, { backgroundColor: colors.inputBackground }]}>
-                    <Pressable onPress={handleOpenPicker} style={styles.pickerDisplay}>
-                      <Text style={{ color: colors.text, fontSize: 18, fontWeight: '500' }}>
-                        {editValues.currency ? `${currencies[editValues.currency]?.name} (${currencies[editValues.currency]?.symbol})` : t('select_currency') || 'Select currency'}
-                      </Text>
-                    </Pressable>
-                    <CurrencyPickerModal
-                      visible={pickerVisible}
-                      onClose={handleClosePicker}
-                      currencies={currencies}
-                      colors={colors}
-                      t={t}
-                      onSelect={handleCurrencySelect}
-                    />
-                  </View>
-                {errors.currency && <Text style={styles.error}>{errors.currency}</Text>}
-              </ScrollView>
-                <View style={[styles.modalButtonRowSticky, { backgroundColor: colors.card }]}>
-                  <Pressable style={[styles.actionButton, styles.modalButton, { backgroundColor: colors.secondary }]} onPress={handleCloseModal}>
-                    <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel') || 'Cancel'}</Text>
-                  </Pressable>
-                  {editingId !== 'new' && (
-                    <Pressable
-                      style={[styles.actionButton, styles.modalButton, { backgroundColor: colors.delete }]}
-                      onPress={() => deleteAccountHandler(editingId)}
-                    >
-                      <Text style={[styles.buttonText, { color: colors.card }]}>{t('delete') || 'Delete'}</Text>
-                    </Pressable>
-                  )}
-                  <Pressable style={[styles.actionButton, styles.modalButton, { backgroundColor: colors.primary }]} onPress={saveEdit}>
-                    <Text style={[styles.buttonText, { color: colors.text }]}>{t('save') || 'Save'}</Text>
-                  </Pressable>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          >
+            <ScrollView
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={{ paddingBottom: 20 }}
+            >
+              <Text variant="headlineSmall" style={styles.modalTitle}>{t('edit_account') || 'Edit Account'}</Text>
+              <PaperTextInput
+                mode="outlined"
+                label={t('account_name') || 'Account Name'}
+                value={editValues.name}
+                onChangeText={handleNameChange}
+                error={!!errors.name}
+                autoFocus
+                returnKeyType="next"
+                onSubmitEditing={() => balanceInputRef.current?.focus()}
+                blurOnSubmit={false}
+                style={styles.textInput}
+              />
+              {errors.name && <Text variant="bodySmall" style={styles.error}>{errors.name}</Text>}
+              <PaperTextInput
+                ref={balanceInputRef}
+                mode="outlined"
+                label={t('balance') || 'Balance'}
+                value={editValues.balance}
+                onChangeText={handleBalanceChange}
+                error={!!errors.balance}
+                keyboardType="numeric"
+                returnKeyType="done"
+                onSubmitEditing={Keyboard.dismiss}
+                style={styles.textInput}
+              />
+              {errors.balance && <Text variant="bodySmall" style={styles.error}>{errors.balance}</Text>}
+              <TouchableRipple onPress={handleOpenPicker} style={[styles.pickerWrapper, { backgroundColor: colors.inputBackground }]}>
+                <View style={styles.pickerDisplay}>
+                  <Text variant="bodyLarge">
+                    {editValues.currency ? `${currencies[editValues.currency]?.name} (${currencies[editValues.currency]?.symbol})` : t('select_currency') || 'Select currency'}
+                  </Text>
                 </View>
-            </Pressable>
-          </Pressable>
-        </KeyboardAvoidingView>
-      </Modal>
+              </TouchableRipple>
+              {errors.currency && <Text variant="bodySmall" style={styles.error}>{errors.currency}</Text>}
+            </ScrollView>
+            <View style={styles.modalButtonRow}>
+              <Button mode="outlined" onPress={handleCloseModal} style={styles.modalButton}>
+                {t('cancel') || 'Cancel'}
+              </Button>
+              {editingId !== 'new' && (
+                <Button
+                  mode="contained"
+                  buttonColor={colors.delete}
+                  onPress={() => deleteAccountHandler(editingId)}
+                  style={styles.modalButton}
+                >
+                  {t('delete') || 'Delete'}
+                </Button>
+              )}
+              <Button mode="contained" onPress={saveEdit} style={styles.modalButton}>
+                {t('save') || 'Save'}
+              </Button>
+            </View>
+          </KeyboardAvoidingView>
+        </Modal>
+      </Portal>
+      <CurrencyPickerModal
+        visible={pickerVisible}
+        onClose={handleClosePicker}
+        currencies={currencies}
+        colors={colors}
+        t={t}
+        onSelect={handleCurrencySelect}
+      />
       {/* Settings modal is managed at the top-level Header in SimpleTabs */}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-    verticalDivider: {
-      width: 1,
-      height: '70%',
-      backgroundColor: 'rgba(120,120,120,0.13)', // subtle vertical divider
-      alignSelf: 'center',
-      marginHorizontal: 2,
-    },
+  verticalDivider: {
+    width: 1,
+    height: '70%',
+    backgroundColor: 'rgba(120,120,120,0.13)',
+    alignSelf: 'center',
+    marginHorizontal: 2,
+  },
   container: { flex: 1 },
   loadingContainer: {
     justifyContent: 'center',
     alignItems: 'center',
   },
-  loadingText: {
-    marginTop: 12,
-    fontSize: 16,
-  },
   errorContainer: {
     justifyContent: 'center',
     alignItems: 'center',
   },
-  errorText: {
-    fontSize: 16,
-    textAlign: 'center',
-  },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginTop: 40,
-    marginBottom: 16,
-  },
-  title: { fontSize: 24, fontWeight: 'bold' },
-  hamburgerButton: {
-    width: 36,
-    height: 36,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 6,
-    borderRadius: 18,
-    backgroundColor: 'transparent',
-  },
-  hamburgerLine: {
-    width: 20,
-    height: 3,
-    backgroundColor: '#000',
-    marginVertical: 2,
-    borderRadius: 2,
+  accountCard: {
+    marginHorizontal: 8,
+    marginVertical: 4,
+    borderRadius: 8,
   },
   accountRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    borderBottomWidth: 1,
-    borderColor: 'rgba(120,120,120,0.13)', // slightly visible divider
     minHeight: 56,
   },
   accountContentWrapper: {
     flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 16,
+    paddingVertical: 12,
   },
   dragHandle: {
     paddingHorizontal: 12,
@@ -429,79 +392,42 @@ const styles = StyleSheet.create({
     paddingRight: 16,
     paddingLeft: 8,
   },
-  buttonGroup: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginLeft: 8,
+  textInput: {
+    marginBottom: 8,
   },
-  actionButton: {
-    borderRadius: 6,
-    paddingVertical: 6,
-    paddingHorizontal: 14,
-    marginLeft: 8,
+  error: {
+    color: 'red',
+    marginBottom: 8,
+    marginLeft: 12,
   },
-  buttonText: {
-    fontSize: 16,
-    fontWeight: '500',
-    color: '#000',
+  pickerWrapper: {
+    marginBottom: 8,
+    marginTop: 8,
+    borderRadius: 8,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: 'rgba(0, 0, 0, 0.12)',
   },
-  input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 4, padding: 8, marginBottom: 4 },
-  inputError: { borderColor: 'red' },
-  error: { color: 'red', fontSize: 12, marginBottom: 4 },
-  text: { fontSize: 16 },
-  accountText: { fontSize: 22, fontWeight: '500', marginBottom: 4 },
-  link: { color: 'blue', marginLeft: 8 },
-  picker: { height: 80, width: '100%' },
-  pickerWrapper: { marginBottom: 4, marginTop: 4, borderRadius: 4, overflow: 'hidden' },
-  pickerDisplay: { padding: 12, justifyContent: 'center' },
+  pickerDisplay: {
+    padding: 16,
+    justifyContent: 'center',
+  },
   pickerModalContent: {
-    width: '90%',
-    maxHeight: '70%',
+    margin: 20,
+    padding: 20,
     borderRadius: 12,
-    padding: 12,
   },
   pickerOption: {
-    paddingVertical: 12,
-    paddingHorizontal: 8,
-    borderBottomWidth: 1,
-    borderColor: '#eee',
-  },
-  closeButton: {
-    marginTop: 8,
-    alignSelf: 'center',
-    padding: 10,
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    justifyContent: 'center',
-    alignItems: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 16,
   },
   modalContent: {
-    width: '90%',
-    minHeight: 280,
-    backgroundColor: '#fff',
-    borderRadius: 12,
+    margin: 20,
     padding: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 5,
-    flexDirection: 'column',
-    justifyContent: 'space-between',
+    borderRadius: 12,
     maxHeight: '90%',
   },
-    modalButtonRowSticky: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      marginTop: 16,
-      backgroundColor: '#fff',
-      paddingBottom: 0,
-    },
   modalTitle: {
-    fontSize: 20,
-    fontWeight: 'bold',
     marginBottom: 16,
     textAlign: 'center',
   },
@@ -509,35 +435,16 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginTop: 16,
+    gap: 8,
   },
   modalButton: {
     flex: 1,
-    marginHorizontal: 8,
   },
-  addButtonWrapper: {
-    padding: 16,
-    paddingBottom: 8,
-  },
-  addButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: 56,
-    borderRadius: 12,
-    paddingHorizontal: 24,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 3,
-  },
-  addButtonIcon: {
-    marginRight: 8,
-  },
-  addButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
+  fab: {
+    position: 'absolute',
+    margin: 16,
+    right: 0,
+    bottom: 0,
   },
 });
 

--- a/app/CategoriesScreen.js
+++ b/app/CategoriesScreen.js
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, TouchableOpacity, Button, Alert, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, FlatList, TouchableOpacity, Alert } from 'react-native';
+import { Text, FAB, ActivityIndicator } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useTheme } from './ThemeContext';
 import { useLocalization } from './LocalizationContext';
@@ -154,8 +155,8 @@ const CategoriesScreen = () => {
   if (loading) {
     return (
       <View style={[styles.container, styles.loadingContainer, { backgroundColor: colors.background }]}>
-        <ActivityIndicator size="large" color={colors.primary} />
-        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+        <ActivityIndicator size="large" />
+        <Text variant="bodyLarge" style={{ marginTop: 12, color: colors.mutedText }}>
           {t('loading_categories') || 'Loading categories...'}
         </Text>
       </View>
@@ -182,19 +183,14 @@ const CategoriesScreen = () => {
         removeClippedSubviews={true}
       />
 
-      <View style={styles.addButtonWrapper}>
-        <TouchableOpacity
-          style={[styles.addButton, { backgroundColor: colors.primary }]}
-          onPress={handleAddCategory}
-          activeOpacity={0.7}
-          accessibilityRole="button"
-          accessibilityLabel={t('add_category')}
-          accessibilityHint={t('add_category_hint') || 'Opens form to create a new category'}
-        >
-          <Icon name="plus" size={20} color="#fff" style={styles.addButtonIcon} />
-          <Text style={styles.addButtonText}>{t('add_category')}</Text>
-        </TouchableOpacity>
-      </View>
+      <FAB
+        icon="plus"
+        label={t('add_category')}
+        style={styles.fab}
+        onPress={handleAddCategory}
+        accessibilityLabel={t('add_category')}
+        accessibilityHint={t('add_category_hint') || 'Opens form to create a new category'}
+      />
 
       <CategoryModal
         visible={modalVisible}
@@ -214,10 +210,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  loadingText: {
-    marginTop: 12,
-    fontSize: 16,
-  },
   categoryRow: {
     borderBottomWidth: 1,
     minHeight: 56,
@@ -229,8 +221,8 @@ const styles = StyleSheet.create({
     paddingRight: 16,
   },
   expandButton: {
-    width: 44,  // Increased to minimum touch target
-    height: 44, // Increased to minimum touch target
+    width: 44,
+    height: 44,
     marginRight: 8,
     alignItems: 'center',
     justifyContent: 'center',
@@ -256,8 +248,8 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   deleteButton: {
-    width: 44,  // Increased to minimum touch target
-    height: 44, // Increased to minimum touch target
+    width: 44,
+    height: 44,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -270,30 +262,11 @@ const styles = StyleSheet.create({
   emptyList: {
     flex: 1,
   },
-  addButtonWrapper: {
-    padding: 16,
-    paddingBottom: 8,
-  },
-  addButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: 56,
-    borderRadius: 12,
-    paddingHorizontal: 24,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 3,
-  },
-  addButtonIcon: {
-    marginRight: 8,
-  },
-  addButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
+  fab: {
+    position: 'absolute',
+    margin: 16,
+    right: 0,
+    bottom: 0,
   },
 });
 

--- a/app/Header.js
+++ b/app/Header.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { Appbar } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from './ThemeContext';
 import { useLocalization } from './LocalizationContext';
@@ -10,49 +11,29 @@ export default function Header({ onOpenSettings }) {
   const insets = useSafeAreaInsets();
 
   return (
-    <View
+    <Appbar.Header
+      elevated
       style={[
         styles.container,
         {
           backgroundColor: colors.surface,
-          borderBottomColor: colors.border,
-          paddingTop: insets.top + 8,
+          paddingTop: insets.top,
         }
       ]}
     >
-      <Text style={[styles.title, { color: colors.text }]}>{t('Money Tracker') || 'Money Tracker'}</Text>
-      <TouchableOpacity
+      <Appbar.Content title={t('Money Tracker') || 'Money Tracker'} />
+      <Appbar.Action
+        icon="cog"
         onPress={onOpenSettings}
         accessibilityLabel={t('settings')}
-        accessibilityRole="button"
         accessibilityHint="Opens settings menu"
-        style={[styles.burger, { backgroundColor: colors.secondary }]}
-        hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
-      >
-        <View style={[styles.line, { backgroundColor: colors.text }]} />
-        <View style={[styles.line, { backgroundColor: colors.text }]} />
-        <View style={[styles.line, { backgroundColor: colors.text }]} />
-      </TouchableOpacity>
-    </View>
+      />
+    </Appbar.Header>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: 16,
-    paddingBottom: 16,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    borderBottomWidth: 1,
+    elevation: 2,
   },
-  title: { fontSize: 18, fontWeight: '700' },
-  burger: {
-    width: 44,  // Increased to minimum touch target
-    height: 44, // Increased to minimum touch target
-    borderRadius: 22,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  line: { width: 18, height: 2, marginVertical: 2 },
 });

--- a/app/Header.js
+++ b/app/Header.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
-import { Appbar } from 'react-native-paper';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from './ThemeContext';
 import { useLocalization } from './LocalizationContext';
@@ -11,29 +10,49 @@ export default function Header({ onOpenSettings }) {
   const insets = useSafeAreaInsets();
 
   return (
-    <Appbar.Header
-      elevated
+    <View
       style={[
         styles.container,
         {
           backgroundColor: colors.surface,
-          paddingTop: insets.top,
+          borderBottomColor: colors.border,
+          paddingTop: insets.top + 8,
         }
       ]}
     >
-      <Appbar.Content title={t('Money Tracker') || 'Money Tracker'} />
-      <Appbar.Action
-        icon="cog"
+      <Text style={[styles.title, { color: colors.text }]}>{t('Money Tracker') || 'Money Tracker'}</Text>
+      <TouchableOpacity
         onPress={onOpenSettings}
         accessibilityLabel={t('settings')}
+        accessibilityRole="button"
         accessibilityHint="Opens settings menu"
-      />
-    </Appbar.Header>
+        style={[styles.burger, { backgroundColor: colors.secondary }]}
+        hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
+      >
+        <View style={[styles.line, { backgroundColor: colors.text }]} />
+        <View style={[styles.line, { backgroundColor: colors.text }]} />
+        <View style={[styles.line, { backgroundColor: colors.text }]} />
+      </TouchableOpacity>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    elevation: 2,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderBottomWidth: 1,
   },
+  title: { fontSize: 18, fontWeight: '700' },
+  burger: {
+    width: 44,  // Increased to minimum touch target
+    height: 44, // Increased to minimum touch target
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  line: { width: 18, height: 2, marginVertical: 2 },
 });

--- a/app/SettingsModal.js
+++ b/app/SettingsModal.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Modal, View, Text, Pressable, StyleSheet, Alert } from 'react-native';
+import { View, StyleSheet, Alert } from 'react-native';
+import { Portal, Modal, Text, Button, RadioButton, Divider } from 'react-native-paper';
 import { useTheme } from './ThemeContext';
 import { useLocalization } from './LocalizationContext';
 import { useAccounts } from './AccountsContext';
@@ -48,158 +49,105 @@ export default function SettingsModal({ visible, onClose }) {
   }, [visible, theme, language]);
 
   return (
-    <Modal
-      visible={visible}
-      animationType="slide"
-      transparent={true}
-      onRequestClose={onClose}
-    >
-      <Pressable style={styles.overlay} onPress={onClose}>
-        <Pressable style={[styles.content, { backgroundColor: colors.card }]} onPress={() => {}}>
-          <Text style={[styles.title, { color: colors.text }]}>{t('settings')}</Text>
-          <Text style={[styles.subtitle, { color: colors.text }]}>{t('theme') || 'Theme'}</Text>
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onClose}
+        contentContainerStyle={[styles.content, { backgroundColor: colors.card }]}
+      >
+        <Text variant="headlineSmall" style={styles.title}>{t('settings')}</Text>
+
+        <Text variant="titleMedium" style={styles.subtitle}>{t('theme') || 'Theme'}</Text>
+        <RadioButton.Group onValueChange={setLocalSelection} value={localSelection}>
           {themeOptions.map(opt => (
-            <Pressable
+            <RadioButton.Item
               key={opt.value}
-              style={({ pressed }) => [
-                styles.option,
-                { backgroundColor: colors.secondary },
-                localSelection === opt.value && { backgroundColor: colors.primary },
-                pressed && { opacity: 0.9 },
-              ]}
-              onPress={() => setLocalSelection(opt.value)}
-            >
-              <Text style={[styles.optionText, { color: localSelection === opt.value ? colors.card : colors.text }]}>{opt.label}</Text>
-              {localSelection === opt.value && <Text style={{ color: colors.card, fontSize: 18 }}>✓</Text>}
-            </Pressable>
+              label={opt.label}
+              value={opt.value}
+              style={styles.radioItem}
+            />
           ))}
-          <Text style={[styles.subtitle, { color: colors.text, marginTop: 16 }]}>{t('language')}</Text>
+        </RadioButton.Group>
+
+        <Divider style={styles.divider} />
+
+        <Text variant="titleMedium" style={styles.subtitle}>{t('language')}</Text>
+        <RadioButton.Group onValueChange={setLocalLang} value={localLang}>
           {availableLanguages.map(lng => (
-            <Pressable
+            <RadioButton.Item
               key={lng}
-              style={({ pressed }) => [
-                styles.option,
-                { backgroundColor: colors.secondary },
-                localLang === lng && { backgroundColor: colors.primary },
-                pressed && { opacity: 0.9 },
-              ]}
-              onPress={() => setLocalLang(lng)}
-            >
-              <Text style={[styles.optionText, { color: localLang === lng ? colors.card : colors.text }]}>{t(lng === 'en' ? 'english' : 'russian')}</Text>
-              {localLang === lng && <Text style={{ color: colors.card, fontSize: 18 }}>✓</Text>}
-            </Pressable>
+              label={t(lng === 'en' ? 'english' : 'russian')}
+              value={lng}
+              style={styles.radioItem}
+            />
           ))}
+        </RadioButton.Group>
 
-          <Text style={[styles.subtitle, { color: colors.text, marginTop: 16 }]}>{t('database') || 'Database'}</Text>
-          <Pressable
-            style={({ pressed }) => [
-              styles.resetButton,
-              { backgroundColor: '#dc3545' },
-              pressed && { opacity: 0.8 },
-            ]}
-            onPress={handleResetDatabase}
+        <Divider style={styles.divider} />
+
+        <Text variant="titleMedium" style={styles.subtitle}>{t('database') || 'Database'}</Text>
+        <Button
+          mode="contained"
+          buttonColor="#dc3545"
+          onPress={handleResetDatabase}
+          style={styles.resetButton}
+        >
+          {t('reset_database') || 'Reset Database'}
+        </Button>
+
+        <View style={styles.modalButtonRow}>
+          <Button mode="outlined" onPress={onClose} style={styles.modalButton}>
+            {t('cancel') || 'Cancel'}
+          </Button>
+          <Button
+            mode="contained"
+            onPress={() => {
+              setTheme(localSelection);
+              setLanguage(localLang);
+              onClose();
+            }}
+            style={styles.modalButton}
           >
-            <Text style={[styles.resetButtonText, { color: '#ffffff' }]}>{t('reset_database') || 'Reset Database'}</Text>
-          </Pressable>
-
-          <View style={styles.modalButtonRow}>
-            <Pressable style={[styles.modalButton, { backgroundColor: colors.secondary }]} onPress={onClose}>
-              <Text style={[styles.closeText, { color: colors.text }]}>{t('cancel') || 'Cancel'}</Text>
-            </Pressable>
-            <Pressable
-              style={[styles.modalButton, { backgroundColor: colors.primary }]}
-              onPress={() => {
-                setTheme(localSelection);
-                setLanguage(localLang);
-                onClose();
-              }}
-            >
-              <Text style={[styles.closeText, { color: colors.card }]}>{t('save') || 'Save'}</Text>
-            </Pressable>
-          </View>
-        </Pressable>
-      </Pressable>
-    </Modal>
+            {t('save') || 'Save'}
+          </Button>
+        </View>
+      </Modal>
+    </Portal>
   );
 }
 
-// Styles are defined using StyleSheet.create for performance and consistency.
-// For dynamic styling, consider using styled-components or tailwind-rn.
-// For responsive design, consider Dimensions, PixelRatio, or react-native-size-matters.
-
 const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   content: {
-    width: '85%',
+    margin: 20,
     borderRadius: 12,
     padding: 24,
-    alignItems: 'stretch',
+    maxHeight: '90%',
   },
   title: {
-    fontSize: 22,
-    fontWeight: 'bold',
     marginBottom: 16,
     textAlign: 'center',
   },
   subtitle: {
-    fontSize: 16,
-    fontWeight: '500',
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  radioItem: {
+    paddingVertical: 4,
+  },
+  divider: {
+    marginVertical: 12,
+  },
+  resetButton: {
+    marginTop: 8,
     marginBottom: 8,
-  },
-  option: {
-    paddingVertical: 12,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    marginBottom: 8,
-    backgroundColor: 'transparent',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  selected: {
-    backgroundColor: '#c0e0ff',
-  },
-  selectedDark: {
-    backgroundColor: '#005fa3',
-  },
-  optionText: {
-    fontSize: 18,
-  },
-  closeButton: {
-    marginTop: 16,
-    alignSelf: 'center',
-    padding: 10,
-  },
-  closeText: {
-    color: '#007AFF',
-    fontSize: 16,
   },
   modalButtonRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginTop: 12,
+    marginTop: 16,
+    gap: 8,
   },
   modalButton: {
     flex: 1,
-    marginHorizontal: 8,
-    paddingVertical: 10,
-    borderRadius: 8,
-    alignItems: 'center',
-  },
-  resetButton: {
-    paddingVertical: 12,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    marginBottom: 8,
-    alignItems: 'center',
-  },
-  resetButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
   },
 });

--- a/app/SimpleTabs.js
+++ b/app/SimpleTabs.js
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback, memo } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { TouchableRipple, Text, Surface } from 'react-native-paper';
 import OperationsScreen from './OperationsScreen';
 import AccountsScreen from './AccountsScreen';
 import CategoriesScreen from './CategoriesScreen';
@@ -17,26 +18,30 @@ const TabButton = memo(({ tab, isActive, colors, onPress }) => {
     isActive && { backgroundColor: colors.selected }
   ], [isActive, colors.selected]);
 
-  const textStyle = useMemo(() => [
-    styles.tabText,
-    { color: isActive ? colors.text : colors.mutedText },
-    isActive && styles.tabTextActive
-  ], [isActive, colors.text, colors.mutedText]);
+  const textStyle = useMemo(() => ({
+    fontWeight: isActive ? '700' : 'normal',
+  }), [isActive]);
 
   const handlePress = useCallback(() => {
     onPress(tab.key);
   }, [onPress, tab.key]);
 
   return (
-    <TouchableOpacity
+    <TouchableRipple
       style={tabStyle}
       onPress={handlePress}
+      rippleColor="rgba(0, 0, 0, .12)"
       accessibilityRole="button"
       accessibilityState={{ selected: isActive }}
       accessibilityLabel={tab.label}
     >
-      <Text style={textStyle}>{tab.label}</Text>
-    </TouchableOpacity>
+      <View style={styles.tabContent}>
+        <Text variant="labelMedium" style={textStyle}>
+          {tab.label}
+        </Text>
+        {isActive && <View style={[styles.indicator, { backgroundColor: colors.primary }]} />}
+      </View>
+    </TouchableRipple>
   );
 });
 
@@ -87,17 +92,19 @@ export default function SimpleTabs() {
       <Header onOpenSettings={handleOpenSettings} />
       <View style={styles.content}>{renderActive()}</View>
       <SettingsModal visible={settingsVisible} onClose={handleCloseSettings} />
-      <SafeAreaView style={[styles.tabBar, { borderTopColor: colors.border, backgroundColor: colors.surface }]} edges={['bottom']}>
-        {TABS.map(tab => (
-          <TabButton
-            key={tab.key}
-            tab={tab}
-            isActive={active === tab.key}
-            colors={colors}
-            onPress={handleTabPress}
-          />
-        ))}
-      </SafeAreaView>
+      <Surface style={styles.tabBarSurface} elevation={3}>
+        <SafeAreaView style={styles.tabBar} edges={['bottom']}>
+          {TABS.map(tab => (
+            <TabButton
+              key={tab.key}
+              tab={tab}
+              isActive={active === tab.key}
+              colors={colors}
+              onPress={handleTabPress}
+            />
+          ))}
+        </SafeAreaView>
+      </Surface>
     </SafeAreaView>
   );
 }
@@ -105,16 +112,27 @@ export default function SimpleTabs() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   content: { flex: 1 },
+  tabBarSurface: {
+    elevation: 3,
+  },
   tabBar: {
     flexDirection: 'row',
-    borderTopWidth: 1,
   },
   tab: {
     flex: 1,
+    minHeight: 56,
+  },
+  tabContent: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    minHeight: 56, // Ensure adequate touch target
+    position: 'relative',
   },
-  tabText: { fontSize: 13 },
-  tabTextActive: { fontWeight: '700' },
+  indicator: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 3,
+  },
 });

--- a/app/SimpleTabs.js
+++ b/app/SimpleTabs.js
@@ -13,14 +13,10 @@ import SettingsModal from './SettingsModal';
 
 // Memoized tab button component to prevent unnecessary re-renders
 const TabButton = memo(({ tab, isActive, colors, onPress }) => {
-  const tabStyle = useMemo(() => [
-    styles.tab,
-    isActive && { backgroundColor: colors.selected }
-  ], [isActive, colors.selected]);
-
   const textStyle = useMemo(() => ({
     fontWeight: isActive ? '700' : 'normal',
-  }), [isActive]);
+    color: isActive ? colors.primary : colors.mutedText,
+  }), [isActive, colors.primary, colors.mutedText]);
 
   const handlePress = useCallback(() => {
     onPress(tab.key);
@@ -28,7 +24,7 @@ const TabButton = memo(({ tab, isActive, colors, onPress }) => {
 
   return (
     <TouchableRipple
-      style={tabStyle}
+      style={styles.tab}
       onPress={handlePress}
       rippleColor="rgba(0, 0, 0, .12)"
       accessibilityRole="button"

--- a/app/useMaterialTheme.js
+++ b/app/useMaterialTheme.js
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { MD3LightTheme, MD3DarkTheme } from 'react-native-paper';
+import { useTheme } from './ThemeContext';
+
+/**
+ * Hook to bridge our existing ThemeContext with React Native Paper's theme
+ * Maps our custom colors to Material Design 3 color tokens
+ */
+export function useMaterialTheme() {
+  const { colorScheme, colors } = useTheme();
+
+  const paperTheme = useMemo(() => {
+    const baseTheme = colorScheme === 'dark' ? MD3DarkTheme : MD3LightTheme;
+
+    return {
+      ...baseTheme,
+      colors: {
+        ...baseTheme.colors,
+        // Primary colors
+        primary: colors.primary,
+        primaryContainer: colorScheme === 'dark' ? '#004a77' : '#c0e0ff',
+        onPrimary: colorScheme === 'dark' ? '#ffffff' : '#ffffff',
+        onPrimaryContainer: colorScheme === 'dark' ? '#c0e0ff' : '#001d35',
+
+        // Secondary colors
+        secondary: colors.secondary,
+        secondaryContainer: colorScheme === 'dark' ? '#444444' : '#e8e8e8',
+        onSecondary: colors.text,
+        onSecondaryContainer: colors.text,
+
+        // Background & Surface
+        background: colors.background,
+        onBackground: colors.text,
+        surface: colors.surface,
+        onSurface: colors.text,
+        surfaceVariant: colors.altRow,
+        onSurfaceVariant: colors.mutedText,
+
+        // Elevation
+        elevation: {
+          level0: 'transparent',
+          level1: colors.surface,
+          level2: colors.card,
+          level3: colors.surface,
+          level4: colors.surface,
+          level5: colors.surface,
+        },
+
+        // Error/Danger
+        error: colors.danger,
+        errorContainer: colorScheme === 'dark' ? '#93000a' : '#ffdad6',
+        onError: '#ffffff',
+        onErrorContainer: colorScheme === 'dark' ? '#ffdad6' : '#410002',
+
+        // Outline/Border
+        outline: colors.border,
+        outlineVariant: colors.inputBorder,
+
+        // Surface tints
+        surfaceDisabled: colorScheme === 'dark' ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)',
+        onSurfaceDisabled: colorScheme === 'dark' ? 'rgba(255,255,255,0.38)' : 'rgba(0,0,0,0.38)',
+
+        // Scrim for modals
+        backdrop: colors.modalBackground,
+
+        // Custom colors from our theme
+        custom: {
+          expense: colors.expense,
+          income: colors.income,
+          transfer: colors.transfer,
+          expenseBackground: colors.expenseBackground,
+          incomeBackground: colors.incomeBackground,
+          transferBackground: colors.transferBackground,
+          selected: colors.selected,
+          altRow: colors.altRow,
+          mutedText: colors.mutedText,
+          delete: colors.delete,
+        },
+      },
+      // Animation configs
+      animation: {
+        scale: 1.0,
+      },
+      // Roundness for Material Design
+      roundness: 8,
+    };
+  }, [colorScheme, colors]);
+
+  return paperTheme;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,12 @@
         "react-native-chart-kit": "^6.12.0",
         "react-native-draggable-flatlist": "^4.0.3",
         "react-native-gesture-handler": "^2.29.1",
+        "react-native-paper": "^5.14.5",
         "react-native-safe-area-context": "^5.6.2",
         "react-native-screens": "^4.18.0",
         "react-native-svg": "^15.15.0",
         "react-native-uuid": "^2.0.3",
+        "react-native-vector-icons": "^10.3.0",
         "react-native-web": "^0.21.0"
       },
       "devDependencies": {
@@ -2272,6 +2274,28 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz",
+      "integrity": "sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
@@ -5389,6 +5413,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5405,6 +5439,31 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -10995,6 +11054,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -11308,6 +11384,26 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-paper": {
+      "version": "5.14.5",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.14.5.tgz",
+      "integrity": "sha512-eaIH5bUQjJ/mYm4AkI6caaiyc7BcHDwX6CqNDi6RIxfxfWxROsHpll1oBuwn/cFvknvA8uEAkqLk/vzVihI3AQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.9",
+        "color": "^3.1.2",
+        "use-latest-callback": "^0.2.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": "*"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.5.tgz",
@@ -11385,6 +11481,61 @@
       "engines": {
         "node": ">=10.0.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.3.0.tgz",
+      "integrity": "sha512-IFQ0RE57819hOUdFvgK4FowM5aMXg7C7XKsuGLevqXkkIJatc3QopN0wYrb2IrzUgmdpfP+QVIbI3S6h7M0btw==",
+      "deprecated": "react-native-vector-icons package has moved to a new model of per-icon-family packages. See the https://github.com/oblador/react-native-vector-icons/blob/master/MIGRATION.md on how to migrate",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa-upgrade.sh": "bin/fa-upgrade.sh",
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "fa6-upgrade": "bin/fa6-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-web": {
@@ -12147,6 +12298,21 @@
         "bplist-parser": "0.3.1",
         "plist": "^3.0.5"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -13036,6 +13202,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-latest-callback": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
+      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "react-native-chart-kit": "^6.12.0",
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "^2.29.1",
+    "react-native-paper": "^5.14.5",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "^4.18.0",
     "react-native-svg": "^15.15.0",
     "react-native-uuid": "^2.0.3",
+    "react-native-vector-icons": "^10.3.0",
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Add Material Design components throughout the app using React Native Paper:

- Install react-native-paper and react-native-vector-icons dependencies
- Create useMaterialTheme hook to bridge existing theme with Paper's MD3 theme
- Wrap app in PaperProvider with custom theme integration

Component Updates:
- AccountsScreen: Use Paper Card, FAB, TextInput, Button, Modal, TouchableRipple
- Header: Replace custom header with Material Appbar component
- SettingsModal: Add RadioButton groups, Dividers, and Material buttons
- SimpleTabs: Add TouchableRipple with tab indicator and elevated Surface

Benefits:
- Ripple effects on all interactive elements (Material Design feedback)
- Proper Material elevation system for cards and surfaces
- Floating Action Button (FAB) for primary actions
- Material text inputs with outlined mode and floating labels
- Consistent button variants (contained, outlined, text)
- Material typography variants throughout
- Better accessibility with Material Design components