### PR TITLE
Scroll to end twice on description focus to reveal suggestion chips

### DIFF
--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -184,8 +184,13 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   }, [isShadowOperation, setValues]);
 
   // Handler for description focus (auto-scroll to end)
+  // We scroll twice: immediately for initial positioning, then again after the
+  // suggestion chips have animated in (150ms fade-in), so chips are visible.
   const handleDescriptionFocus = useCallback(() => {
     scrollViewRef.current?.scrollToEnd({ animated: true });
+    setTimeout(() => {
+      scrollViewRef.current?.scrollToEnd({ animated: true });
+    }, 200);
   }, []);
 
   // Handler for opening date picker


### PR DESCRIPTION
The chips animate in 150ms after focus, so the initial scrollToEnd
call finishes before they render. A second scroll after 200ms ensures
the chips are visible without needing to manually scroll down.

https://claude.ai/code/session_01K8nh8tgzzd34VMh4aJCsHv

BEGIN_COMMIT_OVERRIDE

fix: description hints visibility

END_COMMIT_OVERRIDE