### PR TITLE
fix(workflows): add version prefix to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           release-type: node
           package-name: penny
+          include-v-in-tag: true


### PR DESCRIPTION
Configure release-please to include 'v' prefix in version tags (e.g., v0.1.0 instead of 0.1.0)