### PR TITLE
feat: add date picker to operations screen for quick date navigation

### DIFF
--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -46,11 +46,14 @@ const OperationsScreen = () => {
     operations,
     loading: operationsLoading,
     loadingMore,
+    loadingNewer,
     hasMoreOperations,
+    hasNewerOperations,
     deleteOperation,
     addOperation,
     validateOperation,
     loadMoreOperations,
+    loadNewerOperations,
     jumpToDate,
     activeFilters,
     filtersActive,
@@ -450,21 +453,32 @@ const OperationsScreen = () => {
   ], [t]);
 
   const quickAddFormComponent = useMemo(() => (
-    <QuickAddForm
-      colors={colors}
-      t={t}
-      quickAddValues={quickAddValues}
-      setQuickAddValues={setQuickAddValues}
-      accounts={visibleAccounts}
-      filteredCategories={filteredCategories}
-      getAccountName={getAccountName}
-      getAccountBalance={getAccountBalance}
-      getCategoryName={getCategoryName}
-      openPicker={openPicker}
-      handleQuickAdd={handleQuickAdd}
-      TYPES={TYPES}
-    />
-  ), [colors, t, quickAddValues, visibleAccounts, filteredCategories, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, TYPES]);
+    <>
+      {/* Loading indicator for newer operations at the top */}
+      {loadingNewer && (
+        <View style={styles.loadingNewerContainer}>
+          <ActivityIndicator size="small" color={colors.primary} />
+          <Text style={[styles.loadingNewerText, { color: colors.mutedText }]}>
+            {t('loading_newer')}
+          </Text>
+        </View>
+      )}
+      <QuickAddForm
+        colors={colors}
+        t={t}
+        quickAddValues={quickAddValues}
+        setQuickAddValues={setQuickAddValues}
+        accounts={visibleAccounts}
+        filteredCategories={filteredCategories}
+        getAccountName={getAccountName}
+        getAccountBalance={getAccountBalance}
+        getCategoryName={getCategoryName}
+        openPicker={openPicker}
+        handleQuickAdd={handleQuickAdd}
+        TYPES={TYPES}
+      />
+    </>
+  ), [colors, t, loadingNewer, quickAddValues, visibleAccounts, filteredCategories, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, TYPES]);
 
   // Handle end reached for lazy loading
   const handleEndReached = useCallback(() => {
@@ -473,12 +487,18 @@ const OperationsScreen = () => {
     }
   }, [loadingMore, hasMoreOperations, loadMoreOperations]);
 
-  // Handle scroll event to show/hide scroll-to-top button
+  // Handle scroll event to show/hide scroll-to-top button and load newer operations
   const handleScroll = useCallback((event) => {
     const offsetY = event.nativeEvent.contentOffset.y;
     // Show button when scrolled down past the calculator (roughly 250px)
     setShowScrollToTop(offsetY > 250);
-  }, []);
+
+    // Load newer operations when scrolling near the top
+    // Trigger when offset is less than 50px from top
+    if (offsetY < 50 && !loadingNewer && hasNewerOperations) {
+      loadNewerOperations();
+    }
+  }, [loadingNewer, hasNewerOperations, loadNewerOperations]);
 
   // Scroll to top handler
   const scrollToTop = useCallback(() => {
@@ -837,6 +857,15 @@ const styles = StyleSheet.create({
   loadingMoreText: {
     fontSize: 14,
     marginTop: SPACING.sm,
+  },
+  loadingNewerContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: SPACING.md,
+  },
+  loadingNewerText: {
+    fontSize: 14,
+    marginTop: SPACING.xs,
   },
   loadingText: {
     fontSize: 16,

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -46,14 +46,11 @@ const OperationsScreen = () => {
     operations,
     loading: operationsLoading,
     loadingMore,
-    loadingNewer,
     hasMoreOperations,
-    hasNewerOperations,
     deleteOperation,
     addOperation,
     validateOperation,
     loadMoreOperations,
-    loadNewerOperations,
     jumpToDate,
     activeFilters,
     filtersActive,
@@ -71,6 +68,8 @@ const OperationsScreen = () => {
   const [showScrollToTop, setShowScrollToTop] = useState(false);
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date());
+  const [scrollToDateString, setScrollToDateString] = useState(null);
+  const [pendingScroll, setPendingScroll] = useState(false);
 
   // Ref for FlatList to enable scrolling to top
   const flatListRef = useRef(null);
@@ -114,6 +113,76 @@ const OperationsScreen = () => {
     }
     setDefaultAccount();
   }, [visibleAccounts]);
+
+  // Scroll to date after operations are loaded
+  useEffect(() => {
+    if (scrollToDateString && !operationsLoading && groupedOperations.length > 0) {
+      const separatorIndex = groupedOperations.findIndex(
+        item => item.type === 'separator' && item.date === scrollToDateString,
+      );
+
+      if (separatorIndex !== -1) {
+        // Mark that we have a pending scroll
+        setPendingScroll(true);
+      } else {
+        // Date not found, clear the scroll target
+        setScrollToDateString(null);
+        setPendingScroll(false);
+      }
+    }
+  }, [scrollToDateString, operationsLoading, groupedOperations]);
+
+  // Handle content size change - this fires after FlatList has laid out content
+  const handleContentSizeChange = useCallback((width, height) => {
+    if (pendingScroll && scrollToDateString && !operationsLoading) {
+      const separatorIndex = groupedOperations.findIndex(
+        item => item.type === 'separator' && item.date === scrollToDateString,
+      );
+
+      console.log('handleContentSizeChange:', {
+        pendingScroll,
+        scrollToDateString,
+        separatorIndex,
+        totalItems: groupedOperations.length,
+        contentHeight: height,
+      });
+
+      if (separatorIndex !== -1) {
+        // Use scrollToOffset with estimated position
+        // Each item is roughly 70-80px tall (operations) + separators are ~60px
+        // This is more reliable than scrollToIndex for virtualized lists
+        const estimatedItemHeight = 75;
+        const estimatedOffset = separatorIndex * estimatedItemHeight;
+
+        setTimeout(() => {
+          console.log('Scrolling to offset:', estimatedOffset, 'for index:', separatorIndex);
+
+          // Use scrollToOffset which works better for large lists
+          flatListRef.current?.scrollToOffset({
+            offset: estimatedOffset,
+            animated: false, // Use non-animated scroll for large distances
+          });
+
+          // After scrolling to approximate position, try to fine-tune with scrollToIndex
+          setTimeout(() => {
+            try {
+              flatListRef.current?.scrollToIndex({
+                index: separatorIndex,
+                animated: true,
+                viewPosition: 0,
+              });
+            } catch (error) {
+              console.log('Fine-tuning scroll failed, staying at estimated position');
+            }
+          }, 100);
+
+          // Clear the scroll target
+          setScrollToDateString(null);
+          setPendingScroll(false);
+        }, 100);
+      }
+    }
+  }, [pendingScroll, scrollToDateString, operationsLoading, groupedOperations]);
 
   // Auto-prefill "To Account" for transfers with same currency
   useEffect(() => {
@@ -159,16 +228,31 @@ const OperationsScreen = () => {
     setShowDatePicker(true);
   }, []);
 
-  const handleDatePickerChange = useCallback((event, date) => {
+  const handleDatePickerChange = useCallback(async (event, date) => {
     setShowDatePicker(false);
     if (date) {
-      // Jump to the selected date
       const dateString = toDateString(date);
-      jumpToDate(dateString);
-      // Scroll to top to show the newly loaded operations
-      flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+
+      // Find the index of the date separator for this date in current list
+      const separatorIndex = groupedOperations.findIndex(
+        item => item.type === 'separator' && item.date === dateString,
+      );
+
+      if (separatorIndex !== -1) {
+        // Date is in the current list - scroll to it immediately
+        flatListRef.current?.scrollToIndex({
+          index: separatorIndex,
+          animated: true,
+          viewPosition: 0, // Position at the top of the viewport
+        });
+      } else {
+        // Date is not in current list - load from that date to today
+        // Set the target date for scrolling after load completes
+        setScrollToDateString(dateString);
+        await jumpToDate(dateString);
+      }
     }
-  }, [jumpToDate]);
+  }, [groupedOperations, jumpToDate]);
 
   // Quick add handlers
   const openPicker = useCallback((type, data) => {
@@ -453,32 +537,21 @@ const OperationsScreen = () => {
   ], [t]);
 
   const quickAddFormComponent = useMemo(() => (
-    <>
-      {/* Loading indicator for newer operations at the top */}
-      {loadingNewer && (
-        <View style={styles.loadingNewerContainer}>
-          <ActivityIndicator size="small" color={colors.primary} />
-          <Text style={[styles.loadingNewerText, { color: colors.mutedText }]}>
-            {t('loading_newer')}
-          </Text>
-        </View>
-      )}
-      <QuickAddForm
-        colors={colors}
-        t={t}
-        quickAddValues={quickAddValues}
-        setQuickAddValues={setQuickAddValues}
-        accounts={visibleAccounts}
-        filteredCategories={filteredCategories}
-        getAccountName={getAccountName}
-        getAccountBalance={getAccountBalance}
-        getCategoryName={getCategoryName}
-        openPicker={openPicker}
-        handleQuickAdd={handleQuickAdd}
-        TYPES={TYPES}
-      />
-    </>
-  ), [colors, t, loadingNewer, quickAddValues, visibleAccounts, filteredCategories, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, TYPES]);
+    <QuickAddForm
+      colors={colors}
+      t={t}
+      quickAddValues={quickAddValues}
+      setQuickAddValues={setQuickAddValues}
+      accounts={visibleAccounts}
+      filteredCategories={filteredCategories}
+      getAccountName={getAccountName}
+      getAccountBalance={getAccountBalance}
+      getCategoryName={getCategoryName}
+      openPicker={openPicker}
+      handleQuickAdd={handleQuickAdd}
+      TYPES={TYPES}
+    />
+  ), [colors, t, quickAddValues, visibleAccounts, filteredCategories, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, TYPES]);
 
   // Handle end reached for lazy loading
   const handleEndReached = useCallback(() => {
@@ -487,22 +560,43 @@ const OperationsScreen = () => {
     }
   }, [loadingMore, hasMoreOperations, loadMoreOperations]);
 
-  // Handle scroll event to show/hide scroll-to-top button and load newer operations
+  // Handle scroll event to show/hide scroll-to-top button
   const handleScroll = useCallback((event) => {
     const offsetY = event.nativeEvent.contentOffset.y;
     // Show button when scrolled down past the calculator (roughly 250px)
     setShowScrollToTop(offsetY > 250);
-
-    // Load newer operations when scrolling near the top
-    // Trigger when offset is less than 50px from top
-    if (offsetY < 50 && !loadingNewer && hasNewerOperations) {
-      loadNewerOperations();
-    }
-  }, [loadingNewer, hasNewerOperations, loadNewerOperations]);
+  }, []);
 
   // Scroll to top handler
   const scrollToTop = useCallback(() => {
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+  }, []);
+
+  // Handle scroll to index failures (when item is not rendered yet)
+  const handleScrollToIndexFailed = useCallback((info) => {
+    console.log('scrollToIndex failed for index:', info.index, 'Using offset fallback');
+
+    // Scroll to approximate position using offset
+    const estimatedItemHeight = 75;
+    const estimatedOffset = info.index * estimatedItemHeight;
+
+    flatListRef.current?.scrollToOffset({
+      offset: estimatedOffset,
+      animated: false,
+    });
+
+    // Try scrollToIndex again after a delay
+    setTimeout(() => {
+      try {
+        flatListRef.current?.scrollToIndex({
+          index: info.index,
+          animated: true,
+          viewPosition: 0,
+        });
+      } catch (error) {
+        console.log('Second scrollToIndex attempt failed');
+      }
+    }, 500);
   }, []);
 
   // Footer component showing loading indicator
@@ -573,7 +667,7 @@ const OperationsScreen = () => {
         ListEmptyComponent={
           <View style={styles.emptyContainer}>
             <Icon name="cash-multiple" size={64} color={colors.mutedText} />
-            <Text style={[styles.emptyText, { color: colors.mutedText }]}> 
+            <Text style={[styles.emptyText, { color: colors.mutedText }]}>
               {t('no_operations')}
             </Text>
           </View>
@@ -583,6 +677,8 @@ const OperationsScreen = () => {
         scrollEventThrottle={16}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
+        onScrollToIndexFailed={handleScrollToIndexFailed}
+        onContentSizeChange={handleContentSizeChange}
         windowSize={10}
         maxToRenderPerBatch={10}
         initialNumToRender={15}
@@ -857,15 +953,6 @@ const styles = StyleSheet.create({
   loadingMoreText: {
     fontSize: 14,
     marginTop: SPACING.sm,
-  },
-  loadingNewerContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingVertical: SPACING.md,
-  },
-  loadingNewerText: {
-    fontSize: 14,
-    marginTop: SPACING.xs,
   },
   loadingText: {
     fontSize: 16,

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -151,6 +151,7 @@
   "delete_operation_confirm": "Sind Sie sicher, dass Sie diesen Vorgang löschen möchten?",
   "loading_operations": "Vorgänge werden geladen...",
   "loading_more": "Mehr laden...",
+  "loading_newer": "Loading newer...",
   "transfer": "Überweisung",
   "to_account": "Zum Konto",
   "today": "Heute",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -151,6 +151,7 @@
   "delete_operation_confirm": "Are you sure you want to delete this operation?",
   "loading_operations": "Loading operations...",
   "loading_more": "Loading more...",
+  "loading_newer": "Loading newer...",
   "transfer": "Transfer",
   "to_account": "To Account",
   "today": "Today",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -151,6 +151,7 @@
   "delete_operation_confirm": "¿Estás seguro de que quieres eliminar esta operación?",
   "loading_operations": "Cargando operaciones...",
   "loading_more": "Cargando más...",
+  "loading_newer": "Loading newer...",
   "transfer": "Transferencia",
   "to_account": "A la cuenta",
   "today": "Hoy",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -151,6 +151,7 @@
   "delete_operation_confirm": "Êtes-vous sûr de vouloir supprimer cette opération ?",
   "loading_operations": "Chargement des opérations...",
   "loading_more": "Chargement...",
+  "loading_newer": "Loading newer...",
   "transfer": "Virement",
   "to_account": "Vers le compte",
   "today": "Aujourd'hui",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -151,6 +151,7 @@
   "delete_operation_confirm": "Վստա՞հ եք, որ ցանկանում եք ջնջել այս գործարքը։",
   "loading_operations": "Բեռնվում են գործարքները...",
   "loading_more": "Բեռնվում են ավելին...",
+  "loading_newer": "Loading newer...",
   "transfer": "Փոխանցում",
   "to_account": "Հաշվին",
   "today": "Այսօր",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -149,6 +149,7 @@
   "delete_operation_confirm": "Вы уверены, что хотите удалить эту операцию?",
   "loading_operations": "Загрузка операций...",
   "loading_more": "Загрузка...",
+  "loading_newer": "Loading newer...",
   "transfer": "Перевод",
   "to_account": "На счет",
   "today": "Сегодня",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -151,6 +151,7 @@
   "delete_operation_confirm": "确定要删除此操作吗？",
   "loading_operations": "加载操作中...",
   "loading_more": "加载更多...",
+  "loading_newer": "Loading newer...",
   "transfer": "转账",
   "to_account": "到账户",
   "today": "今天",


### PR DESCRIPTION
## Summary

Add date picker functionality to the operations screen that allows users to quickly jump to any date. When a date is selected, all operations from that date to today are loaded, and the list scrolls to show the selected date.

## Changes

### Date Picker UI
- Added date picker that opens when tapping on a date separator
- Shows current date by default when opened
- Dismisses after selecting a date

### Jump to Date Functionality
- Modified `jumpToDate` to load **all operations from selected date to today** (instead of just one week)
- Added `getFilteredOperationsByDateRange` function to OperationsDB for filtered date range queries
- Disabled lazy loading for newer operations since we always load up to today
- Set `hasNewerOperations` to `false` after jumping to a date

### Scroll Behavior
- If selected date is already loaded: scrolls to it immediately
- If selected date is not loaded: loads data then scrolls to the date
- Uses `onContentSizeChange` callback to wait for FlatList to finish rendering
- Two-phase scroll: `scrollToOffset` for initial positioning, then `scrollToIndex` to fine-tune
- Better error handling with fallback to estimated scroll position

### UI Improvements
- Removed "loading newer" indicator (no longer needed)
- Bidirectional scrolling still works via "load more" at the bottom
- Cleaner user experience with continuous date range

## User Experience

Users can now:
- Tap on any date separator to open the date picker
- Select any date to quickly jump to that point in history
- View a continuous list of all operations from the selected date to today
- Scroll down to load even older operations if needed

This creates a natural scroll experience - as if the user manually scrolled down to that date, rather than loading disconnected chunks of data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)