### PR TITLE
Replace Sharing with IntentLauncher for APK installation

### DIFF
--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -1,5 +1,5 @@
 import * as FileSystem from 'expo-file-system/legacy';
-import * as Sharing from 'expo-sharing';
+import * as IntentLauncher from 'expo-intent-launcher';
 
 const APP_VERSION = require('../../package.json').version;
 
@@ -178,8 +178,10 @@ export const downloadAndInstallApk = async (downloadUrl, onProgress) => {
     throw new Error('Download failed');
   }
 
-  await Sharing.shareAsync(result.uri, {
-    mimeType: 'application/vnd.android.package-archive',
-    dialogTitle: 'Install Update',
+  const contentUri = await FileSystem.getContentUriAsync(result.uri);
+  await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
+    data: contentUri,
+    flags: 1, // FLAG_GRANT_READ_URI_PERMISSION
+    type: 'application/vnd.android.package-archive',
   });
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "expo-dev-client": "~6.0.20",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "^19.0.21",
+    "expo-intent-launcher": "^55.0.9",
     "expo-sharing": "~14.0.8",
     "expo-sqlite": "~16.0.10",
     "expo-updates": "~29.0.15",


### PR DESCRIPTION
## Summary
Changed the APK installation mechanism from using the `expo-sharing` module to `expo-intent-launcher` for more direct control over the installation process.

## Key Changes
- Replaced `expo-sharing` import with `expo-intent-launcher`
- Updated `downloadAndInstallApk()` to use `IntentLauncher.startActivityAsync()` instead of `Sharing.shareAsync()`
- Added `FileSystem.getContentUriAsync()` call to convert the file URI to a content URI before passing it to the intent launcher
- Configured the intent with appropriate flags and MIME type for APK installation

## Implementation Details
- The new approach uses Android's `android.intent.action.VIEW` intent action to directly trigger the package installer
- Includes `FLAG_GRANT_READ_URI_PERMISSION` (flag value: 1) to ensure the installer has permission to read the APK file
- Maintains the same MIME type (`application/vnd.android.package-archive`) for proper file type handling

https://claude.ai/code/session_017Y9PRZ9dzaDRg7GAr8QLcf

BEGIN_COMMIT_OVERRIDE

fix: replace sharing with intenrLauncher for APK installation

END_COMMIT_OVERRIDE