### PR TITLE
feat: account deletion transfer confirmation dialog

### DIFF
--- a/app/AccountsScreen.js
+++ b/app/AccountsScreen.js
@@ -722,7 +722,7 @@ const styles = StyleSheet.create({
   confirmationButtons: {
     flexDirection: 'row',
     gap: 12,
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
   },
   confirmationButton: {
     minWidth: 100,

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -123,27 +123,82 @@ export const updateAccount = async (id, updates) => {
 };
 
 /**
- * Delete an account
- * @param {string} id
- * @returns {Promise<void>}
- * @throws {Error} If account has associated operations
+ * Transfer all operations from one account to another
+ * @param {string} fromAccountId - Account to transfer operations from
+ * @param {string} toAccountId - Account to transfer operations to
+ * @returns {Promise<number>} Number of operations transferred
  */
-export const deleteAccount = async (id) => {
+export const transferOperations = async (fromAccountId, toAccountId) => {
   try {
-    // Check if account has any operations (expense, income, or transfers)
-    const operationCheck = await queryFirst(
+    return await executeTransaction(async (db) => {
+      // Update operations where the account is the source (account_id)
+      const sourceResult = await db.runAsync(
+        'UPDATE operations SET account_id = ? WHERE account_id = ?',
+        [toAccountId, fromAccountId]
+      );
+
+      // Update operations where the account is the destination (to_account_id) for transfers
+      const destResult = await db.runAsync(
+        'UPDATE operations SET to_account_id = ? WHERE to_account_id = ?',
+        [toAccountId, fromAccountId]
+      );
+
+      const totalTransferred = (sourceResult.changes || 0) + (destResult.changes || 0);
+      console.log(`Transferred ${totalTransferred} operations from ${fromAccountId} to ${toAccountId}`);
+
+      return totalTransferred;
+    });
+  } catch (error) {
+    console.error('Failed to transfer operations:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get the count of operations linked to an account
+ * @param {string} id - Account ID
+ * @returns {Promise<number>} Number of operations
+ */
+export const getOperationCount = async (id) => {
+  try {
+    const result = await queryFirst(
       `SELECT COUNT(*) as count FROM operations
        WHERE account_id = ? OR to_account_id = ?`,
       [id, id]
     );
+    return result ? result.count : 0;
+  } catch (error) {
+    console.error('Failed to get operation count:', error);
+    throw error;
+  }
+};
 
-    if (operationCheck && operationCheck.count > 0) {
-      throw new Error(
-        `Cannot delete account: ${operationCheck.count} transaction(s) are associated with this account. Please delete or reassign the transactions first.`
-      );
+/**
+ * Delete an account (with optional operation transfer)
+ * @param {string} id - Account ID to delete
+ * @param {string|null} transferToAccountId - Optional account ID to transfer operations to
+ * @returns {Promise<void>}
+ * @throws {Error} If account has associated operations and no transfer account is specified
+ */
+export const deleteAccount = async (id, transferToAccountId = null) => {
+  try {
+    // Check if account has any operations (expense, income, or transfers)
+    const operationCount = await getOperationCount(id);
+
+    if (operationCount > 0) {
+      if (!transferToAccountId) {
+        // No transfer account specified, throw error with count
+        throw new Error(
+          `Cannot delete account: ${operationCount} transaction(s) are associated with this account. Please delete or reassign the transactions first.`
+        );
+      }
+
+      // Transfer operations to the specified account
+      await transferOperations(id, transferToAccountId);
+      console.log(`Transferred ${operationCount} operations before deleting account ${id}`);
     }
 
-    // Safe to delete - no operations are linked to this account
+    // Safe to delete - no operations are linked or they've been transferred
     await executeQuery('DELETE FROM accounts WHERE id = ?', [id]);
   } catch (error) {
     console.error('Failed to delete account:', error);

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -580,6 +580,17 @@ const initializeDatabase = async (db) => {
       didMigrate = true;
     }
 
+    // Force-check for V7 columns (safety net for migration issues)
+    console.log('Verifying V7 schema...');
+    const tableInfo = await db.getAllAsync('PRAGMA table_info(operations)');
+    const hasExchangeRate = tableInfo.some(col => col.name === 'exchange_rate');
+
+    if (!hasExchangeRate) {
+      console.log('V7 columns missing! Force-running V7 migration...');
+      await migrateToV7(db);
+      didMigrate = true;
+    }
+
     // Now create or update tables
     await db.execAsync(`
       -- Accounts table

--- a/assets/i18n.json
+++ b/assets/i18n.json
@@ -230,7 +230,10 @@
     "transfer_operations_message": "This account has transactions. Select an account to transfer them to:",
     "account_deleted_operations_transferred": "Account deleted and operations transferred successfully.",
     "failed_to_delete_account": "Failed to delete account. Please try again.",
-    "no_same_currency_account": "This account has transactions but there are no other accounts with the same currency. Please create another account with the same currency first, or delete the transactions."
+    "no_same_currency_account": "This account has transactions but there are no other accounts with the same currency. Please create another account with the same currency first, or delete the transactions.",
+    "account_not_found": "Account not found. Please try again.",
+    "confirm_delete_and_transfer": "Confirm Deletion",
+    "confirm_delete_and_transfer_message": "This will permanently delete the account and irreversibly move all transactions to the selected account.\n\nThis action cannot be undone."
   },
   "ru": {
     "accounts": "Счета",
@@ -463,7 +466,10 @@
     "transfer_operations_message": "У этого счета есть транзакции. Выберите счет для переноса:",
     "account_deleted_operations_transferred": "Счет удален и операции успешно перенесены.",
     "failed_to_delete_account": "Не удалось удалить счет. Попробуйте еще раз.",
-    "no_same_currency_account": "У этого счета есть транзакции, но нет других счетов с той же валютой. Пожалуйста, создайте другой счет с той же валютой или удалите транзакции."
+    "no_same_currency_account": "У этого счета есть транзакции, но нет других счетов с той же валютой. Пожалуйста, создайте другой счет с той же валютой или удалите транзакции.",
+    "account_not_found": "Счет не найден. Попробуйте еще раз.",
+    "confirm_delete_and_transfer": "Подтвердите удаление",
+    "confirm_delete_and_transfer_message": "Это безвозвратно удалит счет и переместит все транзакции на выбранный счет.\n\nЭто действие нельзя отменить."
   }
 }
 

--- a/assets/i18n.json
+++ b/assets/i18n.json
@@ -220,7 +220,16 @@
     "json_description": "Standard format, compatible with all versions",
     "csv_description": "Plain text format, easy to edit",
     "excel_description": "Spreadsheet format with multiple sheets",
-    "sqlite_description": "Raw database file, complete backup"
+    "sqlite_description": "Raw database file, complete backup",
+    "ok": "OK",
+    "success": "Success",
+    "cannot_delete_account": "Cannot Delete Account",
+    "cannot_delete_last_account_with_operations": "This is the only account and it has transactions. Please delete the transactions first, or create another account to transfer them to.",
+    "failed_to_check_operations": "Failed to check operations. Please try again.",
+    "transfer_operations": "Transfer Operations",
+    "transfer_operations_message": "This account has transactions. Select an account to transfer them to:",
+    "account_deleted_operations_transferred": "Account deleted and operations transferred successfully.",
+    "failed_to_delete_account": "Failed to delete account. Please try again."
   },
   "ru": {
     "accounts": "Счета",
@@ -443,7 +452,16 @@
     "json_description": "Стандартный формат, совместим со всеми версиями",
     "csv_description": "Текстовый формат, легко редактировать",
     "excel_description": "Формат электронной таблицы с несколькими листами",
-    "sqlite_description": "Исходный файл базы данных, полная резервная копия"
+    "sqlite_description": "Исходный файл базы данных, полная резервная копия",
+    "ok": "ОК",
+    "success": "Успешно",
+    "cannot_delete_account": "Невозможно удалить счет",
+    "cannot_delete_last_account_with_operations": "Это единственный счет и у него есть транзакции. Пожалуйста, удалите транзакции сначала, или создайте другой счет для переноса.",
+    "failed_to_check_operations": "Не удалось проверить операции. Попробуйте еще раз.",
+    "transfer_operations": "Перенос операций",
+    "transfer_operations_message": "У этого счета есть транзакции. Выберите счет для переноса:",
+    "account_deleted_operations_transferred": "Счет удален и операции успешно перенесены.",
+    "failed_to_delete_account": "Не удалось удалить счет. Попробуйте еще раз."
   }
 }
 

--- a/assets/i18n.json
+++ b/assets/i18n.json
@@ -229,7 +229,8 @@
     "transfer_operations": "Transfer Operations",
     "transfer_operations_message": "This account has transactions. Select an account to transfer them to:",
     "account_deleted_operations_transferred": "Account deleted and operations transferred successfully.",
-    "failed_to_delete_account": "Failed to delete account. Please try again."
+    "failed_to_delete_account": "Failed to delete account. Please try again.",
+    "no_same_currency_account": "This account has transactions but there are no other accounts with the same currency. Please create another account with the same currency first, or delete the transactions."
   },
   "ru": {
     "accounts": "Счета",
@@ -461,7 +462,8 @@
     "transfer_operations": "Перенос операций",
     "transfer_operations_message": "У этого счета есть транзакции. Выберите счет для переноса:",
     "account_deleted_operations_transferred": "Счет удален и операции успешно перенесены.",
-    "failed_to_delete_account": "Не удалось удалить счет. Попробуйте еще раз."
+    "failed_to_delete_account": "Не удалось удалить счет. Попробуйте еще раз.",
+    "no_same_currency_account": "У этого счета есть транзакции, но нет других счетов с той же валютой. Пожалуйста, создайте другой счет с той же валютой или удалите транзакции."
   }
 }
 


### PR DESCRIPTION
When deleting an account with linked operations, users are now prompted to select a destination account to transfer those operations to. This prevents data loss and provides a better user experience.

Changes:
- Added transferOperations() function to AccountsDB to reassign operations
- Added getOperationCount() function to check for linked operations
- Updated deleteAccount() to support optional operation transfer
- Modified AccountsContext to pass transfer account ID and reload data
- Enhanced AccountsScreen with transfer account picker modal
- Added i18n translations for new prompts (EN/RU)
- Special handling for last account with operations case

Fixes account deletion workflow to preserve operation history.