### PR TITLE
refactor: modernize settings modal UX

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -165,6 +165,7 @@ jobs:
               { file: '02_graphs', desc: 'Graphs' },
               { file: '03_accounts', desc: 'Accounts' },
               { file: '04_categories', desc: 'Categories' },
+              { file: '07_settings', desc: 'Settings' },
             ];
 
             const lines = [

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -67,6 +67,19 @@ appId: com.heywood8.monkeep
     timeout: 3000
 - takeScreenshot: screenshots/04_categories_light
 
+# Open Settings modal
+- tapOn:
+    id: "settings-button"
+- waitForAnimationToEnd:
+    timeout: 2000
+- takeScreenshot: screenshots/07_settings_light
+
+# Close Settings modal
+- tapOn:
+    id: "settings-close-button"
+- waitForAnimationToEnd:
+    timeout: 2000
+
 # ============================================
 # SWITCH TO DARK MODE
 # ============================================
@@ -136,3 +149,16 @@ appId: com.heywood8.monkeep
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/04_categories_dark
+
+# Open Settings modal
+- tapOn:
+    id: "settings-button"
+- waitForAnimationToEnd:
+    timeout: 2000
+- takeScreenshot: screenshots/07_settings_dark
+
+# Close Settings modal
+- tapOn:
+    id: "settings-close-button"
+- waitForAnimationToEnd:
+    timeout: 2000

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -249,7 +249,7 @@ export default function SettingsModal({ visible, onClose }) {
           <View style={styles.header}>
             <View style={styles.closeButton} />
             <Text variant="titleLarge" style={[styles.headerTitle, { color: colors.text }]}>{t('settings')}</Text>
-            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+            <TouchableOpacity onPress={onClose} style={styles.closeButton} testID="settings-close-button">
               <Ionicons name="close" size={24} color={colors.mutedText} />
             </TouchableOpacity>
           </View>


### PR DESCRIPTION
## Summary

- Replace save/cancel footer with a centered title + close (X) button header — language changes now apply immediately on selection
- Replace cramped horizontal button row (Export/Import/Reset) with vertical TouchableRipple list rows with icons
- Replace bordered dropdown-style language selector with a simple tappable settings row showing current language as a subtitle
- Add settings modal (light/dark) to emulator screenshot workflow

## Test plan

- [ ] Open settings modal — verify title is centered with X close button
- [ ] Tap language row — verify language subpage opens, selecting a language applies it immediately
- [ ] Tap export row — verify export format picker opens
- [ ] Tap import row — verify confirmation dialog appears
- [ ] Tap reset row (red text) — verify confirmation dialog appears
- [ ] Verify light and dark mode both render correctly
- [ ] All 2716 tests passing