### PR TITLE
fix: apk install intent missing permission and activity flag

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -26,6 +26,7 @@ module.exports = {
       },
       edgeToEdgeEnabled: true,
       package: 'com.heywood8.monkeep',
+      permissions: ['android.permission.REQUEST_INSTALL_PACKAGES'],
     },
     extra: {
       eas: {

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -181,7 +181,7 @@ export const downloadAndInstallApk = async (downloadUrl, onProgress) => {
   const contentUri = await FileSystem.getContentUriAsync(result.uri);
   await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
     data: contentUri,
-    flags: 1, // FLAG_GRANT_READ_URI_PERMISSION
+    flags: 1 | 268435456, // FLAG_GRANT_READ_URI_PERMISSION | FLAG_ACTIVITY_NEW_TASK
     type: 'application/vnd.android.package-archive',
   });
 };


### PR DESCRIPTION
## Summary

- Refactored `AccountRow` and `TransferAccountPickerModal` to call `useDisplaySettings()` directly instead of receiving `hideBalances` as a prop (removes prop drilling)
- Extended `hideBalances` support to all graph components: `ExpenseSummaryCard`, `IncomeSummaryCard`, `BalanceHistoryCard`, `CategorySpendingCard`, `CustomLegend`, and `BalanceHistoryModal`
- When enabled: currency amounts show `••••`, Y-axis labels are blank, legend/total tables hidden — chart lines remain visible

## Test Plan

- [ ] Toggle hide balances in Settings and navigate to Graphs — all amounts should be masked
- [ ] Tap an expense/income summary card to open the pie chart modal — category amounts should also be masked
- [ ] Tap the balance history chart to open the detail modal — daily balances should be masked
- [ ] Toggle hide balances off — all numbers reappear normally
- [ ] All 2866 tests passing
