### PR TITLE
fix: remove Sentry from the project

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,26 +18,6 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 import { useMaterialTheme } from './app/hooks/useMaterialTheme';
-import * as Sentry from '@sentry/react-native';
-
-Sentry.init({
-  dsn: 'https://f06a0b39f8c767ce0baa256f79dabe5b@o4510430127980544.ingest.de.sentry.io/4510430145740880',
-
-  // Adds more context data to events (IP address, cookies, user, etc.)
-  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
-  sendDefaultPii: false,
-
-  // Enable Logs
-  enableLogs: true,
-
-  // Configure Session Replay
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1,
-  integrations: [Sentry.mobileReplayIntegration(), Sentry.feedbackIntegration()],
-
-  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-  // spotlight: __DEV__,
-});
 
 function ThemedStatusBar() {
   const { colorScheme } = require('./app/contexts/ThemeConfigContext').useThemeConfig();
@@ -69,7 +49,7 @@ function AppContent() {
   );
 }
 
-export default Sentry.wrap(function App() {
+export default function App() {
   return (
     <ErrorBoundary>
       <GestureHandlerRootView style={styles.container}>
@@ -101,7 +81,7 @@ export default Sentry.wrap(function App() {
       </GestureHandlerRootView>
     </ErrorBoundary>
   );
-});
+}
 
 const styles = StyleSheet.create({
   container: {

--- a/app.config.js
+++ b/app.config.js
@@ -49,14 +49,6 @@ module.exports = {
     plugins: [
       'expo-sqlite',
       [
-        '@sentry/react-native/expo',
-        {
-          url: 'https://sentry.io/',
-          project: 'penny',
-          organization: 'heywood8',
-        },
-      ],
-      [
         'expo-build-properties',
         {
           android: {

--- a/app/components/ErrorBoundary.js
+++ b/app/components/ErrorBoundary.js
@@ -15,7 +15,7 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, errorInfo) {
     console.error('Error Boundary caught an error:', error, errorInfo);
-    // In production, log to error tracking service (Sentry, Bugsnag, etc.)
+    // In production, you could log to an error tracking service
   }
 
   handleReset = () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     '<rootDir>/jest.setup.js',
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@sentry/react-native|@sentry/core|@sentry/types|@sentry/utils|drizzle-orm|drizzle-kit|decimal|invariant)|@unimodules|unimodules|sentry-expo|native-base|react-native-svg)/',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|drizzle-orm|drizzle-kit|decimal|invariant)|@unimodules|unimodules|native-base|react-native-svg)/',
   ],
   coverageReporters: [
     'json-summary',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -23,25 +23,6 @@ jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
 );
 
-// Mock Sentry to prevent open handle from AsyncExpiringMap timer
-jest.mock('@sentry/react-native', () => ({
-  init: jest.fn(),
-  wrap: jest.fn((component) => component),
-  ReactNativeProfiler: ({ children }) => children,
-  ReactNavigationInstrumentation: jest.fn(),
-  TouchEventBoundary: ({ children }) => children,
-  FeedbackWidgetProvider: ({ children }) => children,
-  withScope: jest.fn(),
-  captureException: jest.fn(),
-  captureMessage: jest.fn(),
-  setUser: jest.fn(),
-  setTag: jest.fn(),
-  setExtra: jest.fn(),
-  addBreadcrumb: jest.fn(),
-  mobileReplayIntegration: jest.fn(() => ({})),
-  feedbackIntegration: jest.fn(() => ({})),
-}));
-
 // Mock expo-sqlite with async methods
 jest.mock('expo-sqlite', () => ({
   openDatabaseAsync: jest.fn(() => Promise.resolve({
@@ -682,8 +663,6 @@ beforeAll(() => {
       'Check the render method',
       'React will try to recreate',
       'The above error occurred',
-      // Sentry-related messages
-      '@sentry',
     ];
     
     const shouldSuppress = suppressedPatterns.some(pattern => 

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,9 +1,6 @@
-const {
-  getSentryExpoConfig,
-} = require('@sentry/react-native/metro');
+const { getDefaultConfig } = require('expo/metro-config');
 
-
-const config = getSentryExpoConfig(__dirname);
+const config = getDefaultConfig(__dirname);
 
 // Add support for WASM files
 config.resolver.assetExts = config.resolver.assetExts || [];

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "8.6.0",
     "@react-native-picker/picker": "2.11.4",
-    "@sentry/react-native": "~7.8.0",
     "decimal.js": "^10.6.0",
     "drizzle-orm": "^1.0.0-beta.6-7aaf14b",
     "expo": "~54.0.30",

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -29,11 +29,6 @@
 -keep class org.sqlite.** { *; }
 -keep class org.sqlite.database.** { *; }
 
-# Sentry
--keepattributes LineNumberTable,SourceFile
--dontwarn org.slf4j.**
--dontwarn javax.**
-
 # Keep BuildConfig
 -keep class com.heywood8.monkeep.BuildConfig { *; }
 -keep class com.heywood8.monkeep.dev.BuildConfig { *; }


### PR DESCRIPTION
- Remove @sentry/react-native dependency from package.json
- Remove Sentry initialization and wrapper from App.js
- Remove Sentry Expo plugin from app.config.js
- Replace getSentryExpoConfig with getDefaultConfig in metro.config.js
- Remove Sentry mocks from jest.setup.js
- Remove Sentry packages from jest.config.js transformIgnorePatterns
- Remove Sentry ProGuard rules from proguard-rules.pro
- Update ErrorBoundary.js comment to remove Sentry reference

All tests passing (1638 tests).