### PR TITLE
feat: format category reports in single line with columns

### DIFF
--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -36,7 +36,8 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
             ]}
             {...wrapperProps}
           >
-            <View style={styles.legendLeft}>
+            {/* Category column (flexible width) */}
+            <View style={styles.categoryColumn}>
               <View style={[styles.colorIndicator, { backgroundColor: item.color }]} />
               {item.icon && (
                 <Icon
@@ -58,11 +59,20 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
                 />
               )}
             </View>
-            <View style={styles.legendRight}>
-              <Text style={[styles.legendAmount, { color: colors.text }]}>
+
+            {/* Amount column (fixed width) */}
+            <View style={styles.amountColumn}>
+              <Text style={[styles.legendAmount, { color: colors.text }]} numberOfLines={1}>
                 {formatCurrency(item.amount, currency)}
               </Text>
-              <Text style={[styles.legendPercentage, { color: colors.mutedText }]}>
+            </View>
+
+            {/* Separator */}
+            <Text style={[styles.separator, { color: colors.mutedText }]}>|</Text>
+
+            {/* Percentage column (fixed width) */}
+            <View style={styles.percentageColumn}>
+              <Text style={[styles.legendPercentage, { color: colors.text }]}>
                 {percentage}%
               </Text>
             </View>
@@ -94,6 +104,18 @@ CustomLegend.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  amountColumn: {
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    width: 100,
+  },
+  categoryColumn: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 8,
+    minWidth: 0,
+  },
   colorIndicator: {
     borderRadius: 6,
     height: 12,
@@ -116,30 +138,28 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderBottomWidth: 1,
     flexDirection: 'row',
-    justifyContent: 'space-between',
     paddingHorizontal: 4,
     paddingVertical: 12,
   },
   legendItemClickable: {
     opacity: 0.9,
   },
-  legendLeft: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    flex: 1,
-    gap: 8,
-  },
   legendName: {
     flex: 1,
     fontSize: 14,
   },
   legendPercentage: {
-    fontSize: 12,
-    marginTop: 2,
+    fontSize: 14,
+    fontWeight: '500',
   },
-  legendRight: {
+  percentageColumn: {
     alignItems: 'flex-end',
-    marginLeft: 8,
+    justifyContent: 'center',
+    width: 50,
+  },
+  separator: {
+    fontSize: 14,
+    marginHorizontal: 8,
   },
 });
 

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -68,7 +68,7 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
             </View>
 
             {/* Separator */}
-            <Text style={[styles.separator, { color: colors.mutedText }]}>|</Text>
+            <View style={styles.verticalDivider} />
 
             {/* Percentage column (fixed width) */}
             <View style={styles.percentageColumn}>
@@ -157,9 +157,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 50,
   },
-  separator: {
-    fontSize: 14,
+  verticalDivider: {
+    alignSelf: 'center',
+    backgroundColor: 'rgba(120,120,120,0.13)',
+    height: '70%',
     marginHorizontal: 8,
+    width: 1,
   },
 });
 

--- a/app/components/graphs/SpendingPredictionCard.js
+++ b/app/components/graphs/SpendingPredictionCard.js
@@ -59,7 +59,7 @@ const SpendingPredictionCard = ({ colors, t, spendingPrediction, selectedCurrenc
           />
         </View>
         <Text style={[styles.predictionProgressText, { color: colors.mutedText }]}>
-          {spendingPrediction.daysElapsed} / {spendingPrediction.daysInMonth} {t('days_elapsed').toLowerCase()} • {t('daily_average')}: <Text style={{ color: colors.text, fontWeight: '600' }}>{formatCurrency(spendingPrediction.dailyAverage, selectedCurrency)}</Text>
+          {spendingPrediction.daysElapsed} / {spendingPrediction.daysInMonth} {t('days_elapsed').toLowerCase()} • {t('daily_average')}: <Text style={[styles.dailyAverageValue, { color: colors.text }]}>{formatCurrency(spendingPrediction.dailyAverage, selectedCurrency)}</Text>
         </Text>
       </View>
     </View>
@@ -81,6 +81,9 @@ SpendingPredictionCard.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  dailyAverageValue: {
+    fontWeight: '600',
+  },
   predictionArrow: {
     marginHorizontal: 8,
   },


### PR DESCRIPTION
Restructure category reports to display category, amount, and percentage
on a single line with consistent column widths for better readability.

Changes:
- Replace vertical amount/percentage layout with horizontal three-column design
- Add fixed-width columns for amount (100px) and percentage (50px)
- Add separator "|" between amount and percentage
- Ensure consistent font sizing (14px) across all columns
- Improve visual alignment with right-aligned numeric values

Format: category | amount | percentage