### PR TITLE
fix: replaced currency codes with symbols in operations list

### DIFF
--- a/app/OperationModal.js
+++ b/app/OperationModal.js
@@ -22,6 +22,18 @@ import { useAccounts } from './AccountsContext';
 import { useCategories } from './CategoriesContext';
 import { getLastAccessedAccount, setLastAccessedAccount } from './services/LastAccount';
 import * as Currency from './services/currency';
+import currencies from '../assets/currencies.json';
+
+/**
+ * Get currency symbol from currency code
+ * @param {string} currencyCode - Currency code like 'USD', 'EUR', etc.
+ * @returns {string} Currency symbol or code if not found
+ */
+const getCurrencySymbol = (currencyCode) => {
+  if (!currencyCode) return '';
+  const currency = currencies[currencyCode];
+  return currency ? currency.symbol : currencyCode;
+};
 
 export default function OperationModal({ visible, onClose, operation, isNew, onDelete }) {
   const { colors } = useTheme();
@@ -387,7 +399,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
                           <View style={styles.currencyInfo}>
                             <Icon name="swap-horizontal-circle" size={16} color={colors.mutedText} />
                             <Text style={[styles.currencyInfoText, { color: colors.mutedText }]}>
-                              {sourceAccount.currency} → {destinationAccount.currency}
+                              {getCurrencySymbol(sourceAccount.currency)} → {getCurrencySymbol(destinationAccount.currency)}
                             </Text>
                           </View>
 
@@ -444,7 +456,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
                               editable={!isShadowOperation}
                             />
                             <Text style={[styles.currencyLabel, { color: colors.mutedText }]}>
-                              {destinationAccount.currency}
+                              {getCurrencySymbol(destinationAccount.currency)}
                             </Text>
                           </View>
 
@@ -652,7 +664,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
                       <View style={styles.accountOption}>
                         <Text style={[styles.pickerOptionText, { color: colors.text }]}>{item.name}</Text>
                         <Text style={{ color: colors.mutedText, fontSize: 14 }}>
-                          {item.balance} {item.currency}
+                          {getCurrencySymbol(item.currency)}{item.balance}
                         </Text>
                       </View>
                     </Pressable>

--- a/app/OperationsScreen.js
+++ b/app/OperationsScreen.js
@@ -9,6 +9,18 @@ import { useAccounts } from './AccountsContext';
 import { useCategories } from './CategoriesContext';
 import { getLastAccessedAccount, setLastAccessedAccount } from './services/LastAccount';
 import OperationModal from './OperationModal';
+import currencies from '../assets/currencies.json';
+
+/**
+ * Get currency symbol from currency code
+ * @param {string} currencyCode - Currency code like 'USD', 'EUR', etc.
+ * @returns {string} Currency symbol or code if not found
+ */
+const getCurrencySymbol = (currencyCode) => {
+  if (!currencyCode) return '';
+  const currency = currencies[currencyCode];
+  return currency ? currency.symbol : currencyCode;
+};
 
 // Separate memoized component for the quick add form
 const QuickAddForm = memo(({
@@ -334,7 +346,8 @@ const OperationsScreen = () => {
       }).format(numAmount);
     } catch (error) {
       // Fallback if currency is invalid
-      return `${numAmount.toFixed(2)} ${account.currency || 'USD'}`;
+      const symbol = getCurrencySymbol(account.currency || 'USD');
+      return `${symbol}${numAmount.toFixed(2)}`;
     }
   }, [accounts]);
 
@@ -440,7 +453,7 @@ const OperationsScreen = () => {
             </Text>
             {isMultiCurrencyTransfer ? (
               <Text style={[styles.exchangeRate, { color: colors.mutedText }]} numberOfLines={1}>
-                {operation.sourceCurrency} → {operation.destinationCurrency}: {parseFloat(operation.exchangeRate).toFixed(4)}
+                {getCurrencySymbol(operation.sourceCurrency)} → {getCurrencySymbol(operation.destinationCurrency)}: {parseFloat(operation.exchangeRate).toFixed(4)}
               </Text>
             ) : operation.description ? (
               <Text style={[styles.description, { color: colors.mutedText }]} numberOfLines={1}>
@@ -550,7 +563,7 @@ const OperationsScreen = () => {
                       <View style={styles.accountOption}>
                         <Text style={[styles.pickerOptionText, { color: colors.text }]}>{item.name}</Text>
                         <Text style={{ color: colors.mutedText, fontSize: 14 }}>
-                          {item.balance} {item.currency}
+                          {getCurrencySymbol(item.currency)}{item.balance}
                         </Text>
                       </View>
                     </Pressable>


### PR DESCRIPTION
- Import currencies.json to access symbol data
- Add getCurrencySymbol() helper function in both OperationsScreen and OperationModal
- Update formatCurrency fallback to display symbols (e.g., "$" instead of "USD")
- Update account picker balance display to show symbols
- Update multi-currency transfer exchange rate display to show symbols (e.g., "$ → €")
- Update destination amount currency label to show symbols

This improves UX by making currency information more concise and visually clear.