### PR TITLE
Smart description suggestions based on category and amount

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -2506,6 +2506,30 @@ describe('OperationsDB Service', () => {
       expect(params).toEqual(['cat-1', 100]);
     });
 
+    it('sorts same-category descriptions by closest amount when both categoryId and amount are provided', async () => {
+      queryAll.mockResolvedValue([
+        { description: 'Coffee' },
+        { description: 'Groceries' },
+      ]);
+
+      const result = await OperationsDB.getDistinctDescriptions(100, 'cat-1', 25.5);
+
+      expect(result).toEqual(['Coffee', 'Groceries']);
+      const [sql, params] = queryAll.mock.calls[0];
+      expect(sql).toContain('ABS(CAST(amount AS REAL) - ?)');
+      expect(params).toEqual(['cat-1', 'cat-1', 25.5, 100]);
+    });
+
+    it('skips amount sort when amount is null even if categoryId is set', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getDistinctDescriptions(100, 'cat-1', null);
+
+      const [sql, params] = queryAll.mock.calls[0];
+      expect(sql).not.toContain('ABS(CAST(amount AS REAL)');
+      expect(params).toEqual(['cat-1', 100]);
+    });
+
     it('uses frequency-only ordering when no categoryId is provided', async () => {
       queryAll.mockResolvedValue([]);
 

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -2474,6 +2474,7 @@ describe('OperationsDB Service', () => {
       expect(sql).toContain('COUNT(*)');
       expect(sql).toContain('LIMIT ?');
       expect(sql).toContain("description IS NOT NULL AND description != ''");
+      expect(sql).toContain("description NOT LIKE '[MoneyOK]%'");
       expect(params).toEqual([50]);
     });
 

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -2491,5 +2491,29 @@ describe('OperationsDB Service', () => {
 
       await expect(OperationsDB.getDistinctDescriptions()).rejects.toThrow('DB error');
     });
+
+    it('prioritises same-category descriptions when categoryId is provided', async () => {
+      queryAll.mockResolvedValue([
+        { description: 'Coffee' },
+        { description: 'Groceries' },
+      ]);
+
+      const result = await OperationsDB.getDistinctDescriptions(100, 'cat-1');
+
+      expect(result).toEqual(['Coffee', 'Groceries']);
+      const [sql, params] = queryAll.mock.calls[0];
+      expect(sql).toContain('CASE WHEN category_id = ?');
+      expect(params).toEqual(['cat-1', 100]);
+    });
+
+    it('uses frequency-only ordering when no categoryId is provided', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getDistinctDescriptions(100, null);
+
+      const [sql, params] = queryAll.mock.calls[0];
+      expect(sql).not.toContain('CASE WHEN');
+      expect(params).toEqual([100]);
+    });
   });
 });

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -129,12 +129,18 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   const [descriptionSuggestions, setDescriptionSuggestions] = useState([]);
 
   useEffect(() => {
-    if (visible) {
-      getDistinctDescriptions(100, values.categoryId || null)
-        .then(setDescriptionSuggestions)
-        .catch(() => {});
-    }
-  }, [visible, values.categoryId]);
+    if (!visible) return;
+    let cancelled = false;
+    const numericAmount = parseFloat(values.amount);
+    getDistinctDescriptions(
+      100,
+      values.categoryId || null,
+      isNaN(numericAmount) ? null : numericAmount,
+    ).then(results => {
+      if (!cancelled) setDescriptionSuggestions(results);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [visible, values.categoryId, values.amount]);
 
   // Determine if split button should be shown
   // Only for editing expense/income (not transfers, not shadow operations, not new)

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -130,9 +130,11 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
 
   useEffect(() => {
     if (visible) {
-      getDistinctDescriptions().then(setDescriptionSuggestions).catch(() => {});
+      getDistinctDescriptions(100, values.categoryId || null)
+        .then(setDescriptionSuggestions)
+        .catch(() => {});
     }
-  }, [visible]);
+  }, [visible, values.categoryId]);
 
   // Determine if split button should be shown
   // Only for editing expense/income (not transfers, not shadow operations, not new)

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1621,7 +1621,7 @@ export const getTopCategoriesFromLastMonth = async (limitPerType = 3) => {
 export const getDistinctDescriptions = async (limit = 100, categoryId = null, amount = null) => {
   try {
     let results;
-    const baseWhere = `description IS NOT NULL AND description != '' AND description NOT LIKE '[MoneyOK]%'`;
+    const baseWhere = 'description IS NOT NULL AND description != \'\' AND description NOT LIKE \'[MoneyOK]%\'';
     if (categoryId && amount !== null) {
       results = await queryAll(
         `SELECT description

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1621,11 +1621,12 @@ export const getTopCategoriesFromLastMonth = async (limitPerType = 3) => {
 export const getDistinctDescriptions = async (limit = 100, categoryId = null, amount = null) => {
   try {
     let results;
+    const baseWhere = `description IS NOT NULL AND description != '' AND description NOT LIKE '[MoneyOK]%'`;
     if (categoryId && amount !== null) {
       results = await queryAll(
         `SELECT description
          FROM operations
-         WHERE description IS NOT NULL AND description != ''
+         WHERE ${baseWhere}
          GROUP BY description
          ORDER BY MAX(CASE WHEN category_id = ? THEN 1 ELSE 0 END) DESC,
                   MIN(CASE WHEN category_id = ? THEN ABS(CAST(amount AS REAL) - ?) ELSE NULL END) ASC,
@@ -1638,7 +1639,7 @@ export const getDistinctDescriptions = async (limit = 100, categoryId = null, am
       results = await queryAll(
         `SELECT description
          FROM operations
-         WHERE description IS NOT NULL AND description != ''
+         WHERE ${baseWhere}
          GROUP BY description
          ORDER BY MAX(CASE WHEN category_id = ? THEN 1 ELSE 0 END) DESC,
                   COUNT(*) DESC,
@@ -1650,7 +1651,7 @@ export const getDistinctDescriptions = async (limit = 100, categoryId = null, am
       results = await queryAll(
         `SELECT description
          FROM operations
-         WHERE description IS NOT NULL AND description != ''
+         WHERE ${baseWhere}
          GROUP BY description
          ORDER BY COUNT(*) DESC, description ASC
          LIMIT ?`,

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1608,21 +1608,38 @@ export const getTopCategoriesFromLastMonth = async (limitPerType = 3) => {
 
 /**
  * Get distinct operation descriptions ordered by usage frequency (most used first).
+ * When categoryId is provided, descriptions used in that category are listed first.
  * Used for autocomplete suggestions in the operation form.
  * @param {number} limit - Maximum number of descriptions to return
- * @returns {Promise<string[]>} Array of description strings, most used first
+ * @param {string|null} categoryId - If provided, descriptions from this category appear first
+ * @returns {Promise<string[]>} Array of description strings, same-category first then by frequency
  */
-export const getDistinctDescriptions = async (limit = 100) => {
+export const getDistinctDescriptions = async (limit = 100, categoryId = null) => {
   try {
-    const results = await queryAll(
-      `SELECT description
-       FROM operations
-       WHERE description IS NOT NULL AND description != ''
-       GROUP BY description
-       ORDER BY COUNT(*) DESC, description ASC
-       LIMIT ?`,
-      [limit],
-    );
+    let results;
+    if (categoryId) {
+      results = await queryAll(
+        `SELECT description
+         FROM operations
+         WHERE description IS NOT NULL AND description != ''
+         GROUP BY description
+         ORDER BY MAX(CASE WHEN category_id = ? THEN 1 ELSE 0 END) DESC,
+                  COUNT(*) DESC,
+                  description ASC
+         LIMIT ?`,
+        [categoryId, limit],
+      );
+    } else {
+      results = await queryAll(
+        `SELECT description
+         FROM operations
+         WHERE description IS NOT NULL AND description != ''
+         GROUP BY description
+         ORDER BY COUNT(*) DESC, description ASC
+         LIMIT ?`,
+        [limit],
+      );
+    }
     return (results || []).map(row => row.description);
   } catch (error) {
     console.error('Failed to get distinct descriptions:', error);

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1609,15 +1609,32 @@ export const getTopCategoriesFromLastMonth = async (limitPerType = 3) => {
 /**
  * Get distinct operation descriptions ordered by usage frequency (most used first).
  * When categoryId is provided, descriptions used in that category are listed first.
+ * When amount is also provided, same-category descriptions are further sorted by
+ * closest historical amount (ascending absolute difference) before frequency.
  * Used for autocomplete suggestions in the operation form.
  * @param {number} limit - Maximum number of descriptions to return
  * @param {string|null} categoryId - If provided, descriptions from this category appear first
- * @returns {Promise<string[]>} Array of description strings, same-category first then by frequency
+ * @param {number|null} amount - If provided alongside categoryId, same-category descriptions
+ *   are sorted by closest amount match first
+ * @returns {Promise<string[]>} Array of description strings
  */
-export const getDistinctDescriptions = async (limit = 100, categoryId = null) => {
+export const getDistinctDescriptions = async (limit = 100, categoryId = null, amount = null) => {
   try {
     let results;
-    if (categoryId) {
+    if (categoryId && amount !== null) {
+      results = await queryAll(
+        `SELECT description
+         FROM operations
+         WHERE description IS NOT NULL AND description != ''
+         GROUP BY description
+         ORDER BY MAX(CASE WHEN category_id = ? THEN 1 ELSE 0 END) DESC,
+                  MIN(CASE WHEN category_id = ? THEN ABS(CAST(amount AS REAL) - ?) ELSE NULL END) ASC,
+                  COUNT(*) DESC,
+                  description ASC
+         LIMIT ?`,
+        [categoryId, categoryId, amount, limit],
+      );
+    } else if (categoryId) {
       results = await queryAll(
         `SELECT description
          FROM operations


### PR DESCRIPTION
## Summary
Enhanced the description autocomplete feature to provide smarter suggestions by considering the selected category and amount when fetching operation descriptions.

## Key Changes
- **Enhanced `getDistinctDescriptions` function**: Added optional `categoryId` and `amount` parameters to enable intelligent sorting of suggestions
  - When `categoryId` is provided, descriptions from that category are prioritized first
  - When both `categoryId` and `amount` are provided, same-category descriptions are further sorted by closest historical amount match (ascending absolute difference) before falling back to frequency
  - Maintains backward compatibility with frequency-only ordering when no parameters are provided

- **Updated OperationModal**: Modified the description suggestions effect hook to pass current category and amount values
  - Now calls `getDistinctDescriptions` with the selected category ID and numeric amount
  - Added cancellation logic to prevent state updates from stale requests
  - Extended dependency array to re-fetch suggestions when category or amount changes

- **Comprehensive test coverage**: Added four new test cases validating:
  - Category-based prioritization
  - Amount-based sorting within same category
  - Proper handling of null amount values
  - Fallback to frequency-only ordering when no category is provided

## Implementation Details
- Uses SQL `CASE WHEN` expressions to prioritize category matches and calculate amount differences
- Implements request cancellation pattern to avoid race conditions in the modal
- Maintains existing behavior when called without optional parameters

https://claude.ai/code/session_01EVMRSDYcsRHEi3AHJGRoKt