### PR TITLE
fix: increase Gradle memory allocation to resolve Metaspace OOM error

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -7,6 +7,11 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "android": {
+        "gradleProperties": {
+          "org.gradle.jvmargs": "-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
+        }
+      },
       "env": {
         "APP_VARIANT": "development"
       },
@@ -16,7 +21,10 @@
       "distribution": "internal",
       "android": {
         "buildType": "apk",
-        "gradleCommand": ":app:assembleRelease"
+        "gradleCommand": ":app:assembleRelease",
+        "gradleProperties": {
+          "org.gradle.jvmargs": "-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
+        }
       },
       "env": {
         "APP_VARIANT": "preview"
@@ -27,7 +35,10 @@
       "autoIncrement": true,
       "android": {
         "buildType": "app-bundle",
-        "gradleCommand": ":app:bundleRelease"
+        "gradleCommand": ":app:bundleRelease",
+        "gradleProperties": {
+          "org.gradle.jvmargs": "-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError"
+        }
       },
       "env": {
         "APP_VARIANT": "production"


### PR DESCRIPTION
- Added gradleProperties to all Android build profiles in eas.json
- Set JVM args: -Xmx4g (4GB heap) and -XX:MaxMetaspaceSize=1g (1GB metaspace)
- Added heap dump generation on OOM for debugging
- Fixes build failures in EAS Android builds caused by insufficient metaspace