### PR TITLE
feat(graphs): redesign category spending card with interactive bar chart

### DIFF
--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -25,11 +25,6 @@ jest.mock('../../../assets/currencies.json', () => ({
   JPY: { symbol: '¥', decimal_digits: 0 },
 }));
 
-// Mock react-native-chart-kit
-jest.mock('react-native-chart-kit', () => ({
-  LineChart: 'LineChart',
-}));
-
 describe('CategorySpendingCard', () => {
   const defaultColors = {
     text: '#000000',
@@ -85,7 +80,6 @@ describe('CategorySpendingCard', () => {
     useCategoryMonthlySpending.mockReturnValue({
       monthlyData: defaultMonthlyData,
       loading: false,
-      totalYearlySpending: 1550,
       loadData: jest.fn(),
     });
   });
@@ -100,21 +94,19 @@ describe('CategorySpendingCard', () => {
       expect(getByText('Food')).toBeTruthy();
     });
 
-    it('renders LineChart with 12 months', () => {
+    it('renders bar chart SVG with 12 months of bars', () => {
       const { UNSAFE_getByType } = render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      const barChart = UNSAFE_getByType('LineChart');
-      expect(barChart).toBeTruthy();
-      expect(barChart.props.data.labels).toHaveLength(12);
+      const svg = UNSAFE_getByType('Svg');
+      expect(svg).toBeTruthy();
     });
 
     it('shows loading indicator when loading', () => {
       useCategoryMonthlySpending.mockReturnValue({
         monthlyData: [],
         loading: true,
-        totalYearlySpending: 0,
         loadData: jest.fn(),
       });
 
@@ -132,7 +124,6 @@ describe('CategorySpendingCard', () => {
       useCategoryMonthlySpending.mockReturnValue({
         monthlyData: emptyData,
         loading: false,
-        totalYearlySpending: 0,
         loadData: jest.fn(),
       });
 
@@ -141,8 +132,7 @@ describe('CategorySpendingCard', () => {
       );
 
       expect(getByText('no_spending_data')).toBeTruthy();
-      // Should not render LineChart
-      expect(UNSAFE_queryByType('LineChart')).toBeFalsy();
+      expect(UNSAFE_queryByType('Svg')).toBeFalsy();
     });
 
     it('renders null when no parent expense categories', () => {
@@ -276,19 +266,22 @@ describe('CategorySpendingCard', () => {
   });
 
   describe('Currency Formatting', () => {
-    it('formats currency correctly for USD', () => {
+    it('formats current month amount with currency symbol for USD', () => {
       const { getByText } = render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(getByText('1550.00 USD')).toBeTruthy();
+      // Last month total is 200, USD symbol is $
+      expect(getByText('$200.00')).toBeTruthy();
     });
 
-    it('formats currency correctly for JPY (0 decimals)', () => {
+    it('formats current month amount with currency symbol for JPY (0 decimals)', () => {
+      const jpyData = generateMonthlyData().map((item, i) =>
+        i === 11 ? { ...item, total: 5000 } : item,
+      );
       useCategoryMonthlySpending.mockReturnValue({
-        monthlyData: defaultMonthlyData,
+        monthlyData: jpyData,
         loading: false,
-        totalYearlySpending: 5000,
         loadData: jest.fn(),
       });
 
@@ -299,7 +292,7 @@ describe('CategorySpendingCard', () => {
         />,
       );
 
-      expect(getByText('5000 JPY')).toBeTruthy();
+      expect(getByText('¥5000')).toBeTruthy();
     });
   });
 
@@ -327,69 +320,23 @@ describe('CategorySpendingCard', () => {
         ]),
       );
     });
-
-    it('uses default expense color when not provided', () => {
-      const colorsWithoutExpense = {
-        ...defaultColors,
-        expense: undefined,
-      };
-
-      const { getByText } = render(
-        <CategorySpendingCard
-          {...defaultProps}
-          colors={colorsWithoutExpense}
-        />,
-      );
-
-      const totalValue = getByText('1550.00 USD');
-      expect(totalValue.props.style).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ color: '#ff4444' }),
-        ]),
-      );
-    });
-  });
-
-  describe('Chart Configuration', () => {
-    it('passes correct data to LineChart', () => {
-      const { UNSAFE_getByType } = render(
-        <CategorySpendingCard {...defaultProps} />,
-      );
-
-      const barChart = UNSAFE_getByType('LineChart');
-
-      expect(barChart.props.data.datasets[0].data).toEqual(
-        defaultMonthlyData.map(item => item.total),
-      );
-    });
-
-    it('uses correct chart dimensions', () => {
-      const { UNSAFE_getByType } = render(
-        <CategorySpendingCard {...defaultProps} />,
-      );
-
-      const barChart = UNSAFE_getByType('LineChart');
-
-      expect(barChart.props.height).toBe(220);
-      expect(barChart.props.fromZero).toBe(true);
-    });
   });
 
   describe('Title and Labels', () => {
-    it('displays spending trend title', () => {
+    it('displays spending trend title uppercased', () => {
       const { getByText } = render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(getByText('category_spending_trend')).toBeTruthy();
+      expect(getByText('CATEGORY_SPENDING_TREND')).toBeTruthy();
     });
 
-    it('displays last 12 months total label', () => {
+    it('displays this_month label for current month', () => {
       const { getByText } = render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(getByText('last_12_months_total')).toBeTruthy();
+      expect(getByText('this_month')).toBeTruthy();
     });
   });
 
@@ -404,21 +351,20 @@ describe('CategorySpendingCard', () => {
       useDisplaySettings.mockReturnValue({ hideBalances: false });
     });
 
-    it('does not render the 12-month total row', () => {
+    it('does not render the amount', () => {
       const { queryByText } = render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(queryByText('last_12_months_total')).toBeFalsy();
-      expect(queryByText('1550.00 USD')).toBeFalsy();
+      expect(queryByText('$200.00')).toBeFalsy();
     });
 
-    it('still renders the LineChart', () => {
+    it('still renders the bar chart', () => {
       const { UNSAFE_getByType } = render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(UNSAFE_getByType('LineChart')).toBeTruthy();
+      expect(UNSAFE_getByType('Svg')).toBeTruthy();
     });
   });
 

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Dimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import PropTypes from 'prop-types';
-import { LineChart } from 'react-native-chart-kit';
+import Svg, { Line, Rect, Text as SvgText } from 'react-native-svg';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import currencies from '../../../assets/currencies.json';
 import useCategoryMonthlySpending from '../../hooks/useCategoryMonthlySpending';
@@ -14,19 +14,130 @@ const screenWidth = Dimensions.get('window').width;
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
   const decimals = currencyInfo?.decimal_digits ?? 2;
-  return `${parseFloat(amount).toFixed(decimals)} ${currency}`;
+  const symbol = currencyInfo?.symbol ?? currency;
+  return `${symbol}${parseFloat(amount).toFixed(decimals)}`;
 };
 
-const formatYLabel = (value) => {
-  const numValue = parseFloat(value);
-  if (numValue >= 1000000) {
-    return `${(numValue / 1000000).toFixed(1)}M`;
-  } else if (numValue >= 1000) {
-    return `${(numValue / 1000).toFixed(0)}K`;
-  }
-  return numValue.toFixed(0);
+const BAR_HEIGHT = 90;
+const LABEL_HEIGHT = 18;
+const TOP_PADDING = 8;
+const Y_AXIS_WIDTH = 32;
+
+const formatYTick = (value) => {
+  if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(0)}K`;
+  return value.toFixed(0);
 };
 
+const BarChart = ({ data, monthAbbreviations, colors, width, selectedIndex, onBarPress }) => {
+  const max = Math.max(...data.map(d => d.total), 1);
+  const count = data.length;
+  const chartW = width - Y_AXIS_WIDTH;
+  const slotW = chartW / count;
+  const barW = slotW * 0.55;
+  const gap = slotW * 0.45;
+  const totalHeight = TOP_PADDING + BAR_HEIGHT + LABEL_HEIGHT;
+
+  const niceStep = (() => {
+    const raw = max / 5;
+    const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+    const normalized = raw / mag;
+    let nice;
+    if (normalized < 1.5) nice = 1;
+    else if (normalized < 3.5) nice = 2;
+    else if (normalized < 7.5) nice = 5;
+    else nice = 10;
+    return nice * mag;
+  })();
+
+  const axisMax = Math.ceil(max / niceStep) * niceStep;
+  const tickCount = Math.round(axisMax / niceStep);
+
+  const yTicks = Array.from({ length: tickCount + 1 }, (_, i) => ({
+    value: niceStep * i,
+    y: TOP_PADDING + BAR_HEIGHT - (niceStep * i / axisMax) * BAR_HEIGHT,
+  }));
+
+  return (
+    <Svg width={width} height={totalHeight} style={styles.barChartSvg}>
+      {/* Y axis ticks */}
+      {yTicks.map(({ value, y }) => (
+        <SvgText
+          key={value}
+          x={Y_AXIS_WIDTH - 4}
+          y={y + 3.5}
+          fontSize={8}
+          fontFamily="Inter"
+          fill={colors.mutedText}
+          textAnchor="end"
+          opacity={0.7}
+        >
+          {formatYTick(value)}
+        </SvgText>
+      ))}
+
+      {/* Selected bar dotted line */}
+      {selectedIndex !== null && selectedIndex !== undefined && data[selectedIndex] && (() => {
+        const selH = Math.max((data[selectedIndex].total / axisMax) * BAR_HEIGHT, data[selectedIndex].total > 0 ? 2 : 0);
+        const lineY = TOP_PADDING + BAR_HEIGHT - selH;
+        return (
+          <Line
+            x1={Y_AXIS_WIDTH}
+            y1={lineY}
+            x2={width}
+            y2={lineY}
+            stroke={colors.primary}
+            strokeWidth={1}
+            strokeDasharray="3,3"
+            opacity={0.5}
+          />
+        );
+      })()}
+
+      {/* Bars */}
+      {data.map((d, i) => {
+        const h = Math.max((d.total / axisMax) * BAR_HEIGHT, d.total > 0 ? 2 : 0);
+        const x = Y_AXIS_WIDTH + i * slotW + gap / 2;
+        const y = TOP_PADDING + BAR_HEIGHT - h;
+        const isSelected = i === selectedIndex;
+        const label = monthAbbreviations[d.month];
+        return (
+          <React.Fragment key={i}>
+            <Rect
+              x={x}
+              y={TOP_PADDING}
+              width={barW}
+              height={BAR_HEIGHT}
+              fill="transparent"
+              onPress={() => onBarPress(i)}
+            />
+            <Rect
+              x={x}
+              y={y}
+              width={barW}
+              height={h}
+              rx={3}
+              fill={isSelected ? colors.primary : colors.surface}
+              stroke={isSelected ? 'none' : colors.border}
+              strokeWidth={1}
+              onPress={() => onBarPress(i)}
+            />
+            <SvgText
+              x={x + barW / 2}
+              y={TOP_PADDING + BAR_HEIGHT + 13}
+              fontSize={9.5}
+              fontFamily="Inter"
+              fill={colors.mutedText}
+              textAnchor="middle"
+            >
+              {label}
+            </SvgText>
+          </React.Fragment>
+        );
+      })}
+    </Svg>
+  );
+};
 
 const CategorySpendingCard = ({
   colors,
@@ -38,6 +149,7 @@ const CategorySpendingCard = ({
 }) => {
   const [pickerVisible, setPickerVisible] = useState(false);
   const [expandedParents, setExpandedParents] = useState(new Set());
+  const [selectedBarIndex, setSelectedBarIndex] = useState(null);
 
   // Get all expense categories (parent and child)
   const allExpenseCategories = useMemo(() => {
@@ -70,10 +182,15 @@ const CategorySpendingCard = ({
     return parentExpenseCategories.length > 0 ? parentExpenseCategories[0].id : null;
   }, [selectedCategory, allExpenseCategories, parentExpenseCategories]);
 
-  // Get display name for selected category
+  // Get display info for selected category
   const selectedCategoryName = useMemo(() => {
     const cat = allExpenseCategories.find(c => c.id === effectiveCategory);
     return cat ? cat.name : '';
+  }, [allExpenseCategories, effectiveCategory]);
+
+  const selectedCategoryIcon = useMemo(() => {
+    const cat = allExpenseCategories.find(c => c.id === effectiveCategory);
+    return cat?.icon ?? null;
   }, [allExpenseCategories, effectiveCategory]);
 
   // Toggle parent expansion (only one can be expanded at a time)
@@ -99,33 +216,26 @@ const CategorySpendingCard = ({
   const {
     monthlyData,
     loading,
-    totalYearlySpending,
   } = useCategoryMonthlySpending(selectedCurrency, effectiveCategory, categories);
 
   const { hideBalances } = useDisplaySettings();
 
-  // Two-letter month abbreviations
+  // Two-letter month abbreviations (for bar labels)
   const monthAbbreviations = ['Ja', 'Fe', 'Mr', 'Ap', 'My', 'Jn', 'Jl', 'Au', 'Se', 'Oc', 'No', 'De'];
-
-  // Generate month labels
-  const monthLabels = useMemo(() => {
-    return monthlyData.map(item => monthAbbreviations[item.month]);
-  }, [monthlyData]);
-
-  // Prepare chart data
-  const chartData = useMemo(() => {
-    return {
-      labels: monthLabels,
-      datasets: [
-        {
-          data: monthlyData.map(item => item.total),
-        },
-      ],
-    };
-  }, [monthlyData, monthLabels]);
+  const monthKeys = ['month_january', 'month_february', 'month_march', 'month_april', 'month_may', 'month_june', 'month_july', 'month_august', 'month_september', 'month_october', 'month_november', 'month_december'];
 
   // Check if there's any data to display
   const hasData = monthlyData.some(item => item.total > 0);
+
+  // Reset bar selection when data changes (e.g. category switch)
+  const prevDataRef = React.useRef(monthlyData);
+  if (prevDataRef.current !== monthlyData) {
+    prevDataRef.current = monthlyData;
+    if (selectedBarIndex !== null) setSelectedBarIndex(null);
+  }
+
+  const effectiveBarIndex = selectedBarIndex !== null ? selectedBarIndex : monthlyData.length - 1;
+  const displayedTotal = monthlyData.length > 0 ? (monthlyData[effectiveBarIndex]?.total ?? 0) : 0;
 
   // Don't render if no parent categories available
   if (parentExpenseCategories.length === 0) {
@@ -135,22 +245,35 @@ const CategorySpendingCard = ({
   return (
     <View style={[styles.card, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
       <View style={styles.header}>
-        <View style={styles.titleContainer}>
-          <Icon name="chart-bar" size={24} color={colors.primary} />
-          <Text style={[styles.title, { color: colors.text }]}>
-            {t('category_spending_trend')}
+        {/* Left: label + category selector */}
+        <View style={styles.headerLeft}>
+          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
+            {t('category_spending_trend').toUpperCase()}
+          </Text>
+          <TouchableOpacity
+            style={styles.categorySelector}
+            onPress={() => setPickerVisible(true)}
+          >
+            {selectedCategoryIcon && (
+              <Icon name={selectedCategoryIcon} size={18} color={colors.primary} />
+            )}
+            <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
+              {selectedCategoryName}
+            </Text>
+            <Icon name="chevron-down" size={18} color={colors.mutedText} />
+          </TouchableOpacity>
+        </View>
+        {/* Right: current month amount */}
+        <View style={styles.headerRight}>
+          {!hideBalances && (
+            <Text style={[styles.currentAmount, { color: colors.text }]}>
+              {formatCurrency(displayedTotal, selectedCurrency)}
+            </Text>
+          )}
+          <Text style={[styles.thisMonthLabel, { color: colors.mutedText }]}>
+            {effectiveBarIndex === monthlyData.length - 1 ? t('this_month') : monthlyData[effectiveBarIndex] ? `${t(monthKeys[monthlyData[effectiveBarIndex].month])} ${monthlyData[effectiveBarIndex].year}` : ''}
           </Text>
         </View>
-        {/* Category Picker Button */}
-        <TouchableOpacity
-          style={[styles.pickerButton, { backgroundColor: colors.altRow, borderColor: colors.border }]}
-          onPress={() => setPickerVisible(true)}
-        >
-          <Text style={[styles.pickerButtonText, { color: colors.text }]} numberOfLines={1}>
-            {selectedCategoryName}
-          </Text>
-          <Icon name="chevron-down" size={20} color={colors.mutedText} />
-        </TouchableOpacity>
       </View>
 
       {/* Custom Category Picker Modal */}
@@ -243,61 +366,26 @@ const CategorySpendingCard = ({
           </Text>
         </View>
       ) : (
-        <>
-          <View style={styles.chartContainer}>
-            <LineChart
-              data={chartData}
-              width={screenWidth - 50}
-              height={220}
-              yAxisLabel=""
-              yAxisSuffix=""
-              fromZero={true}
-              withInnerLines={true}
-              formatYLabel={hideBalances ? () => '' : formatYLabel}
-              chartConfig={{
-                backgroundColor: colors.altRow,
-                backgroundGradientFrom: colors.altRow,
-                backgroundGradientTo: colors.altRow,
-                decimalPlaces: 0,
-                color: () => colors.primary,
-                labelColor: () => colors.mutedText,
-                style: {
-                  borderRadius: 16,
-                },
-                propsForLabels: {
-                  fontSize: 11,
-                },
-                propsForBackgroundLines: {
-                  strokeWidth: 1,
-                  stroke: colors.border,
-                  strokeDasharray: '0',
-                },
-                propsForDots: {
-                  r: '4',
-                  strokeWidth: '2',
-                  stroke: colors.primary,
-                },
-              }}
-              bezier
-              style={styles.chart}
-            />
-          </View>
-
-          {/* 12-Month Total */}
-          {!hideBalances && (
-            <View style={styles.totalContainer}>
-              <Text style={[styles.totalLabel, { color: colors.mutedText }]}>
-                {t('last_12_months_total')}
-              </Text>
-              <Text style={[styles.totalValue, { color: colors.expense || '#ff4444' }]}>
-                {formatCurrency(totalYearlySpending, selectedCurrency)}
-              </Text>
-            </View>
-          )}
-        </>
+        <BarChart
+          data={monthlyData}
+          monthAbbreviations={monthAbbreviations}
+          colors={colors}
+          width={screenWidth - 64}
+          selectedIndex={effectiveBarIndex}
+          onBarPress={setSelectedBarIndex}
+        />
       )}
     </View>
   );
+};
+
+BarChart.propTypes = {
+  colors: PropTypes.object.isRequired,
+  data: PropTypes.arrayOf(PropTypes.shape({ total: PropTypes.number, month: PropTypes.number })).isRequired,
+  monthAbbreviations: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onBarPress: PropTypes.func.isRequired,
+  selectedIndex: PropTypes.number,
+  width: PropTypes.number.isRequired,
 };
 
 CategorySpendingCard.propTypes = {
@@ -310,6 +398,9 @@ CategorySpendingCard.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  barChartSvg: {
+    marginTop: 12,
+  },
   card: {
     borderRadius: 8,
     borderWidth: 1,
@@ -322,15 +413,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 12,
   },
+  categoryName: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  categorySelector: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 4,
+    marginTop: 4,
+  },
   categoryText: {
     fontSize: 16,
     fontWeight: '500',
-  },
-  chart: {
-    borderRadius: 8,
-  },
-  chartContainer: {
-    alignItems: 'center',
   },
   childRow: {
     borderBottomWidth: 1,
@@ -341,9 +436,14 @@ const styles = StyleSheet.create({
   childText: {
     fontSize: 15,
   },
+  currentAmount: {
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'right',
+  },
   emptyContainer: {
     alignItems: 'center',
-    height: 220,
+    height: 120,
     justifyContent: 'center',
     paddingHorizontal: 32,
   },
@@ -362,14 +462,20 @@ const styles = StyleSheet.create({
     width: 44,
   },
   header: {
-    alignItems: 'center',
+    alignItems: 'flex-start',
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: 16,
+    marginBottom: 4,
+  },
+  headerLeft: {
+    flex: 1,
+  },
+  headerRight: {
+    alignItems: 'flex-end',
   },
   loadingContainer: {
     alignItems: 'center',
-    height: 220,
+    height: 120,
     justifyContent: 'center',
   },
   modalContent: {
@@ -388,41 +494,14 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     flexDirection: 'row',
   },
-  pickerButton: {
-    alignItems: 'center',
-    borderRadius: 4,
-    borderWidth: 1,
-    flexDirection: 'row',
-    minWidth: 120,
-    paddingHorizontal: 8,
-    paddingVertical: 8,
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '500',
+    letterSpacing: 0.5,
   },
-  pickerButtonText: {
-    flex: 1,
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  titleContainer: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 8,
-  },
-  totalContainer: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginTop: 16,
-  },
-  totalLabel: {
-    fontSize: 14,
-  },
-  totalValue: {
-    fontSize: 18,
-    fontWeight: 'bold',
+  thisMonthLabel: {
+    fontSize: 11,
+    marginTop: 2,
   },
 });
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -364,8 +364,11 @@ jest.mock('react-native-chart-kit', () => ({
 
 // Mock react-native-svg
 jest.mock('react-native-svg', () => ({
+  __esModule: true,
+  default: 'Svg',
   Svg: 'Svg',
   Circle: 'Circle',
+  Line: 'Line',
   Rect: 'Rect',
   Path: 'Path',
   G: 'G',


### PR DESCRIPTION
## Summary
- Replace LineChart with custom SVG bar chart (react-native-svg)
- Tapping any bar updates the header amount and month label
- Selected bar highlighted in primary color with dotted horizontal line at its height
- Human-readable Y axis ticks (nice steps: 1/2/5 x 10^n) with 6 ticks and top padding
- Header redesigned: section label + category icon/name/chevron left, amount + month right
- Currency formatted with symbol (e.g. $538) instead of code (538.00 USD)

## Test plan
- [ ] Verify bar chart renders correctly in light and dark themes
- [ ] Tap each bar and confirm header amount and month label update
- [ ] Confirm current month bar is highlighted by default
- [ ] Switch categories and verify chart resets to current month selection
- [ ] Check Y axis ticks are human-readable across different spending ranges
- [ ] Verify no bar clipping at the top of the chart

🧀
