### PR TITLE
feat: show parent category name in brackets when selecting categories

### DIFF
--- a/__tests__/utils/categoryUtils.test.js
+++ b/__tests__/utils/categoryUtils.test.js
@@ -1,0 +1,149 @@
+import { getCategoryDisplayName } from '../../app/utils/categoryUtils';
+
+describe('categoryUtils', () => {
+  describe('getCategoryDisplayName', () => {
+    const mockT = (key) => key; // Simple mock translation function
+
+    const mockCategories = [
+      {
+        id: 'cat-1',
+        name: 'Food',
+        nameKey: 'category_food',
+        parentId: null,
+      },
+      {
+        id: 'cat-2',
+        name: 'Groceries',
+        nameKey: 'category_groceries',
+        parentId: 'cat-1',
+      },
+      {
+        id: 'cat-3',
+        name: 'Restaurants',
+        nameKey: 'category_restaurants',
+        parentId: 'cat-1',
+      },
+      {
+        id: 'cat-4',
+        name: 'Transport',
+        nameKey: null,
+        parentId: null,
+      },
+      {
+        id: 'cat-5',
+        name: 'Public Transport',
+        nameKey: null,
+        parentId: 'cat-4',
+      },
+    ];
+
+    it('should return category name for root category with nameKey', () => {
+      const result = getCategoryDisplayName('cat-1', mockCategories, mockT);
+      expect(result).toBe('category_food');
+    });
+
+    it('should return category name for root category without nameKey', () => {
+      const result = getCategoryDisplayName('cat-4', mockCategories, mockT);
+      expect(result).toBe('Transport');
+    });
+
+    it('should return category name with parent in brackets for subcategory with nameKey', () => {
+      const result = getCategoryDisplayName('cat-2', mockCategories, mockT);
+      expect(result).toBe('category_groceries (category_food)');
+    });
+
+    it('should return category name with parent in brackets for subcategory without nameKey', () => {
+      const result = getCategoryDisplayName('cat-5', mockCategories, mockT);
+      expect(result).toBe('Public Transport (Transport)');
+    });
+
+    it('should handle multiple subcategories under same parent', () => {
+      const result1 = getCategoryDisplayName('cat-2', mockCategories, mockT);
+      const result2 = getCategoryDisplayName('cat-3', mockCategories, mockT);
+
+      expect(result1).toBe('category_groceries (category_food)');
+      expect(result2).toBe('category_restaurants (category_food)');
+    });
+
+    it('should return empty string for null categoryId', () => {
+      const result = getCategoryDisplayName(null, mockCategories, mockT);
+      expect(result).toBe('');
+    });
+
+    it('should return empty string for undefined categoryId', () => {
+      const result = getCategoryDisplayName(undefined, mockCategories, mockT);
+      expect(result).toBe('');
+    });
+
+    it('should return empty string for non-existent categoryId', () => {
+      const result = getCategoryDisplayName('non-existent', mockCategories, mockT);
+      expect(result).toBe('');
+    });
+
+    it('should handle category with missing parent gracefully', () => {
+      const categoriesWithMissingParent = [
+        {
+          id: 'cat-orphan',
+          name: 'Orphan Category',
+          nameKey: null,
+          parentId: 'non-existent-parent',
+        },
+      ];
+
+      const result = getCategoryDisplayName('cat-orphan', categoriesWithMissingParent, mockT);
+      expect(result).toBe('Orphan Category');
+    });
+
+    it('should use translated names when translation function is provided', () => {
+      const mockTranslate = (key) => {
+        const translations = {
+          'category_food': 'Comida',
+          'category_groceries': 'Compras',
+        };
+        return translations[key] || key;
+      };
+
+      const result = getCategoryDisplayName('cat-2', mockCategories, mockTranslate);
+      expect(result).toBe('Compras (Comida)');
+    });
+
+    it('should handle empty categories array', () => {
+      const result = getCategoryDisplayName('cat-1', [], mockT);
+      expect(result).toBe('');
+    });
+
+    it('should handle category with null nameKey', () => {
+      const categoriesWithNull = [
+        {
+          id: 'cat-null',
+          name: 'Category with Null NameKey',
+          nameKey: null,
+          parentId: null,
+        },
+      ];
+
+      const result = getCategoryDisplayName('cat-null', categoriesWithNull, mockT);
+      expect(result).toBe('Category with Null NameKey');
+    });
+
+    it('should handle parent category with nameKey and child without', () => {
+      const mixedCategories = [
+        {
+          id: 'parent',
+          name: 'Parent',
+          nameKey: 'parent_key',
+          parentId: null,
+        },
+        {
+          id: 'child',
+          name: 'Child Name',
+          nameKey: null,
+          parentId: 'parent',
+        },
+      ];
+
+      const result = getCategoryDisplayName('child', mixedCategories, mockT);
+      expect(result).toBe('Child Name (parent_key)');
+    });
+  });
+});

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -29,6 +29,7 @@ import { formatDate } from '../services/BalanceHistoryDB';
 import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
 import currencies from '../../assets/currencies.json';
 import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
+import { getCategoryDisplayName } from '../utils/categoryUtils';
 
 /**
  * Get currency symbol from currency code
@@ -46,7 +47,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   const { t } = useLocalization();
   const { addOperation, updateOperation, validateOperation } = useOperations();
   const { visibleAccounts: accounts } = useAccounts();
-  const { categories, getCategoryPath } = useCategories();
+  const { categories } = useCategories();
 
   const [values, setValues] = useState({
     type: 'expense',
@@ -267,21 +268,8 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
 
   const getCategoryName = useCallback((categoryId) => {
     if (!categoryId) return t('select_category');
-    const category = categories.find(cat => cat.id === categoryId);
-    if (!category) return t('select_category');
-
-    const categoryName = category.nameKey ? t(category.nameKey) : category.name;
-
-    // If category has a parent, show parent name in brackets
-    if (category.parentId) {
-      const parentCategory = categories.find(cat => cat.id === category.parentId);
-      if (parentCategory) {
-        const parentName = parentCategory.nameKey ? t(parentCategory.nameKey) : parentCategory.name;
-        return `${categoryName} (${parentName})`;
-      }
-    }
-
-    return categoryName;
+    const displayName = getCategoryDisplayName(categoryId, categories, t);
+    return displayName || t('select_category');
   }, [categories, t]);
 
   // Navigate into a category folder

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -46,7 +46,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   const { t } = useLocalization();
   const { addOperation, updateOperation, validateOperation } = useOperations();
   const { visibleAccounts: accounts } = useAccounts();
-  const { categories } = useCategories();
+  const { categories, getCategoryPath } = useCategories();
 
   const [values, setValues] = useState({
     type: 'expense',
@@ -269,7 +269,19 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     if (!categoryId) return t('select_category');
     const category = categories.find(cat => cat.id === categoryId);
     if (!category) return t('select_category');
-    return category.nameKey ? t(category.nameKey) : category.name;
+
+    const categoryName = category.nameKey ? t(category.nameKey) : category.name;
+
+    // If category has a parent, show parent name in brackets
+    if (category.parentId) {
+      const parentCategory = categories.find(cat => cat.id === category.parentId);
+      if (parentCategory) {
+        const parentName = parentCategory.nameKey ? t(parentCategory.nameKey) : parentCategory.name;
+        return `${categoryName} (${parentName})`;
+      }
+    }
+
+    return categoryName;
   }, [categories, t]);
 
   // Navigate into a category folder

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -56,7 +56,7 @@ const OperationsScreen = () => {
     getActiveFilterCount,
   } = useOperations();
   const { accounts, visibleAccounts, loading: accountsLoading } = useAccounts();
-  const { categories, loading: categoriesLoading } = useCategories();
+  const { categories, loading: categoriesLoading, getCategoryPath } = useCategories();
 
   const [modalVisible, setModalVisible] = useState(false);
   const [editingOperation, setEditingOperation] = useState(null);
@@ -273,8 +273,20 @@ const OperationsScreen = () => {
   const getCategoryInfo = useCallback((categoryId) => {
     const category = categories.find(cat => cat.id === categoryId);
     if (!category) return { name: t('unknown_category'), icon: 'help-circle' };
+
+    let categoryName = category.nameKey ? t(category.nameKey) : category.name;
+
+    // If category has a parent, show parent name in brackets
+    if (category.parentId) {
+      const parentCategory = categories.find(cat => cat.id === category.parentId);
+      if (parentCategory) {
+        const parentName = parentCategory.nameKey ? t(parentCategory.nameKey) : parentCategory.name;
+        categoryName = `${categoryName} (${parentName})`;
+      }
+    }
+
     return {
-      name: category.nameKey ? t(category.nameKey) : category.name,
+      name: categoryName,
       icon: category.icon || 'help-circle',
     };
   }, [categories, t]);
@@ -284,7 +296,19 @@ const OperationsScreen = () => {
     if (!categoryId) return t('select_category');
     const category = categories.find(cat => cat.id === categoryId);
     if (!category) return t('select_category');
-    return category.nameKey ? t(category.nameKey) : category.name;
+
+    const categoryName = category.nameKey ? t(category.nameKey) : category.name;
+
+    // If category has a parent, show parent name in brackets
+    if (category.parentId) {
+      const parentCategory = categories.find(cat => cat.id === category.parentId);
+      if (parentCategory) {
+        const parentName = parentCategory.nameKey ? t(parentCategory.nameKey) : parentCategory.name;
+        return `${categoryName} (${parentName})`;
+      }
+    }
+
+    return categoryName;
   }, [categories, t]);
 
   // Filtered categories for quick add form (excluding shadow categories)

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -21,6 +21,7 @@ import QuickAddForm from '../components/operations/QuickAddForm';
 import currencies from '../../assets/currencies.json';
 import * as Currency from '../services/currency';
 import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
+import { getCategoryDisplayName } from '../utils/categoryUtils';
 
 /**
  * Get currency symbol from currency code
@@ -56,7 +57,7 @@ const OperationsScreen = () => {
     getActiveFilterCount,
   } = useOperations();
   const { accounts, visibleAccounts, loading: accountsLoading } = useAccounts();
-  const { categories, loading: categoriesLoading, getCategoryPath } = useCategories();
+  const { categories, loading: categoriesLoading } = useCategories();
 
   const [modalVisible, setModalVisible] = useState(false);
   const [editingOperation, setEditingOperation] = useState(null);
@@ -274,19 +275,10 @@ const OperationsScreen = () => {
     const category = categories.find(cat => cat.id === categoryId);
     if (!category) return { name: t('unknown_category'), icon: 'help-circle' };
 
-    let categoryName = category.nameKey ? t(category.nameKey) : category.name;
-
-    // If category has a parent, show parent name in brackets
-    if (category.parentId) {
-      const parentCategory = categories.find(cat => cat.id === category.parentId);
-      if (parentCategory) {
-        const parentName = parentCategory.nameKey ? t(parentCategory.nameKey) : parentCategory.name;
-        categoryName = `${categoryName} (${parentName})`;
-      }
-    }
+    const categoryName = getCategoryDisplayName(categoryId, categories, t);
 
     return {
-      name: categoryName,
+      name: categoryName || t('unknown_category'),
       icon: category.icon || 'help-circle',
     };
   }, [categories, t]);
@@ -294,21 +286,8 @@ const OperationsScreen = () => {
   // Get category name for form
   const getCategoryName = useCallback((categoryId) => {
     if (!categoryId) return t('select_category');
-    const category = categories.find(cat => cat.id === categoryId);
-    if (!category) return t('select_category');
-
-    const categoryName = category.nameKey ? t(category.nameKey) : category.name;
-
-    // If category has a parent, show parent name in brackets
-    if (category.parentId) {
-      const parentCategory = categories.find(cat => cat.id === category.parentId);
-      if (parentCategory) {
-        const parentName = parentCategory.nameKey ? t(parentCategory.nameKey) : parentCategory.name;
-        return `${categoryName} (${parentName})`;
-      }
-    }
-
-    return categoryName;
+    const displayName = getCategoryDisplayName(categoryId, categories, t);
+    return displayName || t('select_category');
   }, [categories, t]);
 
   // Filtered categories for quick add form (excluding shadow categories)

--- a/app/utils/categoryUtils.js
+++ b/app/utils/categoryUtils.js
@@ -1,0 +1,30 @@
+/**
+ * Utility functions for working with categories
+ */
+
+/**
+ * Get the display name for a category, including parent name in brackets if applicable
+ * @param {string} categoryId - The category ID to get the name for
+ * @param {Array} categories - Array of all categories
+ * @param {Function} t - Translation function
+ * @returns {string} Category name with parent in brackets (e.g., "Groceries (Food)")
+ */
+export const getCategoryDisplayName = (categoryId, categories, t) => {
+  if (!categoryId) return '';
+
+  const category = categories.find(cat => cat.id === categoryId);
+  if (!category) return '';
+
+  const categoryName = category.nameKey ? t(category.nameKey) : category.name;
+
+  // If category has a parent, show parent name in brackets
+  if (category.parentId) {
+    const parentCategory = categories.find(cat => cat.id === category.parentId);
+    if (parentCategory) {
+      const parentName = parentCategory.nameKey ? t(parentCategory.nameKey) : parentCategory.name;
+      return `${categoryName} (${parentName})`;
+    }
+  }
+
+  return categoryName;
+};


### PR DESCRIPTION
When users pick a category for operations (either through quick-add or
when editing an existing operation), the parent category name is now
displayed in brackets next to the category name (e.g., "Groceries (Food)").

This helps users better understand the category hierarchy and distinguish
between subcategories with similar names in different parent categories.

Changes:
- Updated getCategoryName in OperationModal.js to append parent name
- Updated getCategoryInfo and getCategoryName in OperationsScreen.js
- Parent names are shown for both quick-add form and operation list items
- Parent names are translated using the same localization system as categories