### PR TITLE
fix: update emulator skin resolution for screenshot workflow

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -57,7 +57,7 @@ jobs:
           api-level: 31
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 1080x1920
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 640x1280
           disable-animations: true
           emulator-boot-timeout: 300
           script: |


### PR DESCRIPTION
## Summary
Updated the Android emulator skin resolution in the emulator-screenshots workflow from 1080x1920 to 640x1280.

## Changes
- Modified `emulator-options` in `.github/workflows/emulator-screenshots.yml` to use a smaller screen resolution (640x1280 instead of 1080x1920)

## Details
This change reduces the emulator's virtual screen dimensions, which can help with:
- Faster emulator startup and execution in CI/CD pipelines
- Reduced resource consumption during screenshot generation
- Potentially faster screenshot processing and artifact generation

The new 640x1280 resolution maintains a standard mobile aspect ratio while using a more lightweight configuration for automated testing environments.

https://claude.ai/code/session_01V6oD6dHUwd6Xiu3GVcq2TE