### PR TITLE
Create GitHub Action for Android EAS builds

### DIFF
--- a/.github/workflows/eas-build-android.yml
+++ b/.github/workflows/eas-build-android.yml
@@ -1,0 +1,58 @@
+name: EAS Build Android
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'Build profile'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - production
+  push:
+    branches:
+      - main
+    paths:
+      - 'app/**'
+      - 'assets/**'
+      - 'app.json'
+      - 'eas.json'
+      - 'package.json'
+
+jobs:
+  build:
+    name: EAS Build Android
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Android app
+        run: |
+          PROFILE=${{ github.event.inputs.profile || 'preview' }}
+          echo "Building with profile: $PROFILE"
+          eas build --platform android --profile $PROFILE --non-interactive --no-wait
+
+      - name: Comment build URL
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Build started! Check your Expo dashboard for build progress:"
+          echo "https://expo.dev/accounts/lopatinikita/projects/app/builds"


### PR DESCRIPTION
- Supports both manual trigger and automatic builds on main branch changes
- Configurable build profile (preview/production) via workflow_dispatch
- Uses expo/expo-github-action for setup
- Defaults to preview profile
- Non-interactive build with --no-wait flag