### PR TITLE
fix: remove maxHeight constraint from language modal content

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -514,7 +514,6 @@ const styles = StyleSheet.create({
   languageModalContent: {
     borderRadius: 12,
     margin: 20,
-    maxHeight: '80%',
     padding: 0,
   },
   languageModalHeader: {


### PR DESCRIPTION
## Summary
Removed the `maxHeight: '80%'` style constraint from the language modal content container to allow for more flexible modal sizing.

## Changes
- Removed `maxHeight: '80%'` from `languageModalContent` style in SettingsModal.js

## Details
This change allows the language modal to expand beyond the previous 80% height limitation, providing better flexibility for displaying language options without artificial height restrictions. The modal will now size based on its content and other layout constraints rather than being capped at 80% of the viewport height.

https://claude.ai/code/session_011Vym4kuU8R8N6KiXSXTXdk