### PR TITLE
Remove dev build profile conditioning, always build as Penny

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,22 +1,10 @@
-// Determine if this is a development build:
-// - Local dev: no APP_VARIANT set → use 'PennyDev'
-// - EAS development profile: APP_VARIANT === 'development' → use 'PennyDev'
-// - EAS preview/production: APP_VARIANT === 'preview'/'production' → use 'Penny'
-const IS_DEV = !process.env.APP_VARIANT || process.env.APP_VARIANT === 'development';
-
-// App name: PennyDev for local dev/development, Penny for preview/production
-const APP_NAME = IS_DEV ? 'PennyDev' : 'Penny';
-
-// Package name: .dev suffix for local dev/development, clean for preview/production
-const PACKAGE_NAME = IS_DEV ? 'com.heywood8.monkeep.dev' : 'com.heywood8.monkeep';
-
 // Architecture filtering: Only arm64-v8a for preview builds to speed up build time
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
 const ANDROID_ARCHITECTURES = IS_PREVIEW ? ['arm64-v8a'] : undefined; // undefined = all architectures
 
 module.exports = {
   expo: {
-    name: APP_NAME,
+    name: 'Penny',
     slug: 'app',
     version: '0.46.5', // x-release-please-version
     orientation: 'portrait',
@@ -37,7 +25,7 @@ module.exports = {
         backgroundColor: '#ffffff',
       },
       edgeToEdgeEnabled: true,
-      package: PACKAGE_NAME,
+      package: 'com.heywood8.monkeep',
     },
     extra: {
       eas: {

--- a/eas.json
+++ b/eas.json
@@ -7,9 +7,6 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
-      "env": {
-        "APP_VARIANT": "development"
-      },
       "channel": "development"
     },
     "preview": {


### PR DESCRIPTION
The app previously conditionally set its name to 'PennyDev' and package
to 'com.heywood8.monkeep.dev' for development builds. This removes that
conditioning so all builds use the name 'Penny' and package
'com.heywood8.monkeep' regardless of build profile.

https://claude.ai/code/session_014PTCRfgY2yciKmKLz46wxy