### PR TITLE
feat: clean up old APKs after in-app update download

### DIFF
--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -3,9 +3,108 @@ import {
   compareVersions,
   extractApkAsset,
   checkForAppUpdate,
+  cleanupOldApks,
 } from '../../app/services/AppUpdateService';
 
+jest.mock('expo-file-system/legacy', () => ({
+  cacheDirectory: 'file:///cache/',
+  readDirectoryAsync: jest.fn(),
+  getInfoAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+  createDownloadResumable: jest.fn(),
+  getContentUriAsync: jest.fn(),
+}));
+
+const FileSystem = require('expo-file-system/legacy');
+
 describe('AppUpdateService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('cleanupOldApks', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      console.log.mockRestore();
+    });
+
+    it('does nothing when apk count is at or below keep limit', async () => {
+      FileSystem.readDirectoryAsync.mockResolvedValue(['penny-v1.apk', 'penny-v2.apk', 'penny-v3.apk']);
+      FileSystem.getInfoAsync.mockResolvedValue({ modificationTime: 1000 });
+
+      await cleanupOldApks('file:///cache/', 3);
+
+      expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith('[AppUpdate] apk cleanup: 3 apk(s) found, none deleted (limit: 3)');
+    });
+
+    it('deletes oldest apks keeping only the 3 newest', async () => {
+      FileSystem.readDirectoryAsync.mockResolvedValue([
+        'penny-v1.apk',
+        'penny-v2.apk',
+        'penny-v3.apk',
+        'penny-v4.apk',
+        'penny-v5.apk',
+      ]);
+      FileSystem.getInfoAsync.mockImplementation((uri) => {
+        const times = {
+          'file:///cache/penny-v1.apk': 1000,
+          'file:///cache/penny-v2.apk': 2000,
+          'file:///cache/penny-v3.apk': 3000,
+          'file:///cache/penny-v4.apk': 4000,
+          'file:///cache/penny-v5.apk': 5000,
+        };
+        return Promise.resolve({ modificationTime: times[uri] || 0 });
+      });
+      FileSystem.deleteAsync.mockResolvedValue();
+
+      await cleanupOldApks('file:///cache/', 3);
+
+      expect(FileSystem.deleteAsync).toHaveBeenCalledTimes(2);
+      expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/penny-v1.apk', { idempotent: true });
+      expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/penny-v2.apk', { idempotent: true });
+      expect(console.log).toHaveBeenCalledWith('[AppUpdate] apk cleanup: 5 apk(s) found, 2 deleted (limit: 3)');
+    });
+
+    it('ignores non-apk files', async () => {
+      FileSystem.readDirectoryAsync.mockResolvedValue([
+        'penny-v1.apk',
+        'penny-v2.apk',
+        'some-log.txt',
+        'penny-v3.apk',
+        'penny-v4.apk',
+      ]);
+      FileSystem.getInfoAsync.mockImplementation((uri) => {
+        const times = {
+          'file:///cache/penny-v1.apk': 1000,
+          'file:///cache/penny-v2.apk': 2000,
+          'file:///cache/penny-v3.apk': 3000,
+          'file:///cache/penny-v4.apk': 4000,
+        };
+        return Promise.resolve({ modificationTime: times[uri] || 0 });
+      });
+      FileSystem.deleteAsync.mockResolvedValue();
+
+      await cleanupOldApks('file:///cache/', 3);
+
+      expect(FileSystem.deleteAsync).toHaveBeenCalledTimes(1);
+      expect(FileSystem.deleteAsync).toHaveBeenCalledWith('file:///cache/penny-v1.apk', { idempotent: true });
+    });
+
+    it('handles missing modificationTime gracefully', async () => {
+      FileSystem.readDirectoryAsync.mockResolvedValue(['penny-v1.apk', 'penny-v2.apk', 'penny-v3.apk', 'penny-v4.apk']);
+      FileSystem.getInfoAsync.mockResolvedValue({});
+      FileSystem.deleteAsync.mockResolvedValue();
+
+      await cleanupOldApks('file:///cache/', 3);
+
+      expect(FileSystem.deleteAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('parseVersionFromRelease', () => {
     it('parses plain semver tag', () => {
       expect(parseVersionFromRelease({ tag_name: 'v1.2.3' })).toBe('1.2.3');

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -358,7 +358,7 @@ const AccountRow = memo(({ item, colors, onPress, t, drag, isActive }) => {
   return (
     <View style={[styles.accountRow, isActive && { backgroundColor: colors.selected }]}>
       <TouchableOpacity
-        testID={`account-row-${item.name.toLowerCase().replace(/\s+/g, '-')}`}
+        testID={`account-row-${(item.name ?? '').toLowerCase().replace(/\s+/g, '-')}`}
         onPress={handlePress}
         activeOpacity={0.7}
         style={styles.accountTouchableArea}

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -158,6 +158,32 @@ export const checkForAppUpdate = async ({
   }
 };
 
+const APK_KEEP_COUNT = 3;
+
+export const cleanupOldApks = async (cacheDir = FileSystem.cacheDirectory, keep = APK_KEEP_COUNT) => {
+  const files = await FileSystem.readDirectoryAsync(cacheDir);
+  const apkFiles = files.filter((f) => f.toLowerCase().endsWith('.apk'));
+
+  if (apkFiles.length <= keep) {
+    console.log(`[AppUpdate] apk cleanup: ${apkFiles.length} apk(s) found, none deleted (limit: ${keep})`);
+    return;
+  }
+
+  const withInfo = await Promise.all(
+    apkFiles.map(async (name) => {
+      const uri = `${cacheDir}${name}`;
+      const info = await FileSystem.getInfoAsync(uri);
+      return { uri, modificationTime: info.modificationTime || 0 };
+    }),
+  );
+
+  withInfo.sort((a, b) => b.modificationTime - a.modificationTime);
+
+  const toDelete = withInfo.slice(keep);
+  await Promise.all(toDelete.map(({ uri }) => FileSystem.deleteAsync(uri, { idempotent: true })));
+  console.log(`[AppUpdate] apk cleanup: ${apkFiles.length} apk(s) found, ${toDelete.length} deleted (limit: ${keep})`);
+};
+
 export const downloadAndInstallApk = async (downloadUrl, onProgress) => {
   const filename = (downloadUrl.split('/').pop().split('?')[0]) || 'penny-update.apk';
   const localUri = `${FileSystem.cacheDirectory}${filename}`;
@@ -177,6 +203,8 @@ export const downloadAndInstallApk = async (downloadUrl, onProgress) => {
   if (!result?.uri) {
     throw new Error('Download failed');
   }
+
+  await cleanupOldApks();
 
   const contentUri = await FileSystem.getContentUriAsync(result.uri);
   await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {


### PR DESCRIPTION
Closes #391

## Summary
- adds `cleanupOldApks()` to `AppUpdateService` — after each download, lists `.apk` files in cache, sorts by modification time, deletes all but the 3 newest
- logs how many apks were found and how many were deleted
- fixes null-guard crash on `item.name` in `AccountsScreen` testID when account has missing properties

## Test plan
- [ ] `cleanupOldApks` unit tests: no-op at limit, deletes oldest when over limit, ignores non-apk files, handles missing modificationTime
- [ ] existing `AccountsScreen` edge case test now passes
- [ ] all 2876 tests passing

🧀
