### PR TITLE
refactor: compact account picker with icon and balance

### DIFF
--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -168,25 +168,15 @@ const OperationFormFields = memo(({
       {showFieldIcons && (
         <Icon name={iconName} size={18} color={disabled ? colors.mutedText : colors.mutedText} />
       )}
-      {showFieldIcons || showAccountBalance ? (
-        <View style={styles.flex1}>
-          <Text
-            style={[styles.formInputText, { color: disabled ? colors.mutedText : colors.text }]}
-            numberOfLines={1}
-          >
-            {accountId ? getAccountName(accountId) : label}
-          </Text>
-          {showAccountBalance && accountId && (
-            <Text style={[styles.accountBalanceText, { color: colors.mutedText }]} numberOfLines={1}>
-              {getAccountBalance(accountId)}
-            </Text>
-          )}
-        </View>
-      ) : (
-        <Text
-          style={[styles.formInputText, { color: disabled ? colors.mutedText : colors.text }]}
-        >
-          {accountId ? getAccountName(accountId) : label}
+      <Text
+        style={[styles.formInputText, showAccountBalance && styles.flex1, { color: disabled ? colors.mutedText : colors.text }]}
+        numberOfLines={1}
+      >
+        {accountId ? getAccountName(accountId) : label}
+      </Text>
+      {showAccountBalance && accountId && (
+        <Text style={[styles.accountBalanceText, { color: colors.mutedText }]} numberOfLines={1}>
+          {getAccountBalance(accountId)}
         </Text>
       )}
     </Pressable>
@@ -501,7 +491,6 @@ OperationFormFields.propTypes = {
 const styles = StyleSheet.create({
   accountBalanceText: {
     fontSize: 12,
-    marginTop: 2,
   },
   categoryButtonsContainer: {
     flexDirection: 'row',
@@ -559,8 +548,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: SPACING.sm,
     marginBottom: SPACING.md,
-    minHeight: 48,
-    padding: SPACING.md,
+    minHeight: 44,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.sm,
   },
   formInputText: {
     fontSize: 14,

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -5,6 +5,13 @@ import { getLastAccessedAccount, setLastAccessedAccount } from '../services/Last
 import { getCategoryDisplayName } from '../utils/categoryUtils';
 import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
 import * as Currency from '../services/currency';
+import currencies from '../../assets/currencies.json';
+
+const getCurrencySymbol = (currencyCode) => {
+  if (!currencyCode) return '';
+  const currency = currencies[currencyCode];
+  return currency ? currency.symbol : currencyCode;
+};
 
 /**
  * Custom hook for managing operation modal form state and logic
@@ -366,6 +373,14 @@ const useOperationForm = ({
     return account ? account.name : t('select_account');
   }, [accounts, t]);
 
+  // Helper: Get account balance with currency symbol
+  const getAccountBalance = useCallback((accountId) => {
+    const account = accounts.find(acc => acc.id === accountId);
+    if (!account) return '';
+    const symbol = getCurrencySymbol(account.currency);
+    return `${symbol}${Currency.formatAmount(account.balance, account.currency)}`;
+  }, [accounts]);
+
   // Helper: Get category name for display
   const getCategoryName = useCallback((categoryId) => {
     if (!categoryId) return t('select_category');
@@ -478,6 +493,7 @@ const useOperationForm = ({
 
     // Helpers
     getAccountName,
+    getAccountBalance,
     getCategoryName,
     formatDateForDisplay,
     validateFields,

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -89,6 +89,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     handleDelete,
     handleSplit,
     getAccountName,
+    getAccountBalance,
     getCategoryName,
     formatDateForDisplay,
   } = useOperationForm({
@@ -352,13 +353,14 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
                     accounts={accounts}
                     categories={filteredCategories}
                     getAccountName={getAccountName}
+                    getAccountBalance={getAccountBalance}
                     getCategoryName={getCategoryName}
                     openPicker={openPicker}
                     onAmountChange={handleAmountChange}
                     TYPES={TYPES}
                     showTypeSelector={true}
-                    showAccountBalance={false}
-                    showFieldIcons={false}
+                    showAccountBalance={true}
+                    showFieldIcons={true}
                     transferLayout="sideBySide"
                     disabled={isShadowOperation}
                     containerBackground={colors.card}

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -270,8 +270,8 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
           ]}
         >
           <View style={styles.accountOption}>
-            <Text style={[styles.pickerOptionText, { color: colors.text }]}>{item.name}</Text>
-            <Text style={[styles.pickerOptionCurrency, { color: colors.mutedText }]}>
+            <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
+            <Text style={[styles.pickerOptionCurrency, { color: colors.mutedText }]} numberOfLines={1}>
               {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
             </Text>
           </View>
@@ -564,6 +564,10 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
 }
 
 const styles = StyleSheet.create({
+  accountName: {
+    flex: 1,
+    marginRight: SPACING.sm,
+  },
   accountOption: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -718,9 +722,9 @@ const styles = StyleSheet.create({
   pickerOption: {
     borderBottomWidth: 1,
     justifyContent: 'center',
-    minHeight: 48,
+    minHeight: 44,
     paddingHorizontal: 8,
-    paddingVertical: 12,
+    paddingVertical: 8,
   },
   pickerOptionCurrency: {
     fontSize: 14,


### PR DESCRIPTION
## Summary
- Compact account picker rows: single-line layout with name left, balance right, reduced height (48→44px)
- Unified account picker across OperationModal and QuickAddForm — both now show wallet icon, account name, and balance via shared `OperationFormFields` with the same flags
- Added `getAccountBalance` helper to `useOperationForm` hook

## Test plan
- [x] All 2716 tests pass
- [ ] Verify QuickAddForm account picker shows icon + name + balance in one line
- [ ] Verify OperationModal account picker shows icon + name + balance in one line
- [ ] Verify long account names truncate with ellipsis
- [ ] Verify transfer mode source/destination pickers both render correctly