### PR TITLE
feat: add date picker to operations screen for quick date navigation

### DIFF
--- a/app/components/operations/DateSeparator.js
+++ b/app/components/operations/DateSeparator.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 
@@ -9,13 +9,22 @@ const getCurrencySymbol = (currencyCode) => {
   return currency ? currency.symbol : currencyCode;
 };
 
-const DateSeparator = ({ date, spendingSums, formatDate, colors, t }) => {
+const DateSeparator = ({ date, spendingSums, formatDate, colors, t, onPress }) => {
   const hasSpending = spendingSums && Object.keys(spendingSums).length > 0;
 
   return (
     <View style={[styles.dateSeparator, { backgroundColor: colors.background }]}>
       <View style={[styles.dateSeparatorLine, { backgroundColor: colors.border }]} />
-      <View style={styles.dateSeparatorContent}>
+      <Pressable
+        style={({ pressed }) => [
+          styles.dateSeparatorContent,
+          pressed && styles.pressed,
+        ]}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={`${formatDate(date)}, press to select date`}
+        accessibilityHint="Opens date picker to jump to a specific date"
+      >
         <Text style={[styles.dateSeparatorText, { color: colors.mutedText }]}>
           {formatDate(date)}
         </Text>
@@ -31,7 +40,7 @@ const DateSeparator = ({ date, spendingSums, formatDate, colors, t }) => {
               .join(', ')}
           </Text>
         )}
-      </View>
+      </Pressable>
       <View style={[styles.dateSeparatorLine, { backgroundColor: colors.border }]} />
     </View>
   );
@@ -43,6 +52,7 @@ DateSeparator.propTypes = {
   formatDate: PropTypes.func.isRequired,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
+  onPress: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
@@ -57,6 +67,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'column',
     gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
   },
   dateSeparatorLine: {
     flex: 1,
@@ -69,6 +82,9 @@ const styles = StyleSheet.create({
   dateSeparatorText: {
     fontSize: 14,
     fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });
 

--- a/app/components/operations/DateSeparator.js
+++ b/app/components/operations/DateSeparator.js
@@ -65,11 +65,11 @@ const styles = StyleSheet.create({
   },
   dateSeparatorContent: {
     alignItems: 'center',
+    borderRadius: 8,
     flexDirection: 'column',
     gap: 4,
     paddingHorizontal: 8,
     paddingVertical: 4,
-    borderRadius: 8,
   },
   dateSeparatorLine: {
     flex: 1,

--- a/app/contexts/OperationsContext.js
+++ b/app/contexts/OperationsContext.js
@@ -323,6 +323,37 @@ export const OperationsProvider = ({ children }) => {
     await updateFilters(emptyFilters);
   }, [updateFilters]);
 
+  // Jump to a specific date (loads a week of operations starting from that date)
+  const jumpToDate = useCallback(async (date) => {
+    try {
+      setLoading(true);
+      const isFiltered = hasActiveFilters(activeFilters);
+
+      // Load a week of operations starting from the selected date
+      const operationsData = isFiltered
+        ? await OperationsDB.getFilteredOperationsByWeekFromDate(date, activeFilters)
+        : await OperationsDB.getOperationsByWeekFromDate(date);
+
+      setOperations(operationsData);
+
+      // Track the oldest date in the loaded data
+      if (operationsData.length > 0) {
+        const oldestOp = operationsData[operationsData.length - 1];
+        setOldestLoadedDate(oldestOp.date);
+      } else {
+        setOldestLoadedDate(date);
+      }
+
+      // Assume there might be more operations
+      setHasMoreOperations(true);
+      setDataLoaded(true);
+    } catch (error) {
+      console.error('Failed to jump to date:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [activeFilters, hasActiveFilters]);
+
   const validateOperation = useCallback((operation, t = (key) => key) => {
     if (!operation.type) {
       return t('operation_type_required') || 'Operation type is required';
@@ -382,6 +413,7 @@ export const OperationsProvider = ({ children }) => {
     reloadOperations,
     loadMoreOperations,
     loadInitialOperations,
+    jumpToDate,
     activeFilters,
     filtersActive,
     updateFilters,
@@ -402,6 +434,7 @@ export const OperationsProvider = ({ children }) => {
     reloadOperations,
     loadMoreOperations,
     loadInitialOperations,
+    jumpToDate,
     activeFilters,
     filtersActive,
     updateFilters,

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { View, Text, StyleSheet, FlatList, TouchableOpacity, ActivityIndicator, TextInput, Pressable, Modal, Keyboard } from 'react-native';
 import { FAB } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { useTheme } from '../contexts/ThemeContext';
 import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -49,6 +50,7 @@ const OperationsScreen = () => {
     addOperation,
     validateOperation,
     loadMoreOperations,
+    jumpToDate,
     activeFilters,
     filtersActive,
     updateFilters,
@@ -63,6 +65,8 @@ const OperationsScreen = () => {
   const [isNew, setIsNew] = useState(false);
   const [filterModalVisible, setFilterModalVisible] = useState(false);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(new Date());
 
   // Ref for FlatList to enable scrolling to top
   const flatListRef = useRef(null);
@@ -143,6 +147,24 @@ const OperationsScreen = () => {
       ],
     );
   };
+
+  const handleDateSeparatorPress = useCallback((dateString) => {
+    // Parse the date and set it as the selected date
+    const date = new Date(dateString);
+    setSelectedDate(date);
+    setShowDatePicker(true);
+  }, []);
+
+  const handleDatePickerChange = useCallback((event, date) => {
+    setShowDatePicker(false);
+    if (date) {
+      // Jump to the selected date
+      const dateString = toDateString(date);
+      jumpToDate(dateString);
+      // Scroll to top to show the newly loaded operations
+      flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+    }
+  }, [jumpToDate]);
 
   // Quick add handlers
   const openPicker = useCallback((type, data) => {
@@ -483,6 +505,7 @@ const OperationsScreen = () => {
           formatDate={formatDate}
           colors={colors}
           t={t}
+          onPress={() => handleDateSeparatorPress(item.date)}
         />
       );
     }
@@ -500,7 +523,7 @@ const OperationsScreen = () => {
         onPress={() => handleEditOperation(item)}
       />
     );
-  }, [colors, t, getCategoryInfo, getAccountName, formatCurrency, formatDate, handleEditOperation]);
+  }, [colors, t, getCategoryInfo, getAccountName, formatCurrency, formatDate, handleEditOperation, handleDateSeparatorPress]);
 
   if (operationsLoading || accountsLoading || categoriesLoading) {
     return (
@@ -717,6 +740,16 @@ const OperationsScreen = () => {
         isNew={isNew}
         onDelete={handleDeleteOperation}
       />
+
+      {/* Date Picker for jumping to a specific date */}
+      {showDatePicker && (
+        <DateTimePicker
+          value={selectedDate}
+          mode="date"
+          display="default"
+          onChange={handleDatePickerChange}
+        />
+      )}
     </View>
   );
 };


### PR DESCRIPTION
Add the ability to press on a date separator in the operations screen to open a date picker and jump to a specific date. This makes it easier for users to navigate to operations from different time periods.

Changes:
- Made DateSeparator component pressable with visual feedback
- Added date picker state management to OperationsScreen
- Implemented jumpToDate method in OperationsContext to load operations from a specific date
- Integrated DateTimePicker component to allow date selection
- Added automatic scroll to top after jumping to a new date

The feature maintains compatibility with existing filters and lazy loading functionality.