### PR TITLE
fix: correct days elapsed calculation in expense prediction

### DIFF
--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -942,9 +942,9 @@ const GraphsScreen = () => {
     // Calculate days in the selected month
     const daysInMonth = new Date(selectedYear, selectedMonth + 1, 0).getDate();
 
-    // Calculate days elapsed (from 1st to today)
+    // Calculate days elapsed (from 1st to today, excluding current day)
     const currentDay = now.getDate();
-    const daysElapsed = currentDay;
+    const daysElapsed = currentDay - 1;
 
     // If it's the first day, we can't make a good prediction yet
     if (daysElapsed < 1) {


### PR DESCRIPTION
The expense prediction was incorrectly counting the current day as elapsed,
leading to off-by-one errors. For example:
- On Jan 8th, it showed "8/31 days elapsed" instead of "7/31"
- On Jan 31st, it would show "31/31" and predict 0 remaining

Changed daysElapsed calculation from currentDay to (currentDay - 1) to
only count fully completed days, excluding the current day in progress.

This ensures accurate expense predictions throughout the month.