### PR TITLE
refactor: Replace deprecated SafeAreaView with safe-area-context

### DIFF
--- a/app/screens/LanguageSelectionScreen.js
+++ b/app/screens/LanguageSelectionScreen.js
@@ -5,10 +5,10 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   StatusBar,
   Platform,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import enTranslations from '../../assets/i18n/en.json';
 import itTranslations from '../../assets/i18n/it.json';
 import ruTranslations from '../../assets/i18n/ru.json';


### PR DESCRIPTION
Replace deprecated SafeAreaView from react-native with the recommended react-native-safe-area-context library in LanguageSelectionScreen.

This resolves the deprecation warning and ensures compatibility with future React Native versions.