### PR TITLE
feat(graphs): redesign filter chips and summary cards

### DIFF
--- a/__tests__/components/graphs/ExpenseSummaryCard.test.js
+++ b/__tests__/components/graphs/ExpenseSummaryCard.test.js
@@ -210,7 +210,7 @@ describe('ExpenseSummaryCard', () => {
 
       const text = getByText(/\$1\.5K/);
       expect(text.props.style).toEqual(
-        expect.objectContaining({ color: '#E57373' }),
+        expect.arrayContaining([expect.objectContaining({ color: '#FF0000' })]),
       );
     });
   });

--- a/__tests__/components/graphs/IncomeSummaryCard.test.js
+++ b/__tests__/components/graphs/IncomeSummaryCard.test.js
@@ -202,7 +202,7 @@ describe('IncomeSummaryCard', () => {
 
       const text = getByText(/\$3\.5K/);
       expect(text.props.style).toEqual(
-        expect.objectContaining({ color: '#81C784' }),
+        expect.arrayContaining([expect.objectContaining({ color: '#00FF00' })]),
       );
     });
   });

--- a/app/components/SimplePicker.js
+++ b/app/components/SimplePicker.js
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, StyleSheet, TouchableOpacity, Modal, FlatList, Platform } from 'react-native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import ModalBlurOverlay from './ModalBlurOverlay';
 
@@ -8,7 +9,7 @@ import ModalBlurOverlay from './ModalBlurOverlay';
  * SimplePicker - A picker component for Android
  * Uses native HTML select on web, custom modal picker on Android
  */
-const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors }) => {
+const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, leftIcon }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   // Defensive check for undefined items with warning
@@ -64,15 +65,29 @@ const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors })
   // Android: Use custom modal picker for better control
   return (
     <>
-      <TouchableOpacity
-        style={[styles.androidButton, style]}
-        onPress={() => setModalVisible(true)}
-        activeOpacity={0.7}
-      >
-        <Text style={[styles.androidButtonText, textStyle, { color: safeColors.text }]} numberOfLines={1}>
-          {selectedLabel}
-        </Text>
-      </TouchableOpacity>
+      {leftIcon ? (
+        <TouchableOpacity
+          style={[styles.chipButton, style]}
+          onPress={() => setModalVisible(true)}
+          activeOpacity={0.7}
+        >
+          <Icon name={leftIcon} size={16} color={safeColors.mutedText ?? '#666666'} />
+          <Text style={[styles.chipButtonText, textStyle, { color: safeColors.text }]} numberOfLines={1}>
+            {selectedLabel}
+          </Text>
+          <Icon name="chevron-down" size={16} color={safeColors.mutedText ?? '#666666'} />
+        </TouchableOpacity>
+      ) : (
+        <TouchableOpacity
+          style={[styles.androidButton, style]}
+          onPress={() => setModalVisible(true)}
+          activeOpacity={0.7}
+        >
+          <Text style={[styles.androidButtonText, textStyle, { color: safeColors.text }]} numberOfLines={1}>
+            {selectedLabel}
+          </Text>
+        </TouchableOpacity>
+      )}
 
 
       {modalVisible && <ModalBlurOverlay />}
@@ -129,6 +144,20 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     textAlign: 'center',
   },
+  // Chip-style button with left icon and right chevron
+  chipButton: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+    height: 44,
+    paddingHorizontal: 14,
+    width: '100%',
+  },
+  chipButtonText: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '500',
+  },
   // Modal styles
   modalContent: {
     borderRadius: 8,
@@ -181,7 +210,9 @@ SimplePicker.propTypes = {
     surface: PropTypes.string,
     border: PropTypes.string,
     selected: PropTypes.string,
+    mutedText: PropTypes.string,
   }),
+  leftIcon: PropTypes.string,
 };
 
 SimplePicker.defaultProps = {

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
@@ -29,15 +30,21 @@ const ExpenseSummaryCard = ({
   const { hideBalances } = useDisplaySettings();
   return (
     <TouchableOpacity
-      style={[styles.summaryCard, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+      style={[styles.summaryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
       accessibilityLabel={t('expenses_by_category')}
     >
-      <Text style={styles.summaryText}>
-        {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
-      </Text>
+      <View style={styles.iconBadge}>
+        <Icon name="arrow-top-right" size={16} color="#d93025" />
+      </View>
+      <View style={styles.textContent}>
+        <Text style={[styles.label, { color: colors.mutedText }]}>{t('expense').toUpperCase()}</Text>
+        <Text style={[styles.amount, { color: colors.text }]}>
+          {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
+        </Text>
+      </View>
     </TouchableOpacity>
   );
 };
@@ -52,17 +59,35 @@ ExpenseSummaryCard.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  amount: {
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginTop: 1,
+  },
+  iconBadge: {
+    alignItems: 'center',
+    height: 26,
+    justifyContent: 'center',
+    width: 26,
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: '500',
+    letterSpacing: 0.3,
+  },
   summaryCard: {
-    borderRadius: 8,
+    alignItems: 'center',
+    borderRadius: 14,
     borderWidth: 1,
     flex: 1,
+    flexDirection: 'row',
+    gap: 8,
     padding: 10,
   },
-  summaryText: {
-    color: '#E57373',
-    fontSize: 14,
-    fontWeight: '600',
-    textAlign: 'center',
+  textContent: {
+    flex: 1,
+    minWidth: 0,
   },
 });
 

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
@@ -29,15 +30,21 @@ const IncomeSummaryCard = ({
   const { hideBalances } = useDisplaySettings();
   return (
     <TouchableOpacity
-      style={[styles.summaryCard, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+      style={[styles.summaryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
       accessibilityLabel={t('income_by_category')}
     >
-      <Text style={styles.summaryText}>
-        {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
-      </Text>
+      <View style={styles.iconBadge}>
+        <Icon name="arrow-bottom-left" size={16} color={colors.income} />
+      </View>
+      <View style={styles.textContent}>
+        <Text style={[styles.label, { color: colors.mutedText }]}>{t('income').toUpperCase()}</Text>
+        <Text style={[styles.amount, { color: colors.text }]}>
+          {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
+        </Text>
+      </View>
     </TouchableOpacity>
   );
 };
@@ -52,17 +59,35 @@ IncomeSummaryCard.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  amount: {
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginTop: 1,
+  },
+  iconBadge: {
+    alignItems: 'center',
+    height: 26,
+    justifyContent: 'center',
+    width: 26,
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: '500',
+    letterSpacing: 0.3,
+  },
   summaryCard: {
-    borderRadius: 8,
+    alignItems: 'center',
+    borderRadius: 14,
     borderWidth: 1,
     flex: 1,
+    flexDirection: 'row',
+    gap: 8,
     padding: 10,
   },
-  summaryText: {
-    color: '#81C784',
-    fontSize: 14,
-    fontWeight: '600',
-    textAlign: 'center',
+  textContent: {
+    flex: 1,
+    minWidth: 0,
   },
 });
 

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -368,22 +368,24 @@ const GraphsScreen = () => {
           {/* Filters Row */}
           <View style={styles.filtersRow}>
             {/* Currency Picker */}
-            <View style={[styles.pickerWrapper, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
+            <View style={[styles.pickerWrapper, { backgroundColor: colors.surface, borderColor: colors.border }]}>
               <SimplePicker
                 value={selectedCurrency}
                 onValueChange={setSelectedCurrency}
                 items={currencyItems}
                 colors={colors}
+                leftIcon="currency-usd"
               />
             </View>
 
             {/* Period Picker (Combined Month + Year) */}
-            <View style={[styles.periodPickerWrapper, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
+            <View style={[styles.periodPickerWrapper, { backgroundColor: colors.surface, borderColor: colors.border }]}>
               <SimplePicker
                 value={selectedPeriod}
                 onValueChange={setSelectedPeriod}
                 items={periodItems}
                 colors={colors}
+                leftIcon="calendar-month"
               />
             </View>
           </View>
@@ -495,17 +497,17 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   periodPickerWrapper: {
-    borderRadius: 8,
+    borderRadius: 12,
     borderWidth: 1,
     flex: 1,
-    height: 40,
+    height: 44,
     overflow: 'hidden',
   },
   pickerWrapper: {
-    borderRadius: 8,
+    borderRadius: 12,
     borderWidth: 1,
-    flex: 1,
-    height: 40,
+    height: 44,
+    minWidth: 110,
     overflow: 'hidden',
   },
   scrollContent: {


### PR DESCRIPTION
## Summary
- **SimplePicker**: new `leftIcon` prop renders chip-style button with icon + label + chevron
- **GraphsScreen**: currency and period pickers styled as rounded chips with calendar/dollar icons and surface background
- **IncomeSummaryCard / ExpenseSummaryCard**: redesigned with horizontal layout — directional arrow icons, uppercase label, bold amount; expense arrow uses vivid red (#d93025) for contrast

## Test plan
- [ ] Graphs screen filter row shows currency chip (dollar icon + currency code + chevron) and period chip (calendar icon + month + chevron)
- [ ] Income card shows green arrow-bottom-left + INCOME label + formatted amount
- [ ] Expense card shows vivid red arrow-top-right + EXPENSE label + formatted amount
- [ ] Tapping chips opens picker modal as before
- [ ] hideBalances mode shows •••• in both cards
- [ ] Light and dark theme render correctly

🧀
