### PR TITLE
fix: properly reload all screens after database reset

### DIFF
--- a/__tests__/contexts/OperationsContext.test.js
+++ b/__tests__/contexts/OperationsContext.test.js
@@ -748,10 +748,12 @@ describe('OperationsContext', () => {
         return jest.fn(); // Unsubscribe function
       });
 
-      OperationsDB.getOperationsByWeekOffset.mockResolvedValue([]);
-      OperationsDB.getAllOperations.mockResolvedValue([
-        { id: 1, type: 'expense', amount: '100', accountId: 'acc1' },
-      ]);
+      // Initially return empty, then return operation after RELOAD_ALL
+      OperationsDB.getOperationsByWeekOffset
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { id: 1, type: 'expense', amount: '100', accountId: 'acc1', date: '2024-01-15' },
+        ]);
 
       const { result } = renderHook(() => useOperations(), { wrapper });
 
@@ -761,7 +763,7 @@ describe('OperationsContext', () => {
 
       expect(appEvents.on).toHaveBeenCalledWith(EVENTS.RELOAD_ALL, expect.any(Function));
 
-      // Trigger the reload event
+      // Trigger the reload event - now uses loadInitialOperations which calls getOperationsByWeekOffset
       await act(async () => {
         reloadListener();
         await new Promise(resolve => setTimeout(resolve, 50));

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -243,11 +243,13 @@ export const OperationsActionsProvider = ({ children }) => {
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
       console.log('Reloading operations due to RELOAD_ALL event');
-      reloadOperations();
+      // Use loadInitialOperations to load the current week's operations
+      // instead of reloadOperations which loads ALL operations
+      loadInitialOperations();
     });
 
     return unsubscribe;
-  }, [reloadOperations]);
+  }, [loadInitialOperations]);
 
   const addOperation = useCallback(async (operation) => {
     try {

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -1,6 +1,5 @@
-import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import * as OperationsDB from '../services/OperationsDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { getJsonPreference, PREF_KEYS } from '../services/PreferencesDB';
 
@@ -76,6 +75,22 @@ export const OperationsDataProvider = ({ children }) => {
     };
     loadFilters();
   }, [hasActiveFilters]);
+
+  // Listen for DATABASE_RESET event to clear operations state
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, () => {
+      console.log('OperationsDataContext: Database reset detected, clearing operations');
+      setOperations([]);
+      setDataLoaded(false);
+      setOldestLoadedDate(null);
+      setNewestLoadedDate(null);
+      setHasMoreOperations(true);
+      setHasNewerOperations(false);
+      setSaveError(null);
+    });
+
+    return unsubscribe;
+  }, []);
 
   const value = useMemo(() => ({
     // Public data

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -328,6 +328,7 @@ export const getDatabaseVersion = async () => {
 export const dropAllTables = async () => {
   try {
     let raw;
+    let openedNewConnection = false;
 
     // Try to get existing database connection, or open a new one
     try {
@@ -336,6 +337,7 @@ export const dropAllTables = async () => {
       } else {
         console.log('Opening database for table drop...');
         raw = await SQLite.openDatabaseAsync(DB_NAME);
+        openedNewConnection = true;
       }
     } catch (openError) {
       console.error('Failed to open database for dropping tables:', openError);
@@ -362,6 +364,15 @@ export const dropAllTables = async () => {
     await raw.runAsync('PRAGMA foreign_keys = ON');
 
     console.log('All tables dropped successfully');
+
+    // Close the database connection properly before resetting instances
+    // This ensures the native connection is released
+    try {
+      await raw.closeAsync();
+      console.log('Database connection closed after dropping tables');
+    } catch (closeError) {
+      console.error('Error closing database after dropping tables:', closeError);
+    }
 
     // Reset the instances to null so it reinitializes on next getDatabase call
     dbInstance = null;

--- a/app/utils/resetDatabase.js
+++ b/app/utils/resetDatabase.js
@@ -5,7 +5,7 @@
  * Useful for development and fixing database migration issues.
  */
 
-import { dropAllTables, getDatabase } from '../services/db';
+import { dropAllTables, getDatabase, closeDatabase } from '../services/db';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 
 /**
@@ -17,6 +17,10 @@ import { appEvents, EVENTS } from '../services/eventEmitter';
 export const resetDatabase = async () => {
   try {
     console.log('Starting database reset...');
+
+    // Close existing database connection first to ensure clean state
+    await closeDatabase();
+    console.log('Existing database connection closed');
 
     // Drop all tables
     await dropAllTables();


### PR DESCRIPTION
- Close database connection properly in dropAllTables() to prevent NullPointerException when contexts try to query after reset
- Add closeDatabase() call before dropping tables in resetDatabase utility
- Add DATABASE_RESET and RELOAD_ALL event listeners to:
  - OperationsDataContext: clear operations state on reset
  - AccountsDataContext: clear and reload accounts
  - GraphsScreen: clear and reload categories and available months
- Change OperationsActionsContext RELOAD_ALL handler to use loadInitialOperations() for better performance
- Update tests to account for new event listener behavior