### PR TITLE
Add Android CLI setup guide and R8 configuration skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: r8-expo-config
+description: "Configures R8 minification, ProGuard rules, and Gradle JVM memory for Expo managed workflow Android builds. Use when the user asks about R8, ProGuard, build minification, shrinking, obfuscation, Gradle memory, EAS build hangs, or OOM errors during Android builds."
+context: fork
+user-invocable: true
+---
+
+# Skill: R8 & Expo Config Plugin
+
+This project uses Expo managed workflow — the `android/` folder is **not committed**. All Gradle and R8 configuration is applied via a config plugin that runs during `expo prebuild`.
+
+## Architecture
+
+```
+proguard-rules.pro          ← source of truth for ProGuard rules
+plugins/withR8Config.js     ← Expo config plugin (applies rules + Gradle props)
+app.config.js               ← registers the plugin
+eas.json                    ← build profiles (production uses app-bundle + R8)
+```
+
+Never edit `android/gradle.properties` or `android/app/proguard-rules.pro` directly — they are regenerated on every prebuild.
+
+## Config Plugin (`plugins/withR8Config.js`)
+
+Uses `withGradleProperties` to inject into `gradle.properties` and `withDangerousMod` to copy `proguard-rules.pro` into `android/app/`.
+
+### Gradle properties set by the plugin
+
+| Property | Value | Purpose |
+|---|---|---|
+| `android.enableMinifyInReleaseBuilds` | `true` | Enables R8 |
+| `android.enableShrinkResourcesInReleaseBuilds` | `true` | Removes unused resources |
+| `android.enablePngCrunchInReleaseBuilds` | `true` | Optimizes PNGs |
+| `org.gradle.jvmargs` | `-Xmx4096m -XX:MaxMetaspaceSize=1024m` | Memory (tuned for GitHub Actions 7GB runners) |
+| `org.gradle.parallel` | `true` | Parallel module compilation |
+| `org.gradle.caching` | `true` | Build cache |
+| `org.gradle.daemon` | `true` | Gradle daemon |
+
+### Memory budget rule
+
+GitHub Actions runners have 7GB RAM. Keep JVM heap + Metaspace ≤ 5GB total to leave headroom for OS, Node.js, and EAS CLI. The current setting (4GB heap + 1GB Metaspace = 5GB) is the safe maximum. If builds hang, reduce `Xmx` — do NOT increase it.
+
+### Preview builds (arm64-v8a only)
+
+When `APP_VARIANT=preview`, the plugin adds:
+```
+reactNativeArchitectures=arm64-v8a
+```
+This halves build time for preview APKs by skipping x86_64.
+
+## ProGuard Rules (`proguard-rules.pro`)
+
+Keep rules are required for:
+- React Native core (`com.facebook.react.**`)
+- Hermes engine (`com.facebook.hermes.**`, `com.facebook.jni.**`)
+- Expo modules (`expo.modules.**`)
+- expo-sqlite (`org.sqlite.**`)
+- Kotlin runtime (`kotlin.**`, `kotlinx.**`)
+- BuildConfig (`com.heywood8.monkeep.BuildConfig`)
+
+Always use `-dontwarn` alongside `-keep` for Expo Kotlin canary classes to suppress false-positive warnings.
+
+## Modifying R8 Configuration
+
+### To change Gradle JVM memory
+
+Edit `plugins/withR8Config.js`, property `org.gradle.jvmargs`. Keep total ≤ 5GB for CI.
+
+### To add a new ProGuard keep rule
+
+Add to `proguard-rules.pro` in the project root. It is automatically copied to `android/app/` during prebuild.
+
+### To add a new Gradle property
+
+Add it to the `properties` object in `plugins/withR8Config.js`:
+```javascript
+const properties = {
+  'your.new.property': 'value',
+  // ...existing props
+};
+```
+
+## Verification Commands
+
+```bash
+# Regenerate android/ and verify plugin ran
+npx expo prebuild --clean
+cat android/gradle.properties | grep -E "(Minify|Shrink|jvmargs)"
+cat android/app/proguard-rules.pro | head -5
+
+# Local release build (requires Android SDK)
+cd android && ./gradlew :app:bundleRelease
+ls -lh app/build/outputs/mapping/release/mapping.txt
+```
+
+## Troubleshooting
+
+**Build hangs on GitHub Actions** → Reduce `Xmx` in `org.gradle.jvmargs`. Check for OOM in logs.
+
+**ProGuard rules not applied** → Confirm `./plugins/withR8Config.js` is listed in `plugins` array in `app.config.js`.
+
+**Missing class warnings** → Add `-dontwarn your.package.**` to `proguard-rules.pro`.
+
+**Crash deobfuscation** → Download `mapping.txt` from EAS dashboard, then:
+```bash
+$ANDROID_HOME/cmdline-tools/latest/bin/retrace mapping.txt stacktrace.txt
+```
+
+## References
+
+- Full setup docs: `docs/R8_CICD_SETUP.md`
+- [R8 shrink code](https://developer.android.com/studio/build/shrink-code)
+- [Expo Config Plugins](https://docs.expo.dev/config-plugins/introduction/)
+- [EAS Build profiles](https://docs.expo.dev/build/eas-json/)

--- a/docs/ANDROID_CLI_MAC_SETUP.md
+++ b/docs/ANDROID_CLI_MAC_SETUP.md
@@ -1,0 +1,115 @@
+# Android CLI Setup (Mac)
+
+This guide gets the Android CLI running on your Mac so you can use `android docs`, `android skills`, and `android run` when developing Penny locally.
+
+## Prerequisites
+
+- macOS 12+
+- Android Studio installed (for SDK)
+- Node.js 18+ (already required by this project)
+- EAS CLI: `npm install -g eas-cli`
+
+## 1. Install Android CLI
+
+Go to [developer.android.com/tools/agents](https://developer.android.com/tools/agents) and click **Download**.
+
+The download is a `.dmg` or `.zip` containing the `android` binary. Move it to your PATH:
+
+```bash
+# If downloaded as a zip, unzip and move the binary
+unzip android-cli-*.zip
+sudo mv android /usr/local/bin/android
+chmod +x /usr/local/bin/android
+
+# Verify
+android --version
+```
+
+## 2. Initialize for Agent Workflows
+
+```bash
+cd path/to/money-tracker
+android init
+```
+
+This installs the `android-cli` skill into your project, enabling agent-aware prompts.
+
+## 3. Load the R8 Skill
+
+This project ships with a `SKILL.md` at the repo root that teaches agents how to handle R8, ProGuard, and Gradle memory configuration.
+
+To also pull Google's official prebuilt skills:
+
+```bash
+android skills list          # see available skills
+android skills add --skill r8-configuration    # if available
+android skills add --skill agp-migration       # Android Gradle Plugin migration
+android skills add --skill edge-to-edge        # useful for the tab bar
+```
+
+Your local `SKILL.md` is picked up automatically by any agent running in this directory — no install step needed.
+
+## 4. Query the Android Knowledge Base
+
+Instead of relying on potentially outdated LLM training data, use the knowledge base for current guidance:
+
+```bash
+# Query docs while developing
+android docs query "expo sqlite drizzle orm"
+android docs query "R8 minification expo managed workflow"
+android docs query "react native new architecture android"
+android docs query "EAS build memory github actions"
+```
+
+## 5. Emulator & Device Commands
+
+```bash
+android emulator list        # list available AVDs
+android emulator start       # start default emulator
+android run                  # build and deploy to connected device/emulator
+```
+
+> Note: `android run` triggers `expo prebuild` + Gradle build + install. Use it instead of the manual `npm run android` flow (which is also disabled per CLAUDE.md).
+
+## 6. Keep the CLI Updated
+
+```bash
+android update               # pull latest CLI version and skills
+```
+
+Run this periodically — the CLI is in active preview (current: v0.7, April 2026).
+
+## Workflow with Claude Code
+
+Once installed, the Android CLI and `SKILL.md` work together with Claude Code:
+
+1. Claude Code reads `SKILL.md` for R8/Gradle context automatically
+2. You can ask: *"analyze the R8 configuration"* and Claude has the right grounding
+3. Use `android docs` to pull current docs into a prompt:
+   ```bash
+   android docs query "expo config plugin withGradleProperties" | pbcopy
+   # paste into your Claude Code session for grounded answers
+   ```
+
+## Troubleshooting
+
+**`android: command not found`** → The binary isn't on your PATH. Check `/usr/local/bin` or add the install directory to `~/.zshrc`:
+```bash
+export PATH="$PATH:/path/to/android-cli"
+```
+
+**`android emulator` not working** → Requires `$ANDROID_HOME` set. Add to `~/.zshrc`:
+```bash
+export ANDROID_HOME=$HOME/Library/Android/sdk
+export PATH="$PATH:$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools"
+```
+
+**Download page shows "not supported"** → Use a desktop browser (Safari or Chrome on Mac), not a mobile browser or server environment.
+
+## References
+
+- [Android CLI overview](https://developer.android.com/tools/agents/android-cli)
+- [Android Skills docs](https://developer.android.com/tools/agents/android-skills)
+- [Android CLI release notes](https://developer.android.com/tools/agents/android-cli/release-notes)
+- [Agent tools landing page](https://developer.android.com/tools/agents)
+- Project R8 setup: `docs/R8_CICD_SETUP.md`


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for setting up the Android CLI on macOS and introduces a reusable skill for managing R8 minification and Gradle configuration in the Expo managed workflow.

## Changes
- **`docs/ANDROID_CLI_MAC_SETUP.md`** – Complete setup guide covering:
  - Android CLI installation from developer.android.com
  - Project initialization with `android init`
  - Loading official Google skills (r8-configuration, agp-migration, edge-to-edge)
  - Querying the Android knowledge base for current documentation
  - Emulator and device commands
  - Troubleshooting common PATH and `$ANDROID_HOME` issues
  - Integration workflow with Claude Code

- **`SKILL.md`** – Agent-invocable skill for R8 and Expo configuration:
  - Documents the config plugin architecture (`plugins/withR8Config.js`)
  - Specifies Gradle properties for minification, resource shrinking, and JVM memory tuning
  - Explains memory budget constraints for GitHub Actions CI (7GB runners)
  - Details ProGuard keep rules for React Native, Hermes, Expo modules, and sqlite
  - Provides verification commands and troubleshooting steps
  - References the full R8 setup documentation

## Implementation Details
- The skill is marked `user-invocable: true` and uses `context: fork` to allow agents to apply R8 configuration changes
- Memory settings are tuned for 7GB GitHub Actions runners (4GB heap + 1GB Metaspace = 5GB total)
- Preview builds optimize for arm64-v8a only to reduce build time
- Both documents emphasize that `android/` is not committed and all configuration is applied via `expo prebuild`

https://claude.ai/code/session_01Bk8N1u8gSriR13kLoVYa5p