### PR TITLE
fix: store emulator screenshots in ci-screenshots branch with preview to post them as pictures to pull request 

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   actions: read
 
@@ -91,31 +91,101 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+      - name: Push screenshots to ci-screenshots branch
+        if: github.event_name == 'pull_request' && always()
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          SCREENSHOT_DIR="pr-${PR_NUMBER}"
+          BACKUP_DIR="/tmp/screenshots-backup"
+
+          # Check if any screenshots exist
+          if ! ls screenshots/*.png 1>/dev/null 2>&1; then
+            echo "No screenshot files found, skipping upload"
+            exit 0
+          fi
+
+          # Save screenshots outside the working tree (branch switches may clean it)
+          mkdir -p "$BACKUP_DIR"
+          cp screenshots/*.png "$BACKUP_DIR/"
+
+          # Configure git for the push
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create or switch to the ci-screenshots orphan branch
+          git fetch origin ci-screenshots 2>/dev/null || true
+          if git rev-parse --verify origin/ci-screenshots >/dev/null 2>&1; then
+            git checkout ci-screenshots
+          else
+            git checkout --orphan ci-screenshots
+            git rm -rf . 2>/dev/null || true
+            git clean -fd 2>/dev/null || true
+            git commit --allow-empty -m "Initialize ci-screenshots branch"
+          fi
+
+          # Copy screenshots into a PR-specific directory
+          mkdir -p "${SCREENSHOT_DIR}"
+          cp "$BACKUP_DIR"/*.png "${SCREENSHOT_DIR}/"
+
+          # Commit and push
+          git add "${SCREENSHOT_DIR}"
+          git commit -m "Update screenshots for PR #${PR_NUMBER}" || echo "No changes to commit"
+          git push origin ci-screenshots
+
+          # Switch back to the PR branch and restore screenshots
+          git checkout - 2>/dev/null || true
+          mkdir -p screenshots
+          cp "$BACKUP_DIR"/*.png screenshots/
+
       - name: Build PR comment body
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@v7
         id: set-screenshot-results
         with:
           script: |
+            const fs = require('fs');
+            const prNumber = context.payload.pull_request.number;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const rawBase = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/ci-screenshots/pr-${prNumber}`;
 
-            const body = [
+            const screens = [
+              { file: '00_language_selection', desc: 'First-launch language picker' },
+              { file: '01_operations', desc: 'Operations tab (default view)' },
+              { file: '02_graphs', desc: 'Graphs tab' },
+              { file: '03_accounts', desc: 'Accounts tab' },
+              { file: '04_categories', desc: 'Categories tab' },
+            ];
+
+            // Check which screenshots actually exist
+            const available = screens.filter(s =>
+              fs.existsSync(`screenshots/${s.file}.png`)
+            );
+
+            const lines = [
               '## App Screenshots',
               '',
-              'Emulator screenshots of the main app screens have been captured for this PR.',
-              '',
-              '| Screen | Description |',
-              '|--------|-------------|',
-              '| `00_language_selection` | First-launch language picker |',
-              '| `01_operations` | Operations tab (default view) |',
-              '| `02_graphs` | Graphs tab |',
-              '| `03_accounts` | Accounts tab |',
-              '| `04_categories` | Categories tab |',
-              '',
-              `**[Download screenshots from workflow artifacts](${runUrl}#artifacts)**`,
-            ].join('\n');
+            ];
 
-            core.setOutput('message', body);
+            if (available.length > 0) {
+              // Build a table with embedded images
+              lines.push(
+                '| Screen | Screenshot |',
+                '|--------|-----------|',
+              );
+              for (const s of available) {
+                const imgUrl = `${rawBase}/${s.file}.png`;
+                lines.push(`| **${s.desc}** | <img src="${imgUrl}" width="270" /> |`);
+              }
+            } else {
+              lines.push('> No screenshots were captured for this run.');
+            }
+
+            lines.push(
+              '',
+              `**[Download full-resolution screenshots from workflow artifacts](${runUrl}#artifacts)**`,
+            );
+
+            core.setOutput('message', lines.join('\n'));
 
       - uses: marocchino/sticky-pull-request-comment@v2.9.4
         if: github.event_name == 'pull_request' && always()


### PR DESCRIPTION
## Summary
This PR enhances the emulator screenshot workflow to persist screenshots across PR runs by storing them in a dedicated `ci-screenshots` branch, and displays embedded image previews directly in PR comments instead of just linking to artifacts.

## Key Changes
- **Elevated permissions**: Changed `contents` permission from `read` to `write` to enable pushing to the `ci-screenshots` branch
- **Screenshot persistence**: Added a new step that pushes captured screenshots to an orphan `ci-screenshots` branch organized by PR number (`pr-{number}/` directories)
- **Improved PR comments**: Updated the comment generation to:
  - Embed actual screenshot images in the PR comment using raw GitHub URLs
  - Display screenshots in a table format with descriptions
  - Show a fallback message if no screenshots were captured
  - Maintain a link to full-resolution artifacts for download
- **Robust git handling**: Implemented safe git operations including:
  - Backing up screenshots before branch switches to prevent data loss
  - Creating an orphan branch if `ci-screenshots` doesn't exist
  - Gracefully handling cases where no screenshots are found

## Implementation Details
- Screenshots are organized in the `ci-screenshots` branch under `pr-{PR_NUMBER}/` directories for easy tracking across multiple PRs
- The workflow uses `fs.existsSync()` to verify which screenshots actually exist before including them in the comment
- Images are embedded at 270px width for readable previews while keeping the comment compact
- The backup/restore mechanism ensures the workflow can safely switch branches without losing generated screenshots

https://claude.ai/code/session_01RkRhgLdSh8UdSg6uFndAnZ