### PR TITLE
feat: rework QuickAdd transfer layout with target account shortcuts

### DIFF
--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -24,23 +24,8 @@ appId: com.heywood8.monkeep
 # Screenshot 1: Operations screen (default first tab)
 - takeScreenshot: screenshots/01_operations_light
 
-# Screenshot 1b: Multi-currency transfer
+# Screenshot 1b: Transfer mode of QuickAdd (shows target account shortcuts below calculator)
 - tapOn: "Transfer"
-- waitForAnimationToEnd:
-    timeout: 2000
-# Tap destination account picker (right-side picker shows "To Account")
-- tapOn:
-    id: "to-account-picker"
-- waitForAnimationToEnd:
-    timeout: 2000
-- tapOn: "EUR Cash"
-- waitForAnimationToEnd:
-    timeout: 2000
-# Type amount on calculator using testID selectors
-- tapOn:
-    id: "calc-btn-1"
-- tapOn:
-    id: "calc-btn-2"
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/05_transfer_light
@@ -85,21 +70,8 @@ appId: com.heywood8.monkeep
     timeout: 3000
 - takeScreenshot: screenshots/01_operations_dark
 
-# Screenshot 5 dark: Multi-currency transfer
+# Screenshot 5 dark: Transfer mode of QuickAdd
 - tapOn: "Transfer"
-- waitForAnimationToEnd:
-    timeout: 2000
-- tapOn:
-    id: "to-account-picker"
-- waitForAnimationToEnd:
-    timeout: 2000
-- tapOn: "EUR Cash"
-- waitForAnimationToEnd:
-    timeout: 2000
-- tapOn:
-    id: "calc-btn-1"
-- tapOn:
-    id: "calc-btn-2"
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/05_transfer_dark

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -29,6 +29,21 @@ appId: com.heywood8.monkeep
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/05_transfer_light
+
+# Screenshot 1c: Multi-currency transfer (select different-currency account, enter amount)
+- tapOn: "All accounts"
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn: "EUR Cash"
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn:
+    id: "calc-btn-1"
+- tapOn:
+    id: "calc-btn-2"
+- waitForAnimationToEnd:
+    timeout: 2000
+- takeScreenshot: screenshots/06_multicurrency_transfer_light
 # Switch back to expense type for the rest of the flow
 - tapOn: "Expense"
 - waitForAnimationToEnd:
@@ -75,6 +90,21 @@ appId: com.heywood8.monkeep
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/05_transfer_dark
+
+# Screenshot 6 dark: Multi-currency transfer
+- tapOn: "All accounts"
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn: "EUR Cash"
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn:
+    id: "calc-btn-1"
+- tapOn:
+    id: "calc-btn-2"
+- waitForAnimationToEnd:
+    timeout: 2000
+- takeScreenshot: screenshots/06_multicurrency_transfer_dark
 - tapOn: "Expense"
 - waitForAnimationToEnd:
     timeout: 2000

--- a/app/components/operations/QuickAddForm.js
+++ b/app/components/operations/QuickAddForm.js
@@ -35,6 +35,8 @@ const QuickAddForm = memo(({
   handleExchangeRateChange,
   handleDestinationAmountChange,
   onAutoAddWithCategory,
+  topTransferAccounts,
+  onAutoAddWithAccount,
   TYPES,
   rateSource,
 }) => {
@@ -77,6 +79,8 @@ const QuickAddForm = memo(({
           onExchangeRateChange={handleExchangeRateChange}
           onDestinationAmountChange={handleDestinationAmountChange}
           onAutoAddWithCategory={onAutoAddWithCategory}
+          topTransferAccounts={topTransferAccounts}
+          onAutoAddWithAccount={onAutoAddWithAccount}
           rateSource={rateSource}
         />
       </View>
@@ -104,6 +108,8 @@ QuickAddForm.propTypes = {
   handleExchangeRateChange: PropTypes.func.isRequired,
   handleDestinationAmountChange: PropTypes.func.isRequired,
   onAutoAddWithCategory: PropTypes.func,
+  topTransferAccounts: PropTypes.array,
+  onAutoAddWithAccount: PropTypes.func,
   TYPES: PropTypes.array.isRequired,
   rateSource: PropTypes.oneOf(['loading', 'live', 'offline']),
 };

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -77,6 +77,7 @@ const OperationsScreen = () => {
     getCategoryName,
     filteredCategories,
     topCategoriesForType,
+    topTransferAccountsForForm,
     resetForm,
   } = useQuickAddForm(visibleAccounts, accounts, categories, t);
 
@@ -303,7 +304,7 @@ const OperationsScreen = () => {
   }, [groupedOperations, jumpToDate]);
 
   // Quick add handlers
-  const handleQuickAdd = useCallback(async (overrideCategoryId) => {
+  const handleQuickAdd = useCallback(async (overrideCategoryId, overrideToAccountId) => {
     // Automatically evaluate any pending math operation before saving
     let finalAmount = quickAddValues.amount;
 
@@ -319,6 +320,8 @@ const OperationsScreen = () => {
       amount: finalAmount, // Use the evaluated amount
       // Use override categoryId if provided (for auto-add from category selection)
       categoryId: overrideCategoryId !== undefined ? overrideCategoryId : quickAddValues.categoryId,
+      // Use override toAccountId if provided (for auto-add from transfer target shortcuts)
+      toAccountId: overrideToAccountId !== undefined ? overrideToAccountId : quickAddValues.toAccountId,
       date: toDateString(new Date()),
     };
 
@@ -368,6 +371,14 @@ const OperationsScreen = () => {
     // Pass the selected categoryId directly to avoid race conditions
     await handleQuickAdd(categoryId);
   }, [resetForm, closePicker, handleQuickAdd]);
+
+  // Handler for auto-add with target account (from transfer target shortcuts)
+  const handleAutoAddWithAccount = useCallback(async (toAccountId) => {
+    resetForm();
+
+    // Pass undefined for categoryId override, pass toAccountId override
+    await handleQuickAdd(undefined, toAccountId);
+  }, [resetForm, handleQuickAdd]);
 
   // Calculate spending sums by currency for a group of operations
   const calculateSpendingSums = useCallback((operations) => {
@@ -517,10 +528,12 @@ const OperationsScreen = () => {
       handleExchangeRateChange={handleExchangeRateChange}
       handleDestinationAmountChange={handleDestinationAmountChange}
       onAutoAddWithCategory={handleAutoAddWithCategory}
+      topTransferAccounts={topTransferAccountsForForm}
+      onAutoAddWithAccount={handleAutoAddWithAccount}
       TYPES={TYPES}
       rateSource={rateSource}
     />
-  ), [colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, TYPES, rateSource]);
+  ), [colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource]);
 
   // Handle scroll event to show/hide scroll-to-top button
   const handleScroll = useCallback((event) => {

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -315,5 +315,6 @@
   "end": "Ende",
   "daily_avg": "Täglicher Ø",
   "tap_for_details": "Tippen für Details",
-  "all_categories": "Alle Kategorien"
+  "all_categories": "Alle Kategorien",
+  "all_accounts": "Alle Konten"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -315,5 +315,6 @@
   "end": "End",
   "daily_avg": "Daily Avg",
   "tap_for_details": "Tap for details",
-  "all_categories": "All categories"
+  "all_categories": "All categories",
+  "all_accounts": "All accounts"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -315,5 +315,6 @@
   "end": "Fin",
   "daily_avg": "Prom. diario",
   "tap_for_details": "Toca para detalles",
-  "all_categories": "Todas las categorías"
+  "all_categories": "Todas las categorías",
+  "all_accounts": "Todas las cuentas"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -315,5 +315,6 @@
   "end": "Fin",
   "daily_avg": "Moy. quotid.",
   "tap_for_details": "Appuyez pour les détails",
-  "all_categories": "Toutes les catégories"
+  "all_categories": "Toutes les catégories",
+  "all_accounts": "Tous les comptes"
 }

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -311,5 +311,6 @@
   "daily_avg": "Օրական միջին",
   "tap_for_details": "Սեղմեք մանրամասների համար",
   "all_categories": "Բոլոր կատեգորիաները",
-  "manual_rate_info": "Ձեռակի փոխարժեք"
+  "manual_rate_info": "Ձեռակի փոխարժեք",
+  "all_accounts": "Բոլոր հաշվեր"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -74,5 +74,6 @@
   "end": "Fine",
   "daily_avg": "Media giorn.",
   "tap_for_details": "Tocca per i dettagli",
-  "all_categories": "Tutte le categorie"
+  "all_categories": "Tutte le categorie",
+  "all_accounts": "Tutti i conti"
 }

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -313,5 +313,6 @@
   "end": "Конец",
   "daily_avg": "Дн. средн.",
   "tap_for_details": "Нажмите для деталей",
-  "all_categories": "Все категории"
+  "all_categories": "Все категории",
+  "all_accounts": "Все счета"
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -315,5 +315,6 @@
   "end": "期末",
   "daily_avg": "日均",
   "tap_for_details": "点击查看详情",
-  "all_categories": "所有类别"
+  "all_categories": "所有类别",
+  "all_accounts": "所有账户"
 }


### PR DESCRIPTION
## Summary
- Move transfer target account picker below calculator in QuickAdd, mirroring the category shortcut pattern
- Add `getTopTransferTargetAccounts()` DB query for top 3 most-used transfer destinations (last 90 days)
- Target account shortcuts show account name + balance, with auto-submit when amount is entered
- Falls back to visible accounts when no transfer history exists

## Test plan
- [x] `npm test -- --silent` passes (2720 tests, 0 failures)
- [ ] Select transfer type in QuickAdd — source account alone above calculator, target shortcuts below
- [ ] Tap a target shortcut with amount entered — auto-submits the transfer
- [ ] Tap a target shortcut without amount — highlights/selects it
- [ ] Tap "All accounts" button — opens full account picker
- [ ] Verify expense/income layout is unchanged
- [ ] Verify OperationModal stacked transfer layout is unchanged