### PR TITLE
fix(workflows): conditional signing of APK

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,9 +111,12 @@ android {
             signingConfig signingConfigs.debug
         }
         release {
-            // Caution! In production, you need to generate your own keystore file.
-            // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            // Only sign if keystore exists (for local builds)
+            // In CI, release builds will be unsigned
+            def keystoreFile = file('debug.keystore')
+            if (keystoreFile.exists()) {
+                signingConfig signingConfigs.debug
+            }
             def enableShrinkResources = findProperty('android.enableShrinkResourcesInReleaseBuilds') ?: 'false'
             shrinkResources enableShrinkResources.toBoolean()
             minifyEnabled enableMinifyInReleaseBuilds

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,6 +111,8 @@ android {
             signingConfig signingConfigs.debug
         }
         release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
             // Only sign if keystore exists (for local builds)
             // In CI, release builds will be unsigned
             def keystoreFile = file('debug.keystore')


### PR DESCRIPTION
The validateSigningRelease task was failing in GitHub Actions because the debug.keystore file doesn't exist in CI. Now the release build only applies signing config if the keystore file exists, allowing unsigned builds in CI while maintaining signed builds locally.