### PR TITLE
Optimize emulator screenshot build to target x86_64 architecture only

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -61,8 +61,8 @@ jobs:
           disable-animations: true
           emulator-boot-timeout: 300
           script: |
-            # Build release APK with embedded JS bundle (ANDROID_HOME is set by the emulator runner)
-            APP_VARIANT=production ./android/gradlew -p android assembleRelease
+            # Build release APK for x86_64 only (matches emulator arch, skips unnecessary ABIs)
+            APP_VARIANT=production ./android/gradlew -p android assembleRelease -PreactNativeArchitectures=x86_64
 
             # Install the APK
             adb install android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
## Summary
Optimized the Android emulator screenshot workflow to build the release APK for x86_64 architecture only, matching the emulator's native architecture and reducing build time by skipping unnecessary ABI builds.

## Changes
- Added `-PreactNativeArchitectures=x86_64` gradle flag to the release APK build command
- Updated the build comment to reflect that the build now targets x86_64 only instead of all architectures
- This optimization skips compilation for unused ABIs (armeabi-v7a, arm64-v8a, x86) during emulator testing

## Benefits
- Faster build times in CI/CD pipeline for emulator screenshot generation
- Reduced resource consumption during the build process
- No functional impact since the emulator runs on x86_64 architecture

https://claude.ai/code/session_017DJCzH4SHzQiDopu5Xe9Ut