### PR TITLE
fix: correct daily avg calculation for previous month in balance history chart

### DIFF
--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -338,10 +338,19 @@ const BalanceHistoryCard = ({
             if (spendingPrediction && isCurrentMonth) {
               actualDailyAvg = -spendingPrediction.dailyAverage;
             } else if (actualValues.length > 1) {
-              // For past months, calculate from start to end
-              const startBalance = actualValues[0];
-              const endBalance = actualValues[actualValues.length - 1];
-              actualDailyAvg = (endBalance - startBalance) / (daysInMonth - 1);
+              // For past months, calculate from first to last actual recorded data point.
+              // Use balanceHistoryData.actual (which carries day numbers) so the span
+              // matches the real days between observations, not the full month length.
+              const actualDataPoints = balanceHistoryData.actual || [];
+              if (actualDataPoints.length >= 2) {
+                const firstPoint = actualDataPoints[0];
+                const lastPoint = actualDataPoints[actualDataPoints.length - 1];
+                const daySpan = lastPoint.x - firstPoint.x;
+                actualDailyAvg = daySpan > 0 ? (lastPoint.y - firstPoint.y) / daySpan : 0;
+              } else {
+                // Only one actual data point recorded – no change to measure
+                actualDailyAvg = 0;
+              }
             }
 
             // Plain avg row values


### PR DESCRIPTION
When viewing a past month, the daily average was divided by (daysInMonth - 1),
which incorrectly assumed data spanned the entire month. If the first recorded
balance entry was on day 5 and the last on day 28 of a 31-day month, the divisor
was 30 instead of the actual 23-day span, producing a value ~30% too small.

Fix: use balanceHistoryData.actual (which stores real day numbers as .x) to
compute the interval between the first and last recorded data points. The divisor
is now (lastPoint.x - firstPoint.x), matching the true observation window.

Adds three regression tests:
- mid-month start: verifies -21.74 instead of the buggy -16.67
- full-month span: sanity-checks unchanged behaviour when data covers day 1→N
- single data point: verifies daily avg is 0 when no change can be measured

https://claude.ai/code/session_01EYWamQFGAADeBaSRMyvtrg