### PR TITLE
feat: add planned operations feature for monthly budget planning

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -184,6 +184,7 @@ jobs:
               { file: '02_graphs', desc: 'Graphs' },
               { file: '03_accounts', desc: 'Accounts' },
               { file: '04_categories', desc: 'Categories' },
+              { file: '08_planned', desc: 'Planned Operations' },
               { file: '07_settings', desc: 'Settings' },
             ];
 

--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -67,6 +67,12 @@ appId: com.heywood8.monkeep
     timeout: 3000
 - takeScreenshot: screenshots/04_categories_light
 
+# Navigate to Planned tab
+- tapOn: "Planned"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/08_planned_light
+
 # Open Settings modal
 - tapOn:
     id: "settings-button"
@@ -149,6 +155,12 @@ appId: com.heywood8.monkeep
 - waitForAnimationToEnd:
     timeout: 2000
 - takeScreenshot: screenshots/04_categories_dark
+
+# Navigate to Planned tab
+- tapOn: "Planned"
+- waitForAnimationToEnd:
+    timeout: 3000
+- takeScreenshot: screenshots/08_planned_dark
 
 # Open Settings modal
 - tapOn:

--- a/app/modals/PlannedOperationModal.js
+++ b/app/modals/PlannedOperationModal.js
@@ -251,6 +251,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
                 <View style={styles.typeRow}>
                   {TYPE_OPTIONS.map(opt => {
                     const isActive = values.type === opt.key;
+                    const typeLabelStyle = { color: isActive ? '#fff' : colors.mutedText };
                     return (
                       <Pressable
                         key={opt.key}
@@ -264,7 +265,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
                         onPress={() => setValues(v => ({ ...v, type: opt.key, categoryId: null }))}
                       >
                         <Icon name={opt.icon} size={18} color={isActive ? '#fff' : colors.mutedText} />
-                        <Text style={[styles.typeLabel, { color: isActive ? '#fff' : colors.mutedText }]}>
+                        <Text style={[styles.typeLabel, typeLabelStyle]}>
                           {t(`${opt.key}_label`) || t(opt.key)}
                         </Text>
                       </Pressable>
@@ -340,7 +341,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
 
               {/* Recurring Toggle */}
               <View style={[styles.inputContainer, styles.switchRow]}>
-                <Text style={[styles.inputLabel, { color: colors.mutedText, marginBottom: 0 }]}>
+                <Text style={[styles.inputLabel, styles.inputLabelNoMargin, { color: colors.mutedText }]}>
                   {t('recurring')}
                 </Text>
                 <Switch
@@ -466,6 +467,9 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.sm,
     fontWeight: '500',
     marginBottom: SPACING.xs,
+  },
+  inputLabelNoMargin: {
+    marginBottom: 0,
   },
   modalContent: {
     borderTopLeftRadius: BORDER_RADIUS.lg,

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -141,16 +141,15 @@ export default function PlannedOperationsScreen() {
     const currencySymbol = getCurrencySymbol(accountCurrency);
     const typeColor = colors[TYPE_COLORS[item.type]] || colors.text;
 
+    const itemStyle = {
+      backgroundColor: colors.card,
+      borderColor: colors.border,
+      opacity: executed ? 0.6 : 1,
+    };
+
     return (
       <Pressable
-        style={[
-          styles.itemContainer,
-          {
-            backgroundColor: colors.card,
-            borderColor: colors.border,
-            opacity: executed ? 0.6 : 1,
-          },
-        ]}
+        style={[styles.itemContainer, itemStyle]}
         onPress={() => handleEdit(item)}
         onLongPress={() => handleLongPress(item)}
       >
@@ -221,18 +220,21 @@ export default function PlannedOperationsScreen() {
     );
   }, [loading, colors, t]);
 
+  const recurringTabStyle = {
+    backgroundColor: activeTab === 'recurring' ? colors.primary + '1A' : 'transparent',
+    borderColor: activeTab === 'recurring' ? colors.primary : colors.border,
+  };
+  const oneTimeTabStyle = {
+    backgroundColor: activeTab === 'one_time' ? colors.primary + '1A' : 'transparent',
+    borderColor: activeTab === 'one_time' ? colors.primary : colors.border,
+  };
+
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       {/* Tab Selector */}
       <View style={styles.tabRow}>
         <Pressable
-          style={[
-            styles.tab,
-            {
-              backgroundColor: activeTab === 'recurring' ? colors.primary + '1A' : 'transparent',
-              borderColor: activeTab === 'recurring' ? colors.primary : colors.border,
-            },
-          ]}
+          style={[styles.tab, recurringTabStyle]}
           onPress={() => setActiveTab('recurring')}
         >
           <Icon
@@ -245,13 +247,7 @@ export default function PlannedOperationsScreen() {
           </Text>
         </Pressable>
         <Pressable
-          style={[
-            styles.tab,
-            {
-              backgroundColor: activeTab === 'one_time' ? colors.primary + '1A' : 'transparent',
-              borderColor: activeTab === 'one_time' ? colors.primary : colors.border,
-            },
-          ]}
+          style={[styles.tab, oneTimeTabStyle]}
           onPress={() => setActiveTab('one_time')}
         >
           <Icon
@@ -300,7 +296,7 @@ export default function PlannedOperationsScreen() {
         visible={snackbarVisible}
         onDismiss={() => setSnackbarVisible(false)}
         duration={2000}
-        style={{ marginBottom: 100 }}
+        style={styles.snackbar}
       >
         {snackbarMessage}
       </Snackbar>
@@ -388,6 +384,9 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingBottom: 180,
+  },
+  snackbar: {
+    marginBottom: 100,
   },
   tab: {
     alignItems: 'center',


### PR DESCRIPTION
Users can now plan recurring and one-time operations (rent, subscriptions,
groceries, etc.) and quickly add them to the real operations list with one tap.

New features:
- 5th "Planned" tab with recurring/one-time toggle
- Create, edit, delete planned operations with name, type, amount, account, category
- One-tap fast-add: instantly creates a real operation with today's date
- Recurring ops show checkmark when executed this month; one-time ops auto-remove
- Full backup/restore support for planned operations
- Translations in all 8 languages (en, it, ru, es, fr, zh, de, hy)

Implementation:
- New planned_operations table with migration 0005
- PlannedOperationsDB service (CRUD + validation + execution tracking)
- PlannedOperationsContext (single context, event-driven reload)
- PlannedOperationModal (type/amount/account/category/recurring)
- PlannedOperationsScreen (FlatList with execute buttons, Snackbar feedback)
- Updated SimpleTabs navigation (5 tabs), App.js provider hierarchy
- Updated BackupRestore for JSON, CSV, and SQLite formats
- All 2820 tests passing (83 suites)

https://claude.ai/code/session_01RPWMtUE5ctQiiDjmYSJx6z