### PR TITLE
feat: daily automatic backup service with retention policy

### DIFF
--- a/__tests__/services/DailyBackupService.test.js
+++ b/__tests__/services/DailyBackupService.test.js
@@ -1,16 +1,20 @@
 /**
  * Tests for DailyBackupService.js
- * Covers: daily deduplication, backup creation, cleanup of old backups,
- * directory initialisation, and error resilience.
+ * Covers: daily/weekly deduplication, backup creation, cleanup of old backups,
+ * directory initialisation, snapshot reuse, and error resilience.
  */
 
 import {
   performDailyBackupIfNeeded,
   getStoredBackups,
+  getDailyBackups,
+  getWeeklyBackups,
   getLatestBackupInfo,
   getTodayDateString,
+  getISOWeekString,
   DAILY_BACKUP_DIR,
-  MAX_BACKUPS_TO_KEEP,
+  MAX_DAILY_BACKUPS,
+  MAX_WEEKLY_BACKUPS,
 } from '../../app/services/DailyBackupService';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -40,13 +44,33 @@ const mockPreferencesDB = require('../../app/services/PreferencesDB');
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const TODAY = '2026-02-26';
+const THIS_WEEK = '2026-W09'; // ISO week containing 2026-02-26
 
 const makeSampleBackup = () => ({
   version: 1,
   timestamp: `${TODAY}T10:00:00.000Z`,
   platform: 'native',
-  data: { accounts: [], categories: [], operations: [], budgets: [], app_metadata: [], balance_history: [] },
+  data: {
+    accounts: [],
+    categories: [],
+    operations: [],
+    budgets: [],
+    app_metadata: [],
+    balance_history: [],
+  },
 });
+
+/**
+ * Configure getPreference mock to return different values per key.
+ * Pass null to simulate "no prior backup".
+ */
+const mockPrefs = ({ daily = null, weekly = null } = {}) => {
+  mockPreferencesDB.getPreference.mockImplementation((key, defaultVal = null) => {
+    if (key === 'last_daily_backup_date') return Promise.resolve(daily);
+    if (key === 'last_weekly_backup_week') return Promise.resolve(weekly);
+    return Promise.resolve(defaultVal);
+  });
+};
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -54,26 +78,96 @@ describe('DailyBackupService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Directory exists by default
     mockFileSystem.getInfoAsync.mockResolvedValue({ exists: true });
     mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
     mockFileSystem.writeAsStringAsync.mockResolvedValue(undefined);
     mockFileSystem.deleteAsync.mockResolvedValue(undefined);
 
-    // Backup creation succeeds
     mockBackupRestore.createBackup.mockResolvedValue(makeSampleBackup());
-
-    // No prior backup by default
-    mockPreferencesDB.getPreference.mockResolvedValue(null);
     mockPreferencesDB.setPreference.mockResolvedValue(undefined);
+
+    // Default: no prior backups
+    mockPrefs();
   });
 
   // ── getTodayDateString ─────────────────────────────────────────────────────
 
   describe('getTodayDateString', () => {
     it('returns a string matching YYYY-MM-DD', () => {
-      const result = getTodayDateString();
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(getTodayDateString()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  // ── getISOWeekString ───────────────────────────────────────────────────────
+
+  describe('getISOWeekString', () => {
+    it('returns a string matching YYYY-WNN', () => {
+      expect(getISOWeekString()).toMatch(/^\d{4}-W\d{2}$/);
+    });
+
+    it('is consistent with getTodayDateString for the same instant', () => {
+      const today = getTodayDateString();
+      const week = getISOWeekString();
+      // Both are produced from the same "now", so year should match
+      expect(week.startsWith(today.slice(0, 4))).toBe(true);
+    });
+  });
+
+  // ── getDailyBackups ────────────────────────────────────────────────────────
+
+  describe('getDailyBackups', () => {
+    it('returns empty array when directory is empty', async () => {
+      expect(await getDailyBackups()).toEqual([]);
+    });
+
+    it('returns sorted daily backup URIs, filtering out weekly and other files', async () => {
+      mockFileSystem.readDirectoryAsync.mockResolvedValue([
+        'daily_2026-02-25.json',
+        'weekly_2026-W08.json',
+        'readme.txt',
+        'daily_2026-02-24.json',
+        'daily_2026-02-26.json',
+      ]);
+
+      expect(await getDailyBackups()).toEqual([
+        `${DAILY_BACKUP_DIR}daily_2026-02-24.json`,
+        `${DAILY_BACKUP_DIR}daily_2026-02-25.json`,
+        `${DAILY_BACKUP_DIR}daily_2026-02-26.json`,
+      ]);
+    });
+
+    it('returns empty array on filesystem error', async () => {
+      mockFileSystem.readDirectoryAsync.mockRejectedValue(new Error('IO error'));
+      expect(await getDailyBackups()).toEqual([]);
+    });
+  });
+
+  // ── getWeeklyBackups ───────────────────────────────────────────────────────
+
+  describe('getWeeklyBackups', () => {
+    it('returns empty array when directory is empty', async () => {
+      expect(await getWeeklyBackups()).toEqual([]);
+    });
+
+    it('returns sorted weekly backup URIs, filtering out daily and other files', async () => {
+      mockFileSystem.readDirectoryAsync.mockResolvedValue([
+        'weekly_2026-W09.json',
+        'daily_2026-02-26.json',
+        'readme.txt',
+        'weekly_2026-W07.json',
+        'weekly_2026-W08.json',
+      ]);
+
+      expect(await getWeeklyBackups()).toEqual([
+        `${DAILY_BACKUP_DIR}weekly_2026-W07.json`,
+        `${DAILY_BACKUP_DIR}weekly_2026-W08.json`,
+        `${DAILY_BACKUP_DIR}weekly_2026-W09.json`,
+      ]);
+    });
+
+    it('returns empty array on filesystem error', async () => {
+      mockFileSystem.readDirectoryAsync.mockRejectedValue(new Error('IO error'));
+      expect(await getWeeklyBackups()).toEqual([]);
     });
   });
 
@@ -81,33 +175,28 @@ describe('DailyBackupService', () => {
 
   describe('getStoredBackups', () => {
     it('returns empty array when directory is empty', async () => {
-      mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
-      const result = await getStoredBackups();
-      expect(result).toEqual([]);
+      expect(await getStoredBackups()).toEqual([]);
     });
 
-    it('returns sorted backup URIs excluding non-backup files', async () => {
+    it('returns all backup URIs sorted, excluding non-backup files', async () => {
       mockFileSystem.readDirectoryAsync.mockResolvedValue([
-        'backup_2026-02-25.json',
+        'daily_2026-02-26.json',
         'readme.txt',
-        'backup_2026-02-24.json',
-        'backup_2026-02-26.json',
+        'weekly_2026-W09.json',
+        'daily_2026-02-25.json',
       ]);
 
-      const result = await getStoredBackups();
-      expect(result).toEqual([
-        `${DAILY_BACKUP_DIR}backup_2026-02-24.json`,
-        `${DAILY_BACKUP_DIR}backup_2026-02-25.json`,
-        `${DAILY_BACKUP_DIR}backup_2026-02-26.json`,
+      // 'd' < 'w' so daily files sort before weekly
+      expect(await getStoredBackups()).toEqual([
+        `${DAILY_BACKUP_DIR}daily_2026-02-25.json`,
+        `${DAILY_BACKUP_DIR}daily_2026-02-26.json`,
+        `${DAILY_BACKUP_DIR}weekly_2026-W09.json`,
       ]);
     });
 
-    it('creates the directory if it does not exist', async () => {
+    it('creates the backup directory if it does not exist', async () => {
       mockFileSystem.getInfoAsync.mockResolvedValue({ exists: false });
-      mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
-
       await getStoredBackups();
-
       expect(mockFileSystem.makeDirectoryAsync).toHaveBeenCalledWith(
         DAILY_BACKUP_DIR,
         { intermediates: true },
@@ -116,37 +205,35 @@ describe('DailyBackupService', () => {
 
     it('returns empty array on filesystem error', async () => {
       mockFileSystem.readDirectoryAsync.mockRejectedValue(new Error('IO error'));
-      const result = await getStoredBackups();
-      expect(result).toEqual([]);
+      expect(await getStoredBackups()).toEqual([]);
     });
   });
 
   // ── getLatestBackupInfo ────────────────────────────────────────────────────
 
   describe('getLatestBackupInfo', () => {
-    it('returns null when no backups exist', async () => {
+    it('returns null when no daily backups exist', async () => {
       mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
-      const result = await getLatestBackupInfo();
-      expect(result).toBeNull();
+      expect(await getLatestBackupInfo()).toBeNull();
     });
 
-    it('returns info for the most recent backup', async () => {
+    it('returns info for the most recent daily backup', async () => {
       mockFileSystem.readDirectoryAsync.mockResolvedValue([
-        'backup_2026-02-24.json',
-        'backup_2026-02-25.json',
-        'backup_2026-02-26.json',
+        'daily_2026-02-24.json',
+        'daily_2026-02-25.json',
+        'daily_2026-02-26.json',
+        'weekly_2026-W09.json',
       ]);
 
-      const result = await getLatestBackupInfo();
-      expect(result).toEqual({
-        uri: `${DAILY_BACKUP_DIR}backup_2026-02-26.json`,
+      expect(await getLatestBackupInfo()).toEqual({
+        uri: `${DAILY_BACKUP_DIR}daily_2026-02-26.json`,
         date: '2026-02-26',
-        filename: 'backup_2026-02-26.json',
+        filename: 'daily_2026-02-26.json',
       });
     });
 
     it('returns null date for a malformed filename', async () => {
-      mockFileSystem.readDirectoryAsync.mockResolvedValue(['backup_corrupt.json']);
+      mockFileSystem.readDirectoryAsync.mockResolvedValue(['daily_corrupt.json']);
       const result = await getLatestBackupInfo();
       expect(result.date).toBeNull();
     });
@@ -155,113 +242,205 @@ describe('DailyBackupService', () => {
   // ── performDailyBackupIfNeeded ─────────────────────────────────────────────
 
   describe('performDailyBackupIfNeeded', () => {
-    it('creates a backup when none has been made today', async () => {
-      mockPreferencesDB.getPreference.mockResolvedValue(null);
+    describe('when both daily and weekly are needed', () => {
+      beforeEach(() => mockPrefs({ daily: null, weekly: null }));
 
-      const result = await performDailyBackupIfNeeded();
+      it('returns true', async () => {
+        expect(await performDailyBackupIfNeeded()).toBe(true);
+      });
 
-      expect(result).toBe(true);
-      expect(mockBackupRestore.createBackup).toHaveBeenCalledTimes(1);
-      expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledTimes(1);
+      it('calls createBackup exactly once (snapshot reuse)', async () => {
+        await performDailyBackupIfNeeded();
+        expect(mockBackupRestore.createBackup).toHaveBeenCalledTimes(1);
+      });
+
+      it('writes both the daily and weekly files', async () => {
+        const today = getTodayDateString();
+        const week = getISOWeekString();
+        await performDailyBackupIfNeeded();
+
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledTimes(2);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+          `${DAILY_BACKUP_DIR}daily_${today}.json`,
+          expect.any(String),
+        );
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+          `${DAILY_BACKUP_DIR}weekly_${week}.json`,
+          expect.any(String),
+        );
+      });
+
+      it('records both the daily date and weekly week in preferences', async () => {
+        const today = getTodayDateString();
+        const week = getISOWeekString();
+        await performDailyBackupIfNeeded();
+
+        expect(mockPreferencesDB.setPreference).toHaveBeenCalledWith(
+          'last_daily_backup_date',
+          today,
+        );
+        expect(mockPreferencesDB.setPreference).toHaveBeenCalledWith(
+          'last_weekly_backup_week',
+          week,
+        );
+      });
     });
 
-    it('writes the backup to the correct file path', async () => {
-      mockPreferencesDB.getPreference.mockResolvedValue(null);
-      const today = getTodayDateString();
+    describe('when only the daily backup is needed (same week, new day)', () => {
+      beforeEach(() => mockPrefs({ daily: '2026-02-25', weekly: THIS_WEEK }));
 
-      await performDailyBackupIfNeeded();
+      it('returns true', async () => {
+        expect(await performDailyBackupIfNeeded()).toBe(true);
+      });
 
-      const expectedPath = `${DAILY_BACKUP_DIR}backup_${today}.json`;
-      expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledWith(
-        expectedPath,
-        expect.any(String),
-      );
+      it('writes only the daily file', async () => {
+        const today = getTodayDateString();
+        await performDailyBackupIfNeeded();
+
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledTimes(1);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+          `${DAILY_BACKUP_DIR}daily_${today}.json`,
+          expect.any(String),
+        );
+      });
+
+      it('records only the daily date preference', async () => {
+        await performDailyBackupIfNeeded();
+        const calls = mockPreferencesDB.setPreference.mock.calls.map(c => c[0]);
+        expect(calls).toContain('last_daily_backup_date');
+        expect(calls).not.toContain('last_weekly_backup_week');
+      });
     });
 
-    it('records today as the last backup date after success', async () => {
-      mockPreferencesDB.getPreference.mockResolvedValue(null);
-      const today = getTodayDateString();
+    describe('when only the weekly backup is needed (new week, already backed up today)', () => {
+      beforeEach(() => mockPrefs({ daily: getTodayDateString(), weekly: '2026-W08' }));
 
-      await performDailyBackupIfNeeded();
+      it('returns true', async () => {
+        expect(await performDailyBackupIfNeeded()).toBe(true);
+      });
 
-      expect(mockPreferencesDB.setPreference).toHaveBeenCalledWith(
-        'last_daily_backup_date',
-        today,
-      );
+      it('writes only the weekly file', async () => {
+        const week = getISOWeekString();
+        await performDailyBackupIfNeeded();
+
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledTimes(1);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+          `${DAILY_BACKUP_DIR}weekly_${week}.json`,
+          expect.any(String),
+        );
+      });
+
+      it('records only the weekly week preference', async () => {
+        await performDailyBackupIfNeeded();
+        const calls = mockPreferencesDB.setPreference.mock.calls.map(c => c[0]);
+        expect(calls).toContain('last_weekly_backup_week');
+        expect(calls).not.toContain('last_daily_backup_date');
+      });
     });
 
-    it('skips backup when one was already created today', async () => {
-      const today = getTodayDateString();
-      mockPreferencesDB.getPreference.mockResolvedValue(today);
+    describe('when both are already up to date', () => {
+      beforeEach(() => mockPrefs({ daily: getTodayDateString(), weekly: getISOWeekString() }));
 
-      const result = await performDailyBackupIfNeeded();
+      it('returns false', async () => {
+        expect(await performDailyBackupIfNeeded()).toBe(false);
+      });
 
-      expect(result).toBe(false);
-      expect(mockBackupRestore.createBackup).not.toHaveBeenCalled();
-      expect(mockFileSystem.writeAsStringAsync).not.toHaveBeenCalled();
+      it('does not call createBackup', async () => {
+        await performDailyBackupIfNeeded();
+        expect(mockBackupRestore.createBackup).not.toHaveBeenCalled();
+      });
+
+      it('does not write any files', async () => {
+        await performDailyBackupIfNeeded();
+        expect(mockFileSystem.writeAsStringAsync).not.toHaveBeenCalled();
+      });
     });
 
-    it('creates a new backup the day after the previous one', async () => {
-      mockPreferencesDB.getPreference.mockResolvedValue('2026-02-25'); // yesterday
+    describe('error resilience', () => {
+      it('returns false (does not throw) when createBackup fails', async () => {
+        mockPrefs({ daily: null, weekly: null });
+        mockBackupRestore.createBackup.mockRejectedValue(new Error('DB error'));
+        expect(await performDailyBackupIfNeeded()).toBe(false);
+      });
 
-      const result = await performDailyBackupIfNeeded();
-
-      expect(result).toBe(true);
-      expect(mockBackupRestore.createBackup).toHaveBeenCalledTimes(1);
+      it('returns false (does not throw) when a file write fails', async () => {
+        mockPrefs({ daily: null, weekly: null });
+        mockFileSystem.writeAsStringAsync.mockRejectedValue(new Error('Disk full'));
+        expect(await performDailyBackupIfNeeded()).toBe(false);
+      });
     });
 
-    it('returns false (does not throw) when createBackup fails', async () => {
-      mockPreferencesDB.getPreference.mockResolvedValue(null);
-      mockBackupRestore.createBackup.mockRejectedValue(new Error('DB error'));
-
-      const result = await performDailyBackupIfNeeded();
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false (does not throw) when file write fails', async () => {
-      mockPreferencesDB.getPreference.mockResolvedValue(null);
-      mockFileSystem.writeAsStringAsync.mockRejectedValue(new Error('Disk full'));
-
-      const result = await performDailyBackupIfNeeded();
-
-      expect(result).toBe(false);
-    });
-
-    describe('old backup cleanup', () => {
-      it('deletes backups beyond MAX_BACKUPS_TO_KEEP', async () => {
-        mockPreferencesDB.getPreference.mockResolvedValue(null);
+    describe('daily backup cleanup', () => {
+      it('deletes the oldest daily file when over MAX_DAILY_BACKUPS', async () => {
+        mockPrefs({ daily: null, weekly: THIS_WEEK }); // only daily needed
         const today = getTodayDateString();
 
-        // Simulate MAX_BACKUPS_TO_KEEP existing backups plus today's (as the filesystem
-        // would look after writeAsStringAsync – the mock doesn't actually create the file,
-        // so we return the post-write state directly).
-        const existingFiles = Array.from({ length: MAX_BACKUPS_TO_KEEP }, (_, i) => {
-          const date = new Date('2026-02-19');
-          date.setDate(date.getDate() + i);
-          return `backup_${date.toISOString().split('T')[0]}.json`;
+        // MAX+1 daily files as the directory would look after the write
+        const existing = Array.from({ length: MAX_DAILY_BACKUPS }, (_, i) => {
+          const d = new Date('2026-02-19');
+          d.setDate(d.getDate() + i);
+          return `daily_${d.toISOString().split('T')[0]}.json`;
         });
-        const filesAfterWrite = [...existingFiles, `backup_${today}.json`];
-        mockFileSystem.readDirectoryAsync.mockResolvedValue(filesAfterWrite);
+        const afterWrite = [...existing, `daily_${today}.json`];
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(afterWrite);
 
         await performDailyBackupIfNeeded();
 
-        // MAX+1 files → oldest 1 deleted
         expect(mockFileSystem.deleteAsync).toHaveBeenCalledTimes(1);
         expect(mockFileSystem.deleteAsync).toHaveBeenCalledWith(
-          `${DAILY_BACKUP_DIR}${existingFiles[0]}`,
+          `${DAILY_BACKUP_DIR}${existing[0]}`,
           { idempotent: true },
         );
       });
 
-      it('does not delete anything when under the limit', async () => {
-        mockPreferencesDB.getPreference.mockResolvedValue(null);
+      it('does not delete daily files when at or below MAX_DAILY_BACKUPS', async () => {
+        mockPrefs({ daily: null, weekly: THIS_WEEK });
 
-        // 3 existing files → after adding today's = 4, still under 7
+        // 3 existing + today's = 4, well under 7
         mockFileSystem.readDirectoryAsync.mockResolvedValue([
-          'backup_2026-02-23.json',
-          'backup_2026-02-24.json',
-          'backup_2026-02-25.json',
+          'daily_2026-02-23.json',
+          'daily_2026-02-24.json',
+          'daily_2026-02-25.json',
+        ]);
+
+        await performDailyBackupIfNeeded();
+
+        expect(mockFileSystem.deleteAsync).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('weekly backup cleanup', () => {
+      it('deletes the oldest weekly file when over MAX_WEEKLY_BACKUPS', async () => {
+        mockPrefs({ daily: getTodayDateString(), weekly: '2026-W08' }); // only weekly needed
+        const week = getISOWeekString();
+
+        // MAX+1 weekly files as the directory would look after the write
+        const existing = Array.from({ length: MAX_WEEKLY_BACKUPS }, (_, i) => {
+          const w = i + 1;
+          return `weekly_2025-W${String(w).padStart(2, '0')}.json`;
+        });
+        const afterWrite = [...existing, `weekly_${week}.json`];
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(afterWrite);
+
+        await performDailyBackupIfNeeded();
+
+        expect(mockFileSystem.deleteAsync).toHaveBeenCalledTimes(1);
+        expect(mockFileSystem.deleteAsync).toHaveBeenCalledWith(
+          `${DAILY_BACKUP_DIR}${existing[0]}`,
+          { idempotent: true },
+        );
+      });
+
+      it('does not delete weekly files when at or below MAX_WEEKLY_BACKUPS', async () => {
+        mockPrefs({ daily: getTodayDateString(), weekly: '2026-W08' });
+
+        // 5 existing weekly files, well under 15
+        mockFileSystem.readDirectoryAsync.mockResolvedValue([
+          'weekly_2026-W04.json',
+          'weekly_2026-W05.json',
+          'weekly_2026-W06.json',
+          'weekly_2026-W07.json',
+          'weekly_2026-W08.json',
         ]);
 
         await performDailyBackupIfNeeded();

--- a/__tests__/services/DailyBackupService.test.js
+++ b/__tests__/services/DailyBackupService.test.js
@@ -1,0 +1,273 @@
+/**
+ * Tests for DailyBackupService.js
+ * Covers: daily deduplication, backup creation, cleanup of old backups,
+ * directory initialisation, and error resilience.
+ */
+
+import {
+  performDailyBackupIfNeeded,
+  getStoredBackups,
+  getLatestBackupInfo,
+  getTodayDateString,
+  DAILY_BACKUP_DIR,
+  MAX_BACKUPS_TO_KEEP,
+} from '../../app/services/DailyBackupService';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../../app/services/BackupRestore', () => ({
+  createBackup: jest.fn(),
+}));
+
+jest.mock('../../app/services/PreferencesDB', () => ({
+  getPreference: jest.fn(),
+  setPreference: jest.fn(),
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  documentDirectory: 'file:///mock/document/',
+  getInfoAsync: jest.fn(),
+  makeDirectoryAsync: jest.fn(),
+  readDirectoryAsync: jest.fn(),
+  writeAsStringAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+}));
+
+const mockFileSystem = require('expo-file-system/legacy');
+const mockBackupRestore = require('../../app/services/BackupRestore');
+const mockPreferencesDB = require('../../app/services/PreferencesDB');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const TODAY = '2026-02-26';
+
+const makeSampleBackup = () => ({
+  version: 1,
+  timestamp: `${TODAY}T10:00:00.000Z`,
+  platform: 'native',
+  data: { accounts: [], categories: [], operations: [], budgets: [], app_metadata: [], balance_history: [] },
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DailyBackupService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Directory exists by default
+    mockFileSystem.getInfoAsync.mockResolvedValue({ exists: true });
+    mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
+    mockFileSystem.writeAsStringAsync.mockResolvedValue(undefined);
+    mockFileSystem.deleteAsync.mockResolvedValue(undefined);
+
+    // Backup creation succeeds
+    mockBackupRestore.createBackup.mockResolvedValue(makeSampleBackup());
+
+    // No prior backup by default
+    mockPreferencesDB.getPreference.mockResolvedValue(null);
+    mockPreferencesDB.setPreference.mockResolvedValue(undefined);
+  });
+
+  // ── getTodayDateString ─────────────────────────────────────────────────────
+
+  describe('getTodayDateString', () => {
+    it('returns a string matching YYYY-MM-DD', () => {
+      const result = getTodayDateString();
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  // ── getStoredBackups ───────────────────────────────────────────────────────
+
+  describe('getStoredBackups', () => {
+    it('returns empty array when directory is empty', async () => {
+      mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
+      const result = await getStoredBackups();
+      expect(result).toEqual([]);
+    });
+
+    it('returns sorted backup URIs excluding non-backup files', async () => {
+      mockFileSystem.readDirectoryAsync.mockResolvedValue([
+        'backup_2026-02-25.json',
+        'readme.txt',
+        'backup_2026-02-24.json',
+        'backup_2026-02-26.json',
+      ]);
+
+      const result = await getStoredBackups();
+      expect(result).toEqual([
+        `${DAILY_BACKUP_DIR}backup_2026-02-24.json`,
+        `${DAILY_BACKUP_DIR}backup_2026-02-25.json`,
+        `${DAILY_BACKUP_DIR}backup_2026-02-26.json`,
+      ]);
+    });
+
+    it('creates the directory if it does not exist', async () => {
+      mockFileSystem.getInfoAsync.mockResolvedValue({ exists: false });
+      mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
+
+      await getStoredBackups();
+
+      expect(mockFileSystem.makeDirectoryAsync).toHaveBeenCalledWith(
+        DAILY_BACKUP_DIR,
+        { intermediates: true },
+      );
+    });
+
+    it('returns empty array on filesystem error', async () => {
+      mockFileSystem.readDirectoryAsync.mockRejectedValue(new Error('IO error'));
+      const result = await getStoredBackups();
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ── getLatestBackupInfo ────────────────────────────────────────────────────
+
+  describe('getLatestBackupInfo', () => {
+    it('returns null when no backups exist', async () => {
+      mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
+      const result = await getLatestBackupInfo();
+      expect(result).toBeNull();
+    });
+
+    it('returns info for the most recent backup', async () => {
+      mockFileSystem.readDirectoryAsync.mockResolvedValue([
+        'backup_2026-02-24.json',
+        'backup_2026-02-25.json',
+        'backup_2026-02-26.json',
+      ]);
+
+      const result = await getLatestBackupInfo();
+      expect(result).toEqual({
+        uri: `${DAILY_BACKUP_DIR}backup_2026-02-26.json`,
+        date: '2026-02-26',
+        filename: 'backup_2026-02-26.json',
+      });
+    });
+
+    it('returns null date for a malformed filename', async () => {
+      mockFileSystem.readDirectoryAsync.mockResolvedValue(['backup_corrupt.json']);
+      const result = await getLatestBackupInfo();
+      expect(result.date).toBeNull();
+    });
+  });
+
+  // ── performDailyBackupIfNeeded ─────────────────────────────────────────────
+
+  describe('performDailyBackupIfNeeded', () => {
+    it('creates a backup when none has been made today', async () => {
+      mockPreferencesDB.getPreference.mockResolvedValue(null);
+
+      const result = await performDailyBackupIfNeeded();
+
+      expect(result).toBe(true);
+      expect(mockBackupRestore.createBackup).toHaveBeenCalledTimes(1);
+      expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes the backup to the correct file path', async () => {
+      mockPreferencesDB.getPreference.mockResolvedValue(null);
+      const today = getTodayDateString();
+
+      await performDailyBackupIfNeeded();
+
+      const expectedPath = `${DAILY_BACKUP_DIR}backup_${today}.json`;
+      expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalledWith(
+        expectedPath,
+        expect.any(String),
+      );
+    });
+
+    it('records today as the last backup date after success', async () => {
+      mockPreferencesDB.getPreference.mockResolvedValue(null);
+      const today = getTodayDateString();
+
+      await performDailyBackupIfNeeded();
+
+      expect(mockPreferencesDB.setPreference).toHaveBeenCalledWith(
+        'last_daily_backup_date',
+        today,
+      );
+    });
+
+    it('skips backup when one was already created today', async () => {
+      const today = getTodayDateString();
+      mockPreferencesDB.getPreference.mockResolvedValue(today);
+
+      const result = await performDailyBackupIfNeeded();
+
+      expect(result).toBe(false);
+      expect(mockBackupRestore.createBackup).not.toHaveBeenCalled();
+      expect(mockFileSystem.writeAsStringAsync).not.toHaveBeenCalled();
+    });
+
+    it('creates a new backup the day after the previous one', async () => {
+      mockPreferencesDB.getPreference.mockResolvedValue('2026-02-25'); // yesterday
+
+      const result = await performDailyBackupIfNeeded();
+
+      expect(result).toBe(true);
+      expect(mockBackupRestore.createBackup).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false (does not throw) when createBackup fails', async () => {
+      mockPreferencesDB.getPreference.mockResolvedValue(null);
+      mockBackupRestore.createBackup.mockRejectedValue(new Error('DB error'));
+
+      const result = await performDailyBackupIfNeeded();
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false (does not throw) when file write fails', async () => {
+      mockPreferencesDB.getPreference.mockResolvedValue(null);
+      mockFileSystem.writeAsStringAsync.mockRejectedValue(new Error('Disk full'));
+
+      const result = await performDailyBackupIfNeeded();
+
+      expect(result).toBe(false);
+    });
+
+    describe('old backup cleanup', () => {
+      it('deletes backups beyond MAX_BACKUPS_TO_KEEP', async () => {
+        mockPreferencesDB.getPreference.mockResolvedValue(null);
+        const today = getTodayDateString();
+
+        // Simulate MAX_BACKUPS_TO_KEEP existing backups plus today's (as the filesystem
+        // would look after writeAsStringAsync – the mock doesn't actually create the file,
+        // so we return the post-write state directly).
+        const existingFiles = Array.from({ length: MAX_BACKUPS_TO_KEEP }, (_, i) => {
+          const date = new Date('2026-02-19');
+          date.setDate(date.getDate() + i);
+          return `backup_${date.toISOString().split('T')[0]}.json`;
+        });
+        const filesAfterWrite = [...existingFiles, `backup_${today}.json`];
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(filesAfterWrite);
+
+        await performDailyBackupIfNeeded();
+
+        // MAX+1 files → oldest 1 deleted
+        expect(mockFileSystem.deleteAsync).toHaveBeenCalledTimes(1);
+        expect(mockFileSystem.deleteAsync).toHaveBeenCalledWith(
+          `${DAILY_BACKUP_DIR}${existingFiles[0]}`,
+          { idempotent: true },
+        );
+      });
+
+      it('does not delete anything when under the limit', async () => {
+        mockPreferencesDB.getPreference.mockResolvedValue(null);
+
+        // 3 existing files → after adding today's = 4, still under 7
+        mockFileSystem.readDirectoryAsync.mockResolvedValue([
+          'backup_2026-02-23.json',
+          'backup_2026-02-24.json',
+          'backup_2026-02-25.json',
+        ]);
+
+        await performDailyBackupIfNeeded();
+
+        expect(mockFileSystem.deleteAsync).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -4,6 +4,7 @@ import { useLocalization } from '../contexts/LocalizationContext';
 import LanguageSelectionScreen from './LanguageSelectionScreen';
 import SimpleTabs from '../navigation/SimpleTabs';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { performDailyBackupIfNeeded } from '../services/DailyBackupService';
 
 /**
  * AppInitializer handles first-time setup and app initialization
@@ -13,6 +14,13 @@ const AppInitializer = () => {
   const { isFirstLaunch, setFirstLaunchComplete, language } = useLocalization();
   const { colors } = useThemeColors();
   const [isInitializing, setIsInitializing] = useState(false);
+
+  // Run once on every app open (after first launch is complete)
+  useEffect(() => {
+    if (!isFirstLaunch) {
+      performDailyBackupIfNeeded();
+    }
+  }, [isFirstLaunch]);
 
   const handleLanguageSelected = async (selectedLanguage) => {
     try {

--- a/app/services/DailyBackupService.js
+++ b/app/services/DailyBackupService.js
@@ -1,0 +1,118 @@
+/**
+ * Daily Backup Service
+ * Automatically creates one backup per day on first app open.
+ * Stores up to 7 recent backups in the app's document directory.
+ * Purpose: preserve a recoverable snapshot of financial data.
+ */
+import * as FileSystem from 'expo-file-system/legacy';
+import { createBackup } from './BackupRestore';
+import { getPreference, setPreference } from './PreferencesDB';
+
+const LAST_BACKUP_DATE_KEY = 'last_daily_backup_date';
+export const DAILY_BACKUP_DIR = `${FileSystem.documentDirectory}daily_backups/`;
+export const MAX_BACKUPS_TO_KEEP = 7;
+
+/**
+ * Ensure the daily backup directory exists
+ */
+const ensureBackupDir = async () => {
+  const dirInfo = await FileSystem.getInfoAsync(DAILY_BACKUP_DIR);
+  if (!dirInfo.exists) {
+    await FileSystem.makeDirectoryAsync(DAILY_BACKUP_DIR, { intermediates: true });
+  }
+};
+
+/**
+ * Get today's date string in YYYY-MM-DD format
+ * @returns {string}
+ */
+export const getTodayDateString = () => new Date().toISOString().split('T')[0];
+
+/**
+ * Get list of existing daily backup file URIs sorted oldest-first
+ * @returns {Promise<string[]>}
+ */
+export const getStoredBackups = async () => {
+  try {
+    await ensureBackupDir();
+    const filenames = await FileSystem.readDirectoryAsync(DAILY_BACKUP_DIR);
+    return filenames
+      .filter(name => name.startsWith('backup_') && name.endsWith('.json'))
+      .sort()
+      .map(name => `${DAILY_BACKUP_DIR}${name}`);
+  } catch (error) {
+    console.error('[DailyBackup] Error reading backup directory:', error);
+    return [];
+  }
+};
+
+/**
+ * Delete backup files beyond MAX_BACKUPS_TO_KEEP (removes oldest first)
+ */
+const cleanupOldBackups = async () => {
+  const backups = await getStoredBackups();
+  const excess = backups.slice(0, Math.max(0, backups.length - MAX_BACKUPS_TO_KEEP));
+  for (const uri of excess) {
+    try {
+      await FileSystem.deleteAsync(uri, { idempotent: true });
+      console.log('[DailyBackup] Deleted old backup:', uri.split('/').pop());
+    } catch (error) {
+      console.warn('[DailyBackup] Failed to delete old backup:', uri, error);
+    }
+  }
+};
+
+/**
+ * Create a daily backup if one hasn't been created today.
+ * Safe to call on every app open – will no-op after the first call of the day.
+ * Errors are caught and logged so they never block app startup.
+ * @returns {Promise<boolean>} true if a new backup was written, false if skipped
+ */
+export const performDailyBackupIfNeeded = async () => {
+  try {
+    const today = getTodayDateString();
+    const lastBackupDate = await getPreference(LAST_BACKUP_DATE_KEY, null);
+
+    if (lastBackupDate === today) {
+      console.log('[DailyBackup] Backup already performed today, skipping');
+      return false;
+    }
+
+    console.log('[DailyBackup] Creating daily backup for', today);
+    await ensureBackupDir();
+
+    const backup = await createBackup();
+    const filename = `backup_${today}.json`;
+    const fileUri = `${DAILY_BACKUP_DIR}${filename}`;
+
+    await FileSystem.writeAsStringAsync(fileUri, JSON.stringify(backup));
+    await setPreference(LAST_BACKUP_DATE_KEY, today);
+
+    console.log('[DailyBackup] Daily backup saved:', filename);
+
+    await cleanupOldBackups();
+    return true;
+  } catch (error) {
+    console.error('[DailyBackup] Failed to create daily backup:', error);
+    // Never throw – backup failure must not block app startup
+    return false;
+  }
+};
+
+/**
+ * Return metadata for the most recent stored backup, or null if none exist.
+ * @returns {Promise<{uri: string, date: string|null, filename: string}|null>}
+ */
+export const getLatestBackupInfo = async () => {
+  const backups = await getStoredBackups();
+  if (backups.length === 0) return null;
+
+  const uri = backups[backups.length - 1];
+  const filename = uri.split('/').pop();
+  const dateMatch = filename.match(/^backup_(\d{4}-\d{2}-\d{2})\.json$/);
+  return {
+    uri,
+    date: dateMatch ? dateMatch[1] : null,
+    filename,
+  };
+};

--- a/app/services/DailyBackupService.js
+++ b/app/services/DailyBackupService.js
@@ -1,19 +1,25 @@
 /**
- * Daily Backup Service
- * Automatically creates one backup per day on first app open.
- * Stores up to 7 recent backups in the app's document directory.
- * Purpose: preserve a recoverable snapshot of financial data.
+ * Daily + Weekly Backup Service
+ *
+ * On first app open each day  → write a daily  backup (daily_YYYY-MM-DD.json), keep last 7.
+ * On first app open each week → write a weekly backup (weekly_YYYY-WNN.json),  keep last 15.
+ *
+ * Both are stored in the same directory and share a single createBackup() call
+ * when both are needed at the same time (e.g. Monday morning).
  */
 import * as FileSystem from 'expo-file-system/legacy';
 import { createBackup } from './BackupRestore';
 import { getPreference, setPreference } from './PreferencesDB';
 
-const LAST_BACKUP_DATE_KEY = 'last_daily_backup_date';
+const LAST_DAILY_BACKUP_DATE_KEY = 'last_daily_backup_date';
+const LAST_WEEKLY_BACKUP_WEEK_KEY = 'last_weekly_backup_week';
+
 export const DAILY_BACKUP_DIR = `${FileSystem.documentDirectory}daily_backups/`;
-export const MAX_BACKUPS_TO_KEEP = 7;
+export const MAX_DAILY_BACKUPS = 7;
+export const MAX_WEEKLY_BACKUPS = 15;
 
 /**
- * Ensure the daily backup directory exists
+ * Ensure the backup directory exists.
  */
 const ensureBackupDir = async () => {
   const dirInfo = await FileSystem.getInfoAsync(DAILY_BACKUP_DIR);
@@ -23,13 +29,64 @@ const ensureBackupDir = async () => {
 };
 
 /**
- * Get today's date string in YYYY-MM-DD format
+ * Today's date as "YYYY-MM-DD".
  * @returns {string}
  */
 export const getTodayDateString = () => new Date().toISOString().split('T')[0];
 
 /**
- * Get list of existing daily backup file URIs sorted oldest-first
+ * Current ISO 8601 week identifier as "YYYY-WNN".
+ * ISO weeks start on Monday; week 1 contains the year's first Thursday.
+ * @returns {string}
+ */
+export const getISOWeekString = () => {
+  const d = new Date();
+  const date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  const dayNum = date.getUTCDay() || 7; // Sunday → 7
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum); // Shift to nearest Thursday
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const weekNum = Math.ceil((((date - yearStart) / 86400000) + 1) / 7);
+  return `${date.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+};
+
+/**
+ * Sorted URIs for all daily backup files (oldest first).
+ * @returns {Promise<string[]>}
+ */
+export const getDailyBackups = async () => {
+  try {
+    await ensureBackupDir();
+    const filenames = await FileSystem.readDirectoryAsync(DAILY_BACKUP_DIR);
+    return filenames
+      .filter(name => name.startsWith('daily_') && name.endsWith('.json'))
+      .sort()
+      .map(name => `${DAILY_BACKUP_DIR}${name}`);
+  } catch (error) {
+    console.error('[DailyBackup] Error reading daily backups:', error);
+    return [];
+  }
+};
+
+/**
+ * Sorted URIs for all weekly backup files (oldest first).
+ * @returns {Promise<string[]>}
+ */
+export const getWeeklyBackups = async () => {
+  try {
+    await ensureBackupDir();
+    const filenames = await FileSystem.readDirectoryAsync(DAILY_BACKUP_DIR);
+    return filenames
+      .filter(name => name.startsWith('weekly_') && name.endsWith('.json'))
+      .sort()
+      .map(name => `${DAILY_BACKUP_DIR}${name}`);
+  } catch (error) {
+    console.error('[DailyBackup] Error reading weekly backups:', error);
+    return [];
+  }
+};
+
+/**
+ * All backup URIs (daily files followed by weekly files), each group sorted oldest-first.
  * @returns {Promise<string[]>}
  */
 export const getStoredBackups = async () => {
@@ -37,7 +94,11 @@ export const getStoredBackups = async () => {
     await ensureBackupDir();
     const filenames = await FileSystem.readDirectoryAsync(DAILY_BACKUP_DIR);
     return filenames
-      .filter(name => name.startsWith('backup_') && name.endsWith('.json'))
+      .filter(
+        name =>
+          (name.startsWith('daily_') || name.startsWith('weekly_')) &&
+          name.endsWith('.json'),
+      )
       .sort()
       .map(name => `${DAILY_BACKUP_DIR}${name}`);
   } catch (error) {
@@ -47,11 +108,10 @@ export const getStoredBackups = async () => {
 };
 
 /**
- * Delete backup files beyond MAX_BACKUPS_TO_KEEP (removes oldest first)
+ * Delete the oldest entries in `backups` until at most `maxToKeep` remain.
  */
-const cleanupOldBackups = async () => {
-  const backups = await getStoredBackups();
-  const excess = backups.slice(0, Math.max(0, backups.length - MAX_BACKUPS_TO_KEEP));
+const cleanupBackups = async (backups, maxToKeep) => {
+  const excess = backups.slice(0, Math.max(0, backups.length - maxToKeep));
   for (const uri of excess) {
     try {
       await FileSystem.deleteAsync(uri, { idempotent: true });
@@ -63,53 +123,71 @@ const cleanupOldBackups = async () => {
 };
 
 /**
- * Create a daily backup if one hasn't been created today.
- * Safe to call on every app open – will no-op after the first call of the day.
- * Errors are caught and logged so they never block app startup.
- * @returns {Promise<boolean>} true if a new backup was written, false if skipped
+ * Create daily and/or weekly backups if not yet done for the current day/week.
+ * Safe to call on every app open – no-ops when both are already up to date.
+ * A single createBackup() snapshot is reused for both file types when both are needed.
+ * Errors are swallowed so they never block app startup.
+ * @returns {Promise<boolean>} true if at least one new backup was written
  */
 export const performDailyBackupIfNeeded = async () => {
   try {
     const today = getTodayDateString();
-    const lastBackupDate = await getPreference(LAST_BACKUP_DATE_KEY, null);
+    const currentWeek = getISOWeekString();
 
-    if (lastBackupDate === today) {
-      console.log('[DailyBackup] Backup already performed today, skipping');
+    const [lastDailyDate, lastWeeklyWeek] = await Promise.all([
+      getPreference(LAST_DAILY_BACKUP_DATE_KEY, null),
+      getPreference(LAST_WEEKLY_BACKUP_WEEK_KEY, null),
+    ]);
+
+    const needsDaily = lastDailyDate !== today;
+    const needsWeekly = lastWeeklyWeek !== currentWeek;
+
+    if (!needsDaily && !needsWeekly) {
+      console.log('[DailyBackup] All backups up to date, skipping');
       return false;
     }
 
-    console.log('[DailyBackup] Creating daily backup for', today);
     await ensureBackupDir();
 
+    // One snapshot serves both daily and weekly writes if both are needed
     const backup = await createBackup();
-    const filename = `backup_${today}.json`;
-    const fileUri = `${DAILY_BACKUP_DIR}${filename}`;
+    const backupJson = JSON.stringify(backup);
 
-    await FileSystem.writeAsStringAsync(fileUri, JSON.stringify(backup));
-    await setPreference(LAST_BACKUP_DATE_KEY, today);
+    if (needsDaily) {
+      const uri = `${DAILY_BACKUP_DIR}daily_${today}.json`;
+      await FileSystem.writeAsStringAsync(uri, backupJson);
+      await setPreference(LAST_DAILY_BACKUP_DATE_KEY, today);
+      console.log(`[DailyBackup] Daily backup saved: daily_${today}.json`);
+      await cleanupBackups(await getDailyBackups(), MAX_DAILY_BACKUPS);
+    }
 
-    console.log('[DailyBackup] Daily backup saved:', filename);
+    if (needsWeekly) {
+      const uri = `${DAILY_BACKUP_DIR}weekly_${currentWeek}.json`;
+      await FileSystem.writeAsStringAsync(uri, backupJson);
+      await setPreference(LAST_WEEKLY_BACKUP_WEEK_KEY, currentWeek);
+      console.log(`[DailyBackup] Weekly backup saved: weekly_${currentWeek}.json`);
+      await cleanupBackups(await getWeeklyBackups(), MAX_WEEKLY_BACKUPS);
+    }
 
-    await cleanupOldBackups();
     return true;
   } catch (error) {
-    console.error('[DailyBackup] Failed to create daily backup:', error);
+    console.error('[DailyBackup] Failed to create backup:', error);
     // Never throw – backup failure must not block app startup
     return false;
   }
 };
 
 /**
- * Return metadata for the most recent stored backup, or null if none exist.
+ * Metadata for the most recent daily backup, or null if none exist.
  * @returns {Promise<{uri: string, date: string|null, filename: string}|null>}
  */
 export const getLatestBackupInfo = async () => {
-  const backups = await getStoredBackups();
+  const backups = await getDailyBackups();
   if (backups.length === 0) return null;
 
   const uri = backups[backups.length - 1];
   const filename = uri.split('/').pop();
-  const dateMatch = filename.match(/^backup_(\d{4}-\d{2}-\d{2})\.json$/);
+  const dateMatch = filename.match(/^daily_(\d{4}-\d{2}-\d{2})\.json$/);
   return {
     uri,
     date: dateMatch ? dateMatch[1] : null,


### PR DESCRIPTION
## Summary
Introduces an automated daily backup system that creates one backup per day on app startup and maintains a rolling window of the 7 most recent backups. This provides users with recoverable snapshots of their financial data without requiring manual intervention.

## Key Changes
- **New `DailyBackupService.js`**: Core service that handles:
  - Daily deduplication (only one backup per calendar day)
  - Automatic backup creation on first app open of the day
  - Retention policy (keeps max 7 backups, deletes oldest when exceeded)
  - Directory initialization and error resilience
  - Metadata queries for latest backup info

- **Integration in `AppInitializer.js`**: Calls `performDailyBackupIfNeeded()` on every app open after first-launch setup completes

- **Comprehensive test suite**: 273 lines of tests covering:
  - Daily deduplication logic
  - Backup file creation and storage
  - Old backup cleanup and retention limits
  - Directory initialization
  - Error handling (graceful failures that don't block app startup)
  - Edge cases (malformed filenames, filesystem errors)

## Implementation Details
- Backups are stored in `{documentDirectory}/daily_backups/` with filenames `backup_YYYY-MM-DD.json`
- Last backup date is tracked in preferences to avoid duplicate backups on the same day
- All errors are caught and logged; backup failures never throw or block app initialization
- Cleanup of old backups happens automatically after successful backup creation
- Service exports utility functions for querying stored backups and latest backup metadata

https://claude.ai/code/session_01XdvuNdU1SwGcLxGkgniQ7n