### PR TITLE
feat: add emulator screenshot workflow for pull requests

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -35,6 +35,12 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Expo prebuild (generate android project)
         run: bunx expo prebuild --platform android --clean
 
@@ -46,12 +52,12 @@ jobs:
       - name: Run emulator and capture screenshots
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          api-level: 31
           arch: x86_64
-          profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
+          emulator-boot-timeout: 300
           script: |
             # Build the debug APK (ANDROID_HOME is set by the emulator runner)
             ./android/gradlew -p android assembleDebug

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -57,7 +57,7 @@ jobs:
           api-level: 31
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 1440x3120
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 1080x1920
           disable-animations: true
           emulator-boot-timeout: 300
           script: |

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -56,9 +56,8 @@ jobs:
         with:
           api-level: 31
           arch: x86_64
-          profile: pixel_7_pro
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 1440x3120
           disable-animations: true
           emulator-boot-timeout: 300
           script: |

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -91,11 +91,11 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
-      - name: Post PR comment with screenshot link
+      - name: Build PR comment body
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@v7
+        id: set-screenshot-results
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
@@ -115,28 +115,12 @@ jobs:
               `**[Download screenshots from workflow artifacts](${runUrl}#artifacts)**`,
             ].join('\n');
 
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            core.setOutput('message', body);
 
-            const marker = '## App Screenshots';
-            const existing = comments.find(c => c.body?.startsWith(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+      - uses: marocchino/sticky-pull-request-comment@v2.9.4
+        if: github.event_name == 'pull_request' && always()
+        with:
+          header: "App Screenshots"
+          message: ${{ steps.set-screenshot-results.outputs.message }}
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -42,6 +42,8 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Expo prebuild (generate android project)
+        env:
+          APP_VARIANT: preview
         run: bunx expo prebuild --platform android --clean
 
       - name: Install Maestro
@@ -59,35 +61,22 @@ jobs:
           disable-animations: true
           emulator-boot-timeout: 300
           script: |
-            # Build the debug APK (ANDROID_HOME is set by the emulator runner)
-            ./android/gradlew -p android assembleDebug
+            # Build release APK with embedded JS bundle (ANDROID_HOME is set by the emulator runner)
+            APP_VARIANT=preview ./android/gradlew -p android assembleRelease
 
             # Install the APK
-            adb install android/app/build/outputs/apk/debug/app-debug.apk
+            adb install android/app/build/outputs/apk/release/app-release.apk
 
             # Launch the app
-            adb shell am start -n com.heywood8.monkeep.dev/.MainActivity
+            adb shell am start -n com.heywood8.monkeep/.MainActivity
 
             # Create output directory
             mkdir -p screenshots
 
-            # Wait for app to start and capture diagnostic info
-            sleep 15
-            echo "=== Device info ==="
-            adb shell getprop ro.build.version.sdk
-            echo "=== Running activities ==="
-            adb shell dumpsys activity activities | grep -E "mResumedActivity|topResumedActivity" || true
-            echo "=== Logcat (last 50 app lines) ==="
-            adb logcat -d -t 50 --pid=$(adb shell pidof com.heywood8.monkeep.dev) 2>/dev/null || true
-            echo "=== ADB screenshot before Maestro ==="
-            adb shell screencap -p /sdcard/debug_before_maestro.png
-            adb pull /sdcard/debug_before_maestro.png screenshots/debug_before_maestro.png || true
-
             # Run Maestro flow to navigate and take screenshots
-            # Maestro uses extendedWaitUntil to poll for app readiness
             maestro test .maestro/take-screenshots.yaml || true
 
-            # Capture Maestro debug artifacts
+            # Capture Maestro debug artifacts on failure
             cp -r ~/.maestro/tests/* screenshots/ 2>/dev/null || true
 
             # List captured screenshots

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -1,0 +1,137 @@
+name: Emulator Screenshots
+
+on:
+  pull_request:
+    branches: ['**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: screenshots-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    name: Capture App Screenshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Expo prebuild (generate android project)
+        run: npx expo prebuild --platform android --clean
+
+      - name: Build debug APK
+        working-directory: android
+        run: ./gradlew assembleDebug
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Run emulator and capture screenshots
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: |
+            # Install the APK
+            adb install android/app/build/outputs/apk/debug/app-debug.apk
+
+            # Launch the app
+            adb shell am start -n com.heywood8.monkeep.dev/.MainActivity
+
+            # Wait for app to fully load
+            sleep 10
+
+            # Create output directory
+            mkdir -p screenshots
+
+            # Run Maestro flow to navigate and take screenshots
+            maestro test .maestro/take-screenshots.yaml || true
+
+            # List captured screenshots
+            ls -la screenshots/ || echo "No screenshots directory found"
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-screenshots
+          path: screenshots/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Post PR comment with screenshot link
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              '## App Screenshots',
+              '',
+              'Emulator screenshots of the main app screens have been captured for this PR.',
+              '',
+              '| Screen | Description |',
+              '|--------|-------------|',
+              '| `01_operations` | Operations tab (default view) |',
+              '| `02_graphs` | Graphs tab |',
+              '| `03_accounts` | Accounts tab |',
+              '| `04_categories` | Categories tab |',
+              '',
+              `**[Download screenshots from workflow artifacts](${runUrl}#artifacts)**`,
+            ].join('\n');
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '## App Screenshots';
+            const existing = comments.find(c => c.body?.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   screenshots:
     name: Capture App Screenshots
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     steps:
       - name: Checkout code
@@ -36,10 +36,14 @@ jobs:
           java-version: 17
 
       - name: Expo prebuild (generate android project)
+        env:
+          APP_VARIANT: preview
         run: bunx expo prebuild --platform android --clean
 
       - name: Build debug APK
         working-directory: android
+        env:
+          APP_VARIANT: preview
         run: ./gradlew assembleDebug
 
       - name: Install Maestro
@@ -51,7 +55,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
-          arch: x86_64
+          arch: arm64-v8a
           profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
@@ -61,7 +65,7 @@ jobs:
             adb install android/app/build/outputs/apk/debug/app-debug.apk
 
             # Launch the app
-            adb shell am start -n com.heywood8.monkeep.dev/.MainActivity
+            adb shell am start -n com.heywood8.monkeep/.MainActivity
 
             # Wait for app to fully load
             sleep 10

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -35,6 +35,9 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
       - name: Expo prebuild (generate android project)
         env:
           APP_VARIANT: preview

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -68,13 +68,11 @@ jobs:
             # Launch the app
             adb shell am start -n com.heywood8.monkeep.dev/.MainActivity
 
-            # Wait for app to fully load
-            sleep 10
-
             # Create output directory
             mkdir -p screenshots
 
             # Run Maestro flow to navigate and take screenshots
+            # Maestro uses extendedWaitUntil to poll for app readiness
             maestro test .maestro/take-screenshots.yaml || true
 
             # List captured screenshots
@@ -104,6 +102,7 @@ jobs:
               '',
               '| Screen | Description |',
               '|--------|-------------|',
+              '| `00_language_selection` | First-launch language picker |',
               '| `01_operations` | Operations tab (default view) |',
               '| `02_graphs` | Graphs tab |',
               '| `03_accounts` | Accounts tab |',

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -35,19 +35,10 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-
       - name: Expo prebuild (generate android project)
         env:
           APP_VARIANT: preview
         run: bunx expo prebuild --platform android --clean
-
-      - name: Build debug APK
-        working-directory: android
-        env:
-          APP_VARIANT: preview
-        run: ./gradlew assembleDebug
 
       - name: Install Maestro
         run: |
@@ -64,6 +55,9 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
           script: |
+            # Build the debug APK (ANDROID_HOME is set by the emulator runner)
+            APP_VARIANT=preview ./android/gradlew -p android assembleDebug
+
             # Install the APK
             adb install android/app/build/outputs/apk/debug/app-debug.apk
 

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   screenshots:
     name: Capture App Screenshots
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Checkout code
@@ -36,8 +36,6 @@ jobs:
           java-version: 17
 
       - name: Expo prebuild (generate android project)
-        env:
-          APP_VARIANT: preview
         run: bunx expo prebuild --platform android --clean
 
       - name: Install Maestro
@@ -49,20 +47,20 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
-          arch: arm64-v8a
+          arch: x86_64
           profile: pixel_6
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
           script: |
             # Build the debug APK (ANDROID_HOME is set by the emulator runner)
-            APP_VARIANT=preview ./android/gradlew -p android assembleDebug
+            ./android/gradlew -p android assembleDebug
 
             # Install the APK
             adb install android/app/build/outputs/apk/debug/app-debug.apk
 
             # Launch the app
-            adb shell am start -n com.heywood8.monkeep/.MainActivity
+            adb shell am start -n com.heywood8.monkeep.dev/.MainActivity
 
             # Wait for app to fully load
             sleep 10

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -71,9 +71,24 @@ jobs:
             # Create output directory
             mkdir -p screenshots
 
+            # Wait for app to start and capture diagnostic info
+            sleep 15
+            echo "=== Device info ==="
+            adb shell getprop ro.build.version.sdk
+            echo "=== Running activities ==="
+            adb shell dumpsys activity activities | grep -E "mResumedActivity|topResumedActivity" || true
+            echo "=== Logcat (last 50 app lines) ==="
+            adb logcat -d -t 50 --pid=$(adb shell pidof com.heywood8.monkeep.dev) 2>/dev/null || true
+            echo "=== ADB screenshot before Maestro ==="
+            adb shell screencap -p /sdcard/debug_before_maestro.png
+            adb pull /sdcard/debug_before_maestro.png screenshots/debug_before_maestro.png || true
+
             # Run Maestro flow to navigate and take screenshots
             # Maestro uses extendedWaitUntil to poll for app readiness
             maestro test .maestro/take-screenshots.yaml || true
+
+            # Capture Maestro debug artifacts
+            cp -r ~/.maestro/tests/* screenshots/ 2>/dev/null || true
 
             # List captured screenshots
             ls -la screenshots/ || echo "No screenshots directory found"

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Expo prebuild (generate android project)
         env:
-          APP_VARIANT: preview
+          APP_VARIANT: production
         run: bunx expo prebuild --platform android --clean
 
       - name: Install Maestro
@@ -62,7 +62,7 @@ jobs:
           emulator-boot-timeout: 300
           script: |
             # Build release APK with embedded JS bundle (ANDROID_HOME is set by the emulator runner)
-            APP_VARIANT=preview ./android/gradlew -p android assembleRelease
+            APP_VARIANT=production ./android/gradlew -p android assembleRelease
 
             # Install the APK
             adb install android/app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -23,14 +23,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: npm
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: npm ci
+        run: bun install
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
@@ -39,7 +36,7 @@ jobs:
           java-version: 17
 
       - name: Expo prebuild (generate android project)
-        run: npx expo prebuild --platform android --clean
+        run: bunx expo prebuild --platform android --clean
 
       - name: Build debug APK
         working-directory: android

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           api-level: 31
           arch: x86_64
+          profile: pixel_7_pro
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -1,0 +1,36 @@
+appId: com.heywood8.monkeep.dev
+---
+# First launch: select English and continue
+- waitForAnimationToEnd:
+    timeout: 10000
+
+- assertVisible: "English"
+- tapOn: "English"
+- tapOn:
+    id: ".*continue.*"
+    optional: true
+- tapOn: "Continue"
+
+- waitForAnimationToEnd:
+    timeout: 5000
+
+# Screenshot 1: Operations screen (default first tab)
+- takeScreenshot: screenshots/01_operations
+
+# Navigate to Graphs tab
+- tapOn: "Graphs"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/02_graphs
+
+# Navigate to Accounts tab
+- tapOn: "Accounts"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/03_accounts
+
+# Navigate to Categories tab
+- tapOn: "Categories"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/04_categories

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -1,18 +1,21 @@
 appId: com.heywood8.monkeep.dev
 ---
-# First launch: select English and continue
-- waitForAnimationToEnd:
-    timeout: 10000
+# Wait for language selection screen to fully load
+- extendedWaitUntil:
+    visible: "Welcome to Penny"
+    timeout: 30000
 
-- assertVisible: "English"
+# Screenshot 0: Language selection screen
+- takeScreenshot: screenshots/00_language_selection
+
+# Select English and continue
 - tapOn: "English"
-- tapOn:
-    id: ".*continue.*"
-    optional: true
 - tapOn: "Continue"
 
-- waitForAnimationToEnd:
-    timeout: 5000
+# Wait for main app to load (Operations tab is the default)
+- extendedWaitUntil:
+    visible: "Operations"
+    timeout: 30000
 
 # Screenshot 1: Operations screen (default first tab)
 - takeScreenshot: screenshots/01_operations

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -1,4 +1,4 @@
-appId: com.heywood8.monkeep.dev
+appId: com.heywood8.monkeep
 ---
 # First launch: select English and continue
 - waitForAnimationToEnd:

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -1,4 +1,4 @@
-appId: com.heywood8.monkeep
+appId: com.heywood8.monkeep.dev
 ---
 # First launch: select English and continue
 - waitForAnimationToEnd:

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -1,4 +1,4 @@
-appId: com.heywood8.monkeep.dev
+appId: com.heywood8.monkeep
 ---
 # Wait for language selection screen to fully load
 - extendedWaitUntil:


### PR DESCRIPTION
Adds a GitHub Actions workflow that captures screenshots of all main
app screens on an Android emulator and posts a comment on the PR
linking to the artifacts. Uses Maestro for reliable UI navigation
through the language selection and all four tabs (Operations, Graphs,
Accounts, Categories).

https://claude.ai/code/session_019tsf4MsuJ2YV5ySJm7L9Ye