### PR TITLE
feat: add planned operations feature for monthly budget planning

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -184,6 +184,7 @@ jobs:
               { file: '02_graphs', desc: 'Graphs' },
               { file: '03_accounts', desc: 'Accounts' },
               { file: '04_categories', desc: 'Categories' },
+              { file: '08_planned', desc: 'Planned Operations' },
               { file: '07_settings', desc: 'Settings' },
             ];
 

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -67,6 +67,12 @@ appId: com.heywood8.monkeep
     timeout: 3000
 - takeScreenshot: screenshots/04_categories_light
 
+# Navigate to Planned tab
+- tapOn: "Planned"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/08_planned_light
+
 # Open Settings modal
 - tapOn:
     id: "settings-button"
@@ -149,6 +155,12 @@ appId: com.heywood8.monkeep
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/04_categories_dark
+
+# Navigate to Planned tab
+- tapOn: "Planned"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/08_planned_dark
 
 # Open Settings modal
 - tapOn:

--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import { CategoriesProvider } from './app/contexts/CategoriesContext';
 import { OperationsDataProvider } from './app/contexts/OperationsDataContext';
 import { OperationsActionsProvider } from './app/contexts/OperationsActionsContext';
 import { BudgetsProvider } from './app/contexts/BudgetsContext';
+import { PlannedOperationsProvider } from './app/contexts/PlannedOperationsContext';
 import { LocalizationProvider } from './app/contexts/LocalizationContext';
 import { DialogProvider } from './app/contexts/DialogContext';
 import { ImportProgressProvider } from './app/contexts/ImportProgressContext';
@@ -67,7 +68,9 @@ export default function App() {
                           <OperationsDataProvider>
                             <OperationsActionsProvider>
                               <BudgetsProvider>
-                                <AppContent />
+                                <PlannedOperationsProvider>
+                                  <AppContent />
+                                </PlannedOperationsProvider>
                               </BudgetsProvider>
                             </OperationsActionsProvider>
                           </OperationsDataProvider>

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -52,6 +52,10 @@ jest.mock('../app/contexts/BudgetsContext', () => ({
   BudgetsProvider: ({ children }) => children,
 }));
 
+jest.mock('../app/contexts/PlannedOperationsContext', () => ({
+  PlannedOperationsProvider: ({ children }) => children,
+}));
+
 jest.mock('../app/contexts/LocalizationContext', () => ({
   LocalizationProvider: ({ children }) => children,
 }));

--- a/__tests__/contexts/PlannedOperationsContext.test.js
+++ b/__tests__/contexts/PlannedOperationsContext.test.js
@@ -1,0 +1,292 @@
+/**
+ * Tests for PlannedOperationsContext - State management for planned operations
+ */
+
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { PlannedOperationsProvider, usePlannedOperations } from '../../app/contexts/PlannedOperationsContext';
+import * as PlannedOperationsDB from '../../app/services/PlannedOperationsDB';
+import { appEvents, EVENTS } from '../../app/services/eventEmitter';
+
+// Mock dependencies
+jest.mock('../../app/services/PlannedOperationsDB');
+jest.mock('../../app/services/BalanceHistoryDB', () => ({
+  formatDate: jest.fn((date) => date.toISOString().split('T')[0]),
+}));
+jest.mock('../../app/services/eventEmitter', () => ({
+  appEvents: {
+    on: jest.fn(() => jest.fn()),
+    emit: jest.fn(),
+  },
+  EVENTS: {
+    RELOAD_ALL: 'RELOAD_ALL',
+    DATABASE_RESET: 'DATABASE_RESET',
+  },
+}));
+
+const mockShowDialog = jest.fn();
+jest.mock('../../app/contexts/DialogContext', () => ({
+  DialogProvider: ({ children }) => children,
+  useDialog: () => ({
+    showDialog: mockShowDialog,
+    hideDialog: jest.fn(),
+  }),
+}));
+
+jest.mock('../../app/contexts/LocalizationContext', () => ({
+  LocalizationProvider: ({ children }) => children,
+  useLocalization: () => ({
+    t: (key) => key,
+    language: 'en',
+  }),
+}));
+
+const mockAddOperation = jest.fn();
+jest.mock('../../app/contexts/OperationsActionsContext', () => ({
+  useOperationsActions: () => ({
+    addOperation: mockAddOperation,
+  }),
+}));
+
+let mockUuidCounter = 0;
+jest.mock('react-native-uuid', () => ({
+  v4: jest.fn(() => `test-uuid-${++mockUuidCounter}`),
+}));
+
+describe('PlannedOperationsContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockShowDialog.mockClear();
+    mockAddOperation.mockClear();
+    mockUuidCounter = 0;
+
+    PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([]);
+    PlannedOperationsDB.createPlannedOperation.mockImplementation(async (op) => op);
+    PlannedOperationsDB.updatePlannedOperation.mockResolvedValue(undefined);
+    PlannedOperationsDB.deletePlannedOperation.mockResolvedValue(undefined);
+    PlannedOperationsDB.markExecuted.mockResolvedValue(undefined);
+    PlannedOperationsDB.validatePlannedOperation.mockReturnValue(null);
+  });
+
+  const wrapper = ({ children }) => <PlannedOperationsProvider>{children}</PlannedOperationsProvider>;
+
+  describe('Initialization', () => {
+    it('loads planned operations on mount', async () => {
+      const mockOps = [
+        { id: '1', name: 'Rent', type: 'expense', amount: '500', accountId: 1, categoryId: 'cat1', isRecurring: true },
+      ];
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue(mockOps);
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.plannedOperations).toEqual(mockOps);
+      expect(PlannedOperationsDB.getAllPlannedOperations).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets loading state correctly', async () => {
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([]);
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    it('handles load error', async () => {
+      PlannedOperationsDB.getAllPlannedOperations.mockRejectedValue(new Error('DB error'));
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.plannedOperations).toEqual([]);
+      expect(result.current.saveError).toBe('DB error');
+    });
+  });
+
+  describe('CRUD Operations', () => {
+    it('adds a planned operation', async () => {
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const newOp = {
+        name: 'Rent',
+        type: 'expense',
+        amount: '500',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: true,
+      };
+
+      await act(async () => {
+        await result.current.addPlannedOperation(newOp);
+      });
+
+      expect(PlannedOperationsDB.createPlannedOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Rent', id: 'test-uuid-1' }),
+      );
+      expect(result.current.plannedOperations).toHaveLength(1);
+    });
+
+    it('updates a planned operation', async () => {
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([
+        { id: '1', name: 'Rent', type: 'expense', amount: '500', accountId: 1, categoryId: 'cat1', isRecurring: true },
+      ]);
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.updatePlannedOperation('1', { amount: '600' });
+      });
+
+      expect(PlannedOperationsDB.updatePlannedOperation).toHaveBeenCalledWith('1', { amount: '600' });
+      expect(result.current.plannedOperations[0].amount).toBe('600');
+    });
+
+    it('deletes a planned operation', async () => {
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([
+        { id: '1', name: 'Rent', type: 'expense', amount: '500', accountId: 1, categoryId: 'cat1', isRecurring: true },
+      ]);
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.deletePlannedOperation('1');
+      });
+
+      expect(PlannedOperationsDB.deletePlannedOperation).toHaveBeenCalledWith('1');
+      expect(result.current.plannedOperations).toHaveLength(0);
+    });
+  });
+
+  describe('Execute Planned Operation', () => {
+    it('creates a real operation and marks as executed for recurring', async () => {
+      const plannedOp = {
+        id: '1',
+        name: 'Rent',
+        type: 'expense',
+        amount: '500',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: true,
+        lastExecutedMonth: null,
+      };
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+      mockAddOperation.mockResolvedValue({ id: 100 });
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.executePlannedOperation(plannedOp);
+      });
+
+      // Should have created a real operation
+      expect(mockAddOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'expense',
+          amount: '500',
+          accountId: 1,
+          categoryId: 'cat1',
+        }),
+      );
+
+      // Should have marked as executed
+      expect(PlannedOperationsDB.markExecuted).toHaveBeenCalledWith('1', expect.stringMatching(/^\d{4}-\d{2}$/));
+
+      // Recurring should stay in list
+      expect(result.current.plannedOperations).toHaveLength(1);
+    });
+
+    it('removes one-time planned operation after execution', async () => {
+      const plannedOp = {
+        id: '2',
+        name: 'One-time',
+        type: 'expense',
+        amount: '100',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: false,
+        lastExecutedMonth: null,
+      };
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+      mockAddOperation.mockResolvedValue({ id: 101 });
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.executePlannedOperation(plannedOp);
+      });
+
+      // One-time should be removed from list
+      expect(PlannedOperationsDB.deletePlannedOperation).toHaveBeenCalledWith('2');
+      expect(result.current.plannedOperations).toHaveLength(0);
+    });
+
+    it('shows dialog when already executed this month', async () => {
+      const currentMonth = `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}`;
+      const plannedOp = {
+        id: '1',
+        name: 'Rent',
+        type: 'expense',
+        amount: '500',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: true,
+        lastExecutedMonth: currentMonth,
+      };
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        const returned = await result.current.executePlannedOperation(plannedOp);
+        expect(returned).toBeNull();
+      });
+
+      expect(mockShowDialog).toHaveBeenCalled();
+      expect(mockAddOperation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isExecutedThisMonth', () => {
+    it('returns true when executed this month', async () => {
+      const currentMonth = `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}`;
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.isExecutedThisMonth({ lastExecutedMonth: currentMonth })).toBe(true);
+    });
+
+    it('returns false when not executed this month', async () => {
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.isExecutedThisMonth({ lastExecutedMonth: '2025-01' })).toBe(false);
+      expect(result.current.isExecutedThisMonth({ lastExecutedMonth: null })).toBe(false);
+    });
+  });
+
+  describe('Event Listeners', () => {
+    it('subscribes to RELOAD_ALL and DATABASE_RESET events', async () => {
+      renderHook(() => usePlannedOperations(), { wrapper });
+
+      await waitFor(() => {
+        expect(appEvents.on).toHaveBeenCalledWith(EVENTS.RELOAD_ALL, expect.any(Function));
+        expect(appEvents.on).toHaveBeenCalledWith(EVENTS.DATABASE_RESET, expect.any(Function));
+      });
+    });
+  });
+});

--- a/__tests__/navigation/SimpleTabs.test.js
+++ b/__tests__/navigation/SimpleTabs.test.js
@@ -32,6 +32,7 @@ jest.mock('../../app/contexts/LocalizationContext', () => ({
         graphs: 'Graphs',
         accounts: 'Accounts',
         categories: 'Categories',
+        planned: 'Planned',
       };
       return translations[key] || key;
     },
@@ -72,6 +73,15 @@ jest.mock('../../app/screens/GraphsScreen', () => {
   return function GraphsScreen() {
     return React.createElement(View, { testID: 'graphs-screen' },
       React.createElement(Text, {}, 'Graphs Screen'));
+  };
+});
+
+jest.mock('../../app/screens/PlannedOperationsScreen', () => {
+  const React = require('react');
+  const { View, Text } = require('react-native');
+  return function PlannedOperationsScreen() {
+    return React.createElement(View, { testID: 'planned-screen' },
+      React.createElement(Text, {}, 'Planned Screen'));
   };
 });
 
@@ -275,22 +285,24 @@ describe('SimpleTabs Component Rendering', () => {
     expect(getByTestId('header')).toBeTruthy();
   });
 
-  it('renders all four tab labels', () => {
+  it('renders all five tab labels', () => {
     const { getByText } = render(<SimpleTabs />);
 
     expect(getByText('Operations')).toBeTruthy();
     expect(getByText('Graphs')).toBeTruthy();
     expect(getByText('Accounts')).toBeTruthy();
     expect(getByText('Categories')).toBeTruthy();
+    expect(getByText('Planned')).toBeTruthy();
   });
 
-  it('renders all four screens', () => {
+  it('renders all five screens', () => {
     const { getByTestId } = render(<SimpleTabs />);
 
     expect(getByTestId('operations-screen')).toBeTruthy();
     expect(getByTestId('graphs-screen')).toBeTruthy();
     expect(getByTestId('accounts-screen')).toBeTruthy();
     expect(getByTestId('categories-screen')).toBeTruthy();
+    expect(getByTestId('planned-screen')).toBeTruthy();
   });
 
   it('switches active tab when tab is pressed', async () => {

--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -169,7 +169,7 @@ describe('BackupRestore', () => {
         },
       });
       expect(backup.timestamp).toBeDefined();
-      expect(mockDb.queryAll).toHaveBeenCalledTimes(6);
+      expect(mockDb.queryAll).toHaveBeenCalledTimes(7);
     });
 
     it('includes empty arrays when tables are empty', async () => {
@@ -554,11 +554,12 @@ describe('BackupRestore', () => {
 
       await BackupRestore.restoreBackup(validBackup);
 
-      expect(deleteCalls[0]).toContain('budgets');
-      expect(deleteCalls[1]).toContain('accounts_balance_history');
-      expect(deleteCalls[2]).toContain('operations');
-      expect(deleteCalls[3]).toContain('categories');
-      expect(deleteCalls[4]).toContain('accounts');
+      expect(deleteCalls[0]).toContain('planned_operations');
+      expect(deleteCalls[1]).toContain('budgets');
+      expect(deleteCalls[2]).toContain('accounts_balance_history');
+      expect(deleteCalls[3]).toContain('operations');
+      expect(deleteCalls[4]).toContain('categories');
+      expect(deleteCalls[5]).toContain('accounts');
     });
 
     it('preserves db_version metadata', async () => {

--- a/__tests__/services/PlannedOperationsDB.test.js
+++ b/__tests__/services/PlannedOperationsDB.test.js
@@ -1,0 +1,262 @@
+/**
+ * Tests for PlannedOperationsDB Service
+ */
+
+import * as PlannedOperationsDB from '../../app/services/PlannedOperationsDB';
+import { executeQuery, queryAll, queryFirst, executeTransaction } from '../../app/services/db';
+
+jest.mock('../../app/services/db');
+
+describe('PlannedOperationsDB Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    executeQuery.mockResolvedValue(undefined);
+    queryAll.mockResolvedValue([]);
+    queryFirst.mockResolvedValue(null);
+  });
+
+  describe('Validation', () => {
+    const validOp = {
+      name: 'Rent',
+      type: 'expense',
+      amount: '500.00',
+      accountId: 1,
+      categoryId: 'cat1',
+    };
+
+    it('validates a valid expense planned operation', () => {
+      const error = PlannedOperationsDB.validatePlannedOperation(validOp);
+      expect(error).toBeNull();
+    });
+
+    it('validates a valid transfer planned operation', () => {
+      const transferOp = {
+        name: 'Savings Transfer',
+        type: 'transfer',
+        amount: '200',
+        accountId: 1,
+        toAccountId: 2,
+      };
+      expect(PlannedOperationsDB.validatePlannedOperation(transferOp)).toBeNull();
+    });
+
+    it('rejects missing name', () => {
+      const op = { ...validOp, name: '' };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('planned_name_required');
+    });
+
+    it('rejects whitespace-only name', () => {
+      const op = { ...validOp, name: '   ' };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('planned_name_required');
+    });
+
+    it('rejects missing type', () => {
+      const op = { ...validOp, type: null };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('operation_type_required');
+    });
+
+    it('rejects invalid type', () => {
+      const op = { ...validOp, type: 'refund' };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('operation_type_required');
+    });
+
+    it('rejects zero amount', () => {
+      const op = { ...validOp, amount: '0' };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('valid_amount_required');
+    });
+
+    it('rejects negative amount', () => {
+      const op = { ...validOp, amount: '-50' };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('valid_amount_required');
+    });
+
+    it('rejects missing accountId', () => {
+      const op = { ...validOp, accountId: null };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('account_required');
+    });
+
+    it('rejects expense without categoryId', () => {
+      const op = { ...validOp, categoryId: null };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('category_required');
+    });
+
+    it('rejects transfer without toAccountId', () => {
+      const op = { name: 'Transfer', type: 'transfer', amount: '100', accountId: 1 };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('destination_account_required');
+    });
+
+    it('rejects transfer with same accounts', () => {
+      const op = { name: 'Transfer', type: 'transfer', amount: '100', accountId: 1, toAccountId: 1 };
+      expect(PlannedOperationsDB.validatePlannedOperation(op)).toBe('accounts_must_be_different');
+    });
+  });
+
+  describe('CRUD Operations', () => {
+    it('creates a planned operation', async () => {
+      const op = {
+        id: 'test-uuid',
+        name: 'Rent',
+        type: 'expense',
+        amount: '500',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: true,
+      };
+
+      const result = await PlannedOperationsDB.createPlannedOperation(op);
+
+      expect(executeQuery).toHaveBeenCalledTimes(1);
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO planned_operations'),
+        expect.arrayContaining(['test-uuid', 'Rent', 'expense', '500', 1, 'cat1']),
+      );
+      expect(result).toEqual(expect.objectContaining({
+        id: 'test-uuid',
+        name: 'Rent',
+        type: 'expense',
+        amount: '500',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: true,
+      }));
+    });
+
+    it('creates a non-recurring planned operation', async () => {
+      const op = {
+        id: 'test-uuid-2',
+        name: 'One-time Purchase',
+        type: 'expense',
+        amount: '100',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: false,
+      };
+
+      const result = await PlannedOperationsDB.createPlannedOperation(op);
+      expect(result.isRecurring).toBe(false);
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO planned_operations'),
+        expect.arrayContaining([0]),
+      );
+    });
+
+    it('rejects creating invalid planned operation', async () => {
+      const invalidOp = { name: '', type: 'expense', amount: '500', accountId: 1, categoryId: 'cat1' };
+      await expect(PlannedOperationsDB.createPlannedOperation(invalidOp)).rejects.toThrow();
+    });
+
+    it('gets planned operation by id', async () => {
+      const mockRow = {
+        id: 'test-uuid',
+        name: 'Rent',
+        type: 'expense',
+        amount: '500',
+        account_id: 1,
+        category_id: 'cat1',
+        to_account_id: null,
+        description: null,
+        is_recurring: 1,
+        last_executed_month: null,
+        display_order: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      };
+      queryFirst.mockResolvedValue(mockRow);
+
+      const result = await PlannedOperationsDB.getPlannedOperationById('test-uuid');
+
+      expect(queryFirst).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT * FROM planned_operations WHERE id = ?'),
+        ['test-uuid'],
+      );
+      expect(result).toEqual(expect.objectContaining({
+        id: 'test-uuid',
+        name: 'Rent',
+        accountId: 1,
+        isRecurring: true,
+      }));
+    });
+
+    it('returns null for non-existent planned operation', async () => {
+      queryFirst.mockResolvedValue(null);
+      const result = await PlannedOperationsDB.getPlannedOperationById('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('gets all planned operations', async () => {
+      const mockRows = [
+        { id: '1', name: 'Rent', type: 'expense', amount: '500', account_id: 1, category_id: 'cat1', to_account_id: null, description: null, is_recurring: 1, last_executed_month: null, display_order: 0, created_at: '', updated_at: '' },
+        { id: '2', name: 'Netflix', type: 'expense', amount: '15', account_id: 1, category_id: 'cat2', to_account_id: null, description: null, is_recurring: 1, last_executed_month: null, display_order: 1, created_at: '', updated_at: '' },
+      ];
+      queryAll.mockResolvedValue(mockRows);
+
+      const result = await PlannedOperationsDB.getAllPlannedOperations();
+
+      expect(queryAll).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT * FROM planned_operations ORDER BY'),
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Rent');
+      expect(result[1].name).toBe('Netflix');
+    });
+
+    it('returns empty array when no planned operations', async () => {
+      queryAll.mockResolvedValue([]);
+      const result = await PlannedOperationsDB.getAllPlannedOperations();
+      expect(result).toEqual([]);
+    });
+
+    it('gets recurring planned operations', async () => {
+      queryAll.mockResolvedValue([]);
+      await PlannedOperationsDB.getRecurringPlannedOperations();
+      expect(queryAll).toHaveBeenCalledWith(
+        expect.stringContaining('is_recurring = 1'),
+      );
+    });
+
+    it('gets one-time planned operations', async () => {
+      queryAll.mockResolvedValue([]);
+      await PlannedOperationsDB.getOneTimePlannedOperations();
+      expect(queryAll).toHaveBeenCalledWith(
+        expect.stringContaining('is_recurring = 0'),
+      );
+    });
+
+    it('updates a planned operation', async () => {
+      await PlannedOperationsDB.updatePlannedOperation('test-uuid', {
+        name: 'Updated Rent',
+        amount: '600',
+      });
+
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE planned_operations SET'),
+        expect.arrayContaining(['Updated Rent', '600', 'test-uuid']),
+      );
+    });
+
+    it('skips update with no fields', async () => {
+      await PlannedOperationsDB.updatePlannedOperation('test-uuid', {});
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('deletes a planned operation', async () => {
+      await PlannedOperationsDB.deletePlannedOperation('test-uuid');
+
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM planned_operations WHERE id = ?'),
+        ['test-uuid'],
+      );
+    });
+  });
+
+  describe('Execution Tracking', () => {
+    it('marks a planned operation as executed', async () => {
+      await PlannedOperationsDB.markExecuted('test-uuid', '2026-03');
+
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE planned_operations SET last_executed_month'),
+        expect.arrayContaining(['2026-03', 'test-uuid']),
+      );
+    });
+  });
+});

--- a/app/contexts/PlannedOperationsContext.js
+++ b/app/contexts/PlannedOperationsContext.js
@@ -1,0 +1,227 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import uuid from 'react-native-uuid';
+import * as PlannedOperationsDB from '../services/PlannedOperationsDB';
+import { appEvents, EVENTS } from '../services/eventEmitter';
+import { useOperationsActions } from './OperationsActionsContext';
+import { useDialog } from './DialogContext';
+import { useLocalization } from './LocalizationContext';
+import { formatDate } from '../services/BalanceHistoryDB';
+
+const PlannedOperationsContext = createContext();
+
+export const usePlannedOperations = () => {
+  const context = useContext(PlannedOperationsContext);
+  if (!context) {
+    throw new Error('usePlannedOperations must be used within a PlannedOperationsProvider');
+  }
+  return context;
+};
+
+/**
+ * Get current month string in YYYY-MM format
+ */
+const getCurrentMonth = () => {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+};
+
+export const PlannedOperationsProvider = ({ children }) => {
+  const { showDialog } = useDialog();
+  const { t } = useLocalization();
+  const { addOperation } = useOperationsActions();
+  const [plannedOperations, setPlannedOperations] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saveError, setSaveError] = useState(null);
+
+  /**
+   * Load all planned operations from database
+   */
+  const reloadPlannedOperations = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await PlannedOperationsDB.getAllPlannedOperations();
+      setPlannedOperations(data);
+      setSaveError(null);
+    } catch (error) {
+      console.error('Failed to load planned operations:', error);
+      setSaveError(error.message);
+      setPlannedOperations([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Load on mount
+  useEffect(() => {
+    reloadPlannedOperations();
+  }, [reloadPlannedOperations]);
+
+  // Listen for RELOAD_ALL
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
+      reloadPlannedOperations();
+    });
+    return unsubscribe;
+  }, [reloadPlannedOperations]);
+
+  // Listen for DATABASE_RESET
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, () => {
+      setPlannedOperations([]);
+    });
+    return unsubscribe;
+  }, []);
+
+  /**
+   * Create a new planned operation
+   */
+  const addPlannedOperation = useCallback(async (op) => {
+    try {
+      const validationError = PlannedOperationsDB.validatePlannedOperation(op);
+      if (validationError) {
+        throw new Error(t(validationError) || validationError);
+      }
+
+      const newOp = {
+        ...op,
+        id: uuid.v4(),
+      };
+
+      const created = await PlannedOperationsDB.createPlannedOperation(newOp);
+      setPlannedOperations(prev => [...prev, created]);
+      setSaveError(null);
+      return created;
+    } catch (error) {
+      console.error('Failed to create planned operation:', error);
+      setSaveError(error.message);
+      showDialog(t('error'), error.message, [{ text: t('ok') }]);
+      throw error;
+    }
+  }, [showDialog, t]);
+
+  /**
+   * Update an existing planned operation
+   */
+  const updatePlannedOperation = useCallback(async (id, updates) => {
+    try {
+      await PlannedOperationsDB.updatePlannedOperation(id, updates);
+      setPlannedOperations(prev =>
+        prev.map(op => op.id === id ? { ...op, ...updates } : op),
+      );
+      setSaveError(null);
+    } catch (error) {
+      console.error('Failed to update planned operation:', error);
+      setSaveError(error.message);
+      showDialog(t('error'), error.message, [{ text: t('ok') }]);
+      throw error;
+    }
+  }, [showDialog, t]);
+
+  /**
+   * Delete a planned operation
+   */
+  const deletePlannedOperation = useCallback(async (id) => {
+    try {
+      await PlannedOperationsDB.deletePlannedOperation(id);
+      setPlannedOperations(prev => prev.filter(op => op.id !== id));
+      setSaveError(null);
+    } catch (error) {
+      console.error('Failed to delete planned operation:', error);
+      setSaveError(error.message);
+      showDialog(t('error'), error.message, [{ text: t('ok') }]);
+      throw error;
+    }
+  }, [showDialog, t]);
+
+  /**
+   * Execute a planned operation — create a real operation with today's date
+   */
+  const executePlannedOperation = useCallback(async (plannedOp) => {
+    try {
+      const currentMonth = getCurrentMonth();
+
+      // Check if already executed this month
+      if (plannedOp.lastExecutedMonth === currentMonth) {
+        showDialog(t('error'), t('already_executed'), [{ text: t('ok') }]);
+        return null;
+      }
+
+      // Build operation data from planned operation template
+      const operationData = {
+        type: plannedOp.type,
+        amount: plannedOp.amount,
+        accountId: plannedOp.accountId,
+        categoryId: plannedOp.categoryId || null,
+        toAccountId: plannedOp.toAccountId || null,
+        date: formatDate(new Date()),
+        description: plannedOp.name || plannedOp.description || null,
+      };
+
+      // Create the real operation
+      const createdOperation = await addOperation(operationData);
+
+      // Mark as executed
+      await PlannedOperationsDB.markExecuted(plannedOp.id, currentMonth);
+
+      // Update local state
+      if (plannedOp.isRecurring) {
+        // For recurring: update lastExecutedMonth
+        setPlannedOperations(prev =>
+          prev.map(op => op.id === plannedOp.id
+            ? { ...op, lastExecutedMonth: currentMonth }
+            : op),
+        );
+      } else {
+        // For one-time: remove from list after execution
+        await PlannedOperationsDB.deletePlannedOperation(plannedOp.id);
+        setPlannedOperations(prev => prev.filter(op => op.id !== plannedOp.id));
+      }
+
+      return createdOperation;
+    } catch (error) {
+      console.error('Failed to execute planned operation:', error);
+      showDialog(t('error'), error.message, [{ text: t('ok') }]);
+      throw error;
+    }
+  }, [addOperation, showDialog, t]);
+
+  /**
+   * Check if a planned operation has been executed this month
+   */
+  const isExecutedThisMonth = useCallback((plannedOp) => {
+    return plannedOp.lastExecutedMonth === getCurrentMonth();
+  }, []);
+
+  const value = useMemo(() => ({
+    plannedOperations,
+    loading,
+    saveError,
+    addPlannedOperation,
+    updatePlannedOperation,
+    deletePlannedOperation,
+    executePlannedOperation,
+    isExecutedThisMonth,
+    reloadPlannedOperations,
+  }), [
+    plannedOperations,
+    loading,
+    saveError,
+    addPlannedOperation,
+    updatePlannedOperation,
+    deletePlannedOperation,
+    executePlannedOperation,
+    isExecutedThisMonth,
+    reloadPlannedOperations,
+  ]);
+
+  return (
+    <PlannedOperationsContext.Provider value={value}>
+      {children}
+    </PlannedOperationsContext.Provider>
+  );
+};
+
+PlannedOperationsProvider.propTypes = {
+  children: PropTypes.node,
+};

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -96,6 +96,30 @@ export const budgets = sqliteTable('budgets', {
 }));
 
 /**
+ * Planned Operations table
+ * Templates for recurring or one-time planned expenses/income/transfers
+ */
+export const plannedOperations = sqliteTable('planned_operations', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  type: text('type', { enum: ['expense', 'income', 'transfer'] }).notNull(),
+  amount: text('amount').notNull(),
+  accountId: integer('account_id').notNull().references(() => accounts.id, { onDelete: 'cascade' }),
+  categoryId: text('category_id').references(() => categories.id, { onDelete: 'set null' }),
+  toAccountId: integer('to_account_id').references(() => accounts.id, { onDelete: 'cascade' }),
+  description: text('description'),
+  isRecurring: integer('is_recurring').notNull().default(1),
+  lastExecutedMonth: text('last_executed_month'),
+  displayOrder: integer('display_order'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => ({
+  accountIdx: index('idx_planned_ops_account').on(table.accountId),
+  typeIdx: index('idx_planned_ops_type').on(table.type),
+  recurringIdx: index('idx_planned_ops_recurring').on(table.isRecurring),
+}));
+
+/**
  * Accounts Balance History table
  * Tracks daily end-of-day balances for accounts
  */

--- a/app/modals/PlannedOperationModal.js
+++ b/app/modals/PlannedOperationModal.js
@@ -251,6 +251,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
                 <View style={styles.typeRow}>
                   {TYPE_OPTIONS.map(opt => {
                     const isActive = values.type === opt.key;
+                    const typeLabelStyle = { color: isActive ? '#fff' : colors.mutedText };
                     return (
                       <Pressable
                         key={opt.key}
@@ -264,7 +265,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
                         onPress={() => setValues(v => ({ ...v, type: opt.key, categoryId: null }))}
                       >
                         <Icon name={opt.icon} size={18} color={isActive ? '#fff' : colors.mutedText} />
-                        <Text style={[styles.typeLabel, { color: isActive ? '#fff' : colors.mutedText }]}>
+                        <Text style={[styles.typeLabel, typeLabelStyle]}>
                           {t(`${opt.key}_label`) || t(opt.key)}
                         </Text>
                       </Pressable>
@@ -340,7 +341,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
 
               {/* Recurring Toggle */}
               <View style={[styles.inputContainer, styles.switchRow]}>
-                <Text style={[styles.inputLabel, { color: colors.mutedText, marginBottom: 0 }]}>
+                <Text style={[styles.inputLabel, styles.inputLabelNoMargin, { color: colors.mutedText }]}>
                   {t('recurring')}
                 </Text>
                 <Switch
@@ -466,6 +467,9 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.sm,
     fontWeight: '500',
     marginBottom: SPACING.xs,
+  },
+  inputLabelNoMargin: {
+    marginBottom: 0,
   },
   modalContent: {
     borderTopLeftRadius: BORDER_RADIUS.lg,

--- a/app/modals/PlannedOperationModal.js
+++ b/app/modals/PlannedOperationModal.js
@@ -1,0 +1,580 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Modal,
+  Pressable,
+  StyleSheet,
+  FlatList,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  Keyboard,
+  Switch,
+} from 'react-native';
+import PropTypes from 'prop-types';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { useDialog } from '../contexts/DialogContext';
+import { usePlannedOperations } from '../contexts/PlannedOperationsContext';
+import { useAccountsData } from '../contexts/AccountsDataContext';
+import { useCategories } from '../contexts/CategoriesContext';
+import { SPACING, BORDER_RADIUS, HEIGHTS, FONT_SIZE } from '../styles/designTokens';
+
+const TYPE_OPTIONS = [
+  { key: 'expense', icon: 'arrow-up', colorKey: 'expense' },
+  { key: 'income', icon: 'arrow-down', colorKey: 'income' },
+  { key: 'transfer', icon: 'swap-horizontal', colorKey: 'transfer' },
+];
+
+export default function PlannedOperationModal({ visible, onClose, plannedOperation, isNew }) {
+  const { colors } = useThemeColors();
+  const { t } = useLocalization();
+  const { showDialog } = useDialog();
+  const { addPlannedOperation, updatePlannedOperation, deletePlannedOperation } = usePlannedOperations();
+  const { visibleAccounts: accounts } = useAccountsData();
+  const { categories } = useCategories();
+
+  const [values, setValues] = useState({
+    name: '',
+    type: 'expense',
+    amount: '',
+    accountId: null,
+    categoryId: null,
+    toAccountId: null,
+    description: '',
+    isRecurring: true,
+  });
+
+  const [errors, setErrors] = useState({});
+  const [accountPickerVisible, setAccountPickerVisible] = useState(false);
+  const [toAccountPickerVisible, setToAccountPickerVisible] = useState(false);
+  const [categoryPickerVisible, setCategoryPickerVisible] = useState(false);
+
+  // Filtered categories based on operation type
+  const filteredCategories = useMemo(() => {
+    if (values.type === 'transfer') return [];
+    const categoryType = values.type === 'expense' ? 'expense' : 'income';
+    return (categories || []).filter(
+      c => c.categoryType === categoryType && c.type === 'entry' && !c.isShadow,
+    );
+  }, [categories, values.type]);
+
+  // Initialize form when modal opens
+  useEffect(() => {
+    if (!visible) return;
+
+    if (plannedOperation && !isNew) {
+      setValues({
+        name: plannedOperation.name || '',
+        type: plannedOperation.type || 'expense',
+        amount: plannedOperation.amount || '',
+        accountId: plannedOperation.accountId || null,
+        categoryId: plannedOperation.categoryId || null,
+        toAccountId: plannedOperation.toAccountId || null,
+        description: plannedOperation.description || '',
+        isRecurring: plannedOperation.isRecurring !== false,
+      });
+    } else {
+      setValues({
+        name: '',
+        type: 'expense',
+        amount: '',
+        accountId: accounts.length > 0 ? accounts[0].id : null,
+        categoryId: null,
+        toAccountId: null,
+        description: '',
+        isRecurring: true,
+      });
+    }
+    setErrors({});
+  }, [plannedOperation, isNew, visible, accounts]);
+
+  const validateForm = useCallback(() => {
+    const newErrors = {};
+
+    if (!values.name || !values.name.trim()) {
+      newErrors.name = t('planned_name_required') || 'Name is required';
+    }
+
+    const amount = parseFloat(values.amount);
+    if (!values.amount || isNaN(amount) || amount <= 0) {
+      newErrors.amount = t('valid_amount_required') || 'Valid amount is required';
+    }
+
+    if (!values.accountId) {
+      newErrors.accountId = t('account_required') || 'Account is required';
+    }
+
+    if (values.type === 'transfer') {
+      if (!values.toAccountId) {
+        newErrors.toAccountId = t('destination_account_required') || 'Destination account is required';
+      }
+      if (values.accountId && values.toAccountId && values.accountId === values.toAccountId) {
+        newErrors.toAccountId = t('accounts_must_be_different') || 'Accounts must be different';
+      }
+    } else {
+      if (!values.categoryId) {
+        newErrors.categoryId = t('category_required') || 'Category is required';
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [values, t]);
+
+  const handleSave = useCallback(async () => {
+    Keyboard.dismiss();
+    if (!validateForm()) return;
+
+    try {
+      const data = {
+        name: values.name.trim(),
+        type: values.type,
+        amount: values.amount,
+        accountId: values.accountId,
+        categoryId: values.type === 'transfer' ? null : values.categoryId,
+        toAccountId: values.type === 'transfer' ? values.toAccountId : null,
+        description: values.description.trim() || null,
+        isRecurring: values.isRecurring,
+      };
+
+      if (isNew) {
+        await addPlannedOperation(data);
+      } else {
+        await updatePlannedOperation(plannedOperation.id, data);
+      }
+      onClose();
+    } catch (error) {
+      console.error('Save planned operation error:', error);
+    }
+  }, [validateForm, values, isNew, addPlannedOperation, updatePlannedOperation, plannedOperation, onClose]);
+
+  const handleClose = useCallback(() => {
+    Keyboard.dismiss();
+    setErrors({});
+    onClose();
+  }, [onClose]);
+
+  const handleDelete = useCallback(() => {
+    showDialog(
+      t('delete_planned_operation'),
+      t('delete_planned_confirm'),
+      [
+        { text: t('cancel'), style: 'cancel' },
+        {
+          text: t('delete'),
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deletePlannedOperation(plannedOperation.id);
+              onClose();
+            } catch (error) {
+              // Error already shown in context
+            }
+          },
+        },
+      ],
+    );
+  }, [plannedOperation, deletePlannedOperation, onClose, t, showDialog]);
+
+  const getAccountName = useCallback((accountId) => {
+    const account = accounts.find(a => a.id === accountId);
+    return account ? account.name : t('select_account');
+  }, [accounts, t]);
+
+  const getCategoryName = useCallback((categoryId) => {
+    const category = (categories || []).find(c => c.id === categoryId);
+    return category ? category.name : t('select_category');
+  }, [categories, t]);
+
+  // Picker modal renderer
+  const renderPickerModal = useCallback((pickerVisible, setPickerVisible, items, onSelect, title) => (
+    <Modal visible={pickerVisible} transparent animationType="fade" onRequestClose={() => setPickerVisible(false)}>
+      <Pressable style={styles.pickerOverlay} onPress={() => setPickerVisible(false)}>
+        <View style={[styles.pickerContent, { backgroundColor: colors.card }]}>
+          <Text style={[styles.pickerTitle, { color: colors.text }]}>{title}</Text>
+          <FlatList
+            data={items}
+            keyExtractor={item => String(item.id)}
+            renderItem={({ item }) => (
+              <Pressable
+                style={[styles.pickerItem, { borderBottomColor: colors.border }]}
+                onPress={() => { onSelect(item.id); setPickerVisible(false); }}
+              >
+                {item.icon && (
+                  <Icon name={item.icon} size={20} color={colors.text} style={styles.pickerItemIcon} />
+                )}
+                <Text style={[styles.pickerItemText, { color: colors.text }]}>{item.name}</Text>
+              </Pressable>
+            )}
+            style={styles.pickerList}
+          />
+          <Pressable style={[styles.pickerCancel, { borderTopColor: colors.border }]} onPress={() => setPickerVisible(false)}>
+            <Text style={[styles.pickerCancelText, { color: colors.primary }]}>{t('cancel')}</Text>
+          </Pressable>
+        </View>
+      </Pressable>
+    </Modal>
+  ), [colors, t]);
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={handleClose}>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.flex1}>
+        <Pressable style={styles.modalOverlay} onPress={handleClose}>
+          <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
+            <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+
+              <Text style={[styles.modalTitle, { color: colors.text }]}>
+                {isNew ? t('add_planned_operation') : t('edit_planned_operation')}
+              </Text>
+
+              {/* Name Input */}
+              <View style={styles.inputContainer}>
+                <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('planned_name')}</Text>
+                <TextInput
+                  style={[styles.input, { color: colors.text, backgroundColor: colors.inputBackground, borderColor: errors.name ? colors.error : colors.inputBorder }]}
+                  value={values.name}
+                  onChangeText={text => setValues(v => ({ ...v, name: text }))}
+                  placeholder={t('planned_operation_name_hint')}
+                  placeholderTextColor={colors.mutedText}
+                  returnKeyType="next"
+                />
+                {errors.name && <Text style={[styles.error, { color: colors.error }]}>{errors.name}</Text>}
+              </View>
+
+              {/* Type Selector */}
+              <View style={styles.inputContainer}>
+                <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('operation_type')}</Text>
+                <View style={styles.typeRow}>
+                  {TYPE_OPTIONS.map(opt => {
+                    const isActive = values.type === opt.key;
+                    return (
+                      <Pressable
+                        key={opt.key}
+                        style={[
+                          styles.typeButton,
+                          {
+                            backgroundColor: isActive ? colors[opt.colorKey] : colors.inputBackground,
+                            borderColor: isActive ? colors[opt.colorKey] : colors.inputBorder,
+                          },
+                        ]}
+                        onPress={() => setValues(v => ({ ...v, type: opt.key, categoryId: null }))}
+                      >
+                        <Icon name={opt.icon} size={18} color={isActive ? '#fff' : colors.mutedText} />
+                        <Text style={[styles.typeLabel, { color: isActive ? '#fff' : colors.mutedText }]}>
+                          {t(`${opt.key}_label`) || t(opt.key)}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+
+              {/* Amount Input */}
+              <View style={styles.inputContainer}>
+                <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('amount')}</Text>
+                <TextInput
+                  style={[styles.input, { color: colors.text, backgroundColor: colors.inputBackground, borderColor: errors.amount ? colors.error : colors.inputBorder }]}
+                  value={values.amount}
+                  onChangeText={text => setValues(v => ({ ...v, amount: text }))}
+                  placeholder="0.00"
+                  placeholderTextColor={colors.mutedText}
+                  keyboardType="decimal-pad"
+                  returnKeyType="done"
+                  onSubmitEditing={Keyboard.dismiss}
+                />
+                {errors.amount && <Text style={[styles.error, { color: colors.error }]}>{errors.amount}</Text>}
+              </View>
+
+              {/* Account Picker */}
+              <View style={styles.inputContainer}>
+                <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('select_account')}</Text>
+                <Pressable
+                  style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.accountId ? colors.error : colors.inputBorder }]}
+                  onPress={() => setAccountPickerVisible(true)}
+                >
+                  <Text style={[styles.pickerButtonText, { color: values.accountId ? colors.text : colors.mutedText }]}>
+                    {values.accountId ? getAccountName(values.accountId) : t('select_account')}
+                  </Text>
+                  <Icon name="chevron-down" size={20} color={colors.mutedText} />
+                </Pressable>
+                {errors.accountId && <Text style={[styles.error, { color: colors.error }]}>{errors.accountId}</Text>}
+              </View>
+
+              {/* Category Picker (for expense/income) */}
+              {values.type !== 'transfer' && (
+                <View style={styles.inputContainer}>
+                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('select_category')}</Text>
+                  <Pressable
+                    style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.categoryId ? colors.error : colors.inputBorder }]}
+                    onPress={() => setCategoryPickerVisible(true)}
+                  >
+                    <Text style={[styles.pickerButtonText, { color: values.categoryId ? colors.text : colors.mutedText }]}>
+                      {values.categoryId ? getCategoryName(values.categoryId) : t('select_category')}
+                    </Text>
+                    <Icon name="chevron-down" size={20} color={colors.mutedText} />
+                  </Pressable>
+                  {errors.categoryId && <Text style={[styles.error, { color: colors.error }]}>{errors.categoryId}</Text>}
+                </View>
+              )}
+
+              {/* To Account Picker (for transfers) */}
+              {values.type === 'transfer' && (
+                <View style={styles.inputContainer}>
+                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('to_account')}</Text>
+                  <Pressable
+                    style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.toAccountId ? colors.error : colors.inputBorder }]}
+                    onPress={() => setToAccountPickerVisible(true)}
+                  >
+                    <Text style={[styles.pickerButtonText, { color: values.toAccountId ? colors.text : colors.mutedText }]}>
+                      {values.toAccountId ? getAccountName(values.toAccountId) : t('select_account')}
+                    </Text>
+                    <Icon name="chevron-down" size={20} color={colors.mutedText} />
+                  </Pressable>
+                  {errors.toAccountId && <Text style={[styles.error, { color: colors.error }]}>{errors.toAccountId}</Text>}
+                </View>
+              )}
+
+              {/* Recurring Toggle */}
+              <View style={[styles.inputContainer, styles.switchRow]}>
+                <Text style={[styles.inputLabel, { color: colors.mutedText, marginBottom: 0 }]}>
+                  {t('recurring')}
+                </Text>
+                <Switch
+                  value={values.isRecurring}
+                  onValueChange={val => setValues(v => ({ ...v, isRecurring: val }))}
+                  trackColor={{ false: colors.border, true: colors.primary + '66' }}
+                  thumbColor={values.isRecurring ? colors.primary : colors.mutedText}
+                />
+              </View>
+
+              {/* Description */}
+              <View style={styles.inputContainer}>
+                <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('description')}</Text>
+                <TextInput
+                  style={[styles.input, styles.multilineInput, { color: colors.text, backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                  value={values.description}
+                  onChangeText={text => setValues(v => ({ ...v, description: text }))}
+                  placeholder={t('description')}
+                  placeholderTextColor={colors.mutedText}
+                  multiline
+                  numberOfLines={2}
+                />
+              </View>
+
+              {/* Action Buttons */}
+              <View style={styles.buttonRow}>
+                {!isNew && (
+                  <Pressable style={[styles.button, { backgroundColor: colors.danger || colors.delete }]} onPress={handleDelete}>
+                    <Text style={styles.buttonText}>{t('delete')}</Text>
+                  </Pressable>
+                )}
+                <Pressable style={[styles.button, { backgroundColor: colors.border }]} onPress={handleClose}>
+                  <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel')}</Text>
+                </Pressable>
+                <Pressable style={[styles.button, { backgroundColor: colors.primary }]} onPress={handleSave}>
+                  <Text style={styles.buttonText}>{t('save')}</Text>
+                </Pressable>
+              </View>
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </KeyboardAvoidingView>
+
+      {/* Account Picker Modal */}
+      {renderPickerModal(
+        accountPickerVisible,
+        setAccountPickerVisible,
+        accounts.map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
+        (id) => setValues(v => ({ ...v, accountId: id })),
+        t('select_account'),
+      )}
+
+      {/* To Account Picker Modal */}
+      {renderPickerModal(
+        toAccountPickerVisible,
+        setToAccountPickerVisible,
+        accounts.filter(a => a.id !== values.accountId).map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
+        (id) => setValues(v => ({ ...v, toAccountId: id })),
+        t('to_account'),
+      )}
+
+      {/* Category Picker Modal */}
+      {renderPickerModal(
+        categoryPickerVisible,
+        setCategoryPickerVisible,
+        filteredCategories.map(c => ({ id: c.id, name: c.name, icon: c.icon })),
+        (id) => setValues(v => ({ ...v, categoryId: id })),
+        t('select_category'),
+      )}
+    </Modal>
+  );
+}
+
+PlannedOperationModal.propTypes = {
+  visible: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  plannedOperation: PropTypes.object,
+  isNew: PropTypes.bool,
+};
+
+PlannedOperationModal.defaultProps = {
+  visible: false,
+  plannedOperation: null,
+  isNew: true,
+};
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    flex: 1,
+    justifyContent: 'center',
+    marginHorizontal: SPACING.xs,
+    paddingVertical: SPACING.md,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    marginTop: SPACING.lg,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: FONT_SIZE.md,
+    fontWeight: '600',
+  },
+  error: {
+    fontSize: FONT_SIZE.sm,
+    marginTop: SPACING.xs,
+  },
+  flex1: {
+    flex: 1,
+  },
+  input: {
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
+    fontSize: FONT_SIZE.base,
+    height: HEIGHTS.input,
+    paddingHorizontal: SPACING.md,
+  },
+  inputContainer: {
+    marginBottom: SPACING.md,
+  },
+  inputLabel: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '500',
+    marginBottom: SPACING.xs,
+  },
+  modalContent: {
+    borderTopLeftRadius: BORDER_RADIUS.lg,
+    borderTopRightRadius: BORDER_RADIUS.lg,
+    maxHeight: '90%',
+    paddingBottom: SPACING.xxl,
+    paddingHorizontal: SPACING.xl,
+    paddingTop: SPACING.lg,
+    width: '100%',
+  },
+  modalOverlay: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  modalTitle: {
+    fontSize: FONT_SIZE.lg,
+    fontWeight: '700',
+    marginBottom: SPACING.lg,
+    textAlign: 'center',
+  },
+  multilineInput: {
+    height: 70,
+    paddingTop: SPACING.md,
+    textAlignVertical: 'top',
+  },
+  pickerButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
+    flexDirection: 'row',
+    height: HEIGHTS.input,
+    justifyContent: 'space-between',
+    paddingHorizontal: SPACING.md,
+  },
+  pickerButtonText: {
+    flex: 1,
+    fontSize: FONT_SIZE.base,
+  },
+  pickerCancel: {
+    alignItems: 'center',
+    borderTopWidth: 1,
+    paddingVertical: SPACING.md,
+  },
+  pickerCancelText: {
+    fontSize: FONT_SIZE.base,
+    fontWeight: '600',
+  },
+  pickerContent: {
+    borderTopLeftRadius: BORDER_RADIUS.lg,
+    borderTopRightRadius: BORDER_RADIUS.lg,
+    maxHeight: '60%',
+    paddingTop: SPACING.lg,
+    width: '100%',
+  },
+  pickerItem: {
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    paddingHorizontal: SPACING.xl,
+    paddingVertical: SPACING.md,
+  },
+  pickerItemIcon: {
+    marginRight: SPACING.sm,
+  },
+  pickerItemText: {
+    fontSize: FONT_SIZE.base,
+  },
+  pickerList: {
+    maxHeight: 300,
+  },
+  pickerOverlay: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  pickerTitle: {
+    fontSize: FONT_SIZE.lg,
+    fontWeight: '600',
+    marginBottom: SPACING.md,
+    paddingHorizontal: SPACING.xl,
+  },
+  scrollContent: {
+    paddingBottom: SPACING.lg,
+  },
+  scrollView: {
+    flexGrow: 0,
+  },
+  switchRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  typeButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    flex: 1,
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    justifyContent: 'center',
+    marginHorizontal: SPACING.xs,
+    paddingVertical: SPACING.sm,
+  },
+  typeLabel: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '600',
+  },
+  typeRow: {
+    flexDirection: 'row',
+  },
+});

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -15,6 +15,7 @@ import OperationsScreen from '../screens/OperationsScreen';
 import AccountsScreen from '../screens/AccountsScreen';
 import CategoriesScreen from '../screens/CategoriesScreen';
 import GraphsScreen from '../screens/GraphsScreen';
+import PlannedOperationsScreen from '../screens/PlannedOperationsScreen';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import Header from '../components/Header';
@@ -33,6 +34,7 @@ const TAB_ICONS = {
   Graphs: 'chart-line',
   Accounts: 'wallet-outline',
   Categories: 'shape-outline',
+  Planned: 'calendar-clock',
 };
 
 // Memoized tab button with icon + label, pill active state
@@ -110,6 +112,7 @@ export default function SimpleTabs() {
     { key: 'Graphs', label: t('graphs') || 'Graphs' },
     { key: 'Accounts', label: t('accounts') || 'Accounts' },
     { key: 'Categories', label: t('categories') || 'Categories' },
+    { key: 'Planned', label: t('planned') || 'Planned' },
   ], [t]);
 
   // Animation shared values
@@ -233,6 +236,9 @@ export default function SimpleTabs() {
         <View style={styles.screen}>
           <CategoriesScreen />
         </View>
+        <View style={styles.screen}>
+          <PlannedOperationsScreen />
+        </View>
       </>
     );
   }, []);
@@ -335,7 +341,7 @@ const styles = StyleSheet.create({
   screensContainer: {
     flex: 1,
     flexDirection: 'row',
-    width: SCREEN_WIDTH * 4,
+    width: SCREEN_WIDTH * 5,
   },
   tab: {
     flex: 1,

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -141,16 +141,15 @@ export default function PlannedOperationsScreen() {
     const currencySymbol = getCurrencySymbol(accountCurrency);
     const typeColor = colors[TYPE_COLORS[item.type]] || colors.text;
 
+    const itemStyle = {
+      backgroundColor: colors.card,
+      borderColor: colors.border,
+      opacity: executed ? 0.6 : 1,
+    };
+
     return (
       <Pressable
-        style={[
-          styles.itemContainer,
-          {
-            backgroundColor: colors.card,
-            borderColor: colors.border,
-            opacity: executed ? 0.6 : 1,
-          },
-        ]}
+        style={[styles.itemContainer, itemStyle]}
         onPress={() => handleEdit(item)}
         onLongPress={() => handleLongPress(item)}
       >
@@ -221,18 +220,21 @@ export default function PlannedOperationsScreen() {
     );
   }, [loading, colors, t]);
 
+  const recurringTabStyle = {
+    backgroundColor: activeTab === 'recurring' ? colors.primary + '1A' : 'transparent',
+    borderColor: activeTab === 'recurring' ? colors.primary : colors.border,
+  };
+  const oneTimeTabStyle = {
+    backgroundColor: activeTab === 'one_time' ? colors.primary + '1A' : 'transparent',
+    borderColor: activeTab === 'one_time' ? colors.primary : colors.border,
+  };
+
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       {/* Tab Selector */}
       <View style={styles.tabRow}>
         <Pressable
-          style={[
-            styles.tab,
-            {
-              backgroundColor: activeTab === 'recurring' ? colors.primary + '1A' : 'transparent',
-              borderColor: activeTab === 'recurring' ? colors.primary : colors.border,
-            },
-          ]}
+          style={[styles.tab, recurringTabStyle]}
           onPress={() => setActiveTab('recurring')}
         >
           <Icon
@@ -245,13 +247,7 @@ export default function PlannedOperationsScreen() {
           </Text>
         </Pressable>
         <Pressable
-          style={[
-            styles.tab,
-            {
-              backgroundColor: activeTab === 'one_time' ? colors.primary + '1A' : 'transparent',
-              borderColor: activeTab === 'one_time' ? colors.primary : colors.border,
-            },
-          ]}
+          style={[styles.tab, oneTimeTabStyle]}
           onPress={() => setActiveTab('one_time')}
         >
           <Icon
@@ -300,7 +296,7 @@ export default function PlannedOperationsScreen() {
         visible={snackbarVisible}
         onDismiss={() => setSnackbarVisible(false)}
         duration={2000}
-        style={{ marginBottom: 100 }}
+        style={styles.snackbar}
       >
         {snackbarMessage}
       </Snackbar>
@@ -388,6 +384,9 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingBottom: 180,
+  },
+  snackbar: {
+    marginBottom: 100,
   },
   tab: {
     alignItems: 'center',

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -1,0 +1,411 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import { View, StyleSheet, FlatList, Pressable } from 'react-native';
+import { Text, FAB, ActivityIndicator, Snackbar } from 'react-native-paper';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HEIGHTS } from '../styles/designTokens';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { useDialog } from '../contexts/DialogContext';
+import { usePlannedOperations } from '../contexts/PlannedOperationsContext';
+import { useAccountsData } from '../contexts/AccountsDataContext';
+import { useCategories } from '../contexts/CategoriesContext';
+import PlannedOperationModal from '../modals/PlannedOperationModal';
+import currencies from '../../assets/currencies.json';
+
+const TYPE_COLORS = {
+  expense: 'expense',
+  income: 'income',
+  transfer: 'transfer',
+};
+
+const TYPE_ICONS = {
+  expense: 'arrow-up',
+  income: 'arrow-down',
+  transfer: 'swap-horizontal',
+};
+
+export default function PlannedOperationsScreen() {
+  const { colors } = useThemeColors();
+  const { t } = useLocalization();
+  const { showDialog } = useDialog();
+  const {
+    plannedOperations,
+    loading,
+    executePlannedOperation,
+    deletePlannedOperation,
+    isExecutedThisMonth,
+  } = usePlannedOperations();
+  const { visibleAccounts: accounts } = useAccountsData();
+  const { categories } = useCategories();
+
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingOp, setEditingOp] = useState(null);
+  const [isNew, setIsNew] = useState(true);
+  const [activeTab, setActiveTab] = useState('recurring');
+  const [snackbarVisible, setSnackbarVisible] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+
+  // Filter planned operations by tab
+  const filteredOps = useMemo(() => {
+    if (activeTab === 'recurring') {
+      return plannedOperations.filter(op => op.isRecurring);
+    }
+    return plannedOperations.filter(op => !op.isRecurring);
+  }, [plannedOperations, activeTab]);
+
+  const getAccountName = useCallback((accountId) => {
+    const account = accounts.find(a => a.id === accountId);
+    return account ? account.name : '?';
+  }, [accounts]);
+
+  const getAccountCurrency = useCallback((accountId) => {
+    const account = accounts.find(a => a.id === accountId);
+    return account ? account.currency : '';
+  }, [accounts]);
+
+  const getCurrencySymbol = useCallback((currencyCode) => {
+    if (!currencyCode) return '';
+    const currency = currencies[currencyCode];
+    return currency ? currency.symbol : currencyCode;
+  }, []);
+
+  const getCategoryInfo = useCallback((categoryId) => {
+    const category = (categories || []).find(c => c.id === categoryId);
+    return category ? { name: category.name, icon: category.icon } : { name: '', icon: null };
+  }, [categories]);
+
+  const handleAdd = useCallback(() => {
+    setEditingOp(null);
+    setIsNew(true);
+    setModalVisible(true);
+  }, []);
+
+  const handleEdit = useCallback((op) => {
+    setEditingOp(op);
+    setIsNew(false);
+    setModalVisible(true);
+  }, []);
+
+  const handleCloseModal = useCallback(() => {
+    setModalVisible(false);
+    setEditingOp(null);
+  }, []);
+
+  const handleExecute = useCallback(async (op) => {
+    try {
+      await executePlannedOperation(op);
+      setSnackbarMessage(t('added_to_operations'));
+      setSnackbarVisible(true);
+    } catch (error) {
+      // Error handled by context
+    }
+  }, [executePlannedOperation, t]);
+
+  const handleLongPress = useCallback((op) => {
+    showDialog(
+      t('select_action'),
+      op.name,
+      [
+        {
+          text: t('edit'),
+          onPress: () => handleEdit(op),
+        },
+        {
+          text: t('delete'),
+          style: 'destructive',
+          onPress: () => {
+            showDialog(
+              t('delete_planned_operation'),
+              t('delete_planned_confirm'),
+              [
+                { text: t('cancel'), style: 'cancel' },
+                {
+                  text: t('delete'),
+                  style: 'destructive',
+                  onPress: () => deletePlannedOperation(op.id),
+                },
+              ],
+            );
+          },
+        },
+        { text: t('cancel'), style: 'cancel' },
+      ],
+    );
+  }, [showDialog, t, handleEdit, deletePlannedOperation]);
+
+  const renderItem = useCallback(({ item }) => {
+    const executed = isExecutedThisMonth(item);
+    const categoryInfo = getCategoryInfo(item.categoryId);
+    const accountCurrency = getAccountCurrency(item.accountId);
+    const currencySymbol = getCurrencySymbol(accountCurrency);
+    const typeColor = colors[TYPE_COLORS[item.type]] || colors.text;
+
+    return (
+      <Pressable
+        style={[
+          styles.itemContainer,
+          {
+            backgroundColor: colors.card,
+            borderColor: colors.border,
+            opacity: executed ? 0.6 : 1,
+          },
+        ]}
+        onPress={() => handleEdit(item)}
+        onLongPress={() => handleLongPress(item)}
+      >
+        {/* Left: Category icon or type icon */}
+        <View style={[styles.iconContainer, { backgroundColor: typeColor + '1A' }]}>
+          <Icon
+            name={categoryInfo.icon || TYPE_ICONS[item.type]}
+            size={22}
+            color={typeColor}
+          />
+        </View>
+
+        {/* Center: Name, account, category */}
+        <View style={styles.itemDetails}>
+          <Text style={[styles.itemName, { color: colors.text }]} numberOfLines={1}>
+            {item.name}
+          </Text>
+          <View style={styles.itemMeta}>
+            <Text style={[styles.itemMetaText, { color: colors.mutedText }]} numberOfLines={1}>
+              {getAccountName(item.accountId)}
+              {categoryInfo.name ? ` • ${categoryInfo.name}` : ''}
+            </Text>
+          </View>
+        </View>
+
+        {/* Right: Amount and execute button */}
+        <View style={styles.itemRight}>
+          <Text style={[styles.itemAmount, { color: typeColor }]} numberOfLines={1}>
+            {currencySymbol}{item.amount}
+          </Text>
+          <Pressable
+            style={[
+              styles.executeButton,
+              {
+                backgroundColor: executed ? colors.income + '1A' : colors.primary + '1A',
+              },
+            ]}
+            onPress={() => !executed && handleExecute(item)}
+            disabled={executed}
+            hitSlop={8}
+          >
+            <Icon
+              name={executed ? 'check-circle' : 'play-circle-outline'}
+              size={24}
+              color={executed ? colors.income : colors.primary}
+            />
+          </Pressable>
+        </View>
+      </Pressable>
+    );
+  }, [colors, isExecutedThisMonth, getCategoryInfo, getAccountName, getAccountCurrency, getCurrencySymbol, handleEdit, handleLongPress, handleExecute]);
+
+  const renderEmpty = useCallback(() => {
+    if (loading) {
+      return (
+        <View style={styles.emptyContainer}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      );
+    }
+    return (
+      <View style={styles.emptyContainer}>
+        <Icon name="calendar-blank-outline" size={48} color={colors.mutedText} />
+        <Text style={[styles.emptyText, { color: colors.mutedText }]}>
+          {t('no_planned_operations')}
+        </Text>
+      </View>
+    );
+  }, [loading, colors, t]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {/* Tab Selector */}
+      <View style={styles.tabRow}>
+        <Pressable
+          style={[
+            styles.tab,
+            {
+              backgroundColor: activeTab === 'recurring' ? colors.primary + '1A' : 'transparent',
+              borderColor: activeTab === 'recurring' ? colors.primary : colors.border,
+            },
+          ]}
+          onPress={() => setActiveTab('recurring')}
+        >
+          <Icon
+            name="refresh"
+            size={16}
+            color={activeTab === 'recurring' ? colors.primary : colors.mutedText}
+          />
+          <Text style={[styles.tabText, { color: activeTab === 'recurring' ? colors.primary : colors.mutedText }]}>
+            {t('recurring')}
+          </Text>
+        </Pressable>
+        <Pressable
+          style={[
+            styles.tab,
+            {
+              backgroundColor: activeTab === 'one_time' ? colors.primary + '1A' : 'transparent',
+              borderColor: activeTab === 'one_time' ? colors.primary : colors.border,
+            },
+          ]}
+          onPress={() => setActiveTab('one_time')}
+        >
+          <Icon
+            name="numeric-1-circle-outline"
+            size={16}
+            color={activeTab === 'one_time' ? colors.primary : colors.mutedText}
+          />
+          <Text style={[styles.tabText, { color: activeTab === 'one_time' ? colors.primary : colors.mutedText }]}>
+            {t('one_time')}
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* List */}
+      <FlatList
+        data={filteredOps}
+        keyExtractor={item => item.id}
+        renderItem={renderItem}
+        ListEmptyComponent={renderEmpty}
+        contentContainerStyle={filteredOps.length === 0 ? styles.emptyList : styles.listContent}
+        windowSize={10}
+        maxToRenderPerBatch={10}
+        removeClippedSubviews={true}
+      />
+
+      {/* FAB */}
+      <FAB
+        icon="plus"
+        label={t('add_planned_operation')}
+        style={[styles.fab, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}
+        color={colors.text}
+        onPress={handleAdd}
+        accessibilityLabel={t('add_planned_operation')}
+      />
+
+      {/* Modal */}
+      <PlannedOperationModal
+        visible={modalVisible}
+        onClose={handleCloseModal}
+        plannedOperation={editingOp}
+        isNew={isNew}
+      />
+
+      {/* Snackbar */}
+      <Snackbar
+        visible={snackbarVisible}
+        onDismiss={() => setSnackbarVisible(false)}
+        duration={2000}
+        style={{ marginBottom: 100 }}
+      >
+        {snackbarMessage}
+      </Snackbar>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingTop: TOP_CONTENT_SPACING,
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    gap: SPACING.md,
+    justifyContent: 'center',
+    paddingTop: 80,
+  },
+  emptyList: {
+    flexGrow: 1,
+  },
+  emptyText: {
+    fontSize: FONT_SIZE.md,
+  },
+  executeButton: {
+    alignItems: 'center',
+    borderRadius: 20,
+    height: 36,
+    justifyContent: 'center',
+    width: 36,
+  },
+  fab: {
+    borderRadius: 28,
+    borderWidth: 1,
+    bottom: 100,
+    elevation: 8,
+    margin: SPACING.lg,
+    position: 'absolute',
+    right: 0,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  iconContainer: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    height: 40,
+    justifyContent: 'center',
+    width: 40,
+  },
+  itemAmount: {
+    fontSize: FONT_SIZE.md,
+    fontWeight: '700',
+    textAlign: 'right',
+  },
+  itemContainer: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: SPACING.md,
+    marginBottom: SPACING.sm,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.md,
+  },
+  itemDetails: {
+    flex: 1,
+    gap: 2,
+  },
+  itemMeta: {
+    flexDirection: 'row',
+  },
+  itemMetaText: {
+    fontSize: FONT_SIZE.sm,
+  },
+  itemName: {
+    fontSize: FONT_SIZE.md,
+    fontWeight: '600',
+  },
+  itemRight: {
+    alignItems: 'flex-end',
+    gap: SPACING.xs,
+  },
+  listContent: {
+    paddingBottom: 180,
+  },
+  tab: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    flex: 1,
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    justifyContent: 'center',
+    marginHorizontal: SPACING.xs,
+    paddingVertical: SPACING.sm,
+  },
+  tabRow: {
+    flexDirection: 'row',
+    marginBottom: SPACING.md,
+  },
+  tabText: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '600',
+  },
+});

--- a/app/services/PlannedOperationsDB.js
+++ b/app/services/PlannedOperationsDB.js
@@ -1,0 +1,261 @@
+import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
+
+/**
+ * Map database field names to camelCase for application use
+ */
+const mapPlannedOperationFields = (dbRow) => {
+  if (!dbRow) return null;
+
+  return {
+    id: dbRow.id,
+    name: dbRow.name,
+    type: dbRow.type,
+    amount: dbRow.amount,
+    accountId: dbRow.account_id,
+    categoryId: dbRow.category_id,
+    toAccountId: dbRow.to_account_id,
+    description: dbRow.description,
+    isRecurring: dbRow.is_recurring === 1,
+    lastExecutedMonth: dbRow.last_executed_month,
+    displayOrder: dbRow.display_order,
+    createdAt: dbRow.created_at,
+    updatedAt: dbRow.updated_at,
+  };
+};
+
+/**
+ * Validate planned operation data
+ * @param {Object} op - Planned operation to validate
+ * @returns {string|null} Error message or null if valid
+ */
+export const validatePlannedOperation = (op) => {
+  if (!op.name || !op.name.trim()) {
+    return 'planned_name_required';
+  }
+
+  if (!op.type || !['expense', 'income', 'transfer'].includes(op.type)) {
+    return 'operation_type_required';
+  }
+
+  if (!op.amount || parseFloat(op.amount) <= 0) {
+    return 'valid_amount_required';
+  }
+
+  if (!op.accountId) {
+    return 'account_required';
+  }
+
+  if (op.type === 'transfer') {
+    if (!op.toAccountId) {
+      return 'destination_account_required';
+    }
+    if (op.accountId === op.toAccountId) {
+      return 'accounts_must_be_different';
+    }
+  } else {
+    if (!op.categoryId) {
+      return 'category_required';
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Create a new planned operation
+ */
+export const createPlannedOperation = async (op) => {
+  try {
+    const validationError = validatePlannedOperation(op);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
+    const now = new Date().toISOString();
+    const data = {
+      id: op.id,
+      name: op.name.trim(),
+      type: op.type,
+      amount: op.amount,
+      account_id: op.accountId,
+      category_id: op.categoryId || null,
+      to_account_id: op.toAccountId || null,
+      description: op.description || null,
+      is_recurring: op.isRecurring !== false ? 1 : 0,
+      last_executed_month: null,
+      display_order: op.displayOrder || null,
+      created_at: now,
+      updated_at: now,
+    };
+
+    await executeQuery(
+      `INSERT INTO planned_operations (id, name, type, amount, account_id, category_id, to_account_id, description, is_recurring, last_executed_month, display_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        data.id, data.name, data.type, data.amount,
+        data.account_id, data.category_id, data.to_account_id,
+        data.description, data.is_recurring, data.last_executed_month,
+        data.display_order, data.created_at, data.updated_at,
+      ],
+    );
+
+    return mapPlannedOperationFields(data);
+  } catch (error) {
+    console.error('Failed to create planned operation:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get planned operation by ID
+ */
+export const getPlannedOperationById = async (id) => {
+  try {
+    const row = await queryFirst(
+      'SELECT * FROM planned_operations WHERE id = ?',
+      [id],
+    );
+    return mapPlannedOperationFields(row);
+  } catch (error) {
+    console.error('Failed to get planned operation:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get all planned operations ordered by display_order then created_at
+ */
+export const getAllPlannedOperations = async () => {
+  try {
+    const rows = await queryAll(
+      'SELECT * FROM planned_operations ORDER BY display_order ASC, created_at ASC',
+    );
+    return (rows || []).map(mapPlannedOperationFields);
+  } catch (error) {
+    console.error('Failed to get planned operations:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get recurring planned operations
+ */
+export const getRecurringPlannedOperations = async () => {
+  try {
+    const rows = await queryAll(
+      'SELECT * FROM planned_operations WHERE is_recurring = 1 ORDER BY display_order ASC, created_at ASC',
+    );
+    return (rows || []).map(mapPlannedOperationFields);
+  } catch (error) {
+    console.error('Failed to get recurring planned operations:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get one-time planned operations
+ */
+export const getOneTimePlannedOperations = async () => {
+  try {
+    const rows = await queryAll(
+      'SELECT * FROM planned_operations WHERE is_recurring = 0 ORDER BY display_order ASC, created_at ASC',
+    );
+    return (rows || []).map(mapPlannedOperationFields);
+  } catch (error) {
+    console.error('Failed to get one-time planned operations:', error);
+    throw error;
+  }
+};
+
+/**
+ * Update a planned operation
+ */
+export const updatePlannedOperation = async (id, updates) => {
+  try {
+    const updatedAt = new Date().toISOString();
+    const fields = [];
+    const values = [];
+
+    if (updates.name !== undefined) {
+      fields.push('name = ?');
+      values.push(updates.name.trim());
+    }
+    if (updates.type !== undefined) {
+      fields.push('type = ?');
+      values.push(updates.type);
+    }
+    if (updates.amount !== undefined) {
+      fields.push('amount = ?');
+      values.push(updates.amount);
+    }
+    if (updates.accountId !== undefined) {
+      fields.push('account_id = ?');
+      values.push(updates.accountId);
+    }
+    if (updates.categoryId !== undefined) {
+      fields.push('category_id = ?');
+      values.push(updates.categoryId || null);
+    }
+    if (updates.toAccountId !== undefined) {
+      fields.push('to_account_id = ?');
+      values.push(updates.toAccountId || null);
+    }
+    if (updates.description !== undefined) {
+      fields.push('description = ?');
+      values.push(updates.description || null);
+    }
+    if (updates.isRecurring !== undefined) {
+      fields.push('is_recurring = ?');
+      values.push(updates.isRecurring ? 1 : 0);
+    }
+    if (updates.lastExecutedMonth !== undefined) {
+      fields.push('last_executed_month = ?');
+      values.push(updates.lastExecutedMonth);
+    }
+    if (updates.displayOrder !== undefined) {
+      fields.push('display_order = ?');
+      values.push(updates.displayOrder);
+    }
+
+    if (fields.length === 0) return;
+
+    fields.push('updated_at = ?');
+    values.push(updatedAt);
+    values.push(id);
+
+    const sql = `UPDATE planned_operations SET ${fields.join(', ')} WHERE id = ?`;
+    await executeQuery(sql, values);
+  } catch (error) {
+    console.error('Failed to update planned operation:', error);
+    throw error;
+  }
+};
+
+/**
+ * Delete a planned operation
+ */
+export const deletePlannedOperation = async (id) => {
+  try {
+    await executeQuery('DELETE FROM planned_operations WHERE id = ?', [id]);
+  } catch (error) {
+    console.error('Failed to delete planned operation:', error);
+    throw error;
+  }
+};
+
+/**
+ * Mark a planned operation as executed for a given month
+ * @param {string} id - Planned operation ID
+ * @param {string} monthStr - 'YYYY-MM' format
+ */
+export const markExecuted = async (id, monthStr) => {
+  try {
+    await executeQuery(
+      'UPDATE planned_operations SET last_executed_month = ?, updated_at = ? WHERE id = ?',
+      [monthStr, new Date().toISOString(), id],
+    );
+  } catch (error) {
+    console.error('Failed to mark planned operation as executed:', error);
+    throw error;
+  }
+};

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -326,5 +326,19 @@
   "log_level_error": "Fehler",
   "log_level_warn": "Warnung",
   "log_level_info": "Info",
-  "log_level_debug": "Debug"
+  "log_level_debug": "Debug",
+  "planned": "Geplant",
+  "planned_operations": "Geplante Operationen",
+  "add_planned_operation": "Geplante hinzufügen",
+  "edit_planned_operation": "Geplante bearbeiten",
+  "delete_planned_operation": "Geplante löschen",
+  "delete_planned_confirm": "Möchten Sie diese geplante Operation wirklich löschen?",
+  "planned_name": "Name",
+  "planned_name_required": "Name ist erforderlich",
+  "one_time": "Einmalig",
+  "no_planned_operations": "Noch keine geplanten Operationen.",
+  "already_executed": "Bereits diesen Monat hinzugefügt",
+  "add_to_operations": "Zu Operationen hinzufügen",
+  "added_to_operations": "Zu Operationen hinzugefügt",
+  "planned_operation_name_hint": "z.B. Miete, Netflix, Lebensmittel"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -326,5 +326,19 @@
   "log_level_error": "Error",
   "log_level_warn": "Warn",
   "log_level_info": "Info",
-  "log_level_debug": "Debug"
+  "log_level_debug": "Debug",
+  "planned": "Planned",
+  "planned_operations": "Planned Operations",
+  "add_planned_operation": "Add Planned",
+  "edit_planned_operation": "Edit Planned",
+  "delete_planned_operation": "Delete Planned",
+  "delete_planned_confirm": "Are you sure you want to delete this planned operation?",
+  "planned_name": "Name",
+  "planned_name_required": "Name is required",
+  "one_time": "One-time",
+  "no_planned_operations": "No planned operations yet.",
+  "already_executed": "Already added this month",
+  "add_to_operations": "Add to Operations",
+  "added_to_operations": "Added to operations",
+  "planned_operation_name_hint": "e.g. Rent, Netflix, Groceries"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -326,5 +326,19 @@
   "log_level_error": "Error",
   "log_level_warn": "Aviso",
   "log_level_info": "Info",
-  "log_level_debug": "Depurar"
+  "log_level_debug": "Depurar",
+  "planned": "Planificados",
+  "planned_operations": "Operaciones Planificadas",
+  "add_planned_operation": "Agregar Planificada",
+  "edit_planned_operation": "Editar Planificada",
+  "delete_planned_operation": "Eliminar Planificada",
+  "delete_planned_confirm": "¿Estás seguro de que quieres eliminar esta operación planificada?",
+  "planned_name": "Nombre",
+  "planned_name_required": "El nombre es obligatorio",
+  "one_time": "Única vez",
+  "no_planned_operations": "No hay operaciones planificadas.",
+  "already_executed": "Ya agregada este mes",
+  "add_to_operations": "Agregar a Operaciones",
+  "added_to_operations": "Agregada a operaciones",
+  "planned_operation_name_hint": "ej. Alquiler, Netflix, Compras"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -326,5 +326,19 @@
   "log_level_error": "Erreur",
   "log_level_warn": "Avertir",
   "log_level_info": "Info",
-  "log_level_debug": "Débogage"
+  "log_level_debug": "Débogage",
+  "planned": "Planifiés",
+  "planned_operations": "Opérations Planifiées",
+  "add_planned_operation": "Ajouter Planifiée",
+  "edit_planned_operation": "Modifier Planifiée",
+  "delete_planned_operation": "Supprimer Planifiée",
+  "delete_planned_confirm": "Êtes-vous sûr de vouloir supprimer cette opération planifiée ?",
+  "planned_name": "Nom",
+  "planned_name_required": "Le nom est obligatoire",
+  "one_time": "Ponctuelle",
+  "no_planned_operations": "Aucune opération planifiée.",
+  "already_executed": "Déjà ajoutée ce mois-ci",
+  "add_to_operations": "Ajouter aux Opérations",
+  "added_to_operations": "Ajoutée aux opérations",
+  "planned_operation_name_hint": "ex. Loyer, Netflix, Courses"
 }

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -312,5 +312,19 @@
   "tap_for_details": "Սեղմեք մանրամասների համար",
   "all_categories": "Բոլոր կատեգորիաները",
   "manual_rate_info": "Ձեռակի փոխարժեք",
-  "all_accounts": "Բոլոր հաշվեր"
+  "all_accounts": "Բոլոր հաշվեր",
+  "planned": "Պլանավորված",
+  "planned_operations": "Պլանավորված գործարկներ",
+  "add_planned_operation": "Ավելացնել պլանավորված",
+  "edit_planned_operation": "Խմբագրել պլանավորվածը",
+  "delete_planned_operation": "Ջնջել պլանավորվածը",
+  "delete_planned_confirm": "Վստահ եք, որ ցանկանում եք ջնջել այս պլանավորված գործարկը։",
+  "planned_name": "Անուն",
+  "planned_name_required": "Անունը պարտադիր է",
+  "one_time": "Միանգամյա",
+  "no_planned_operations": "Պլանավորված գործարկներ չկան։",
+  "already_executed": "Արդեն ավելացվել է այս ամիս",
+  "add_to_operations": "Ավելացնել գործարկներին",
+  "added_to_operations": "Ավելացվել է գործարկներին",
+  "planned_operation_name_hint": "օր. Վարձակալություն, Netflix, Մսերքներ"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -85,5 +85,19 @@
   "log_level_error": "Errore",
   "log_level_warn": "Avviso",
   "log_level_info": "Info",
-  "log_level_debug": "Debug"
+  "log_level_debug": "Debug",
+  "planned": "Pianificati",
+  "planned_operations": "Operazioni Pianificate",
+  "add_planned_operation": "Aggiungi Pianificata",
+  "edit_planned_operation": "Modifica Pianificata",
+  "delete_planned_operation": "Elimina Pianificata",
+  "delete_planned_confirm": "Sei sicuro di voler eliminare questa operazione pianificata?",
+  "planned_name": "Nome",
+  "planned_name_required": "Il nome è obbligatorio",
+  "one_time": "Una tantum",
+  "no_planned_operations": "Nessuna operazione pianificata.",
+  "already_executed": "Già aggiunta questo mese",
+  "add_to_operations": "Aggiungi alle Operazioni",
+  "added_to_operations": "Aggiunta alle operazioni",
+  "planned_operation_name_hint": "es. Affitto, Netflix, Spesa"
 }

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -324,5 +324,19 @@
   "log_level_error": "Ошибки",
   "log_level_warn": "Предупр.",
   "log_level_info": "Инфо",
-  "log_level_debug": "Отладка"
+  "log_level_debug": "Отладка",
+  "planned": "Планы",
+  "planned_operations": "Запланированные операции",
+  "add_planned_operation": "Добавить план",
+  "edit_planned_operation": "Изменить план",
+  "delete_planned_operation": "Удалить план",
+  "delete_planned_confirm": "Вы уверены, что хотите удалить эту запланированную операцию?",
+  "planned_name": "Название",
+  "planned_name_required": "Название обязательно",
+  "one_time": "Разовая",
+  "no_planned_operations": "Нет запланированных операций.",
+  "already_executed": "Уже добавлено в этом месяце",
+  "add_to_operations": "Добавить в операции",
+  "added_to_operations": "Добавлено в операции",
+  "planned_operation_name_hint": "напр. Аренда, Netflix, Продукты"
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -326,5 +326,19 @@
   "log_level_error": "错误",
   "log_level_warn": "警告",
   "log_level_info": "信息",
-  "log_level_debug": "调试"
+  "log_level_debug": "调试",
+  "planned": "计划",
+  "planned_operations": "计划操作",
+  "add_planned_operation": "添加计划",
+  "edit_planned_operation": "编辑计划",
+  "delete_planned_operation": "删除计划",
+  "delete_planned_confirm": "确定要删除此计划操作吗？",
+  "planned_name": "名称",
+  "planned_name_required": "名称为必填项",
+  "one_time": "一次性",
+  "no_planned_operations": "暂无计划操作。",
+  "already_executed": "本月已添加",
+  "add_to_operations": "添加到操作",
+  "added_to_operations": "已添加到操作",
+  "planned_operation_name_hint": "例如：房租、Netflix、杂货"
 }

--- a/drizzle/0005_planned_operations.js
+++ b/drizzle/0005_planned_operations.js
@@ -1,0 +1,30 @@
+/**
+ * Migration 0005: Add planned_operations table
+ *
+ * Creates a table for storing planned/template operations that can be
+ * quickly converted to real operations with one tap.
+ */
+
+const sql = `CREATE TABLE \`planned_operations\` (
+	\`id\` text PRIMARY KEY NOT NULL,
+	\`name\` text NOT NULL,
+	\`type\` text NOT NULL,
+	\`amount\` text NOT NULL,
+	\`account_id\` integer NOT NULL,
+	\`category_id\` text,
+	\`to_account_id\` integer,
+	\`description\` text,
+	\`is_recurring\` integer NOT NULL DEFAULT 1,
+	\`last_executed_month\` text,
+	\`display_order\` integer,
+	\`created_at\` text NOT NULL,
+	\`updated_at\` text NOT NULL,
+	FOREIGN KEY (\`account_id\`) REFERENCES \`accounts\`(\`id\`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (\`category_id\`) REFERENCES \`categories\`(\`id\`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (\`to_account_id\`) REFERENCES \`accounts\`(\`id\`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+CREATE INDEX \`idx_planned_ops_account\` ON \`planned_operations\` (\`account_id\`);--> statement-breakpoint
+CREATE INDEX \`idx_planned_ops_type\` ON \`planned_operations\` (\`type\`);--> statement-breakpoint
+CREATE INDEX \`idx_planned_ops_recurring\` ON \`planned_operations\` (\`is_recurring\`)`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1765900000000,
       "tag": "0004_remove_exclude_from_forecast",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1766000000000,
+      "tag": "0005_planned_operations",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -6,6 +6,7 @@ import m0001 from './0001_modern_lester.js';
 import m0002 from './0002_illegal_apocalypse.js';
 import m0003, { postMigration as m0003PostMigration } from './0003_slow_grandmaster.js';
 import m0004 from './0004_remove_exclude_from_forecast.js';
+import m0005 from './0005_planned_operations.js';
 
 export default {
   journal,
@@ -15,6 +16,7 @@ export default {
     m0002,
     m0003,
     m0004,
+    m0005,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,


### PR DESCRIPTION
Users can now plan recurring and one-time operations (rent, subscriptions,
groceries, etc.) and quickly add them to the real operations list with one tap.

New features:
- 5th "Planned" tab with recurring/one-time toggle
- Create, edit, delete planned operations with name, type, amount, account, category
- One-tap fast-add: instantly creates a real operation with today's date
- Recurring ops show checkmark when executed this month; one-time ops auto-remove
- Full backup/restore support for planned operations
- Translations in all 8 languages (en, it, ru, es, fr, zh, de, hy)

Implementation:
- New planned_operations table with migration 0005
- PlannedOperationsDB service (CRUD + validation + execution tracking)
- PlannedOperationsContext (single context, event-driven reload)
- PlannedOperationModal (type/amount/account/category/recurring)
- PlannedOperationsScreen (FlatList with execute buttons, Snackbar feedback)
- Updated SimpleTabs navigation (5 tabs), App.js provider hierarchy
- Updated BackupRestore for JSON, CSV, and SQLite formats
- All 2820 tests passing (83 suites)

https://claude.ai/code/session_01RPWMtUE5ctQiiDjmYSJx6z