### PR TITLE
fix: add modal overlay tap-to-close functionality to ChartModal

### DIFF
--- a/__tests__/components/graphs/ChartModal.test.js
+++ b/__tests__/components/graphs/ChartModal.test.js
@@ -389,4 +389,29 @@ describe('ChartModal', () => {
       expect(backButton.props.accessibilityHint).toBe('Returns to parent category level');
     });
   });
+
+  describe('Modal interaction', () => {
+    it('closes modal when tapping outside the modal content', () => {
+      const onClose = jest.fn();
+      const { getByTestId } = render(<ChartModal {...defaultProps} onClose={onClose} />);
+
+      // Find the modal overlay (TouchableWithoutFeedback)
+      const overlay = getByTestId('modal-overlay');
+      fireEvent.press(overlay);
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('does not close modal when tapping inside the modal content wrapper', () => {
+      const onClose = jest.fn();
+      const { getByTestId } = render(<ChartModal {...defaultProps} onClose={onClose} />);
+
+      // Find the inner TouchableWithoutFeedback (prevents bubbling)
+      const modalContentWrapper = getByTestId('modal-content-wrapper');
+      fireEvent.press(modalContentWrapper);
+
+      // Should not close because the inner TouchableWithoutFeedback prevents bubbling
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/graphs/ChartModal.js
+++ b/app/components/graphs/ChartModal.js
@@ -91,90 +91,90 @@ const ChartModal = ({
           <TouchableWithoutFeedback onPress={() => {}} testID="modal-content-wrapper">
             <View style={[styles.modalContent, { backgroundColor: colors.surface }]} {...panResponder.panHandlers}>
               <View style={styles.modalHeader}>
-            <View style={styles.modalHeaderLeft}>
-              {((modalType === 'expense' && selectedCategory !== 'all') ||
+                <View style={styles.modalHeaderLeft}>
+                  {((modalType === 'expense' && selectedCategory !== 'all') ||
                 (modalType === 'income' && selectedIncomeCategory !== 'all')) && (
+                    <TouchableOpacity
+                      onPress={handleBackToParent}
+                      style={styles.backButton}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('back') || 'Back to parent category'}
+                      accessibilityHint="Returns to parent category level"
+                    >
+                      <Icon name="arrow-left" size={24} color={colors.primary} />
+                    </TouchableOpacity>
+                  )}
+                  <Text style={[styles.modalTitle, { color: colors.text }]}>
+                    {modalType === 'expense' ? t('expenses_by_category') : t('income_by_category')}
+                  </Text>
+                </View>
                 <TouchableOpacity
-                  onPress={handleBackToParent}
-                  style={styles.backButton}
+                  onPress={onClose}
+                  style={styles.closeButton}
                   accessibilityRole="button"
-                  accessibilityLabel={t('back') || 'Back to parent category'}
-                  accessibilityHint="Returns to parent category level"
+                  accessibilityLabel={t('close')}
                 >
-                  <Icon name="arrow-left" size={24} color={colors.primary} />
+                  <Text style={[styles.closeButtonText, { color: colors.primary }]}>
+                    {t('close')}
+                  </Text>
                 </TouchableOpacity>
-              )}
-              <Text style={[styles.modalTitle, { color: colors.text }]}>
-                {modalType === 'expense' ? t('expenses_by_category') : t('income_by_category')}
-              </Text>
-            </View>
-            <TouchableOpacity
-              onPress={onClose}
-              style={styles.closeButton}
-              accessibilityRole="button"
-              accessibilityLabel={t('close')}
-            >
-              <Text style={[styles.closeButtonText, { color: colors.primary }]}>
-                {t('close')}
-              </Text>
-            </TouchableOpacity>
-          </View>
+              </View>
 
-          {modalType === 'expense' && (
-            <>
-              {/* Expense Category Picker - Only show when not viewing "All" */}
-              {selectedCategory !== 'all' && (
-                <View style={[styles.modalPickerWrapper, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                  <SimplePicker
-                    value={selectedCategory}
-                    onValueChange={onCategoryChange}
-                    items={categoryItems}
-                    colors={colors}
-                  />
-                </View>
-              )}
+              {modalType === 'expense' && (
+                <>
+                  {/* Expense Category Picker - Only show when not viewing "All" */}
+                  {selectedCategory !== 'all' && (
+                    <View style={[styles.modalPickerWrapper, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                      <SimplePicker
+                        value={selectedCategory}
+                        onValueChange={onCategoryChange}
+                        items={categoryItems}
+                        colors={colors}
+                      />
+                    </View>
+                  )}
 
-              <ScrollView style={styles.modalScrollView}>
-                <ExpensePieChart
-                  colors={colors}
-                  t={t}
-                  loading={loading}
-                  chartData={chartData}
-                  selectedCurrency={selectedCurrency}
-                  onLegendItemPress={onExpenseLegendItemPress}
-                  selectedCategory={selectedCategory}
-                />
-              </ScrollView>
-            </>
-          )}
-
-          {modalType === 'income' && (
-            <>
-              {/* Income Category Picker - Only show when not viewing "All" */}
-              {selectedIncomeCategory !== 'all' && (
-                <View style={[styles.modalPickerWrapper, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                  <SimplePicker
-                    value={selectedIncomeCategory}
-                    onValueChange={onIncomeCategoryChange}
-                    items={incomeCategoryItems}
-                    colors={colors}
-                  />
-                </View>
+                  <ScrollView style={styles.modalScrollView}>
+                    <ExpensePieChart
+                      colors={colors}
+                      t={t}
+                      loading={loading}
+                      chartData={chartData}
+                      selectedCurrency={selectedCurrency}
+                      onLegendItemPress={onExpenseLegendItemPress}
+                      selectedCategory={selectedCategory}
+                    />
+                  </ScrollView>
+                </>
               )}
 
-              <ScrollView style={styles.modalScrollView}>
-                <IncomePieChart
-                  colors={colors}
-                  t={t}
-                  loadingIncome={loadingIncome}
-                  incomeChartData={incomeChartData}
-                  selectedCurrency={selectedCurrency}
-                  onLegendItemPress={onIncomeLegendItemPress}
-                  selectedIncomeCategory={selectedIncomeCategory}
-                />
-              </ScrollView>
-            </>
-          )}
+              {modalType === 'income' && (
+                <>
+                  {/* Income Category Picker - Only show when not viewing "All" */}
+                  {selectedIncomeCategory !== 'all' && (
+                    <View style={[styles.modalPickerWrapper, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                      <SimplePicker
+                        value={selectedIncomeCategory}
+                        onValueChange={onIncomeCategoryChange}
+                        items={incomeCategoryItems}
+                        colors={colors}
+                      />
+                    </View>
+                  )}
+
+                  <ScrollView style={styles.modalScrollView}>
+                    <IncomePieChart
+                      colors={colors}
+                      t={t}
+                      loadingIncome={loadingIncome}
+                      incomeChartData={incomeChartData}
+                      selectedCurrency={selectedCurrency}
+                      onLegendItemPress={onIncomeLegendItemPress}
+                      selectedIncomeCategory={selectedIncomeCategory}
+                    />
+                  </ScrollView>
+                </>
+              )}
             </View>
           </TouchableWithoutFeedback>
         </View>

--- a/app/components/graphs/ChartModal.js
+++ b/app/components/graphs/ChartModal.js
@@ -1,5 +1,5 @@
 import React, { useRef, useCallback } from 'react';
-import { View, Text, StyleSheet, Modal, TouchableOpacity, ScrollView, PanResponder } from 'react-native';
+import { View, Text, StyleSheet, Modal, TouchableOpacity, TouchableWithoutFeedback, ScrollView, PanResponder } from 'react-native';
 import PropTypes from 'prop-types';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { HORIZONTAL_PADDING } from '../../styles/layout';
@@ -86,9 +86,11 @@ const ChartModal = ({
       transparent={true}
       onRequestClose={onClose}
     >
-      <View style={styles.modalOverlay}>
-        <View style={[styles.modalContent, { backgroundColor: colors.surface }]} {...panResponder.panHandlers}>
-          <View style={styles.modalHeader}>
+      <TouchableWithoutFeedback onPress={onClose} testID="modal-overlay">
+        <View style={styles.modalOverlay}>
+          <TouchableWithoutFeedback onPress={() => {}} testID="modal-content-wrapper">
+            <View style={[styles.modalContent, { backgroundColor: colors.surface }]} {...panResponder.panHandlers}>
+              <View style={styles.modalHeader}>
             <View style={styles.modalHeaderLeft}>
               {((modalType === 'expense' && selectedCategory !== 'all') ||
                 (modalType === 'income' && selectedIncomeCategory !== 'all')) && (
@@ -173,8 +175,10 @@ const ChartModal = ({
               </ScrollView>
             </>
           )}
+            </View>
+          </TouchableWithoutFeedback>
         </View>
-      </View>
+      </TouchableWithoutFeedback>
     </Modal>
   );
 };


### PR DESCRIPTION
## Summary
Added the ability to close the ChartModal by tapping outside the modal content area, while preventing accidental closes when tapping inside the modal itself.

## Key Changes
- Imported `TouchableWithoutFeedback` from React Native
- Wrapped the modal overlay with `TouchableWithoutFeedback` to detect taps outside the content and trigger `onClose`
- Added an inner `TouchableWithoutFeedback` wrapper around the modal content to prevent event bubbling and stop the overlay's close handler from firing when users interact with the modal content
- Added test IDs (`modal-overlay` and `modal-content-wrapper`) to enable testing of the interaction behavior
- Added comprehensive test cases to verify:
  - Modal closes when tapping the overlay
  - Modal remains open when tapping inside the content area

## Implementation Details
The solution uses nested `TouchableWithoutFeedback` components to create a layered touch handling system:
- Outer layer: Detects taps on the overlay background and closes the modal
- Inner layer: Consumes touch events on the modal content, preventing them from bubbling up to the outer layer

This pattern ensures a smooth user experience where users can dismiss the modal by tapping outside it, but won't accidentally close it while interacting with the modal content.

https://claude.ai/code/session_016i2LuTiyNFYjMAjFtSr5Tn