### PR TITLE
fix(graphs): correct prev month legend daily avg and end calculations

### DIFF
--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -391,11 +391,15 @@ const BalanceHistoryCard = ({
                 return null;
               };
 
-              prevMonthCurrent = prevMonthAtDay(displayDay);
-              // End = last defined value in prev month (handles months shorter than current)
-              prevMonthEnd = prevMonthAtDay(prevMonthAllValues.length);
+              // Number of days in the previous month (e.g. 28 for February)
+              const prevMonthDaysCount = new Date(selectedYear, selectedMonth, 0).getDate();
 
-              // Calculate daily avg from first to last defined index
+              prevMonthCurrent = prevMonthAtDay(displayDay);
+              // End = balance on the actual last day of the previous month
+              prevMonthEnd = prevMonthAtDay(prevMonthDaysCount);
+
+              // Calculate daily avg: change from first to last recorded balance,
+              // divided by the full month's day span so sparse data doesn't skew the result
               let firstIdx = -1;
               let lastIdx = -1;
               prevMonthAllValues.forEach((v, i) => {
@@ -404,8 +408,8 @@ const BalanceHistoryCard = ({
                   lastIdx = i;
                 }
               });
-              if (firstIdx !== -1 && lastIdx > firstIdx) {
-                prevMonthDailyAvg = (prevMonthAllValues[lastIdx] - prevMonthAllValues[firstIdx]) / (lastIdx - firstIdx);
+              if (firstIdx !== -1 && lastIdx > firstIdx && prevMonthDaysCount > 1) {
+                prevMonthDailyAvg = (prevMonthAllValues[lastIdx] - prevMonthAllValues[firstIdx]) / (prevMonthDaysCount - 1);
               } else if (firstIdx !== -1) {
                 prevMonthDailyAvg = 0;
               }


### PR DESCRIPTION
Daily avg was dividing by (lastIdx - firstIdx) — the span between first and
last recorded entries. When balance data only exists for the last few days of
the previous month, this denominator could be as small as 1, producing a
misleadingly tiny result (e.g. 137 instead of ~-11K).

End was using prevMonthAllValues.length (current month's day count) as the
lookup day instead of the actual last day of the previous month.

Fixes:
- Compute prevMonthDaysCount via new Date(selectedYear, selectedMonth, 0)
- Use prevMonthDaysCount - 1 as daily avg denominator (full month span)
- Use prevMonthAtDay(prevMonthDaysCount) for End (explicit last day of prev month)

https://claude.ai/code/session_01QsMWufLoGakSbuvYtvjTA3