### PR TITLE
fix: extend balance graph line to end of month for previous months

### DIFF
--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -63,7 +63,7 @@ const BalanceHistoryCard = ({
                 labels: balanceHistoryData.labels.map(d => d.toString()),
                 datasets: [
                   {
-                    data: balanceHistoryData.actualForChart.filter(v => v !== undefined),
+                    data: balanceHistoryData.actualForChart.map(v => v ?? null),
                     color: () => colors.primary,
                     strokeWidth: 3,
                   },
@@ -74,7 +74,7 @@ const BalanceHistoryCard = ({
                     withDots: false,
                   },
                   ...(balanceHistoryData.prevMonth && balanceHistoryData.prevMonth.some(v => v !== undefined) ? [{
-                    data: balanceHistoryData.prevMonth.filter(v => v !== undefined),
+                    data: balanceHistoryData.prevMonth.map(v => v ?? null),
                     color: () => 'rgba(156, 39, 176, 0.5)',
                     strokeWidth: 2,
                     withDots: false,


### PR DESCRIPTION
Previously, when viewing a previous month's balance history, the graph
would incorrectly display data points due to filtering out undefined
values, which broke alignment between data and day labels.

Now the graph correctly extends the last available balance data point
to the end of the month by:
- Preserving full data array length (matching labels)
- Replacing undefined with null instead of filtering
- Maintaining forward-fill logic for past months

This ensures the balance line appears as a continuous horizontal line
from the last data point to the end of the month when viewing past months.