### PR TITLE
feat: extend hideBalances to graphs page and refactor to context-direct pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ android/
 # Local files
 local/
 *.apk
+
+# Superpowers docs (plans, specs)
+docs/superpowers/

--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -1465,7 +1465,7 @@ describe('BalanceHistoryCard', () => {
 
   describe('when hideBalances is true', () => {
     const mockBalanceHistoryData = {
-      labels: [1, 5, 10, 15, 20, 25, 28],
+      labels: [1, 28],
       actual: [
         { x: 1, y: 1000 },
         { x: 28, y: 1200 },

--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -7,6 +7,13 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import BalanceHistoryCard from '../../app/components/graphs/BalanceHistoryCard';
 
+// Mock DisplaySettingsContext
+jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({
+    hideBalances: false,
+  })),
+}));
+
 // Mock LineChart from react-native-chart-kit
 jest.mock('react-native-chart-kit', () => ({
   LineChart: 'LineChart',
@@ -1453,6 +1460,118 @@ describe('BalanceHistoryCard', () => {
       expect(actualDataset.data.length).toBeGreaterThan(4);
       // First 4 values should be the actual data
       expect(actualDataset.data.slice(0, 4)).toEqual([500, 600, 700, 800]);
+    });
+  });
+
+  describe('when hideBalances is true', () => {
+    const mockBalanceHistoryData = {
+      labels: [1, 5, 10, 15, 20, 25, 28],
+      actual: [
+        { x: 1, y: 1000 },
+        { x: 28, y: 1200 },
+      ],
+      actualForChart: [1000, 1200],
+      burndown: [],
+      prevMonth: [],
+    };
+
+    beforeEach(() => {
+      const { useDisplaySettings } = require('../../app/contexts/DisplaySettingsContext');
+      useDisplaySettings.mockReturnValue({ hideBalances: true });
+    });
+
+    afterEach(() => {
+      const { useDisplaySettings } = require('../../app/contexts/DisplaySettingsContext');
+      useDisplaySettings.mockReturnValue({ hideBalances: false });
+    });
+
+    it('does not render the legend table', () => {
+      const mockDate = new Date(2026, 1, 19);
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+      const { queryByText } = render(
+        <BalanceHistoryCard
+          colors={mockColors}
+          t={mockT}
+          selectedAccount="acc1"
+          onAccountChange={jest.fn()}
+          accountItems={mockAccountItems}
+          loadingBalanceHistory={false}
+          balanceHistoryData={mockBalanceHistoryData}
+          onChartPress={jest.fn()}
+          selectedYear={2023}
+          selectedMonth={11}
+          accounts={mockAccounts}
+          isCurrentMonth={false}
+          spendingPrediction={null}
+        />,
+      );
+
+      expect(queryByText('Actual')).toBeNull();
+      expect(queryByText('Plain avg')).toBeNull();
+      expect(queryByText('Max')).toBeNull();
+      expect(queryByText('Current')).toBeNull();
+      expect(queryByText('Daily Avg')).toBeNull();
+      expect(queryByText('End')).toBeNull();
+
+      global.Date.mockRestore();
+    });
+
+    it('still renders the chart (line curves remain visible)', () => {
+      const mockDate = new Date(2026, 1, 19);
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+      const { UNSAFE_getByType } = render(
+        <BalanceHistoryCard
+          colors={mockColors}
+          t={mockT}
+          selectedAccount="acc1"
+          onAccountChange={jest.fn()}
+          accountItems={mockAccountItems}
+          loadingBalanceHistory={false}
+          balanceHistoryData={mockBalanceHistoryData}
+          onChartPress={jest.fn()}
+          selectedYear={2023}
+          selectedMonth={11}
+          accounts={mockAccounts}
+          isCurrentMonth={false}
+          spendingPrediction={null}
+        />,
+      );
+
+      expect(UNSAFE_getByType('LineChart')).toBeTruthy();
+
+      global.Date.mockRestore();
+    });
+
+    it('formatYLabel returns empty string for all values', () => {
+      const mockDate = new Date(2026, 1, 19);
+      jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+      const { UNSAFE_getByType } = render(
+        <BalanceHistoryCard
+          colors={mockColors}
+          t={mockT}
+          selectedAccount="acc1"
+          onAccountChange={jest.fn()}
+          accountItems={mockAccountItems}
+          loadingBalanceHistory={false}
+          balanceHistoryData={mockBalanceHistoryData}
+          onChartPress={jest.fn()}
+          selectedYear={2023}
+          selectedMonth={11}
+          accounts={mockAccounts}
+          isCurrentMonth={false}
+          spendingPrediction={null}
+        />,
+      );
+
+      const lineChart = UNSAFE_getByType('LineChart');
+      expect(lineChart.props.formatYLabel('1000')).toBe('');
+      expect(lineChart.props.formatYLabel('1000000')).toBe('');
+      expect(lineChart.props.formatYLabel('0')).toBe('');
+
+      global.Date.mockRestore();
     });
   });
 });

--- a/__tests__/components/graphs/BalanceHistoryModal.test.js
+++ b/__tests__/components/graphs/BalanceHistoryModal.test.js
@@ -50,6 +50,8 @@ describe('BalanceHistoryModal', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    const { useDisplaySettings } = require('../../../app/contexts/DisplaySettingsContext');
+    useDisplaySettings.mockReturnValue({ hideBalances: false });
   });
 
   describe('Modal Visibility', () => {
@@ -453,7 +455,7 @@ describe('BalanceHistoryModal', () => {
     it('shows "••••" for rows with a balance', () => {
       const { getAllByText, queryByText } = render(<BalanceHistoryModal {...defaultProps} />);
 
-      expect(getAllByText('••••').length).toBeGreaterThan(0);
+      expect(getAllByText('••••').length).toBe(2);
       expect(queryByText('1500.00')).toBeNull();
       expect(queryByText('1400.00')).toBeNull();
     });

--- a/__tests__/components/graphs/BalanceHistoryModal.test.js
+++ b/__tests__/components/graphs/BalanceHistoryModal.test.js
@@ -14,6 +14,11 @@ jest.mock('@expo/vector-icons', () => ({
   MaterialCommunityIcons: 'Icon',
 }));
 
+// Mock DisplaySettingsContext
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
+}));
+
 describe('BalanceHistoryModal', () => {
   // Default test props
   const defaultProps = {
@@ -436,6 +441,27 @@ describe('BalanceHistoryModal', () => {
       // Should render first and last rows
       expect(getByText('Jan 1, 2024')).toBeTruthy();
       expect(getByText('Jan 30, 2024')).toBeTruthy();
+    });
+  });
+
+  describe('when hideBalances is true', () => {
+    beforeEach(() => {
+      const { useDisplaySettings } = require('../../../app/contexts/DisplaySettingsContext');
+      useDisplaySettings.mockReturnValue({ hideBalances: true });
+    });
+
+    it('shows "••••" for rows with a balance', () => {
+      const { getAllByText, queryByText } = render(<BalanceHistoryModal {...defaultProps} />);
+
+      expect(getAllByText('••••').length).toBeGreaterThan(0);
+      expect(queryByText('1500.00')).toBeNull();
+      expect(queryByText('1400.00')).toBeNull();
+    });
+
+    it('still shows "-" for empty rows', () => {
+      const { getByText } = render(<BalanceHistoryModal {...defaultProps} />);
+
+      expect(getByText('-')).toBeTruthy();
     });
   });
 });

--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -6,6 +6,13 @@ import useCategoryMonthlySpending from '../../../app/hooks/useCategoryMonthlySpe
 // Mock the hook
 jest.mock('../../../app/hooks/useCategoryMonthlySpending');
 
+// Mock DisplaySettingsContext
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({
+    hideBalances: false,
+  })),
+}));
+
 // Mock vector icons
 jest.mock('@expo/vector-icons', () => ({
   MaterialCommunityIcons: 'Icon',
@@ -383,6 +390,35 @@ describe('CategorySpendingCard', () => {
       );
 
       expect(getByText('last_12_months_total')).toBeTruthy();
+    });
+  });
+
+  describe('when hideBalances is true', () => {
+    const { useDisplaySettings } = require('../../../app/contexts/DisplaySettingsContext');
+
+    beforeEach(() => {
+      useDisplaySettings.mockReturnValue({ hideBalances: true });
+    });
+
+    afterEach(() => {
+      useDisplaySettings.mockReturnValue({ hideBalances: false });
+    });
+
+    it('does not render the 12-month total row', () => {
+      const { queryByText } = render(
+        <CategorySpendingCard {...defaultProps} />,
+      );
+
+      expect(queryByText('last_12_months_total')).toBeFalsy();
+      expect(queryByText('1550.00 USD')).toBeFalsy();
+    });
+
+    it('still renders the LineChart', () => {
+      const { UNSAFE_getByType } = render(
+        <CategorySpendingCard {...defaultProps} />,
+      );
+
+      expect(UNSAFE_getByType('LineChart')).toBeTruthy();
     });
   });
 

--- a/__tests__/components/graphs/CustomLegend.test.js
+++ b/__tests__/components/graphs/CustomLegend.test.js
@@ -5,6 +5,12 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import CustomLegend from '../../../app/components/graphs/CustomLegend';
+import { useDisplaySettings } from '../../../app/contexts/DisplaySettingsContext';
+
+// Mock DisplaySettingsContext
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
+}));
 
 // Mock MaterialCommunityIcons
 jest.mock('@expo/vector-icons', () => {
@@ -48,6 +54,7 @@ describe('CustomLegend', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    useDisplaySettings.mockReturnValue({ hideBalances: false });
   });
 
   describe('Rendering', () => {
@@ -285,6 +292,25 @@ describe('CustomLegend', () => {
         return styleArray.some(style => style && style.borderBottomColor === '#00FF00');
       });
       expect(hasExpectedBorder).toBe(true);
+    });
+  });
+
+  describe('when hideBalances is true', () => {
+    beforeEach(() => {
+      useDisplaySettings.mockReturnValue({ hideBalances: true });
+    });
+
+    it('shows •••• instead of the formatted amount', () => {
+      const { getAllByText, queryByText } = render(<CustomLegend {...defaultProps} />);
+      expect(getAllByText('••••').length).toBe(2);
+      expect(queryByText('100.00 USD')).toBeNull();
+      expect(queryByText('50.00 USD')).toBeNull();
+    });
+
+    it('still shows the percentage', () => {
+      const { getByText } = render(<CustomLegend {...defaultProps} />);
+      expect(getByText('66.7%')).toBeTruthy();
+      expect(getByText('33.3%')).toBeTruthy();
     });
   });
 

--- a/__tests__/components/graphs/ExpenseSummaryCard.test.js
+++ b/__tests__/components/graphs/ExpenseSummaryCard.test.js
@@ -165,6 +165,38 @@ describe('ExpenseSummaryCard', () => {
     });
   });
 
+  describe('when hideBalances is true', () => {
+    const { useDisplaySettings } = require('../../../app/contexts/DisplaySettingsContext');
+
+    beforeEach(() => {
+      useDisplaySettings.mockReturnValue({ hideBalances: true });
+    });
+
+    afterEach(() => {
+      useDisplaySettings.mockReturnValue({ hideBalances: false });
+    });
+
+    it('renders \'••••\' instead of the formatted currency amount', () => {
+      const { getByText } = render(<ExpenseSummaryCard {...defaultProps} />);
+
+      expect(getByText('••••')).toBeTruthy();
+    });
+
+    it('does not render the formatted currency amount', () => {
+      const { queryByText } = render(<ExpenseSummaryCard {...defaultProps} />);
+
+      expect(queryByText(/\$1\.5K/)).toBeNull();
+    });
+
+    it('does not show loading indicator even when loading is true', () => {
+      const { queryByText } = render(
+        <ExpenseSummaryCard {...defaultProps} loading={true} />,
+      );
+
+      expect(queryByText(/\.\.\./)).toBeNull();
+    });
+  });
+
   describe('Theming', () => {
     it('applies text color', () => {
       const customColors = {

--- a/__tests__/components/graphs/ExpenseSummaryCard.test.js
+++ b/__tests__/components/graphs/ExpenseSummaryCard.test.js
@@ -9,6 +9,13 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import ExpenseSummaryCard from '../../../app/components/graphs/ExpenseSummaryCard';
 
+// Mock DisplaySettingsContext
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({
+    hideBalances: false,
+  })),
+}));
+
 // Mock currencies.json
 jest.mock('../../../assets/currencies.json', () => ({
   USD: { symbol: '$', name: 'US Dollar', decimal_digits: 2 },

--- a/__tests__/components/graphs/ExpenseSummaryCard.test.js
+++ b/__tests__/components/graphs/ExpenseSummaryCard.test.js
@@ -189,10 +189,11 @@ describe('ExpenseSummaryCard', () => {
     });
 
     it('does not show loading indicator even when loading is true', () => {
-      const { queryByText } = render(
+      const { getByText, queryByText } = render(
         <ExpenseSummaryCard {...defaultProps} loading={true} />,
       );
 
+      expect(getByText('••••')).toBeTruthy();
       expect(queryByText(/\.\.\./)).toBeNull();
     });
   });

--- a/__tests__/components/graphs/IncomeSummaryCard.test.js
+++ b/__tests__/components/graphs/IncomeSummaryCard.test.js
@@ -157,6 +157,38 @@ describe('IncomeSummaryCard', () => {
     });
   });
 
+  describe('when hideBalances is true', () => {
+    const { useDisplaySettings } = require('../../../app/contexts/DisplaySettingsContext');
+
+    beforeEach(() => {
+      useDisplaySettings.mockReturnValue({ hideBalances: true });
+    });
+
+    afterEach(() => {
+      useDisplaySettings.mockReturnValue({ hideBalances: false });
+    });
+
+    it('renders \'••••\' instead of the formatted currency amount', () => {
+      const { getByText } = render(<IncomeSummaryCard {...defaultProps} />);
+
+      expect(getByText('••••')).toBeTruthy();
+    });
+
+    it('does not render the formatted currency amount', () => {
+      const { queryByText } = render(<IncomeSummaryCard {...defaultProps} />);
+
+      expect(queryByText(/\$3\.5K/)).toBeNull();
+    });
+
+    it('does not show loading indicator even when loadingIncome is true', () => {
+      const { queryByText } = render(
+        <IncomeSummaryCard {...defaultProps} loadingIncome={true} />,
+      );
+
+      expect(queryByText(/\.\.\./)).toBeNull();
+    });
+  });
+
   describe('Theming', () => {
     it('applies text color', () => {
       const customColors = {

--- a/__tests__/components/graphs/IncomeSummaryCard.test.js
+++ b/__tests__/components/graphs/IncomeSummaryCard.test.js
@@ -9,6 +9,13 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import IncomeSummaryCard from '../../../app/components/graphs/IncomeSummaryCard';
 
+// Mock DisplaySettingsContext
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({
+    hideBalances: false,
+  })),
+}));
+
 // Mock currencies.json
 jest.mock('../../../assets/currencies.json', () => ({
   USD: { symbol: '$', name: 'US Dollar', decimal_digits: 2 },

--- a/__tests__/components/graphs/IncomeSummaryCard.test.js
+++ b/__tests__/components/graphs/IncomeSummaryCard.test.js
@@ -181,10 +181,11 @@ describe('IncomeSummaryCard', () => {
     });
 
     it('does not show loading indicator even when loadingIncome is true', () => {
-      const { queryByText } = render(
+      const { getByText, queryByText } = render(
         <IncomeSummaryCard {...defaultProps} loadingIncome={true} />,
       );
 
+      expect(getByText('••••')).toBeTruthy();
       expect(queryByText(/\.\.\./)).toBeNull();
     });
   });

--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -39,6 +39,12 @@ jest.mock('../../app/contexts/AccountsDataContext', () => ({
   })),
 }));
 
+jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({
+    hideBalances: false,
+  })),
+}));
+
 jest.mock('../../app/services/OperationsDB', () => ({
   getSpendingByCategoryAndCurrency: jest.fn(() => Promise.resolve([])),
   getIncomeByCategoryAndCurrency: jest.fn(() => Promise.resolve([])),

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -6,6 +6,7 @@ import { Line, Text as SvgText, G } from 'react-native-svg';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import SimplePicker from '../SimplePicker';
 import currencies from '../../../assets/currencies.json';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -90,6 +91,7 @@ const BalanceHistoryCard = ({
   spendingPrediction,
   isCurrentMonth,
 }) => {
+  const { hideBalances } = useDisplaySettings();
   return (
     <View style={[styles.balanceHistoryCard, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
       <View style={styles.balanceHistoryHeader}>
@@ -215,8 +217,7 @@ const BalanceHistoryCard = ({
                   yAxisInterval={niceInterval}
                   segments={4}
                   fromZero={true}
-                  formatYLabel={(value) => {
-                    // Format Y-axis labels to show nice rounded values
+                  formatYLabel={hideBalances ? () => '' : (value) => {
                     const numValue = parseFloat(value);
                     if (numValue >= 1000000) {
                       return `${(numValue / 1000000).toFixed(0)}M`;
@@ -303,7 +304,7 @@ const BalanceHistoryCard = ({
           </TouchableOpacity>
 
           {/* Compact Table Legend */}
-          {(() => {
+          {!hideBalances && (() => {
             const now = new Date();
             const isCurrentMonthLocal = selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
             const displayDay = isCurrentMonthLocal

--- a/app/components/graphs/BalanceHistoryModal.js
+++ b/app/components/graphs/BalanceHistoryModal.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { HORIZONTAL_PADDING } from '../../styles/layout';
 import ModalBlurOverlay from '../ModalBlurOverlay';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 
 /**
  * Modal component for displaying and editing balance history table
@@ -23,6 +24,7 @@ const BalanceHistoryModal = ({
   onSaveBalance,
   onDeleteBalance,
 }) => {
+  const { hideBalances } = useDisplaySettings();
   return (
     <>
       {visible && <ModalBlurOverlay />}
@@ -109,7 +111,7 @@ const BalanceHistoryModal = ({
                     ) : (
                       <>
                         <Text style={[styles.balanceTableCell, { color: row.balance ? colors.text : colors.mutedText }]}>
-                          {row.balance || '-'}
+                          {hideBalances ? (row.balance ? '••••' : '-') : (row.balance || '-')}
                         </Text>
                         <View style={styles.balanceTableActions}>
                           <TouchableOpacity

--- a/app/components/graphs/BalanceHistoryModal.js
+++ b/app/components/graphs/BalanceHistoryModal.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, Text, StyleSheet, Modal, TouchableOpacity, ScrollView, TextInput } from 'react-native';
 import PropTypes from 'prop-types';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -7,6 +7,7 @@ import currencies from '../../../assets/currencies.json';
 import useCategoryMonthlySpending from '../../hooks/useCategoryMonthlySpending';
 import { HORIZONTAL_PADDING } from '../../styles/layout';
 import ModalBlurOverlay from '../ModalBlurOverlay';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -100,6 +101,8 @@ const CategorySpendingCard = ({
     loading,
     totalYearlySpending,
   } = useCategoryMonthlySpending(selectedCurrency, effectiveCategory, categories);
+
+  const { hideBalances } = useDisplaySettings();
 
   // Two-letter month abbreviations
   const monthAbbreviations = ['Ja', 'Fe', 'Mr', 'Ap', 'My', 'Jn', 'Jl', 'Au', 'Se', 'Oc', 'No', 'De'];
@@ -250,7 +253,7 @@ const CategorySpendingCard = ({
               yAxisSuffix=""
               fromZero={true}
               withInnerLines={true}
-              formatYLabel={formatYLabel}
+              formatYLabel={hideBalances ? () => '' : formatYLabel}
               chartConfig={{
                 backgroundColor: colors.altRow,
                 backgroundGradientFrom: colors.altRow,
@@ -281,14 +284,16 @@ const CategorySpendingCard = ({
           </View>
 
           {/* 12-Month Total */}
-          <View style={styles.totalContainer}>
-            <Text style={[styles.totalLabel, { color: colors.mutedText }]}>
-              {t('last_12_months_total')}
-            </Text>
-            <Text style={[styles.totalValue, { color: colors.expense || '#ff4444' }]}>
-              {formatCurrency(totalYearlySpending, selectedCurrency)}
-            </Text>
-          </View>
+          {!hideBalances && (
+            <View style={styles.totalContainer}>
+              <Text style={[styles.totalLabel, { color: colors.mutedText }]}>
+                {t('last_12_months_total')}
+              </Text>
+              <Text style={[styles.totalValue, { color: colors.expense || '#ff4444' }]}>
+                {formatCurrency(totalYearlySpending, selectedCurrency)}
+              </Text>
+            </View>
+          )}
         </>
       )}
     </View>

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import currencies from '../../../assets/currencies.json';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
@@ -11,6 +12,7 @@ const formatCurrency = (amount, currency) => {
 };
 
 const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
+  const { hideBalances } = useDisplaySettings();
   const total = data.reduce((sum, item) => sum + item.amount, 0);
 
   return (
@@ -63,7 +65,7 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
             {/* Amount column (fixed width) */}
             <View style={styles.amountColumn}>
               <Text style={[styles.legendAmount, { color: colors.text }]} numberOfLines={1}>
-                {formatCurrency(item.amount, currency)}
+                {hideBalances ? '••••' : formatCurrency(item.amount, currency)}
               </Text>
             </View>
 

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
@@ -25,6 +26,7 @@ const ExpenseSummaryCard = ({
   selectedCurrency,
   onPress,
 }) => {
+  const { hideBalances } = useDisplaySettings();
   return (
     <TouchableOpacity
       style={[styles.summaryCard, { backgroundColor: colors.altRow, borderColor: colors.border }]}
@@ -34,7 +36,7 @@ const ExpenseSummaryCard = ({
       accessibilityLabel={t('expenses_by_category')}
     >
       <Text style={styles.summaryText}>
-        {loading ? '...' : formatCurrency(totalExpenses, selectedCurrency)}
+        {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
       </Text>
     </TouchableOpacity>
   );

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
@@ -25,6 +26,7 @@ const IncomeSummaryCard = ({
   selectedCurrency,
   onPress,
 }) => {
+  const { hideBalances } = useDisplaySettings();
   return (
     <TouchableOpacity
       style={[styles.summaryCard, { backgroundColor: colors.altRow, borderColor: colors.border }]}
@@ -34,7 +36,7 @@ const IncomeSummaryCard = ({
       accessibilityLabel={t('income_by_category')}
     >
       <Text style={styles.summaryText}>
-        {loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency)}
+        {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
       </Text>
     </TouchableOpacity>
   );

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -74,7 +74,8 @@ CurrencyPickerModal.defaultProps = {
 };
 
 // Memoized transfer account picker modal component
-const TransferAccountPickerModal = memo(({ visible, onClose, accounts, accountToDelete, accountCurrency, operationCount, colors, t, onSelect, currencies, hideBalances }) => {
+const TransferAccountPickerModal = memo(({ visible, onClose, accounts, accountToDelete, accountCurrency, operationCount, colors, t, onSelect, currencies }) => {
+  const { hideBalances } = useDisplaySettings();
   const availableAccounts = useMemo(() => {
     return accounts.filter(a => a.id !== accountToDelete && a.currency === accountCurrency);
   }, [accounts, accountToDelete, accountCurrency]);
@@ -147,7 +148,6 @@ TransferAccountPickerModal.propTypes = {
   t: PropTypes.func,
   onSelect: PropTypes.func,
   currencies: PropTypes.object,
-  hideBalances: PropTypes.bool,
 };
 
 TransferAccountPickerModal.defaultProps = {
@@ -161,7 +161,6 @@ TransferAccountPickerModal.defaultProps = {
   t: (k) => k,
   onSelect: () => {},
   currencies,
-  hideBalances: false,
 };
 
 // Memoized confirmation dialog component
@@ -231,7 +230,8 @@ ConfirmationDialog.defaultProps = {
 };
 
 // Memoized account row component
-const AccountRow = memo(({ item, index, colors, onPress, t, drag, isActive, hideBalances }) => {
+const AccountRow = memo(({ item, index, colors, onPress, t, drag, isActive }) => {
+  const { hideBalances } = useDisplaySettings();
   const isEven = index % 2 === 0;
   const decimals = currencies[item.currency]?.decimal_digits ?? 2;
   const formattedBalance = parseFloat(item.balance).toFixed(decimals);
@@ -290,7 +290,6 @@ AccountRow.propTypes = {
   t: PropTypes.func,
   drag: PropTypes.func,
   isActive: PropTypes.bool,
-  hideBalances: PropTypes.bool,
 };
 
 AccountRow.defaultProps = {
@@ -300,7 +299,6 @@ AccountRow.defaultProps = {
   t: (k) => k,
   drag: () => {},
   isActive: false,
-  hideBalances: false,
 };
 
 export default function AccountsScreen() {
@@ -325,7 +323,6 @@ export default function AccountsScreen() {
 
   const { colorScheme } = useThemeConfig();
   const { colors } = useThemeColors();
-  const { hideBalances } = useDisplaySettings();
   const { accounts, displayedAccounts, hiddenAccounts, showHiddenAccounts, loading, error } = useAccountsData();
   const { toggleShowHiddenAccounts, addAccount, updateAccount, deleteAccount, reorderAccounts, validateAccount, getOperationCount } = useAccountsActions();
   const { t } = useLocalization();
@@ -548,9 +545,8 @@ export default function AccountsScreen() {
       t={t}
       drag={drag}
       isActive={isActive}
-      hideBalances={hideBalances}
     />
-  ), [colors, startEdit, t, hideBalances]);
+  ), [colors, startEdit, t]);
 
   const handleDragEnd = useCallback(({ data }) => {
     reorderAccounts(data);
@@ -748,7 +744,6 @@ export default function AccountsScreen() {
         colors={colors}
         t={t}
         onSelect={handleTransferAndDelete}
-        hideBalances={hideBalances}
       />
 
       {/* Simple delete confirmation */}


### PR DESCRIPTION
## Summary

- Refactored `AccountRow` and `TransferAccountPickerModal` to call `useDisplaySettings()` directly instead of receiving `hideBalances` as a prop (removes prop drilling)
- Extended `hideBalances` support to all graph components: `ExpenseSummaryCard`, `IncomeSummaryCard`, `BalanceHistoryCard`, `CategorySpendingCard`, `CustomLegend`, and `BalanceHistoryModal`
- When enabled: currency amounts show `••••`, Y-axis labels are blank, legend/total tables hidden — chart lines remain visible

## Test Plan

- [ ] Toggle hide balances in Settings and navigate to Graphs — all amounts should be masked
- [ ] Tap an expense/income summary card to open the pie chart modal — category amounts should also be masked
- [ ] Tap the balance history chart to open the detail modal — daily balances should be masked
- [ ] Toggle hide balances off — all numbers reappear normally
- [ ] All 2866 tests passing
