### PR TITLE
Add modal screenshot capture for light and dark themes

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -159,6 +159,13 @@ jobs:
               { file: '04_categories', desc: 'Categories' },
             ];
 
+            // Modal screens with light/dark variants
+            const modalScreens = [
+              { file: '05_settings_modal', desc: 'Settings' },
+              { file: '06_add_account_modal', desc: 'Add Account' },
+              { file: '07_add_category_modal', desc: 'Add Category' },
+            ];
+
             const lines = [
               '## App Screenshots',
               '',
@@ -172,7 +179,12 @@ jobs:
               fs.existsSync(`screenshots/${s.file}_light.png`) || fs.existsSync(`screenshots/${s.file}_dark.png`)
             );
 
-            if (hasWelcome || availableThemed.length > 0) {
+            // Check which modal screenshots exist
+            const availableModals = modalScreens.filter(s =>
+              fs.existsSync(`screenshots/${s.file}_light.png`) || fs.existsSync(`screenshots/${s.file}_dark.png`)
+            );
+
+            if (hasWelcome || availableThemed.length > 0 || availableModals.length > 0) {
               // Welcome screen section (single image, no light/dark)
               if (hasWelcome) {
                 const welcomeUrl = `${rawBase}/${welcomeScreen.file}.png`;
@@ -193,6 +205,26 @@ jobs:
                   '|--------|-------|------|',
                 );
                 for (const s of availableThemed) {
+                  const lightUrl = `${rawBase}/${s.file}_light.png`;
+                  const darkUrl = `${rawBase}/${s.file}_dark.png`;
+                  const hasLight = fs.existsSync(`screenshots/${s.file}_light.png`);
+                  const hasDark = fs.existsSync(`screenshots/${s.file}_dark.png`);
+                  const lightImg = hasLight ? `<img src="${lightUrl}" width="200" />` : '—';
+                  const darkImg = hasDark ? `<img src="${darkUrl}" width="200" />` : '—';
+                  lines.push(`| **${s.desc}** | ${lightImg} | ${darkImg} |`);
+                }
+              }
+
+              // Modal screens section
+              if (availableModals.length > 0) {
+                lines.push(
+                  '',
+                  '### Modals',
+                  '',
+                  '| Modal | Light | Dark |',
+                  '|-------|-------|------|',
+                );
+                for (const s of availableModals) {
                   const lightUrl = `${rawBase}/${s.file}_light.png`;
                   const darkUrl = `${rawBase}/${s.file}_dark.png`;
                   const hasLight = fs.existsSync(`screenshots/${s.file}_light.png`);

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -43,6 +43,50 @@ appId: com.heywood8.monkeep
 - takeScreenshot: screenshots/04_categories_light
 
 # ============================================
+# LIGHT MODE MODAL SCREENSHOTS
+# ============================================
+
+# Settings modal: tap the settings button in the header
+- tapOn:
+    id: "settings-button"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/05_settings_modal_light
+
+# Close settings modal
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Add Account modal: navigate to Accounts tab, tap the FAB
+- tapOn: "Accounts"
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn: "Add Account"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/06_add_account_modal_light
+
+# Close add account modal
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Add Category modal: navigate to Categories tab, tap the FAB
+- tapOn: "Categories"
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn: "Add Category"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/07_add_category_modal_light
+
+# Close add category modal
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# ============================================
 # SWITCH TO DARK MODE
 # ============================================
 
@@ -87,3 +131,47 @@ appId: com.heywood8.monkeep
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/04_categories_dark
+
+# ============================================
+# DARK MODE MODAL SCREENSHOTS
+# ============================================
+
+# Settings modal
+- tapOn:
+    id: "settings-button"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/05_settings_modal_dark
+
+# Close settings modal
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Add Account modal
+- tapOn: "Accounts"
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn: "Add Account"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/06_add_account_modal_dark
+
+# Close add account modal
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Add Category modal
+- tapOn: "Categories"
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn: "Add Category"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/07_add_category_modal_dark
+
+# Close add category modal
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 2000


### PR DESCRIPTION
## Summary
This PR adds automated screenshot capture for modal dialogs (Settings, Add Account, and Add Category) in both light and dark themes, and updates the screenshot documentation generation to include these new modal screenshots.

## Key Changes
- **Screenshot Capture**: Added Maestro test steps to capture three modal dialogs in both light and dark modes:
  - Settings modal (05_settings_modal)
  - Add Account modal (06_add_account_modal)
  - Add Category modal (07_add_category_modal)

- **Documentation Generation**: Updated the GitHub Actions workflow to:
  - Define a new `modalScreens` array with modal metadata
  - Filter available modal screenshots from the file system
  - Generate a new "Modals" section in the screenshot documentation with a light/dark comparison table
  - Include modals in the condition check for whether to generate documentation

## Implementation Details
- Modal screenshots follow the same naming convention as existing themed screenshots (`{name}_light.png` and `{name}_dark.png`)
- Each modal is properly closed after capture using the "Cancel" button to maintain test flow
- Animation timeouts are included to ensure modals are fully rendered before capture
- The documentation table displays modal screenshots side-by-side with light and dark variants, using "—" for missing variants
- Modal screenshots are displayed at 200px width to match existing screenshot styling

https://claude.ai/code/session_01KsahSDe453JJvPCHnaQoui