### PR TITLE
feat: add description autocomplete to operation form

### DIFF
--- a/__tests__/components/DescriptionAutocomplete.test.js
+++ b/__tests__/components/DescriptionAutocomplete.test.js
@@ -1,0 +1,197 @@
+/**
+ * Tests for DescriptionAutocomplete component
+ * Ensures description input, chip filtering, and chip selection work correctly
+ */
+
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import DescriptionAutocomplete from '../../app/components/DescriptionAutocomplete';
+
+const mockColors = {
+  text: '#000',
+  mutedText: '#666',
+  background: '#fff',
+  surface: '#fff',
+  primary: '#1976d2',
+  border: '#e0e0e0',
+  altRow: '#f5f5f5',
+  inputBackground: '#fafafa',
+  inputBorder: '#ccc',
+};
+
+const SUGGESTIONS = ['Coffee', 'Groceries', 'Rent', 'Salary', 'Transport', 'Utilities'];
+
+function renderComponent(props = {}) {
+  const defaultProps = {
+    value: '',
+    onChangeText: jest.fn(),
+    suggestions: SUGGESTIONS,
+    placeholder: 'Description',
+    colors: mockColors,
+  };
+  return render(<DescriptionAutocomplete {...defaultProps} {...props} />);
+}
+
+describe('DescriptionAutocomplete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe('Rendering', () => {
+    it('renders the text input with placeholder', () => {
+      const { getByPlaceholderText } = renderComponent();
+      expect(getByPlaceholderText('Description')).toBeTruthy();
+    });
+
+    it('displays current value in the input', () => {
+      const { getByDisplayValue } = renderComponent({ value: 'Coffee' });
+      expect(getByDisplayValue('Coffee')).toBeTruthy();
+    });
+
+    it('does not show chips before input is focused', () => {
+      const { queryByTestId } = renderComponent();
+      expect(queryByTestId('chips-scroll')).toBeNull();
+    });
+  });
+
+  describe('Chip display on focus', () => {
+    it('shows chips from suggestions when focused with empty value', async () => {
+      const { getByTestId, getByText } = renderComponent({ value: '' });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      await waitFor(() => {
+        expect(getByTestId('chips-scroll')).toBeTruthy();
+      });
+
+      // Should show the first items from suggestions
+      expect(getByText('Coffee')).toBeTruthy();
+      expect(getByText('Groceries')).toBeTruthy();
+    });
+
+    it('shows at most 8 chips', async () => {
+      const manySuggestions = Array.from({ length: 12 }, (_, i) => `Item ${i + 1}`);
+      const { getByTestId, queryAllByText } = renderComponent({
+        value: '',
+        suggestions: manySuggestions,
+      });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      await waitFor(() => {
+        expect(getByTestId('chips-scroll')).toBeTruthy();
+      });
+
+      // Items 1-8 should appear, 9-12 should not
+      const chipElements = queryAllByText(/^Item \d+$/);
+      expect(chipElements.length).toBeLessThanOrEqual(8);
+    });
+
+    it('shows no chips when suggestions array is empty', async () => {
+      const { getByTestId, queryByTestId } = renderComponent({
+        value: '',
+        suggestions: [],
+      });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      // Chips scroll should not appear with no suggestions
+      await act(async () => {
+        jest.runAllTimers();
+      });
+      expect(queryByTestId('chips-scroll')).toBeNull();
+    });
+  });
+
+  describe('Chip filtering', () => {
+    it('filters chips by substring match when value is non-empty', async () => {
+      const { getByTestId, queryByText, getByText } = renderComponent({ value: 'co' });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      await waitFor(() => {
+        expect(getByTestId('chips-scroll')).toBeTruthy();
+      });
+
+      // 'Coffee' contains 'co' (case-insensitive)
+      expect(getByText('Coffee')).toBeTruthy();
+      // 'Rent' does not contain 'co'
+      expect(queryByText('Rent')).toBeNull();
+    });
+
+    it('hides chips entirely when value is an exact case-insensitive match (no remaining suggestions)', async () => {
+      // When 'coffee' matches 'Coffee' exactly and no other suggestions contain 'coffee',
+      // the filtered list is empty and chips-scroll is not rendered.
+      const { getByTestId, queryByTestId } = renderComponent({ value: 'coffee' });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      await act(async () => {
+        jest.runAllTimers();
+      });
+
+      expect(queryByTestId('chips-scroll')).toBeNull();
+    });
+
+    it('shows no chips when no suggestions match the typed value', async () => {
+      const { getByTestId, queryByTestId } = renderComponent({ value: 'xyznotfound' });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      await act(async () => {
+        jest.runAllTimers();
+      });
+
+      expect(queryByTestId('chips-scroll')).toBeNull();
+    });
+  });
+
+  describe('Chip selection', () => {
+    it('calls onChangeText with chip value when chip is tapped', async () => {
+      const onChangeText = jest.fn();
+      const { getByTestId } = renderComponent({ value: '', onChangeText });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      await waitFor(() => {
+        expect(getByTestId('chips-scroll')).toBeTruthy();
+      });
+
+      fireEvent.press(getByTestId('chip-Coffee'));
+
+      expect(onChangeText).toHaveBeenCalledWith('Coffee');
+    });
+
+    it('hides suggestion chips after chip is tapped', async () => {
+      const { getByTestId, queryByTestId } = renderComponent({ value: '' });
+
+      fireEvent(getByTestId('description-input'), 'focus');
+
+      await waitFor(() => {
+        expect(getByTestId('chips-scroll')).toBeTruthy();
+      });
+
+      fireEvent.press(getByTestId('chip-Coffee'));
+
+      await act(async () => {
+        jest.runAllTimers();
+      });
+
+      expect(queryByTestId('chips-scroll')).toBeNull();
+    });
+  });
+
+  describe('Editable prop', () => {
+    it('passes editable=false to TextInput when disabled', () => {
+      const { getByTestId } = renderComponent({ editable: false });
+      const input = getByTestId('description-input');
+      expect(input.props.editable).toBe(false);
+    });
+  });
+});

--- a/__tests__/modals/OperationModal.test.js
+++ b/__tests__/modals/OperationModal.test.js
@@ -376,12 +376,13 @@ describe('OperationModal', () => {
       expect(getByDisplayValue('Test description')).toBeTruthy();
     });
 
-    it('does not show description field for new operations', () => {
+    it('shows description field for new operations', () => {
       const { queryByPlaceholderText } = render(
         <OperationModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
-      expect(queryByPlaceholderText('description')).toBeFalsy();
+      // Description autocomplete is shown for both new and existing operations
+      expect(queryByPlaceholderText('description')).toBeTruthy();
     });
   });
 

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -2442,4 +2442,54 @@ describe('OperationsDB Service', () => {
       await expect(OperationsDB.getTopTransferTargetAccounts(3)).rejects.toThrow('DB error');
     });
   });
+
+  describe('getDistinctDescriptions', () => {
+    it('returns descriptions ordered by frequency', async () => {
+      queryAll.mockResolvedValue([
+        { description: 'Coffee' },
+        { description: 'Groceries' },
+        { description: 'Rent' },
+      ]);
+
+      const result = await OperationsDB.getDistinctDescriptions();
+
+      expect(result).toEqual(['Coffee', 'Groceries', 'Rent']);
+    });
+
+    it('returns empty array when no descriptions exist', async () => {
+      queryAll.mockResolvedValue([]);
+
+      const result = await OperationsDB.getDistinctDescriptions();
+
+      expect(result).toEqual([]);
+    });
+
+    it('queries with GROUP BY, ORDER BY COUNT and applies limit', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getDistinctDescriptions(50);
+
+      const [sql, params] = queryAll.mock.calls[0];
+      expect(sql).toContain('GROUP BY description');
+      expect(sql).toContain('COUNT(*)');
+      expect(sql).toContain('LIMIT ?');
+      expect(sql).toContain("description IS NOT NULL AND description != ''");
+      expect(params).toEqual([50]);
+    });
+
+    it('uses default limit of 100', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getDistinctDescriptions();
+
+      const [, params] = queryAll.mock.calls[0];
+      expect(params).toEqual([100]);
+    });
+
+    it('throws on database error', async () => {
+      queryAll.mockRejectedValue(new Error('DB error'));
+
+      await expect(OperationsDB.getDistinctDescriptions()).rejects.toThrow('DB error');
+    });
+  });
 });

--- a/app/components/DescriptionAutocomplete.js
+++ b/app/components/DescriptionAutocomplete.js
@@ -1,0 +1,238 @@
+import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import {
+  View,
+  TextInput,
+  ScrollView,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  Animated,
+} from 'react-native';
+import PropTypes from 'prop-types';
+import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
+
+const MAX_CHIPS = 8;
+
+/**
+ * DescriptionAutocomplete
+ *
+ * A single-line TextInput that shows a horizontal row of suggestion chips when focused.
+ * Chips are filtered by substring match against the current value.
+ * Tapping a chip fills the input with that description.
+ *
+ * Props:
+ *   value          - current text value
+ *   onChangeText   - callback(text) when value changes
+ *   suggestions    - string[] of past descriptions, ordered by frequency (most used first)
+ *   placeholder    - input placeholder text
+ *   editable       - whether the input is editable (default true)
+ *   colors         - theme colors object from ThemeColorsContext
+ *   containerStyle - optional style override for the outer container
+ */
+const DescriptionAutocomplete = ({
+  value,
+  onChangeText,
+  suggestions,
+  placeholder,
+  editable,
+  colors,
+  containerStyle,
+}) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const [renderChips, setRenderChips] = useState(false);
+  const blurTimerRef = useRef(null);
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const inputRef = useRef(null);
+
+  // Client-side filtered suggestions
+  const filteredSuggestions = useMemo(() => {
+    if (!suggestions || suggestions.length === 0) return [];
+    const trimmed = value ? value.trim() : '';
+    if (trimmed === '') {
+      // No text: show top N suggestions
+      return suggestions.slice(0, MAX_CHIPS);
+    }
+    const lower = trimmed.toLowerCase();
+    return suggestions
+      .filter(s => s.toLowerCase().includes(lower) && s.toLowerCase() !== lower)
+      .slice(0, MAX_CHIPS);
+  }, [suggestions, value]);
+
+  const showSuggestions = isFocused && filteredSuggestions.length > 0;
+
+  // Animate chips panel in/out; unmount after fade-out to collapse layout space
+  useEffect(() => {
+    if (showSuggestions) {
+      setRenderChips(true);
+      fadeAnim.setValue(0);
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 150,
+        useNativeDriver: true,
+      }).start();
+    } else {
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 120,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) setRenderChips(false);
+      });
+    }
+  }, [showSuggestions, fadeAnim]);
+
+  // Cleanup blur timer on unmount
+  useEffect(() => {
+    return () => {
+      if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
+    };
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    if (blurTimerRef.current) {
+      clearTimeout(blurTimerRef.current);
+      blurTimerRef.current = null;
+    }
+    setIsFocused(true);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    // Delay so a chip tap can fire before we hide the suggestions
+    blurTimerRef.current = setTimeout(() => {
+      setIsFocused(false);
+    }, 200);
+  }, []);
+
+  const handleChipPress = useCallback((chip) => {
+    // Cancel the pending blur-hide so we control the timing
+    if (blurTimerRef.current) {
+      clearTimeout(blurTimerRef.current);
+      blurTimerRef.current = null;
+    }
+    onChangeText(chip);
+    setIsFocused(false);
+    inputRef.current?.blur();
+  }, [onChangeText]);
+
+  return (
+    <View style={[styles.container, containerStyle]}>
+      <TextInput
+        ref={inputRef}
+        style={[
+          styles.input,
+          {
+            color: colors.text,
+            backgroundColor: colors.inputBackground,
+            borderColor: isFocused ? colors.primary : colors.inputBorder,
+          },
+          !editable && styles.disabled,
+        ]}
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.mutedText}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        editable={editable}
+        returnKeyType="done"
+        testID="description-input"
+      />
+
+      {/* Animated suggestion chips row */}
+      <Animated.View
+        style={[styles.chipsWrapper, { opacity: fadeAnim }]}
+        pointerEvents={renderChips ? 'auto' : 'none'}
+      >
+        {renderChips && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            keyboardShouldPersistTaps="always"
+            contentContainerStyle={styles.chipsContent}
+            testID="chips-scroll"
+          >
+            {filteredSuggestions.map((chip) => (
+              <TouchableOpacity
+                key={chip}
+                style={[
+                  styles.chip,
+                  {
+                    backgroundColor: colors.altRow,
+                    borderColor: colors.border,
+                  },
+                ]}
+                onPress={() => handleChipPress(chip)}
+                activeOpacity={0.65}
+                testID={`chip-${chip}`}
+              >
+                <Text
+                  style={[styles.chipText, { color: colors.text }]}
+                  numberOfLines={1}
+                >
+                  {chip}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        )}
+      </Animated.View>
+    </View>
+  );
+};
+
+DescriptionAutocomplete.propTypes = {
+  value: PropTypes.string,
+  onChangeText: PropTypes.func.isRequired,
+  suggestions: PropTypes.arrayOf(PropTypes.string),
+  placeholder: PropTypes.string,
+  editable: PropTypes.bool,
+  colors: PropTypes.object.isRequired,
+  containerStyle: PropTypes.object,
+};
+
+DescriptionAutocomplete.defaultProps = {
+  value: '',
+  suggestions: [],
+  placeholder: '',
+  editable: true,
+  containerStyle: undefined,
+};
+
+const styles = StyleSheet.create({
+  chip: {
+    borderRadius: 14,
+    borderWidth: 1,
+    marginRight: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  chipText: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '500',
+    maxWidth: 160,
+  },
+  chipsContent: {
+    alignItems: 'center',
+    paddingHorizontal: 2,
+  },
+  chipsWrapper: {
+    marginBottom: SPACING.md,
+    marginTop: SPACING.xs,
+    minHeight: 30,
+  },
+  container: {
+    marginBottom: SPACING.md,
+  },
+  disabled: {
+    opacity: 0.6,
+  },
+  input: {
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    fontSize: 16,
+    minHeight: 48,
+    padding: SPACING.md,
+  },
+});
+
+export default DescriptionAutocomplete;

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   View,
@@ -11,7 +11,6 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  Keyboard,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -23,8 +22,10 @@ import { useOperationsActions } from '../contexts/OperationsActionsContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
 import { useCategories } from '../contexts/CategoriesContext';
 import { setLastAccessedAccount } from '../services/LastAccount';
+import DescriptionAutocomplete from '../components/DescriptionAutocomplete';
 import OperationFormFields from '../components/operations/OperationFormFields';
 import SplitOperationModal from '../components/operations/SplitOperationModal';
+import { getDistinctDescriptions } from '../services/OperationsDB';
 import * as Currency from '../services/currency';
 import { formatDate } from '../services/BalanceHistoryDB';
 import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
@@ -44,7 +45,7 @@ import useOperationPicker from '../hooks/useOperationPicker';
  * Additional modal-specific fields:
  * - Type picker (opens modal picker)
  * - Date picker
- * - Description field (only when editing)
+ * - Description field with autocomplete suggestions (shown for both new and existing operations)
  * - Multi-currency fields (for cross-currency transfers)
  */
 
@@ -119,6 +120,15 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
 
   // State for split modal
   const [showSplitModal, setShowSplitModal] = useState(false);
+
+  // Autocomplete suggestions for description field
+  const [descriptionSuggestions, setDescriptionSuggestions] = useState([]);
+
+  useEffect(() => {
+    if (visible) {
+      getDistinctDescriptions().then(setDescriptionSuggestions).catch(() => {});
+    }
+  }, [visible]);
 
   // Determine if split button should be shown
   // Only for editing expense/income (not transfers, not shadow operations, not new)
@@ -390,27 +400,15 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
                     </View>
                   </Pressable>
 
-                  {/* Description Input - Only show when editing existing operations */}
-                  {!isNew && (
-                    <TextInput
-                      style={[
-                        styles.input,
-                        styles.descriptionInput,
-                        { color: colors.text, backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                        isShadowOperation && styles.disabledInput,
-                      ]}
-                      value={values.description}
-                      onChangeText={handleDescriptionChange}
-                      placeholder={t('description')}
-                      placeholderTextColor={colors.mutedText}
-                      multiline
-                      numberOfLines={3}
-                      textAlignVertical="top"
-                      returnKeyType="done"
-                      onSubmitEditing={Keyboard.dismiss}
-                      editable={!isShadowOperation}
-                    />
-                  )}
+                  {/* Description Input with autocomplete suggestions */}
+                  <DescriptionAutocomplete
+                    value={values.description || ''}
+                    onChangeText={handleDescriptionChange}
+                    suggestions={descriptionSuggestions}
+                    placeholder={t('description')}
+                    editable={!isShadowOperation}
+                    colors={colors}
+                  />
 
                   {errors.general && <Text style={styles.error}>{errors.general}</Text>}
                 </ScrollView>
@@ -631,9 +629,6 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
   },
-  descriptionInput: {
-    minHeight: 80,
-  },
   disabledButton: {
     opacity: 0.5,
   },
@@ -647,13 +642,6 @@ const styles = StyleSheet.create({
   },
   fullFlex: {
     flex: 1,
-  },
-  input: {
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: 1,
-    fontSize: 16,
-    marginBottom: SPACING.md,
-    padding: SPACING.md,
   },
   modalButton: {
     alignItems: 'center',

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1605,3 +1605,27 @@ export const getTopCategoriesFromLastMonth = async (limitPerType = 3) => {
     throw error;
   }
 };
+
+/**
+ * Get distinct operation descriptions ordered by usage frequency (most used first).
+ * Used for autocomplete suggestions in the operation form.
+ * @param {number} limit - Maximum number of descriptions to return
+ * @returns {Promise<string[]>} Array of description strings, most used first
+ */
+export const getDistinctDescriptions = async (limit = 100) => {
+  try {
+    const results = await queryAll(
+      `SELECT description
+       FROM operations
+       WHERE description IS NOT NULL AND description != ''
+       GROUP BY description
+       ORDER BY COUNT(*) DESC, description ASC
+       LIMIT ?`,
+      [limit],
+    );
+    return (results || []).map(row => row.description);
+  } catch (error) {
+    console.error('Failed to get distinct descriptions:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
feat: add description autocomplete to operation form

Adds tag-like autocomplete suggestions for the operation description field.

- New DescriptionAutocomplete component: single-line TextInput with an animated horizontal chip row showing up to 8 past descriptions, filtered by substring match as the user types
- New getDistinctDescriptions() DB query returns past descriptions ordered by usage frequency (most used first)
- Description field now shown for both new and existing operations (previously hidden for new ops)
- Tapping a chip fills the input instantly, ensuring consistent description labels across operations
