### PR TITLE
feat: add GitHub release APK update checks

### DIFF
--- a/__tests__/screens/AppInitializer.test.js
+++ b/__tests__/screens/AppInitializer.test.js
@@ -9,6 +9,29 @@ import { render, waitFor } from '@testing-library/react-native';
 import AppInitializer from '../../app/screens/AppInitializer';
 import { LocalizationProvider, useLocalization } from '../../app/contexts/LocalizationContext';
 
+jest.mock('../../app/contexts/DialogContext', () => ({
+  useDialog: jest.fn(() => ({
+    showDialog: jest.fn(),
+  })),
+}));
+
+jest.mock('../../app/services/AppUpdateService', () => ({
+  checkForAppUpdate: jest.fn(async () => ({
+    success: true,
+    isUpdateAvailable: false,
+  })),
+}));
+
+jest.mock('../../app/services/PreferencesDB', () => ({
+  PREF_KEYS: {
+    UPDATE_LAST_CHECK_AT: 'update_last_check_at',
+    UPDATE_LAST_PROMPTED_VERSION: 'update_last_prompted_version',
+    UPDATE_SKIP_UNTIL: 'update_skip_until',
+  },
+  getPreference: jest.fn(async () => null),
+  setPreference: jest.fn(async () => undefined),
+}));
+
 // Mock the navigation components
 jest.mock('../../app/screens/LanguageSelectionScreen', () => {
   const React = require('react');

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -1,0 +1,109 @@
+import {
+  parseVersionFromRelease,
+  compareVersions,
+  extractApkAsset,
+  checkForAppUpdate,
+} from '../../app/services/AppUpdateService';
+
+describe('AppUpdateService', () => {
+  describe('parseVersionFromRelease', () => {
+    it('parses plain semver tag', () => {
+      expect(parseVersionFromRelease({ tag_name: 'v1.2.3' })).toBe('1.2.3');
+    });
+
+    it('parses prefixed tag name', () => {
+      expect(parseVersionFromRelease({ tag_name: 'penny-v0.50.4' })).toBe('0.50.4');
+    });
+
+    it('falls back to release name when tag is invalid', () => {
+      expect(parseVersionFromRelease({ tag_name: 'latest', name: 'Release 2.1.0' })).toBe('2.1.0');
+    });
+  });
+
+  describe('compareVersions', () => {
+    it('returns 1 when left version is newer', () => {
+      expect(compareVersions('1.3.0', '1.2.9')).toBe(1);
+    });
+
+    it('returns -1 when left version is older', () => {
+      expect(compareVersions('0.49.9', '0.50.0')).toBe(-1);
+    });
+
+    it('returns 0 for equivalent normalized versions', () => {
+      expect(compareVersions('v1.2.3', 'release-1.2.3')).toBe(0);
+    });
+  });
+
+  describe('extractApkAsset', () => {
+    it('returns first valid apk asset', () => {
+      const asset = extractApkAsset([
+        { name: 'notes.txt', browser_download_url: 'https://example.com/notes.txt' },
+        { name: 'penny-v1.0.0.apk', browser_download_url: 'https://example.com/penny.apk' },
+      ]);
+
+      expect(asset.browser_download_url).toBe('https://example.com/penny.apk');
+    });
+
+    it('returns null when no apk assets exist', () => {
+      expect(extractApkAsset([{ name: 'archive.zip', browser_download_url: 'https://example.com/archive.zip' }])).toBeNull();
+    });
+  });
+
+  describe('checkForAppUpdate', () => {
+    it('reports update availability when latest release is newer', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          tag_name: 'v0.50.4',
+          assets: [{ name: 'penny-v0.50.4.apk', browser_download_url: 'https://example.com/penny-v0.50.4.apk' }],
+          html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v0.50.4',
+          published_at: '2026-03-21T08:00:00Z',
+        }),
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.3',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isUpdateAvailable).toBe(true);
+      expect(result.latestVersion).toBe('0.50.4');
+      expect(result.downloadUrl).toContain('.apk');
+    });
+
+    it('returns no-update when versions match', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          tag_name: 'v0.50.3',
+          assets: [{ name: 'penny-v0.50.3.apk', browser_download_url: 'https://example.com/penny-v0.50.3.apk' }],
+        }),
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.3',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isUpdateAvailable).toBe(false);
+    });
+
+    it('handles GitHub rate limiting response gracefully', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.3',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('rate_limited');
+    });
+  });
+});
+

--- a/__tests__/services/PreferencesDB.test.js
+++ b/__tests__/services/PreferencesDB.test.js
@@ -61,6 +61,9 @@ describe('PreferencesDB', () => {
         'LANGUAGE',
         'LAST_ACCOUNT',
         'OPERATIONS_FILTERS',
+        'UPDATE_LAST_CHECK_AT',
+        'UPDATE_LAST_PROMPTED_VERSION',
+        'UPDATE_SKIP_UNTIL',
       ]);
     });
   });

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, Animated, ScrollView, FlatList } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Animated, ScrollView, FlatList, Linking } from 'react-native';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Portal, Modal, Text, Divider, TouchableRipple } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
@@ -13,6 +13,8 @@ import { exportBackup, importBackup } from '../services/BackupRestore';
 import { useLogEntries } from '../hooks/useLogEntries';
 import { File, Paths } from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
+import { checkForAppUpdate } from '../services/AppUpdateService';
+import { setPreference, PREF_KEYS } from '../services/PreferencesDB';
 
 const LOG_LEVEL_COLORS = {
   error: '#e53935',
@@ -241,6 +243,57 @@ export default function SettingsModal({ visible, onClose }) {
     clearLogs();
   }, [clearLogs]);
 
+  const handleCheckForUpdates = useCallback(async () => {
+    try {
+      const result = await checkForAppUpdate();
+      await setPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, new Date().toISOString());
+
+      if (!result.success) {
+        showDialog(
+          t('check_updates') || 'Check for updates',
+          t('update_check_failed') || 'Could not check updates right now. Please try again later.',
+          [{ text: t('ok') || 'OK' }],
+        );
+        return;
+      }
+
+      if (!result.isUpdateAvailable) {
+        showDialog(
+          t('check_updates') || 'Check for updates',
+          t('up_to_date') || 'You already have the latest version installed.',
+          [{ text: t('ok') || 'OK' }],
+        );
+        return;
+      }
+
+      showDialog(
+        t('update_available_title') || 'Update available',
+        `${(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
+          .replace('{latestVersion}', result.latestVersion)}\n\n${
+          t('update_install_hint')
+          || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'
+        }`,
+        [
+          { text: t('later') || 'Later' },
+          {
+            text: t('update_now') || 'Update now',
+            onPress: async () => {
+              await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
+              await Linking.openURL(result.downloadUrl);
+            },
+          },
+        ],
+      );
+    } catch (error) {
+      console.error('Manual update check failed:', error);
+      showDialog(
+        t('check_updates') || 'Check for updates',
+        t('update_check_failed') || 'Could not check updates right now. Please try again later.',
+        [{ text: t('ok') || 'OK' }],
+      );
+    }
+  }, [showDialog, t]);
+
   useEffect(() => {
     if (visible) {
       setLanguageModalVisible(false);
@@ -385,6 +438,18 @@ export default function SettingsModal({ visible, onClose }) {
               <View style={styles.settingsRowLeft}>
                 <Ionicons name="terminal-outline" size={22} color={colors.text} />
                 <Text style={[styles.settingsRowLabel, { color: colors.text }]}>{t('logs') || 'Logs'}</Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+            </View>
+          </TouchableRipple>
+
+          <TouchableRipple onPress={handleCheckForUpdates} style={styles.settingsRow} testID="check-updates-row">
+            <View style={styles.settingsRowContent}>
+              <View style={styles.settingsRowLeft}>
+                <Ionicons name="download-outline" size={22} color={colors.text} />
+                <Text style={[styles.settingsRowLabel, { color: colors.text }]}>
+                  {t('check_updates') || 'Check for updates'}
+                </Text>
               </View>
               <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
             </View>

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -5,22 +5,87 @@ import LanguageSelectionScreen from './LanguageSelectionScreen';
 import SimpleTabs from '../navigation/SimpleTabs';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { performDailyBackupIfNeeded } from '../services/DailyBackupService';
+import { useDialog } from '../contexts/DialogContext';
+import { checkForAppUpdate } from '../services/AppUpdateService';
+import { getPreference, setPreference, PREF_KEYS } from '../services/PreferencesDB';
+import { Linking } from 'react-native';
+
+const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const UPDATE_REMINDER_DELAY_DAYS = 3;
 
 /**
  * AppInitializer handles first-time setup and app initialization
  * Shows language selection screen on first launch, then initializes categories
  */
 const AppInitializer = () => {
-  const { isFirstLaunch, setFirstLaunchComplete, language } = useLocalization();
+  const { isFirstLaunch, setFirstLaunchComplete, t } = useLocalization();
   const { colors } = useThemeColors();
+  const { showDialog } = useDialog();
   const [isInitializing, setIsInitializing] = useState(false);
 
   // Run once on every app open (after first launch is complete)
   useEffect(() => {
     if (!isFirstLaunch) {
       performDailyBackupIfNeeded();
+
+      const runUpdateCheck = async () => {
+        try {
+          const now = Date.now();
+          const lastCheckIso = await getPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, null);
+          const lastCheckMs = lastCheckIso ? Date.parse(lastCheckIso) : NaN;
+
+          if (Number.isFinite(lastCheckMs) && now - lastCheckMs < AUTO_CHECK_INTERVAL_MS) {
+            return;
+          }
+
+          await setPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, new Date(now).toISOString());
+
+          const result = await checkForAppUpdate();
+          if (!result.success || !result.isUpdateAvailable) {
+            return;
+          }
+
+          const skipUntilIso = await getPreference(PREF_KEYS.UPDATE_SKIP_UNTIL, null);
+          const skipUntilMs = skipUntilIso ? Date.parse(skipUntilIso) : NaN;
+          if (Number.isFinite(skipUntilMs) && skipUntilMs > now) {
+            return;
+          }
+
+          showDialog(
+            t('update_available_title') || 'Update available',
+            `${(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
+              .replace('{latestVersion}', result.latestVersion)}\n\n${
+              t('update_install_hint')
+              || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'
+            }`,
+            [
+              {
+                text: t('later') || 'Later',
+                onPress: async () => {
+                  const suppressUntil = new Date(
+                    Date.now() + UPDATE_REMINDER_DELAY_DAYS * 24 * 60 * 60 * 1000,
+                  ).toISOString();
+                  await setPreference(PREF_KEYS.UPDATE_SKIP_UNTIL, suppressUntil);
+                  await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
+                },
+              },
+              {
+                text: t('update_now') || 'Update now',
+                onPress: async () => {
+                  await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
+                  await Linking.openURL(result.downloadUrl);
+                },
+              },
+            ],
+          );
+        } catch (error) {
+          console.warn('[AppInitializer] Failed to auto-check updates:', error);
+        }
+      };
+
+      runUpdateCheck();
     }
-  }, [isFirstLaunch]);
+  }, [isFirstLaunch, showDialog, t]);
 
   const handleLanguageSelected = async (selectedLanguage) => {
     try {

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -1,0 +1,157 @@
+const APP_VERSION = require('../../package.json').version;
+
+const DEFAULT_GITHUB_OWNER = 'heywood8';
+const DEFAULT_GITHUB_REPO = 'money-tracker';
+
+const GITHUB_API_VERSION = '2022-11-28';
+const UPDATE_CHECK_TIMEOUT_MS = 8000;
+
+const normalizeVersion = (value) => {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+
+  // Handles values like "v1.2.3", "penny-v1.2.3", or "release-1.2.3-beta.1"
+  const match = value.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return null;
+  }
+
+  return `${Number(match[1])}.${Number(match[2])}.${Number(match[3])}`;
+};
+
+export const parseVersionFromRelease = (release) => {
+  if (!release) {
+    return null;
+  }
+  return normalizeVersion(release.tag_name) || normalizeVersion(release.name);
+};
+
+export const compareVersions = (left, right) => {
+  const parsedLeft = normalizeVersion(left);
+  const parsedRight = normalizeVersion(right);
+
+  if (!parsedLeft || !parsedRight) {
+    return 0;
+  }
+
+  const leftParts = parsedLeft.split('.').map(Number);
+  const rightParts = parsedRight.split('.').map(Number);
+
+  for (let i = 0; i < 3; i += 1) {
+    if (leftParts[i] > rightParts[i]) return 1;
+    if (leftParts[i] < rightParts[i]) return -1;
+  }
+
+  return 0;
+};
+
+export const extractApkAsset = (assets = []) => {
+  if (!Array.isArray(assets)) {
+    return null;
+  }
+
+  return assets.find((asset) => {
+    if (!asset || typeof asset.name !== 'string') {
+      return false;
+    }
+    return asset.name.toLowerCase().endsWith('.apk') && !!asset.browser_download_url;
+  }) || null;
+};
+
+const fetchWithTimeout = async (url, options = {}, timeoutMs = UPDATE_CHECK_TIMEOUT_MS, fetchImpl = fetch) => {
+  const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+  const timeoutId = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+
+  try {
+    return await fetchImpl(url, {
+      ...options,
+      ...(controller ? { signal: controller.signal } : {}),
+    });
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+export const checkForAppUpdate = async ({
+  currentVersion = APP_VERSION,
+  owner = DEFAULT_GITHUB_OWNER,
+  repo = DEFAULT_GITHUB_REPO,
+  fetchImpl = fetch,
+} = {}) => {
+  const currentNormalized = normalizeVersion(currentVersion);
+  if (!currentNormalized) {
+    return {
+      success: false,
+      isUpdateAvailable: false,
+      currentVersion,
+      errorCode: 'invalid_current_version',
+    };
+  }
+
+  const endpoint = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
+
+  try {
+    const response = await fetchWithTimeout(
+      endpoint,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': `Penny/${currentNormalized}`,
+          'X-GitHub-Api-Version': GITHUB_API_VERSION,
+        },
+      },
+      UPDATE_CHECK_TIMEOUT_MS,
+      fetchImpl,
+    );
+
+    if (!response.ok) {
+      return {
+        success: false,
+        isUpdateAvailable: false,
+        currentVersion: currentNormalized,
+        errorCode: response.status === 403 ? 'rate_limited' : 'http_error',
+        httpStatus: response.status,
+      };
+    }
+
+    const release = await response.json();
+    const latestVersion = parseVersionFromRelease(release);
+    const apkAsset = extractApkAsset(release.assets);
+
+    if (!latestVersion || !apkAsset) {
+      return {
+        success: false,
+        isUpdateAvailable: false,
+        currentVersion: currentNormalized,
+        latestVersion,
+        errorCode: 'invalid_release_data',
+      };
+    }
+
+    const compare = compareVersions(latestVersion, currentNormalized);
+    const isUpdateAvailable = compare > 0;
+
+    return {
+      success: true,
+      isUpdateAvailable,
+      currentVersion: currentNormalized,
+      latestVersion,
+      downloadUrl: apkAsset.browser_download_url,
+      releaseUrl: release.html_url || apkAsset.browser_download_url,
+      publishedAt: release.published_at || null,
+      releaseName: release.name || release.tag_name || null,
+    };
+  } catch (error) {
+    const isTimeout = error?.name === 'AbortError';
+    return {
+      success: false,
+      isUpdateAvailable: false,
+      currentVersion: currentNormalized,
+      errorCode: isTimeout ? 'timeout' : 'network_error',
+    };
+  }
+};
+

--- a/app/services/PreferencesDB.js
+++ b/app/services/PreferencesDB.js
@@ -6,6 +6,9 @@ export const PREF_KEYS = {
   LANGUAGE: 'app_language',
   LAST_ACCOUNT: 'last_accessed_account_id',
   OPERATIONS_FILTERS: 'operations_active_filters',
+  UPDATE_LAST_CHECK_AT: 'update_last_check_at',
+  UPDATE_LAST_PROMPTED_VERSION: 'update_last_prompted_version',
+  UPDATE_SKIP_UNTIL: 'update_skip_until',
 };
 
 /**

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -340,5 +340,13 @@
   "already_executed": "Bereits diesen Monat hinzugefügt",
   "add_to_operations": "Zu Operationen hinzufügen",
   "added_to_operations": "Zu Operationen hinzugefügt",
-  "planned_operation_name_hint": "z.B. Miete, Netflix, Lebensmittel"
+  "planned_operation_name_hint": "z.B. Miete, Netflix, Lebensmittel",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -340,5 +340,13 @@
   "already_executed": "Already added this month",
   "add_to_operations": "Add to Operations",
   "added_to_operations": "Added to operations",
-  "planned_operation_name_hint": "e.g. Rent, Netflix, Groceries"
+  "planned_operation_name_hint": "e.g. Rent, Netflix, Groceries",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -340,5 +340,13 @@
   "already_executed": "Ya agregada este mes",
   "add_to_operations": "Agregar a Operaciones",
   "added_to_operations": "Agregada a operaciones",
-  "planned_operation_name_hint": "ej. Alquiler, Netflix, Compras"
+  "planned_operation_name_hint": "ej. Alquiler, Netflix, Compras",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -340,5 +340,13 @@
   "already_executed": "Déjà ajoutée ce mois-ci",
   "add_to_operations": "Ajouter aux Opérations",
   "added_to_operations": "Ajoutée aux opérations",
-  "planned_operation_name_hint": "ex. Loyer, Netflix, Courses"
+  "planned_operation_name_hint": "ex. Loyer, Netflix, Courses",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -326,5 +326,13 @@
   "already_executed": "Արդեն ավելացվել է այս ամիս",
   "add_to_operations": "Ավելացնել գործարկներին",
   "added_to_operations": "Ավելացվել է գործարկներին",
-  "planned_operation_name_hint": "օր. Վարձակալություն, Netflix, Մսերքներ"
+  "planned_operation_name_hint": "օր. Վարձակալություն, Netflix, Մսերքներ",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -99,5 +99,13 @@
   "already_executed": "Già aggiunta questo mese",
   "add_to_operations": "Aggiungi alle Operazioni",
   "added_to_operations": "Aggiunta alle operazioni",
-  "planned_operation_name_hint": "es. Affitto, Netflix, Spesa"
+  "planned_operation_name_hint": "es. Affitto, Netflix, Spesa",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -338,5 +338,13 @@
   "already_executed": "Уже добавлено в этом месяце",
   "add_to_operations": "Добавить в операции",
   "added_to_operations": "Добавлено в операции",
-  "planned_operation_name_hint": "напр. Аренда, Netflix, Продукты"
+  "planned_operation_name_hint": "напр. Аренда, Netflix, Продукты",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -340,5 +340,13 @@
   "already_executed": "本月已添加",
   "add_to_operations": "添加到操作",
   "added_to_operations": "已添加到操作",
-  "planned_operation_name_hint": "例如：房租、Netflix、杂货"
+  "planned_operation_name_hint": "例如：房租、Netflix、杂货",
+  "check_updates": "Check for updates",
+  "update_check_failed": "Could not check updates right now. Please try again later.",
+  "up_to_date": "You already have the latest version installed.",
+  "update_available_title": "Update available",
+  "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
+  "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
+  "update_now": "Update now",
+  "later": "Later"
 }


### PR DESCRIPTION
## Summary
- add `AppUpdateService` to fetch latest GitHub release data, parse semver-like tags, and extract APK download URLs
- add startup update checks in `AppInitializer` with 24h check throttling and deferred-prompt persistence
- add manual "Check for updates" action in `SettingsModal`, with user-facing install guidance and i18n keys
- add tests for update service behavior and update impacted tests for AppInitializer/PreferencesDB

## Test plan
- [x] `npm test -- --silent`
- [x] `npm test -- --silent AppUpdateService.test.js`
- [x] lints pass via pre-commit hook