### PR TITLE
chore: switch emulator to Pixel 7 Pro with reduced hardware

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -54,10 +54,14 @@ jobs:
       - name: Run emulator and capture screenshots
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 31
+          api-level: 34
           arch: x86_64
+          profile: pixel_7_pro
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -skin 640x1280
+          ram-size: 2048
+          heap-size: 512
+          disk-size: 4096M
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -cores 2 -memory 2048
           disable-animations: true
           emulator-boot-timeout: 300
           script: |

--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -61,12 +61,15 @@ jobs:
           ram-size: 2048
           heap-size: 512
           disk-size: 4096M
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -cores 2 -memory 2048
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -cores 2 -memory 2048 -skin 1080x2340
           disable-animations: true
           emulator-boot-timeout: 300
           script: |
             # Build release APK for x86_64 only (matches emulator arch, skips unnecessary ABIs)
             APP_VARIANT=production ./android/gradlew -p android assembleRelease -PreactNativeArchitectures=x86_64
+
+            # Enable gesture navigation (disables legacy 3-button nav bar)
+            adb shell cmd overlay enable com.android.internal.systemui.navbar.gestural
 
             # Install the APK
             adb install android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
## Summary
- Switch screenshot emulator from generic skin (640x1280) to **Pixel 7 Pro** AVD profile on API 34
- Set explicit resolution to **1080x2340**
- Enable **gesture navigation** (disables legacy 3-button nav bar)
- Reduce hardware settings for CI: 2GB RAM, 512MB heap, 4GB disk, 2 CPU cores

## Test plan
- [x] Verify the emulator screenshots workflow runs successfully
- [x] Confirm screenshots are captured at 1080x2340 resolution
- [x] Confirm legacy navigation buttons are not visible in screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)