### PR TITLE
feat: add default operations on first app launch

### DIFF
--- a/app/defaults/defaultOperations.js
+++ b/app/defaults/defaultOperations.js
@@ -1,0 +1,59 @@
+/**
+ * Default operations for first app launch
+ * These provide sample data to demonstrate app functionality
+ *
+ * Note: accountId will be resolved dynamically during initialization
+ * since account IDs are auto-generated. The operations use the first
+ * visible account (typically "Ameria card" with AMD currency).
+ */
+
+/**
+ * Get default operations for app initialization
+ * @param {string} today - Today's date in YYYY-MM-DD format
+ * @param {number} accountId - ID of the account to use for operations
+ * @returns {Array} Array of operation objects
+ */
+const getDefaultOperations = (today, accountId) => [
+  {
+    type: 'income',
+    amount: '50000',
+    accountId: accountId,
+    categoryId: 'income-salary',
+    date: today,
+    description: 'Sample salary',
+  },
+  {
+    type: 'expense',
+    amount: '5000',
+    accountId: accountId,
+    categoryId: 'expense-food-groceries',
+    date: today,
+    description: 'Weekly groceries',
+  },
+  {
+    type: 'expense',
+    amount: '800',
+    accountId: accountId,
+    categoryId: 'expense-food-coffee-cafe',
+    date: today,
+    description: 'Morning coffee',
+  },
+  {
+    type: 'expense',
+    amount: '300',
+    accountId: accountId,
+    categoryId: 'expense-transportation-public-transport',
+    date: today,
+    description: 'Metro fare',
+  },
+  {
+    type: 'expense',
+    amount: '3500',
+    accountId: accountId,
+    categoryId: 'expense-food-restaurants',
+    date: today,
+    description: 'Dinner with friends',
+  },
+];
+
+export default getDefaultOperations;

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -59,15 +59,18 @@ const AppInitializer = () => {
     }
   };
 
-  // If showing language selection or initializing, don't show main app yet
+  // Show loading spinner while initializing (must check before isFirstLaunch
+  // because setFirstLaunchComplete sets isFirstLaunch=false mid-initialization)
+  if (isInitializing) {
+    return (
+      <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  // Show language selection on first launch
   if (isFirstLaunch) {
-    if (isInitializing) {
-      return (
-        <View style={[styles.loadingContainer, { backgroundColor: colors.background }]}>
-          <ActivityIndicator size="large" color={colors.primary} />
-        </View>
-      );
-    }
     return <LanguageSelectionScreen onLanguageSelected={handleLanguageSelected} />;
   }
 

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -7,6 +7,7 @@ import { useThemeColors } from '../contexts/ThemeColorsContext';
 import * as AccountsDB from '../services/AccountsDB';
 import * as OperationsDB from '../services/OperationsDB';
 import defaultAccounts from '../defaults/defaultAccounts';
+import { appEvents, EVENTS } from '../services/eventEmitter';
 
 /**
  * AppInitializer handles first-time setup and app initialization
@@ -46,6 +47,9 @@ const AppInitializer = () => {
       if (firstVisibleAccount) {
         await OperationsDB.initializeDefaultOperations(firstVisibleAccount.id);
       }
+
+      // Emit reload event to refresh all contexts with the new data
+      appEvents.emit(EVENTS.RELOAD_ALL);
 
       // Initialization complete, will automatically show main app
     } catch (error) {

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -4,6 +4,8 @@ import { useLocalization } from '../contexts/LocalizationContext';
 import LanguageSelectionScreen from './LanguageSelectionScreen';
 import SimpleTabs from '../navigation/SimpleTabs';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
+import * as AccountsDB from '../services/AccountsDB';
+import * as OperationsDB from '../services/OperationsDB';
 
 /**
  * AppInitializer handles first-time setup and app initialization
@@ -21,6 +23,14 @@ const AppInitializer = () => {
       // Set the language preference (this marks first launch as complete)
       // This will trigger CategoriesContext to automatically initialize categories
       await setFirstLaunchComplete(selectedLanguage);
+
+      // Initialize default operations for first launch
+      // Get the first visible account to use for sample operations
+      const accounts = await AccountsDB.getAllAccounts();
+      const firstVisibleAccount = accounts.find(acc => !acc.hidden);
+      if (firstVisibleAccount) {
+        await OperationsDB.initializeDefaultOperations(firstVisibleAccount.id);
+      }
 
       // Initialization complete, will automatically show main app
     } catch (error) {


### PR DESCRIPTION
Create 5 sample operations (1 income, 4 expenses) when the app is first
launched to demonstrate functionality. Operations use today's date and
the first visible account.

- Add defaultOperations.js with sample operations generator
- Add initializeDefaultOperations and getOperationsCount to OperationsDB
- Call operation initialization in AppInitializer after language selection

https://claude.ai/code/session_01DZGS6otfBsjSDqQpif4Mzh