### PR TITLE
fix: enable vertical scrolling with horizontal swipe gestures

### DIFF
--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -138,6 +138,9 @@ export default function SimpleTabs() {
   // Pan gesture for swipe navigation with real-time feedback
   const panGesture = useMemo(() => {
     return Gesture.Pan()
+      // Only activate on horizontal movements, allow vertical scrolling
+      .activeOffsetX([-10, 10])
+      .failOffsetY([-10, 10])
       .onStart(() => {
         'worklet';
         startTranslateX.value = translateX.value;


### PR DESCRIPTION
Configure Pan gesture to only activate on horizontal movements
and fail on vertical movements, allowing FlatList vertical
scrolling to work properly while keeping horizontal tab swipes.

- Add activeOffsetX([-10, 10]) to require 10px horizontal movement
- Add failOffsetY([-10, 10]) to fail on vertical movement
- This prevents gesture conflicts between horizontal swipes and vertical scrolls