### PR TITLE
ci: enable auto-merge for release-please PRs when checks pass

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release-please
         with:
           config-file: release-please-config.json
           token: ${{ secrets.RELEASE_TOKEN }}
+      - name: Enable auto-merge for release PR
+        if: ${{ steps.release-please.outputs.pr }}
+        run: gh pr merge --auto --squash "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ fromJSON(steps.release-please.outputs.pr).number }}


### PR DESCRIPTION
Adds a step after release-please-action to call `gh pr merge --auto --squash`
on any release PR it creates or updates. The step only runs when the action
outputs a PR (i.e. a release PR was created or modified).

https://claude.ai/code/session_01AjuZRNozB2mm6EBiZFUg8Q