### PR TITLE
Fix PR_NUMBER extraction when release-please outputs null

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ fromJSON(steps.release-please.outputs.pr).number }}
+          PR_NUMBER: ${{ fromJSON(steps.release-please.outputs.pr || '{"number":0}').number }}


### PR DESCRIPTION
## Summary
This change fixes a potential runtime error in the release workflow by providing a fallback value when the release-please action doesn't output a PR object.

## Key Changes
- Updated the `PR_NUMBER` environment variable assignment to handle cases where `steps.release-please.outputs.pr` is null or undefined
- Added a fallback JSON object `'{"number":0}'` to prevent `fromJSON()` from failing on null input
- This ensures the workflow continues gracefully even when release-please doesn't create a pull request

## Implementation Details
The fix uses the `||` operator to provide a default value before JSON parsing. When `steps.release-please.outputs.pr` is empty or null, the expression will use `'{"number":0}'` instead, allowing `fromJSON()` to successfully parse the value and extract the `number` property without errors.

https://claude.ai/code/session_01Cnr1Pb9hEGDfb5VedMsL4W