### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint:
     name: Code Quality - Lint


### PR DESCRIPTION
Potential fix for [https://github.com/heywood8/money-tracker/security/code-scanning/3](https://github.com/heywood8/money-tracker/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions` block either at the top (workflow level) or inside each job, granting only the minimal scopes needed. Since both `lint` and `test` jobs post comments to pull requests using actions that rely on pull request write access, they need `pull-requests: write`. They also use `actions/checkout`, which requires `contents: read`. No other special scopes (e.g., `issues`, `checks`) are clearly required from the snippet.

The best minimal-change fix is to add a workflow-level `permissions` block after the `on:` section so it applies to all jobs. This will satisfy CodeQL and avoid repeating configuration per job. The block should grant `contents: read` and `pull-requests: write`, which is sufficient for checking out code and updating sticky comments on pull requests. No other parts of the workflow need to change, and no new imports or methods are required since this is a YAML configuration-only change.

Concretely:
- Edit `.github/workflows/npm-test.yml`.
- After the `on:` block (after the `pull_request` trigger definition), insert:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This constrains the GITHUB_TOKEN for both `lint` and `test` jobs while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
