### PR TITLE
feat: local Maestro screenshot flow (all 26 screens, light + dark)

### DIFF
--- a/.maestro/local-screenshots.yaml
+++ b/.maestro/local-screenshots.yaml
@@ -1,0 +1,636 @@
+appId: com.heywood8.monkeep.dev
+---
+# Extended local screenshot flow — covers all 26 screens in light + dark.
+# Run via: bash scripts/screenshot.sh
+# Prerequisites: emulator running, app installed.
+
+
+# ============================================================
+# SEED: Create one expense operation so edit modal is reachable
+# ============================================================
+# Dismiss any system ANR dialog before interacting with the app
+- runFlow:
+    when:
+      visible: "isn't responding"
+    commands:
+      - tapOn: "Wait"
+      - waitForAnimationToEnd:
+          timeout: 250
+
+- runFlow:
+    when:
+      visible: "Welcome to Penny"
+    commands:
+      - takeScreenshot: local/screenshots/00_language_selection
+      - tapOn: "English"
+      - tapOn: "Continue"
+      - runFlow:
+          when:
+            visible: "Update available"
+          commands:
+            - tapOn: "LATER"
+            - waitForAnimationToEnd:
+                timeout: 250
+      - extendedWaitUntil:
+          visible: "Operations"
+          timeout: 15000
+
+- waitForAnimationToEnd:
+    timeout: 250
+
+# Dismiss update dialog if present
+- runFlow:
+    when:
+      visible: "Update available"
+    commands:
+      - tapOn: "LATER"
+      - waitForAnimationToEnd:
+          timeout: 250
+
+# Ensure we start on Operations tab in light mode
+- tapOn: "Operations"
+- waitForAnimationToEnd:
+    timeout: 250
+- runFlow:
+    when:
+      visible: "Switch to light theme"
+    commands:
+      - tapOn:
+          id: "theme-toggle-button"
+      - waitForAnimationToEnd:
+          timeout: 500
+
+# Create a Groceries expense (amount 5, tap shortcut → auto-saves)
+- tapOn: "Expense"
+- waitForAnimationToEnd:
+    timeout: 250
+- tapOn:
+    id: "calc-btn-5"
+- tapOn:
+    id: "category-shortcut-0"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# ============================================================
+# LIGHT MODE
+# ============================================================
+
+# 01: Operations
+- tapOn: "Operations"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/01_operations_light
+
+# 05: Transfer
+- tapOn: "Transfer"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/05_transfer_light
+
+# 06: Multi-currency transfer
+- tapOn: "All accounts"
+- extendedWaitUntil:
+    visible: "EUR Cash"
+    timeout: 2500
+- tapOn: "EUR Cash"
+- waitForAnimationToEnd:
+    timeout: 250
+- tapOn:
+    id: "calc-btn-1"
+- tapOn:
+    id: "calc-btn-2"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/06_multicurrency_transfer_light
+- tapOn: "Expense"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 07: Operation edit modal
+- tapOn:
+    id: "operation-item-0"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/07_operation_modal_light
+
+# 08: Split modal
+- tapOn:
+    id: "split-button"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/08_split_modal_light
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 09: Filter modal
+- tapOn:
+    id: "filter-fab"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/09_filter_modal_light
+- tapOn:
+    id: "close-filter-modal"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 02: Graphs
+- tapOn: "Graphs"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/02_graphs_light
+
+# 14: Expense chart modal
+- tapOn:
+    id: "expense-summary-card"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/14_chart_modal_expense_light
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 15: Income chart modal
+- tapOn:
+    id: "income-summary-card"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/15_chart_modal_income_light
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 16+17: Balance history (only if chart is visible)
+- runFlow:
+    when:
+      visible:
+        id: "balance-history-chart"
+    commands:
+      - tapOn:
+          id: "balance-history-chart"
+      - waitForAnimationToEnd:
+          timeout: 250
+      - takeScreenshot: local/screenshots/16_balance_history_modal_light
+      - runFlow:
+          when:
+            visible:
+              id: "balance-history-edit-0"
+          commands:
+            - tapOn:
+                id: "balance-history-edit-0"
+            - waitForAnimationToEnd:
+                timeout: 250
+            - takeScreenshot: local/screenshots/17_balance_history_modal_edit_light
+      - tapOn:
+          id: "balance-history-close"
+      - waitForAnimationToEnd:
+          timeout: 250
+
+# 03: Accounts
+- tapOn: "Accounts"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/03_accounts_light
+
+# 23: Account edit modal
+- tapOn:
+    id: "account-row-checking"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/23_account_edit_modal_light
+
+# 24: Delete confirmation
+- tapOn:
+    id: "account-delete-button"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/24_confirmation_dialog_light
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 04: Categories (grid)
+- tapOn: "Categories"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/04_categories_light
+
+# 18: Category modal
+- tapOn:
+    id: "categories-add-fab"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/18_category_modal_light
+
+# 19: Icon picker
+- tapOn:
+    id: "category-icon-picker"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/19_icon_picker_light
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 25: Material dialog (long-press category)
+- tapOn: "List view"
+- waitForAnimationToEnd:
+    timeout: 250
+- longPressOn: "Food"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/25_material_dialog_light
+
+# 26: Budget modal
+- tapOn: "SET BUDGET"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/26_budget_modal_light
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 08: Planned tab
+- tapOn: "Planned"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/08_planned_light
+
+# 20: Planned operation modal
+- tapOn:
+    id: "planned-add-fab"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/20_planned_operation_modal_light
+
+# 21: Account picker
+- tapOn:
+    id: "planned-account-picker"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/21_picker_modal_account_light
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 22: Category picker
+- tapOn:
+    id: "planned-category-picker"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/22_picker_modal_category_light
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+# Settings screenshots
+- tapOn: "Operations"
+- waitForAnimationToEnd:
+    timeout: 250
+- tapOn:
+    id: "settings-button"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/07_settings_light
+
+# 10: Language
+- tapOn:
+    id: "settings-language-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/10_settings_language_light
+- tapOn:
+    id: "settings-language-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 11: Export
+- tapOn:
+    id: "settings-export-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/11_settings_export_light
+- tapOn:
+    id: "settings-export-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 12: Backups
+- tapOn:
+    id: "settings-backups-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/12_settings_backups_light
+- tapOn:
+    id: "settings-backups-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# 13: Logs
+- tapOn:
+    id: "logs-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/13_settings_logs_light
+- tapOn:
+    id: "settings-logs-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "settings-close-button"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# ============================================================
+# SWITCH TO DARK MODE
+# ============================================================
+- tapOn:
+    id: "theme-toggle-button"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# ============================================================
+# DARK MODE (same sequence)
+# ============================================================
+
+- tapOn: "Operations"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/01_operations_dark
+
+- tapOn: "Transfer"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/05_transfer_dark
+
+- tapOn: "All accounts"
+- extendedWaitUntil:
+    visible: "EUR Cash"
+    timeout: 2500
+- tapOn: "EUR Cash"
+- waitForAnimationToEnd:
+    timeout: 250
+- tapOn:
+    id: "calc-btn-1"
+- tapOn:
+    id: "calc-btn-2"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/06_multicurrency_transfer_dark
+- tapOn: "Expense"
+- waitForAnimationToEnd:
+    timeout: 250
+- tapOn:
+    id: "category-shortcut-0"
+- waitForAnimationToEnd:
+    timeout: 500
+
+- tapOn:
+    id: "operation-item-0"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/07_operation_modal_dark
+
+- tapOn:
+    id: "split-button"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/08_split_modal_dark
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "filter-fab"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/09_filter_modal_dark
+- tapOn:
+    id: "close-filter-modal"
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn: "Graphs"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/02_graphs_dark
+
+- tapOn:
+    id: "expense-summary-card"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/14_chart_modal_expense_dark
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "income-summary-card"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/15_chart_modal_income_dark
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- runFlow:
+    when:
+      visible:
+        id: "balance-history-chart"
+    commands:
+      - tapOn:
+          id: "balance-history-chart"
+      - waitForAnimationToEnd:
+          timeout: 250
+      - takeScreenshot: local/screenshots/16_balance_history_modal_dark
+      - runFlow:
+          when:
+            visible:
+              id: "balance-history-edit-0"
+          commands:
+            - tapOn:
+                id: "balance-history-edit-0"
+            - waitForAnimationToEnd:
+                timeout: 250
+            - takeScreenshot: local/screenshots/17_balance_history_modal_edit_dark
+      - tapOn:
+          id: "balance-history-close"
+      - waitForAnimationToEnd:
+          timeout: 250
+
+- tapOn: "Accounts"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/03_accounts_dark
+
+- tapOn:
+    id: "account-row-checking"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/23_account_edit_modal_dark
+
+- tapOn:
+    id: "account-delete-button"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/24_confirmation_dialog_dark
+- tapOn: "Cancel"
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn: "Categories"
+- waitForAnimationToEnd:
+    timeout: 1500
+- swipe:
+    start: 50%, 70%
+    end: 50%, 40%
+- swipe:
+    start: 50%, 40%
+    end: 50%, 70%
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/04_categories_dark
+
+- tapOn:
+    id: "categories-add-fab"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/18_category_modal_dark
+
+- tapOn:
+    id: "category-icon-picker"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/19_icon_picker_dark
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn: "List view"
+- waitForAnimationToEnd:
+    timeout: 250
+- longPressOn: "Food"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/25_material_dialog_dark
+- tapOn: "SET BUDGET"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/26_budget_modal_dark
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn: "Planned"
+- waitForAnimationToEnd:
+    timeout: 1500
+- takeScreenshot: local/screenshots/08_planned_dark
+
+- tapOn:
+    id: "planned-add-fab"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/20_planned_operation_modal_dark
+
+- tapOn:
+    id: "planned-account-picker"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/21_picker_modal_account_dark
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "planned-category-picker"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/22_picker_modal_category_dark
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+- pressKey: Back
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn: "Operations"
+- waitForAnimationToEnd:
+    timeout: 250
+- tapOn:
+    id: "settings-button"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/07_settings_dark
+
+- tapOn:
+    id: "settings-language-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/10_settings_language_dark
+- tapOn:
+    id: "settings-language-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "settings-export-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/11_settings_export_dark
+- tapOn:
+    id: "settings-export-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "settings-backups-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/12_settings_backups_dark
+- tapOn:
+    id: "settings-backups-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "logs-row"
+- waitForAnimationToEnd:
+    timeout: 250
+- takeScreenshot: local/screenshots/13_settings_logs_dark
+- tapOn:
+    id: "settings-logs-back"
+- waitForAnimationToEnd:
+    timeout: 250
+
+- tapOn:
+    id: "settings-close-button"
+- waitForAnimationToEnd:
+    timeout: 250
+
+# Restore light theme
+- tapOn:
+    id: "theme-toggle-button"
+- waitForAnimationToEnd:
+    timeout: 250

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -160,6 +160,7 @@ const BalanceHistoryCard = ({
       ) : balanceHistoryData.actual && balanceHistoryData.actual.length > 0 ? (
         <>
           <TouchableOpacity
+            testID="balance-history-chart"
             style={styles.balanceHistoryChartContainer}
             onPress={onChartPress}
             activeOpacity={0.7}

--- a/app/components/graphs/BalanceHistoryModal.js
+++ b/app/components/graphs/BalanceHistoryModal.js
@@ -43,6 +43,7 @@ const BalanceHistoryModal = ({
                 </Text>
               </View>
               <TouchableOpacity
+                testID="balance-history-close"
                 style={styles.closeButton}
                 onPress={onClose}
               >
@@ -114,6 +115,7 @@ const BalanceHistoryModal = ({
                         </Text>
                         <View style={styles.balanceTableActions}>
                           <TouchableOpacity
+                            testID={`balance-history-edit-${index}`}
                             style={[styles.balanceActionButton, { backgroundColor: colors.primary }]}
                             onPress={() => onEditBalance(row.date, row.balance)}
                           >

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -30,6 +30,7 @@ const ExpenseSummaryCard = ({
   const { hideBalances } = useDisplaySettings();
   return (
     <TouchableOpacity
+      testID="expense-summary-card"
       style={[styles.summaryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
       onPress={onPress}
       activeOpacity={0.7}

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -30,6 +30,7 @@ const IncomeSummaryCard = ({
   const { hideBalances } = useDisplaySettings();
   return (
     <TouchableOpacity
+      testID="income-summary-card"
       style={[styles.summaryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
       onPress={onPress}
       activeOpacity={0.7}

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -266,7 +266,7 @@ const OperationFormFields = memo(({
           </Pressable>
 
           {/* Top 3 category shortcut buttons */}
-          {topCategoriesForType.map((category) => {
+          {topCategoriesForType.map((category, index) => {
             const categoryInfo = getCategoryInfo ? getCategoryInfo(category.id) : { name: category.name, icon: category.icon, parentName: null };
             const isSelected = values.categoryId === category.id;
             const textColor = isSelected ? '#fff' : (disabled ? colors.mutedText : colors.text);
@@ -275,6 +275,7 @@ const OperationFormFields = memo(({
             return (
               <Pressable
                 key={category.id}
+                testID={`category-shortcut-${index}`}
                 style={[
                   styles.categoryShortcutButton,
                   {

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -16,6 +16,7 @@ const OperationListItem = ({
   formatCurrency,
   isLast,
   onPress,
+  testID,
 }) => {
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
@@ -72,6 +73,7 @@ const OperationListItem = ({
   return (
     <>
       <TouchableRipple
+        testID={testID}
         onPress={onPress}
         rippleColor="rgba(0, 0, 0, .08)"
         accessibilityRole="button"
@@ -136,10 +138,12 @@ OperationListItem.propTypes = {
   formatCurrency: PropTypes.func.isRequired,
   isLast: PropTypes.bool,
   onPress: PropTypes.func.isRequired,
+  testID: PropTypes.string,
 };
 
 OperationListItem.defaultProps = {
   isLast: false,
+  testID: undefined,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -157,6 +157,7 @@ const OperationsList = forwardRef(({
           {item.operations.map((operation, index) => (
             <OperationListItem
               key={operation.id}
+              testID={`operation-item-${index}`}
               operation={operation}
               colors={colors}
               t={t}

--- a/app/modals/CategoryModal.js
+++ b/app/modals/CategoryModal.js
@@ -221,6 +221,7 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
 
                 {/* Icon Picker */}
                 <Pressable
+                  testID="category-icon-picker"
                   style={[styles.iconPickerButton, styles.iconPickerButtonThemed, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
                   onPress={() => setIconPickerVisible(true)}
                 >

--- a/app/modals/PlannedOperationModal.js
+++ b/app/modals/PlannedOperationModal.js
@@ -308,6 +308,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
                 <View style={styles.inputContainer}>
                   <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('select_account')}</Text>
                   <Pressable
+                    testID="planned-account-picker"
                     style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.accountId ? colors.error : colors.inputBorder }]}
                     onPress={() => setAccountPickerVisible(true)}
                   >
@@ -324,6 +325,7 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
                   <View style={styles.inputContainer}>
                     <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('select_category')}</Text>
                     <Pressable
+                      testID="planned-category-picker"
                       style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.categoryId ? colors.error : colors.inputBorder }]}
                       onPress={() => openCategoryPicker('category', filteredCategories)}
                     >

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -569,7 +569,7 @@ export default function SettingsModal({ visible, onClose }) {
             </TouchableOpacity>
           </View>
 
-          <TouchableRipple onPress={openLanguageModal} style={styles.settingsRow}>
+          <TouchableRipple onPress={openLanguageModal} style={styles.settingsRow} testID="settings-language-row">
             <View style={styles.settingsRowContent}>
               <View style={styles.settingsRowLeft}>
                 <Ionicons name="language-outline" size={22} color={colors.text} />
@@ -607,7 +607,7 @@ export default function SettingsModal({ visible, onClose }) {
 
           <Text variant="labelLarge" style={[styles.sectionLabel, { color: colors.mutedText }]}>{t('database') || 'Database'}</Text>
 
-          <TouchableRipple onPress={handleExportBackup} style={styles.settingsRow}>
+          <TouchableRipple onPress={handleExportBackup} style={styles.settingsRow} testID="settings-export-row">
             <View style={styles.settingsRowContent}>
               <View style={styles.settingsRowLeft}>
                 <Ionicons name="cloud-upload-outline" size={22} color={colors.text} />
@@ -627,7 +627,7 @@ export default function SettingsModal({ visible, onClose }) {
             </View>
           </TouchableRipple>
 
-          <TouchableRipple onPress={openBackupsModal} style={styles.settingsRow}>
+          <TouchableRipple onPress={openBackupsModal} style={styles.settingsRow} testID="settings-backups-row">
             <View style={styles.settingsRowContent}>
               <View style={styles.settingsRowLeft}>
                 <Ionicons name="archive-outline" size={22} color={colors.text} />
@@ -685,7 +685,7 @@ export default function SettingsModal({ visible, onClose }) {
           !languageModalVisible && styles.hidden,
         ]}>
           <View style={styles.languageModalHeader}>
-            <TouchableOpacity onPress={closeLanguageModal} style={styles.backButton}>
+            <TouchableOpacity onPress={closeLanguageModal} style={styles.backButton} testID="settings-language-back">
               <Ionicons name="arrow-back" size={24} color={colors.text} />
             </TouchableOpacity>
             <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
@@ -728,7 +728,7 @@ export default function SettingsModal({ visible, onClose }) {
           !exportFormatModalVisible && styles.hidden,
         ]}>
           <View style={styles.languageModalHeader}>
-            <TouchableOpacity onPress={closeExportFormatModal} style={styles.backButton}>
+            <TouchableOpacity onPress={closeExportFormatModal} style={styles.backButton} testID="settings-export-back">
               <Ionicons name="arrow-back" size={24} color={colors.text} />
             </TouchableOpacity>
             <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
@@ -812,7 +812,7 @@ export default function SettingsModal({ visible, onClose }) {
           !logsModalVisible && styles.hidden,
         ]}>
           <View style={styles.languageModalHeader}>
-            <TouchableOpacity onPress={closeLogsModal} style={styles.backButton}>
+            <TouchableOpacity onPress={closeLogsModal} style={styles.backButton} testID="settings-logs-back">
               <Ionicons name="arrow-back" size={24} color={colors.text} />
             </TouchableOpacity>
             <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
@@ -890,7 +890,7 @@ export default function SettingsModal({ visible, onClose }) {
           !backupsModalVisible && styles.hidden,
         ]}>
           <View style={styles.languageModalHeader}>
-            <TouchableOpacity onPress={closeBackupsModal} style={styles.backButton}>
+            <TouchableOpacity onPress={closeBackupsModal} style={styles.backButton} testID="settings-backups-back">
               <Ionicons name="arrow-back" size={24} color={colors.text} />
             </TouchableOpacity>
             <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -358,6 +358,7 @@ const AccountRow = memo(({ item, colors, onPress, t, drag, isActive }) => {
   return (
     <View style={[styles.accountRow, isActive && { backgroundColor: colors.selected }]}>
       <TouchableOpacity
+        testID={`account-row-${item.name.toLowerCase().replace(/\s+/g, '-')}`}
         onPress={handlePress}
         activeOpacity={0.7}
         style={styles.accountTouchableArea}
@@ -751,6 +752,7 @@ export default function AccountsScreen() {
       </ScrollView>
 
       <FAB
+        testID="accounts-add-fab"
         icon="plus"
         style={[styles.fab, { backgroundColor: colors.text }]}
         color={colors.background}
@@ -845,6 +847,7 @@ export default function AccountsScreen() {
                 </Button>
                 {editingId !== 'new' && (
                   <Button
+                    testID="account-delete-button"
                     mode="contained"
                     buttonColor={colors.delete}
                     onPress={handleDeleteEditingAccount}

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -313,6 +313,7 @@ const CategoriesScreen = () => {
       )}
 
       <FAB
+        testID="categories-add-fab"
         icon="plus"
         style={[styles.fab, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}
         color={colors.text}

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -278,6 +278,7 @@ export default function PlannedOperationsScreen() {
 
       {/* FAB */}
       <FAB
+        testID="planned-add-fab"
         icon="plus"
         label={t('add_planned_operation')}
         style={[styles.fab, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}

--- a/scripts/screenshot.sh
+++ b/scripts/screenshot.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Captures all 26 Penny app screens in light + dark themes using Maestro.
+# Prerequisites: emulator running, app installed and open.
+# Output: local/screenshots/*.png
+# Run: bash scripts/screenshot.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+mkdir -p local/screenshots
+
+maestro test .maestro/local-screenshots.yaml


### PR DESCRIPTION
feat: add local Maestro screenshot flow covering all 26 screens

Adds .maestro/local-screenshots.yaml — an extended flow that captures
all 26 app screens in both light and dark themes to local/screenshots/.
Also adds scripts/screenshot.sh as a simple wrapper to run it.

To support reliable element targeting, testIDs were added to:
- OperationListItem / OperationsList (operation-item-{n})
- OperationFormFields category shortcuts (category-shortcut-{n})
- ExpenseSummaryCard, IncomeSummaryCard, BalanceHistoryCard/Modal
- SettingsModal sub-screen rows and back buttons
- AccountsScreen account rows, FAB, delete button
- CategoriesScreen FAB, CategoryModal icon picker
- PlannedOperationsScreen FAB, PlannedOperationModal pickers

🧀