### PR TITLE
Enhance bar chart visual styling and selection indicators

### DIFF
--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -87,9 +87,9 @@ const BarChart = ({ data, monthAbbreviations, colors, width, selectedIndex, onBa
             x2={width}
             y2={lineY}
             stroke={colors.primary}
-            strokeWidth={1}
-            strokeDasharray="3,3"
-            opacity={0.5}
+            strokeWidth={2}
+            strokeDasharray="5,3"
+            opacity={0.9}
           />
         );
       })()}
@@ -117,9 +117,8 @@ const BarChart = ({ data, monthAbbreviations, colors, width, selectedIndex, onBa
               width={barW}
               height={h}
               rx={3}
-              fill={isSelected ? colors.primary : colors.surface}
-              stroke={isSelected ? 'none' : colors.border}
-              strokeWidth={1}
+              fill={isSelected ? colors.primary : colors.mutedText}
+              fillOpacity={isSelected ? 1 : 0.3}
               onPress={() => onBarPress(i)}
             />
             <SvgText


### PR DESCRIPTION
## Summary
Improved the visual appearance and clarity of the category spending bar chart by enhancing the reference line styling and refining the bar selection states.

## Key Changes
- **Reference line improvements**: Increased stroke width from 1 to 2, adjusted dash pattern from "3,3" to "5,3", and increased opacity from 0.5 to 0.9 for better visibility
- **Bar styling refinement**: 
  - Changed unselected bar fill color from `colors.surface` to `colors.mutedText` for better contrast
  - Replaced stroke-based styling with `fillOpacity` approach (1 for selected, 0.3 for unselected)
  - Removed explicit stroke and strokeWidth properties in favor of opacity-based distinction

## Implementation Details
The changes maintain the same interactive behavior while improving visual hierarchy. Selected bars remain fully opaque with the primary color, while unselected bars now use a muted color with reduced opacity (30%) to create a clearer visual distinction without relying on border strokes.

https://claude.ai/code/session_01HWRgcQc7Ra3PXqVxfSpuAG

BEGIN_COMMIT_OVERRIDE
fix: spending trend visibility
END_COMMIT_OVERRIDE
