### PR TITLE
feat(operations): redesign operations list with grouped date cards

### DIFF
--- a/__tests__/components/operations/DateSeparator.test.js
+++ b/__tests__/components/operations/DateSeparator.test.js
@@ -1,7 +1,7 @@
 /**
  * DateSeparator Component Tests
  *
- * Tests for the DateSeparator component which displays date dividers
+ * Tests for the DateSeparator component which displays date headers
  * in the operations list with optional spending sums.
  */
 
@@ -30,7 +30,6 @@ describe('DateSeparator', () => {
       mutedText: '#888888',
       expense: '#FF0000',
     },
-    t: (key) => key,
     onPress: jest.fn(),
   };
 
@@ -39,10 +38,10 @@ describe('DateSeparator', () => {
   });
 
   describe('Basic Rendering', () => {
-    it('renders formatted date', () => {
+    it('renders formatted date uppercased', () => {
       const { getByText } = render(<DateSeparator {...defaultProps} />);
 
-      expect(getByText('Formatted: 2024-01-15')).toBeTruthy();
+      expect(getByText('FORMATTED: 2024-01-15')).toBeTruthy();
     });
 
     it('renders with custom formatDate function', () => {
@@ -52,44 +51,7 @@ describe('DateSeparator', () => {
       );
 
       expect(customFormatDate).toHaveBeenCalledWith('2024-01-15');
-      expect(getByText('Date: 2024-01-15')).toBeTruthy();
-    });
-
-    it('applies background color from colors prop', () => {
-      const customColors = {
-        ...defaultProps.colors,
-        background: '#F0F0F0',
-      };
-      const { toJSON } = render(
-        <DateSeparator {...defaultProps} colors={customColors} />,
-      );
-
-      const json = toJSON();
-      // Root view should have the background color
-      expect(json.props.style).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ backgroundColor: '#F0F0F0' }),
-        ]),
-      );
-    });
-
-    it('applies border color to separator lines', () => {
-      const customColors = {
-        ...defaultProps.colors,
-        border: '#DDDDDD',
-      };
-      const { toJSON } = render(
-        <DateSeparator {...defaultProps} colors={customColors} />,
-      );
-
-      const json = toJSON();
-      // Find the line views (first and last children with height: 1)
-      const lineViews = json.children.filter(
-        (child) =>
-          child.type === 'View' &&
-          child.props.style?.some?.((s) => s.height === 1),
-      );
-      expect(lineViews.length).toBe(2);
+      expect(getByText('DATE: 2024-01-15')).toBeTruthy();
     });
 
     it('applies mutedText color to date text', () => {
@@ -101,7 +63,7 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} colors={customColors} />,
       );
 
-      const dateText = getByText('Formatted: 2024-01-15');
+      const dateText = getByText('FORMATTED: 2024-01-15');
       expect(dateText.props.style).toEqual(
         expect.arrayContaining([expect.objectContaining({ color: '#999999' })]),
       );
@@ -125,22 +87,22 @@ describe('DateSeparator', () => {
       expect(queryByText(/spent_amount/)).toBeNull();
     });
 
-    it('shows spending for single currency', () => {
+    it('shows spending for single currency with minus prefix', () => {
       const spendingSums = { USD: 123.45 };
       const { getByText } = render(
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      expect(getByText('$123.45')).toBeTruthy();
+      expect(getByText('-$123.45')).toBeTruthy();
     });
 
-    it('shows spending for multiple currencies', () => {
+    it('shows spending for multiple currencies each with minus prefix', () => {
       const spendingSums = { USD: 100.00, EUR: 85.50 };
       const { getByText } = render(
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      expect(getByText('$100.00, €85.50')).toBeTruthy();
+      expect(getByText('-$100.00, -€85.50')).toBeTruthy();
     });
 
     it('respects decimal_digits from currency config', () => {
@@ -150,7 +112,7 @@ describe('DateSeparator', () => {
       );
 
       // JPY has 0 decimal digits, USD has 2
-      expect(getByText('¥1000, $50.50')).toBeTruthy();
+      expect(getByText('-¥1000, -$50.50')).toBeTruthy();
     });
 
     it('handles currency with many decimal places (BTC)', () => {
@@ -159,13 +121,13 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      expect(getByText('₿0.00012345')).toBeTruthy();
+      expect(getByText('-₿0.00012345')).toBeTruthy();
     });
 
-    it('applies expense color to spending text', () => {
+    it('applies mutedText color to spending text', () => {
       const customColors = {
         ...defaultProps.colors,
-        expense: '#E53935',
+        mutedText: '#777777',
       };
       const spendingSums = { USD: 50 };
       const { getByText } = render(
@@ -176,25 +138,10 @@ describe('DateSeparator', () => {
         />,
       );
 
-      const spentText = getByText('$50.00');
+      const spentText = getByText('-$50.00');
       expect(spentText.props.style).toEqual(
-        expect.arrayContaining([expect.objectContaining({ color: '#E53935' })]),
+        expect.arrayContaining([expect.objectContaining({ color: '#777777' })]),
       );
-    });
-
-    it('does not use spent_amount translation (label removed)', () => {
-      const customT = jest.fn((key) => `Translated: ${key}`);
-      const spendingSums = { USD: 25 };
-      const { getByText } = render(
-        <DateSeparator
-          {...defaultProps}
-          t={customT}
-          spendingSums={spendingSums}
-        />,
-      );
-
-      expect(customT).not.toHaveBeenCalledWith('spent_amount');
-      expect(getByText('$25.00')).toBeTruthy();
     });
   });
 
@@ -205,7 +152,7 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      expect(getByText('£75.25')).toBeTruthy();
+      expect(getByText('-£75.25')).toBeTruthy();
     });
 
     it('uses RUB symbol correctly', () => {
@@ -214,7 +161,7 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      expect(getByText('₽1500.50')).toBeTruthy();
+      expect(getByText('-₽1500.50')).toBeTruthy();
     });
 
     it('falls back to currency code for unknown currencies', () => {
@@ -225,7 +172,7 @@ describe('DateSeparator', () => {
       );
 
       // Unknown currency code should be used as symbol, defaults to 2 decimals
-      expect(getByText('XYZ100.00')).toBeTruthy();
+      expect(getByText('-XYZ100.00')).toBeTruthy();
     });
 
     it('handles empty currency code gracefully', () => {
@@ -236,7 +183,7 @@ describe('DateSeparator', () => {
       );
 
       // Empty currency code returns empty string for symbol
-      expect(getByText('50.00')).toBeTruthy();
+      expect(getByText('-50.00')).toBeTruthy();
     });
   });
 
@@ -288,7 +235,7 @@ describe('DateSeparator', () => {
       expect(getByRole('button')).toBeTruthy();
     });
 
-    it('has accessibility label with formatted date', () => {
+    it('has accessibility label with formatted date (non-uppercased in label)', () => {
       const { getByLabelText } = render(<DateSeparator {...defaultProps} />);
 
       expect(
@@ -328,7 +275,7 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      expect(getByText('$999999999.99')).toBeTruthy();
+      expect(getByText('-$999999999.99')).toBeTruthy();
     });
 
     it('handles zero amount', () => {
@@ -337,16 +284,7 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      expect(getByText('$0.00')).toBeTruthy();
-    });
-
-    it('handles negative amounts', () => {
-      const spendingSums = { USD: -50.25 };
-      const { getByText } = render(
-        <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
-      );
-
-      expect(getByText('$-50.25')).toBeTruthy();
+      expect(getByText('-$0.00')).toBeTruthy();
     });
 
     it('handles many currencies at once', () => {
@@ -361,7 +299,7 @@ describe('DateSeparator', () => {
       );
 
       expect(
-        getByText('$100.00, €85.00, £70.00, ¥10000'),
+        getByText('-$100.00, -€85.00, -£70.00, -¥10000'),
       ).toBeTruthy();
     });
 
@@ -377,7 +315,7 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} date="Today" />,
       );
 
-      expect(getByText('Formatted: Today')).toBeTruthy();
+      expect(getByText('FORMATTED: TODAY')).toBeTruthy();
     });
   });
 
@@ -390,8 +328,8 @@ describe('DateSeparator', () => {
         <DateSeparator {...defaultProps} spendingSums={spendingSums} />,
       );
 
-      // ABC123.46 because toFixed(2) rounds
-      expect(getByText('ABC123.46')).toBeTruthy();
+      // -ABC123.46 because toFixed(2) rounds
+      expect(getByText('-ABC123.46')).toBeTruthy();
     });
   });
 });

--- a/app/components/operations/DateSeparator.js
+++ b/app/components/operations/DateSeparator.js
@@ -2,6 +2,7 @@ import React, { memo } from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
+import { SPACING, FONT_SIZE, FONT_WEIGHT } from '../../styles/designTokens';
 
 const getCurrencySymbol = (currencyCode) => {
   if (!currencyCode) return '';
@@ -9,40 +10,33 @@ const getCurrencySymbol = (currencyCode) => {
   return currency ? currency.symbol : currencyCode;
 };
 
-const DateSeparator = ({ date, spendingSums, formatDate, colors, t, onPress }) => {
+const DateSeparator = ({ date, spendingSums, formatDate, colors, onPress }) => {
   const hasSpending = spendingSums && Object.keys(spendingSums).length > 0;
 
   return (
-    <View style={[styles.dateSeparator, { backgroundColor: colors.background }]}>
-      <View style={[styles.dateSeparatorLine, { backgroundColor: colors.border }]} />
-      <Pressable
-        style={({ pressed }) => [
-          styles.dateSeparatorContent,
-          pressed && styles.pressed,
-        ]}
-        onPress={onPress}
-        accessibilityRole="button"
-        accessibilityLabel={`${formatDate(date)}, press to select date`}
-        accessibilityHint="Opens date picker to jump to a specific date"
-      >
-        <Text style={[styles.dateSeparatorText, { color: colors.mutedText }]}>
-          {formatDate(date)}
+    <Pressable
+      style={({ pressed }) => [styles.container, pressed && styles.pressed]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${formatDate(date)}, press to select date`}
+      accessibilityHint="Opens date picker to jump to a specific date"
+    >
+      <Text style={[styles.dateText, { color: colors.mutedText }]}>
+        {formatDate(date).toUpperCase()}
+      </Text>
+      {hasSpending && (
+        <Text style={[styles.totalText, { color: colors.mutedText }]}>
+          {Object.entries(spendingSums)
+            .map(([currency, amount]) => {
+              const symbol = getCurrencySymbol(currency);
+              const currencyInfo = currencies[currency];
+              const decimals = currencyInfo?.decimal_digits ?? 2;
+              return `-${symbol}${amount.toFixed(decimals)}`;
+            })
+            .join(', ')}
         </Text>
-        {hasSpending && (
-          <Text style={[styles.dateSeparatorSpent, { color: colors.expense }]}>
-            {Object.entries(spendingSums)
-              .map(([currency, amount]) => {
-                const symbol = getCurrencySymbol(currency);
-                const currencyInfo = currencies[currency];
-                const decimals = currencyInfo?.decimal_digits ?? 2;
-                return `${symbol}${amount.toFixed(decimals)}`;
-              })
-              .join(', ')}
-          </Text>
-        )}
-      </Pressable>
-      <View style={[styles.dateSeparatorLine, { backgroundColor: colors.border }]} />
-    </View>
+      )}
+    </Pressable>
   );
 };
 
@@ -51,40 +45,29 @@ DateSeparator.propTypes = {
   spendingSums: PropTypes.object,
   formatDate: PropTypes.func.isRequired,
   colors: PropTypes.object.isRequired,
-  t: PropTypes.func.isRequired,
   onPress: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
-  dateSeparator: {
+  container: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
-    marginVertical: 6,
-    paddingHorizontal: 16,
+    justifyContent: 'space-between',
+    paddingBottom: SPACING.xs,
+    paddingHorizontal: SPACING.lg + SPACING.sm,
+    paddingTop: SPACING.lg,
   },
-  dateSeparatorContent: {
-    alignItems: 'center',
-    borderRadius: 8,
-    flexDirection: 'row',
-    gap: 6,
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-  },
-  dateSeparatorLine: {
-    flex: 1,
-    height: 1,
-  },
-  dateSeparatorSpent: {
-    fontSize: 11,
-    fontWeight: '500',
-  },
-  dateSeparatorText: {
-    fontSize: 12,
-    fontWeight: '600',
+  dateText: {
+    fontSize: FONT_SIZE.xs,
+    fontWeight: FONT_WEIGHT.semibold,
+    letterSpacing: 0.6,
   },
   pressed: {
     opacity: 0.6,
+  },
+  totalText: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: FONT_WEIGHT.medium,
   },
 });
 

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -1,8 +1,10 @@
 import React, { memo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { TouchableRipple } from 'react-native-paper';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
-import ListCard from '../ListCard';
 import { getCategoryNames } from '../../utils/categoryUtils';
+import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
 
 const OperationListItem = ({
   operation,
@@ -12,102 +14,105 @@ const OperationListItem = ({
   getCategoryInfo,
   getAccountName,
   formatCurrency,
-  formatDate,
+  isLast,
   onPress,
 }) => {
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
   const isTransfer = operation.type === 'transfer';
 
-  // Check if this is a multi-currency transfer
   const isMultiCurrencyTransfer = isTransfer && operation.exchangeRate && operation.destinationAmount;
 
-  // For transfers, use transfer icon and localized name instead of category
   const categoryInfo = isTransfer
     ? { icon: 'swap-horizontal' }
     : getCategoryInfo(operation.categoryId);
 
-  // Get category and parent names separately
   const { categoryName, parentName } = isTransfer
     ? { categoryName: t('transfer'), parentName: null }
     : getCategoryNames(operation.categoryId, categories, t);
 
   const accountName = getAccountName(operation.accountId);
 
-  // Build comprehensive accessibility label
-  const typeLabel = isExpense ? t('expense_label') : isIncome ? t('income_label') : t('transfer_label');
-  let accessibilityLabel = `${typeLabel}, ${categoryName}`;
+  // Title: user's description if set, otherwise the category name
+  const title = (operation.description && operation.description.trim())
+    ? operation.description.trim()
+    : categoryName;
 
-  if (parentName) {
-    accessibilityLabel += `, ${parentName}`;
-  }
-
-  accessibilityLabel += `, ${formatCurrency(operation.accountId, operation.amount)}, ${accountName}`;
-
-  if (isTransfer && operation.toAccountId) {
+  // Subtitle: "Category · Account" when description is the title, else "ParentCat · Account"
+  let subtitle;
+  if (isTransfer) {
     const toAccountName = getAccountName(operation.toAccountId);
-    accessibilityLabel = `${typeLabel} from ${accountName} to ${toAccountName}, ${formatCurrency(operation.accountId, operation.amount)}`;
-
-    if (isMultiCurrencyTransfer) {
-      accessibilityLabel += `, exchange rate ${operation.exchangeRate}`;
-    }
+    subtitle = `${accountName} → ${toAccountName}`;
+  } else if (operation.description && operation.description.trim()) {
+    subtitle = parentName
+      ? `${parentName} / ${categoryName} · ${accountName}`
+      : `${categoryName} · ${accountName}`;
+  } else if (parentName) {
+    subtitle = `${parentName} · ${accountName}`;
+  } else {
+    subtitle = accountName;
   }
 
+  const formattedAmount = formatCurrency(operation.accountId, operation.amount);
+  const displayAmount = formattedAmount;
+
+  const amountColor = isExpense
+    ? colors.expense
+    : isIncome
+      ? colors.income
+      : colors.transfer;
+
+  // Build accessibility label
+  const typeLabel = isExpense ? t('expense_label') : isIncome ? t('income_label') : t('transfer_label');
+  let accessibilityLabel = `${typeLabel}, ${title}, ${displayAmount}`;
   if (operation.description) {
     accessibilityLabel += `, note: ${operation.description}`;
   }
 
   return (
-    <ListCard
-      variant={operation.type}
-      onPress={onPress}
-      leftIcon={categoryInfo.icon}
-      leftIconBackground={true}
-      accessibilityLabel={accessibilityLabel}
-      accessibilityHint={t('edit_operation_hint')}
-    >
-      <View style={styles.operationContent}>
-        {/* Category & Parent Category */}
-        <View style={styles.operationInfo}>
-          <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
-            {categoryName}
-          </Text>
-          {parentName && (
-            <Text style={[styles.parentName, { color: colors.mutedText }]} numberOfLines={1}>
-              {parentName}
-            </Text>
-          )}
-        </View>
+    <>
+      <TouchableRipple
+        onPress={onPress}
+        rippleColor="rgba(0, 0, 0, .08)"
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={t('edit_operation_hint')}
+      >
+        <View style={styles.row}>
+          {/* Icon */}
+          <View style={styles.iconContainer}>
+            <Icon name={categoryInfo.icon} size={ICON_SIZE.md} color={amountColor} />
+          </View>
 
-        {/* Amount & Account */}
-        <View style={styles.operationRight}>
-          <Text
-            style={[
-              styles.amount,
-              {
-                color: isExpense
-                  ? colors.expense
-                  : isIncome
-                    ? colors.income
-                    : colors.text,
-              },
-            ]}
-            numberOfLines={1}
-          >
-            {formatCurrency(operation.accountId, operation.amount)}
-            {isMultiCurrencyTransfer && operation.toAccountId && (
-              <Text style={styles.destinationAmount}>
-                {' → '}{formatCurrency(operation.toAccountId, operation.destinationAmount)}
-              </Text>
-            )}
-          </Text>
-          <Text style={[styles.accountName, { color: colors.mutedText }]} numberOfLines={1}>
-            {accountName}
-            {isTransfer && operation.toAccountId && ` → ${getAccountName(operation.toAccountId)}`}
-          </Text>
+          {/* Text */}
+          <View style={styles.textContainer}>
+            <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
+              {title}
+            </Text>
+            <Text style={[styles.subtitle, { color: colors.mutedText }]} numberOfLines={1}>
+              {subtitle}
+            </Text>
+          </View>
+
+          {/* Amount */}
+          <View style={styles.amountContainer}>
+            <Text style={[styles.amount, { color: amountColor }]} numberOfLines={1}>
+              {displayAmount}
+              {isMultiCurrencyTransfer && operation.toAccountId && (
+                <Text style={[styles.destinationAmount, { color: colors.mutedText }]}>
+                  {' → '}{formatCurrency(operation.toAccountId, operation.destinationAmount)}
+                </Text>
+              )}
+            </Text>
+          </View>
         </View>
-      </View>
-    </ListCard>
+      </TouchableRipple>
+
+      {/* Separator line between items (not after the last one) */}
+      {!isLast && (
+        <View style={[styles.separator, { backgroundColor: colors.border }]} />
+      )}
+    </>
   );
 };
 
@@ -129,53 +134,59 @@ OperationListItem.propTypes = {
   getCategoryInfo: PropTypes.func.isRequired,
   getAccountName: PropTypes.func.isRequired,
   formatCurrency: PropTypes.func.isRequired,
-  formatDate: PropTypes.func.isRequired,
+  isLast: PropTypes.bool,
   onPress: PropTypes.func.isRequired,
 };
 
+OperationListItem.defaultProps = {
+  isLast: false,
+};
+
 const styles = StyleSheet.create({
-  accountName: {
-    fontSize: 13,
-    includeFontPadding: false,
-    marginTop: 2,
-    textAlign: 'right',
-    textAlignVertical: 'center',
-  },
   amount: {
-    fontSize: 16,
-    fontWeight: '600',
+    fontSize: FONT_SIZE.base,
+    fontWeight: FONT_WEIGHT.semibold,
     includeFontPadding: false,
     textAlign: 'right',
-    textAlignVertical: 'center',
   },
-  categoryName: {
-    fontSize: 15,
-    fontWeight: '500',
+  amountContainer: {
+    alignItems: 'flex-end',
+    marginLeft: SPACING.md,
   },
   destinationAmount: {
-    includeFontPadding: false,
-    textAlign: 'right',
-    textAlignVertical: 'center',
+    fontSize: FONT_SIZE.sm,
+    fontWeight: FONT_WEIGHT.regular,
   },
-  operationContent: {
+  iconContainer: {
     alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-    gap: 12,
-    justifyContent: 'space-between',
+    marginRight: SPACING.md,
+    width: 32,
   },
-  operationInfo: {
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    minHeight: HEIGHTS.listItem,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+  },
+  separator: {
+    height: 1,
+    marginLeft: SPACING.lg + 32 + SPACING.md,
+  },
+  subtitle: {
+    fontSize: FONT_SIZE.sm,
+    includeFontPadding: false,
+    marginTop: 2,
+  },
+  textContainer: {
     flex: 1,
     justifyContent: 'center',
     minWidth: 0,
   },
-  operationRight: {
-    alignItems: 'flex-end',
-    justifyContent: 'center',
-  },
-  parentName: {
-    fontSize: 13,
-    marginTop: 2,
+  title: {
+    fontSize: FONT_SIZE.md + 1,
+    fontWeight: FONT_WEIGHT.medium,
+    includeFontPadding: false,
   },
 });
 

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -5,13 +5,10 @@ import PropTypes from 'prop-types';
 import DateSeparator from './DateSeparator';
 import OperationListItem from './OperationListItem';
 import currencies from '../../../assets/currencies.json';
-import * as Currency from '../../services/currency';
-import { SPACING } from '../../styles/layout';
+import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
 
 /**
  * Get currency symbol from currency code
- * @param {string} currencyCode - Currency code like 'USD', 'EUR', etc.
- * @returns {string} Currency symbol or code if not found
  */
 const getCurrencySymbol = (currencyCode) => {
   if (!currencyCode) return '';
@@ -22,10 +19,8 @@ const getCurrencySymbol = (currencyCode) => {
 /**
  * OperationsList Component
  *
- * Displays a list of financial operations (already grouped by date) with
- * lazy loading and scroll functionality.
- *
- * @component
+ * Displays a list of financial operations grouped by date. Each date group
+ * renders as a single card containing all operations for that day.
  */
 const OperationsList = forwardRef(({
   groupedOperations,
@@ -44,7 +39,7 @@ const OperationsList = forwardRef(({
   headerComponent,
 }, ref) => {
 
-  // Format date (memoized)
+  // Format date label for the separator header
   const formatDate = useCallback((dateString) => {
     const date = new Date(dateString);
     const today = new Date();
@@ -61,14 +56,14 @@ const OperationsList = forwardRef(({
       return t('yesterday');
     } else {
       return date.toLocaleDateString(undefined, {
-        year: 'numeric',
+        weekday: 'short',
         month: 'short',
         day: 'numeric',
       });
     }
   }, [t]);
 
-  // Format amount with currency (memoized)
+  // Format amount with currency symbol
   const formatCurrency = useCallback((accountId, amount) => {
     const account = accounts.find(acc => acc.id === accountId);
     if (!account) return amount;
@@ -76,37 +71,33 @@ const OperationsList = forwardRef(({
     const numAmount = parseFloat(amount);
     if (isNaN(numAmount)) return amount;
 
-    // Get currency-specific decimal places
     const currency = currencies[account.currency];
     const decimals = currency?.decimal_digits ?? 2;
 
-    // Always use symbol instead of Intl.NumberFormat to ensure consistent symbol display
     const symbol = getCurrencySymbol(account.currency || 'USD');
     return `${symbol}${numAmount.toFixed(decimals)}`;
   }, [accounts]);
 
-  // Get category info
+  // Get category info (icon + name)
   const getCategoryInfo = useCallback((categoryId) => {
     const category = categories.find(cat => cat.id === categoryId);
     if (!category) return { name: t('unknown_category'), icon: 'help-circle' };
 
-    // Import getCategoryDisplayName utility
-    const getCategoryDisplayName = (categoryId, categories, t) => {
-      const category = categories.find(cat => cat.id === categoryId);
-      if (!category) return null;
+    const getCategoryDisplayName = (catId, cats, translate) => {
+      const cat = cats.find(c => c.id === catId);
+      if (!cat) return null;
 
-      const categoryName = category.nameKey ? t(category.nameKey) : category.name;
+      const name = cat.nameKey ? translate(cat.nameKey) : cat.name;
 
-      // If category has parent, build full path
-      if (category.parentId) {
-        const parent = categories.find(cat => cat.id === category.parentId);
+      if (cat.parentId) {
+        const parent = cats.find(c => c.id === cat.parentId);
         if (parent) {
-          const parentName = parent.nameKey ? t(parent.nameKey) : parent.name;
-          return `${parentName} / ${categoryName}`;
+          const parentName = parent.nameKey ? translate(parent.nameKey) : parent.name;
+          return `${parentName} / ${name}`;
         }
       }
 
-      return categoryName;
+      return name;
     };
 
     const categoryName = getCategoryDisplayName(categoryId, categories, t);
@@ -143,35 +134,42 @@ const OperationsList = forwardRef(({
     );
   }, [loadingMore, colors, t]);
 
-  // Render individual list items (separators and operations)
+  // Render a full date group (header + card with operations)
   const renderItem = useCallback(({ item }) => {
-    // Render date separator
-    if (item.type === 'separator') {
-      return (
+    return (
+      <View style={styles.groupContainer}>
         <DateSeparator
           date={item.date}
           spendingSums={item.spendingSums}
           formatDate={formatDate}
           colors={colors}
-          t={t}
           onPress={() => onDateSeparatorPress(item.date)}
         />
-      );
-    }
-
-    // Render operation
-    return (
-      <OperationListItem
-        operation={item}
-        colors={colors}
-        t={t}
-        categories={categories}
-        getCategoryInfo={getCategoryInfo}
-        getAccountName={getAccountName}
-        formatCurrency={formatCurrency}
-        formatDate={formatDate}
-        onPress={() => onEditOperation(item)}
-      />
+        <View
+          style={[
+            styles.operationsCard,
+            {
+              backgroundColor: colors.surface,
+              borderColor: colors.border,
+            },
+          ]}
+        >
+          {item.operations.map((operation, index) => (
+            <OperationListItem
+              key={operation.id}
+              operation={operation}
+              colors={colors}
+              t={t}
+              categories={categories}
+              getCategoryInfo={getCategoryInfo}
+              getAccountName={getAccountName}
+              formatCurrency={formatCurrency}
+              isLast={index === item.operations.length - 1}
+              onPress={() => onEditOperation(operation)}
+            />
+          ))}
+        </View>
+      </View>
     );
   }, [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency, formatDate, onEditOperation, onDateSeparatorPress]);
 
@@ -205,8 +203,8 @@ const OperationsList = forwardRef(({
         autoscrollToTopThreshold: 10,
       }}
       windowSize={10}
-      maxToRenderPerBatch={10}
-      initialNumToRender={15}
+      maxToRenderPerBatch={5}
+      initialNumToRender={10}
       updateCellsBatchingPeriod={50}
       removeClippedSubviews={true}
     />
@@ -255,6 +253,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     marginTop: SPACING.lg,
   },
+  groupContainer: {
+    marginBottom: SPACING.sm,
+  },
   listContent: {
     paddingBottom: 180,
   },
@@ -266,6 +267,12 @@ const styles = StyleSheet.create({
   loadingMoreText: {
     fontSize: 14,
     marginTop: SPACING.sm,
+  },
+  operationsCard: {
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    marginHorizontal: SPACING.lg,
+    overflow: 'hidden',
   },
 });
 

--- a/app/contexts/ThemeColorsContext.js
+++ b/app/contexts/ThemeColorsContext.js
@@ -24,8 +24,8 @@ const lightTheme = {
     selected: '#c0e0ff',
     altRow: '#f8f8f8', // Added for alternating rows
     expense: '#5a3030',
-    income: '#44aa44',
-    transfer: '#4444ff',
+    income: '#4a8a4a',
+    transfer: '#5575aa',
     expenseBackground: '#f5f0f0',
     incomeBackground: '#e5ffe5',
     transferBackground: '#e5e5ff',
@@ -52,8 +52,8 @@ const darkTheme = {
     selected: '#005fa3',
     altRow: '#1a1a1a', // Added for alternating rows
     expense: '#e6cccc',
-    income: '#66dd66',
-    transfer: '#6b6bff',
+    income: '#66aa66',
+    transfer: '#7799cc',
     expenseBackground: '#2a2020',
     incomeBackground: '#204a20',
     transferBackground: '#20204a',

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -104,7 +104,7 @@ const OperationsScreen = () => {
   useEffect(() => {
     if (scrollToDateString && !operationsLoading && groupedOperations.length > 0) {
       const separatorIndex = groupedOperations.findIndex(
-        item => item.type === 'separator' && item.date === scrollToDateString,
+        item => item.type === 'dateGroup' && item.date === scrollToDateString,
       );
 
       if (separatorIndex !== -1) {
@@ -123,7 +123,7 @@ const OperationsScreen = () => {
   const handleContentSizeChange = useCallback((width, height) => {
     if (pendingScroll && scrollToDateString && !operationsLoading) {
       const separatorIndex = groupedOperations.findIndex(
-        item => item.type === 'separator' && item.date === scrollToDateString,
+        item => item.type === 'dateGroup' && item.date === scrollToDateString,
       );
 
       if (separatorIndex !== -1) {
@@ -268,7 +268,7 @@ const OperationsScreen = () => {
 
       // Find the index of the date separator for this date in current list
       const separatorIndex = groupedOperations.findIndex(
-        item => item.type === 'separator' && item.date === dateString,
+        item => item.type === 'dateGroup' && item.date === dateString,
       );
 
       if (separatorIndex !== -1) {
@@ -407,84 +407,41 @@ const OperationsScreen = () => {
     await handleQuickAdd(undefined, toAccountId);
   }, [resetForm, closePicker, handleQuickAdd]);
 
-  // Calculate spending sums by currency for a group of operations
-  const calculateSpendingSums = useCallback((operations) => {
-    const sumsByCurrency = {};
+  // Group operations by date into date-group objects for the list
+  const groupedOperations = useMemo(() => {
+    const sorted = [...operations].sort((a, b) => new Date(b.date) - new Date(a.date));
+    const groups = [];
+    let currentGroup = null;
 
-    operations.forEach((operation) => {
+    sorted.forEach((operation) => {
+      if (!currentGroup || operation.date !== currentGroup.date) {
+        currentGroup = {
+          type: 'dateGroup',
+          id: `group-${operation.date}`,
+          date: operation.date,
+          spendingSums: {},
+          operations: [],
+        };
+        groups.push(currentGroup);
+      }
+
+      currentGroup.operations.push(operation);
+
+      // Accumulate spending sums for expenses
       if (operation.type === 'expense') {
         const account = accounts.find(acc => acc.id === operation.accountId);
         if (account) {
           const currency = account.currency || 'USD';
           const amount = parseFloat(operation.amount);
           if (!isNaN(amount)) {
-            if (!sumsByCurrency[currency]) {
-              sumsByCurrency[currency] = 0;
-            }
-            sumsByCurrency[currency] += amount;
+            currentGroup.spendingSums[currency] = (currentGroup.spendingSums[currency] || 0) + amount;
           }
         }
       }
     });
 
-    return sumsByCurrency;
-  }, [accounts]);
-
-  // Group operations by date and create flat list with separators
-  const groupedOperations = useMemo(() => {
-    const sorted = [...operations].sort((a, b) => new Date(b.date) - new Date(a.date));
-    const grouped = [];
-    let currentDate = null;
-    let currentDateOperations = [];
-
-    sorted.forEach((operation, index) => {
-      if (operation.date !== currentDate) {
-        // If we have accumulated operations for previous date, calculate sums
-        if (currentDate !== null && currentDateOperations.length > 0) {
-          const spendingSums = calculateSpendingSums(currentDateOperations);
-          // Update the separator that was already added with the spending sums
-          const separatorIndex = grouped.findIndex(
-            item => item.type === 'separator' && item.date === currentDate,
-          );
-          if (separatorIndex !== -1) {
-            grouped[separatorIndex].spendingSums = spendingSums;
-          }
-        }
-
-        // Start new date group
-        currentDate = operation.date;
-        currentDateOperations = [operation];
-
-        // Add date separator (sums will be added later)
-        grouped.push({
-          type: 'separator',
-          date: operation.date,
-          id: `separator-${operation.date}`,
-        });
-      } else {
-        currentDateOperations.push(operation);
-      }
-
-      // Add operation
-      grouped.push({
-        type: 'operation',
-        ...operation,
-      });
-
-      // Handle last date group
-      if (index === sorted.length - 1 && currentDateOperations.length > 0) {
-        const spendingSums = calculateSpendingSums(currentDateOperations);
-        const separatorIndex = grouped.findIndex(
-          item => item.type === 'separator' && item.date === currentDate,
-        );
-        if (separatorIndex !== -1) {
-          grouped[separatorIndex].spendingSums = spendingSums;
-        }
-      }
-    });
-
-    return grouped;
-  }, [operations, calculateSpendingSums]);
+    return groups;
+  }, [operations, accounts]);
 
   const TYPES = useMemo(() => [
     { key: 'expense', label: t('expense'), icon: 'minus-circle' },


### PR DESCRIPTION
## Summary

- Operations list redesigned to group items by date into shared rounded cards (matching Copilot/Monarch-style layout)
- Date headers simplified to a flat row: uppercase date label on the left, daily expense total on the right
- Each item row shows description (or category) as title with `Category · Account` as subtitle
- Icons use operation-type color (expense/income/transfer) with a muted palette
- Amount signs removed from individual items (color conveys type); daily totals keep the `−` prefix

## Test plan

- [ ] All 2871 existing tests pass (`npm test -- --silent`)
- [ ] Operations grouped correctly by date in a single card per day
- [ ] Tapping a date header still opens the date picker for jump-to-date
- [ ] Infinite scroll / load-more still works at the bottom of the list
- [ ] Expense icon/amount shows in muted red, income in muted green, transfer in muted blue
- [ ] Daily total shows `−$XX.XX` in the date header; item amounts show no sign prefix
- [ ] Description field (when set) appears as item title; otherwise falls back to category name
- [ ] Dark mode renders correctly with adjusted palette

🧀
