### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/eas-build-android.yml
+++ b/.github/workflows/eas-build-android.yml
@@ -19,6 +19,8 @@ jobs:
   build:
     name: EAS Build Android
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: 🏗 Setup repo


### PR DESCRIPTION
Potential fix for [https://github.com/heywood8/money-tracker/security/code-scanning/2](https://github.com/heywood8/money-tracker/security/code-scanning/2)

In general, the fix is to explicitly define `permissions` for the workflow or for the specific job, limiting the `GITHUB_TOKEN` to only what is required. Here, only the `📤 Upload APK to Release` step (using `softprops/action-gh-release@v2`) needs write access to repository contents in order to create or update GitHub Releases. The rest of the steps operate locally (checkout, build, file operations) or use external services via secrets, and do not need any GitHub write scopes.

The best minimal fix without changing existing functionality is to add a `permissions` block at the job level for `build`, granting `contents: write` (for releases) and leaving all other scopes at their default of `none`. Place this block under the `runs-on: ubuntu-latest` line in the `build` job. We do not need any imports or additional definitions; this is purely a YAML configuration change within `.github/workflows/eas-build-android.yml`.

Concretely:
- Edit `.github/workflows/eas-build-android.yml`.
- Under `jobs: build: runs-on: ubuntu-latest`, add:
  ```yaml
  permissions:
    contents: write
  ```
- Keep indentation consistent with the existing YAML structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
