### PR TITLE
fix: download APK in-app to fix 99% hang on Android

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1,8 +1,8 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, Animated, ScrollView, FlatList, Linking } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Animated, ScrollView, FlatList } from 'react-native';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
-import { Portal, Modal, Text, Divider, TouchableRipple } from 'react-native-paper';
+import { Portal, Modal, Text, Divider, TouchableRipple, ProgressBar } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -13,7 +13,7 @@ import { exportBackup, importBackup } from '../services/BackupRestore';
 import { useLogEntries } from '../hooks/useLogEntries';
 import { File, Paths } from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
-import { checkForAppUpdate } from '../services/AppUpdateService';
+import { checkForAppUpdate, downloadAndInstallApk } from '../services/AppUpdateService';
 import { setPreference, PREF_KEYS } from '../services/PreferencesDB';
 
 const LOG_LEVEL_COLORS = {
@@ -35,6 +35,7 @@ export default function SettingsModal({ visible, onClose }) {
   const [exportFormatModalVisible, setExportFormatModalVisible] = useState(false);
   const [logsModalVisible, setLogsModalVisible] = useState(false);
   const [logFilter, setLogFilter] = useState('all');
+  const [apkDownloadProgress, setApkDownloadProgress] = useState(null);
 
   // Animation values
   const slideAnim = useRef(new Animated.Value(0)).current;
@@ -279,7 +280,18 @@ export default function SettingsModal({ visible, onClose }) {
             text: t('update_now') || 'Update now',
             onPress: async () => {
               await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
-              await Linking.openURL(result.downloadUrl);
+              setApkDownloadProgress(0);
+              try {
+                await downloadAndInstallApk(result.downloadUrl, setApkDownloadProgress);
+              } catch (e) {
+                showDialog(
+                  t('error') || 'Error',
+                  t('update_download_failed') || 'Could not download the update. Please try again.',
+                  [{ text: t('ok') || 'OK' }],
+                );
+              } finally {
+                setApkDownloadProgress(null);
+              }
             },
           },
         ],
@@ -672,6 +684,25 @@ export default function SettingsModal({ visible, onClose }) {
           </View>
         </Animated.View>
       </Modal>
+      {apkDownloadProgress !== null && (
+        <Modal
+          visible
+          dismissable={false}
+          contentContainerStyle={[styles.downloadModal, { backgroundColor: colors.card }]}
+        >
+          <Text variant="bodyLarge" style={[styles.downloadTitle, { color: colors.text }]}>
+            {t('downloading_update') || 'Downloading update...'}
+          </Text>
+          <ProgressBar
+            progress={apkDownloadProgress}
+            color={colors.primary}
+            style={styles.downloadProgressBar}
+          />
+          <Text variant="bodySmall" style={[styles.downloadPercent, { color: colors.mutedText }]}>
+            {`${Math.round(apkDownloadProgress * 100)}%`}
+          </Text>
+        </Modal>
+      )}
     </Portal>
   );
 }
@@ -704,6 +735,25 @@ const styles = StyleSheet.create({
   },
   divider: {
     marginVertical: SPACING.xs,
+  },
+  downloadModal: {
+    alignItems: 'center',
+    borderRadius: 12,
+    margin: 40,
+    padding: 24,
+  },
+  downloadPercent: {
+    marginTop: 8,
+  },
+  downloadProgressBar: {
+    borderRadius: 4,
+    height: 8,
+    marginTop: 16,
+    width: '100%',
+  },
+  downloadTitle: {
+    marginBottom: 4,
+    textAlign: 'center',
   },
   filterChip: {
     borderRadius: 16,

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -6,9 +6,9 @@ import SimpleTabs from '../navigation/SimpleTabs';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { performDailyBackupIfNeeded } from '../services/DailyBackupService';
 import { useDialog } from '../contexts/DialogContext';
-import { checkForAppUpdate } from '../services/AppUpdateService';
+import { checkForAppUpdate, downloadAndInstallApk } from '../services/AppUpdateService';
 import { getPreference, setPreference, PREF_KEYS } from '../services/PreferencesDB';
-import { Linking } from 'react-native';
+import { Portal, Modal, ProgressBar, Text } from 'react-native-paper';
 
 const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const UPDATE_REMINDER_DELAY_DAYS = 3;
@@ -22,6 +22,7 @@ const AppInitializer = () => {
   const { colors } = useThemeColors();
   const { showDialog } = useDialog();
   const [isInitializing, setIsInitializing] = useState(false);
+  const [apkDownloadProgress, setApkDownloadProgress] = useState(null);
 
   // Run once on every app open (after first launch is complete)
   useEffect(() => {
@@ -73,7 +74,18 @@ const AppInitializer = () => {
                 text: t('update_now') || 'Update now',
                 onPress: async () => {
                   await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
-                  await Linking.openURL(result.downloadUrl);
+                  setApkDownloadProgress(0);
+                  try {
+                    await downloadAndInstallApk(result.downloadUrl, setApkDownloadProgress);
+                  } catch (e) {
+                    showDialog(
+                      t('error') || 'Error',
+                      t('update_download_failed') || 'Could not download the update. Please try again.',
+                      [{ text: t('ok') || 'OK' }],
+                    );
+                  } finally {
+                    setApkDownloadProgress(null);
+                  }
                 },
               },
             ],
@@ -116,10 +128,54 @@ const AppInitializer = () => {
   }
 
   // Normal app flow - not first launch
-  return <SimpleTabs />;
+  return (
+    <>
+      <SimpleTabs />
+      {apkDownloadProgress !== null && (
+        <Portal>
+          <Modal
+            visible
+            dismissable={false}
+            contentContainerStyle={[styles.downloadModal, { backgroundColor: colors.card }]}
+          >
+            <Text variant="bodyLarge" style={[styles.downloadTitle, { color: colors.text }]}>
+              {t('downloading_update') || 'Downloading update...'}
+            </Text>
+            <ProgressBar
+              progress={apkDownloadProgress}
+              color={colors.primary}
+              style={styles.downloadProgressBar}
+            />
+            <Text variant="bodySmall" style={[styles.downloadPercent, { color: colors.mutedText }]}>
+              {`${Math.round(apkDownloadProgress * 100)}%`}
+            </Text>
+          </Modal>
+        </Portal>
+      )}
+    </>
+  );
 };
 
 const styles = StyleSheet.create({
+  downloadModal: {
+    alignItems: 'center',
+    borderRadius: 12,
+    margin: 40,
+    padding: 24,
+  },
+  downloadPercent: {
+    marginTop: 8,
+  },
+  downloadProgressBar: {
+    borderRadius: 4,
+    height: 8,
+    marginTop: 16,
+    width: '100%',
+  },
+  downloadTitle: {
+    marginBottom: 4,
+    textAlign: 'center',
+  },
   loadingContainer: {
     alignItems: 'center',
     flex: 1,

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -1,3 +1,6 @@
+import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
+
 const APP_VERSION = require('../../package.json').version;
 
 const DEFAULT_GITHUB_OWNER = 'heywood8';
@@ -155,3 +158,28 @@ export const checkForAppUpdate = async ({
   }
 };
 
+export const downloadAndInstallApk = async (downloadUrl, onProgress) => {
+  const filename = (downloadUrl.split('/').pop().split('?')[0]) || 'penny-update.apk';
+  const localUri = `${FileSystem.cacheDirectory}${filename}`;
+
+  const downloadResumable = FileSystem.createDownloadResumable(
+    downloadUrl,
+    localUri,
+    {},
+    ({ totalBytesWritten, totalBytesExpectedToWrite }) => {
+      if (onProgress && totalBytesExpectedToWrite > 0) {
+        onProgress(totalBytesWritten / totalBytesExpectedToWrite);
+      }
+    },
+  );
+
+  const result = await downloadResumable.downloadAsync();
+  if (!result?.uri) {
+    throw new Error('Download failed');
+  }
+
+  await Sharing.shareAsync(result.uri, {
+    mimeType: 'application/vnd.android.package-archive',
+    dialogTitle: 'Install Update',
+  });
+};


### PR DESCRIPTION
## What
Replace `Linking.openURL(browser_download_url)` with in-app download via `expo-file-system` + `expo-sharing` in both the auto-update prompt (AppInitializer) and the manual check (SettingsModal).

## Why
Android's browser download manager stalls at ~99% when downloading from GitHub release URLs. This is caused by GitHub's redirect chain combined with a Content-Length mismatch. The download completes at the network level but the manager never transitions to done.

## How
- Added `downloadAndInstallApk(url, onProgress)` to `AppUpdateService.js` using `FileSystem.createDownloadResumable` (same legacy API already used by BackupRestore and DailyBackupService)
- On completion, calls `Sharing.shareAsync(localUri, { mimeType: 'application/vnd.android.package-archive' })` which surfaces Android's Package Installer
- Both update entry points (auto-prompt on launch and manual Settings check) now show a ProgressBar modal (0-100%) during download instead of handing off to the browser

## Verified
All 2848 tests pass.
