### PR TITLE
fix: account picker balance inline and bottom-sheet style

### DIFF
--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -362,7 +362,7 @@ const OperationFormFields = memo(({
               <Pressable
                 key={account.id}
                 style={[
-                  styles.categoryShortcutButton,
+                  styles.accountShortcutButton,
                   {
                     backgroundColor: isSelected ? colors.primary : colors.inputBackground,
                     borderColor: colors.inputBorder,
@@ -372,41 +372,24 @@ const OperationFormFields = memo(({
                 onPress={() => handleTargetPress(account.id)}
                 disabled={disabled}
               >
-                {getAccountBalance ? (
-                  <>
+                <Text
+                  style={[styles.accountShortcutName, { color: textColor }]}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {account.name}
+                </Text>
+                {getAccountBalance && (
+                  hideBalances ? (
+                    <View style={styles.hiddenBalanceSmall} />
+                  ) : (
                     <Text
-                      style={[styles.categoryShortcutText, { color: textColor }]}
+                      style={[styles.accountShortcutBalance, { color: balanceColor }]}
                       numberOfLines={1}
-                      ellipsizeMode="tail"
                     >
-                      {account.name}
+                      {getAccountBalance(account.id)}
                     </Text>
-                    <View style={styles.categoryParentRow}>
-                      <Icon name="wallet" size={14} color={balanceColor} />
-                      {hideBalances ? (
-                        <View style={styles.hiddenBalanceSmall} />
-                      ) : (
-                        <Text
-                          style={[styles.categoryShortcutParent, { color: balanceColor }]}
-                          numberOfLines={1}
-                          ellipsizeMode="tail"
-                        >
-                          {getAccountBalance(account.id)}
-                        </Text>
-                      )}
-                    </View>
-                  </>
-                ) : (
-                  <>
-                    <Icon name="wallet" size={18} color={textColor} />
-                    <Text
-                      style={[styles.categoryShortcutText, { color: textColor }]}
-                      numberOfLines={1}
-                      ellipsizeMode="tail"
-                    >
-                      {account.name}
-                    </Text>
-                  </>
+                  )
                 )}
               </Pressable>
             );
@@ -505,16 +488,31 @@ const styles = StyleSheet.create({
   accountBalanceText: {
     fontSize: 12,
   },
+  accountShortcutBalance: {
+    flexShrink: 1,
+    fontSize: 10,
+  },
+  accountShortcutButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    flex: 1,
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    justifyContent: 'space-between',
+    minHeight: 44,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+  },
+  accountShortcutName: {
+    flex: 1,
+    fontSize: FONT_SIZE.xs,
+    fontWeight: '500',
+  },
   categoryButtonsContainer: {
     flexDirection: 'row',
     gap: SPACING.xs,
     marginBottom: SPACING.md,
-  },
-  categoryParentRow: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 3,
-    marginTop: 1,
   },
   categoryPickerButton: {
     alignItems: 'center',
@@ -543,10 +541,6 @@ const styles = StyleSheet.create({
     minHeight: 56,
     paddingHorizontal: SPACING.xs,
     paddingVertical: SPACING.xs,
-  },
-  categoryShortcutParent: {
-    fontSize: 9,
-    textAlign: 'center',
   },
   categoryShortcutText: {
     fontSize: FONT_SIZE.xs,

--- a/app/components/operations/PickerModal.js
+++ b/app/components/operations/PickerModal.js
@@ -91,8 +91,8 @@ const PickerModal = ({
                       ]}
                     >
                       <View style={styles.accountOption}>
-                        <Text style={[styles.pickerOptionText, { color: colors.text }]}>{item.name}</Text>
-                        <Text style={[styles.pickerSmallText, { color: colors.mutedText }]}>
+                        <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
+                        <Text style={[styles.pickerSmallText, { color: colors.mutedText }]} numberOfLines={1}>
                           {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
                         </Text>
                       </View>
@@ -163,10 +163,15 @@ const PickerModal = ({
 };
 
 const styles = StyleSheet.create({
-  accountOption: {
-    alignItems: 'flex-start',
+  accountName: {
     flex: 1,
-    justifyContent: 'center',
+    marginRight: 4,
+  },
+  accountOption: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
   },
   backButton: {
     marginRight: 8,
@@ -227,7 +232,7 @@ const styles = StyleSheet.create({
   },
   pickerSmallText: {
     fontSize: 14,
-    marginTop: 4,
+    marginLeft: 8,
   },
 });
 

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -595,7 +595,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
         transparent
         onRequestClose={closePicker}
       >
-        <Pressable style={styles.modalOverlay} onPress={closePicker}>
+        <Pressable style={styles.pickerOverlay} onPress={closePicker}>
           <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={handleStopPropagation}>
             {/* Breadcrumb navigation for categories */}
             {pickerState.type === 'category' && categoryNavigation.breadcrumb.length > 0 && (
@@ -773,10 +773,11 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   pickerModalContent: {
-    borderRadius: BORDER_RADIUS.lg,
+    borderTopLeftRadius: BORDER_RADIUS.lg,
+    borderTopRightRadius: BORDER_RADIUS.lg,
     maxHeight: '70%',
     padding: SPACING.md,
-    width: '90%',
+    width: '100%',
   },
   pickerOption: {
     borderBottomWidth: 1,
@@ -789,7 +790,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   pickerOptionText: {
-    fontSize: 18,
+    fontSize: 16,
+  },
+  pickerOverlay: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'flex-end',
   },
   scrollContent: {
     paddingBottom: SPACING.xl,


### PR DESCRIPTION
## Summary
- Account picker list now shows balance inline next to account name instead of below it, reducing row height
- OperationModal's picker now slides up from the bottom full-width, matching PickerModal's bottom-sheet style
- Transfer target account shortcuts in QuickAdd use a row layout (minHeight 44 instead of 56)
- Normalized account name font size to 16px across both pickers

## Test plan
- [ ] Fast-add expense: tap account field, verify balance appears to the right of account name on same line
- [ ] Edit saved operation: tap account field, verify picker slides from bottom full-width
- [ ] Fast-add transfer: verify target account shortcuts show name + balance in a single row
- [ ] Verify category shortcuts are unaffected

🧀
