### PR TITLE
feat(logs): persist app logs to daily files

### DIFF
--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -352,8 +352,8 @@ describe('BalanceHistoryCard', () => {
 
       const lineChart = UNSAFE_getByType('LineChart');
       expect(lineChart.props.data.labels).toEqual(['1', '5', '10', '15', '20', '25', '28']);
-      // Should have 3 datasets: actual + plain avg + prevMonth (no forecast when not current month)
-      expect(lineChart.props.data.datasets).toHaveLength(3);
+      // Should have 4 datasets: actual + plain avg + prevMonth + zero baseline (no forecast when not current month)
+      expect(lineChart.props.data.datasets).toHaveLength(4);
     });
 
     it('includes actual dataset with correct styling', () => {
@@ -440,8 +440,8 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = UNSAFE_getByType('LineChart');
-      // Should have 3 datasets: combined actual+forecast + plain avg + prevMonth
-      expect(lineChart.props.data.datasets).toHaveLength(3);
+      // Should have 4 datasets: combined actual+forecast + plain avg + prevMonth + zero baseline
+      expect(lineChart.props.data.datasets).toHaveLength(4);
 
       global.Date.mockRestore();
     });
@@ -466,8 +466,8 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = UNSAFE_getByType('LineChart');
-      // Should have 3 datasets: actual + plain avg + prevMonth (no forecast)
-      expect(lineChart.props.data.datasets).toHaveLength(3);
+      // Should have 4 datasets: actual + plain avg + prevMonth + zero baseline (no forecast)
+      expect(lineChart.props.data.datasets).toHaveLength(4);
       const prevMonthDataset = lineChart.props.data.datasets[2];
       expect(prevMonthDataset.withDots).toBe(false);
     });
@@ -495,8 +495,8 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = UNSAFE_getByType('LineChart');
-      // Should have 2 datasets: actual + plain avg (no prevMonth)
-      expect(lineChart.props.data.datasets).toHaveLength(2);
+      // Should have 3 datasets: actual + plain avg + zero baseline (no prevMonth)
+      expect(lineChart.props.data.datasets).toHaveLength(3);
     });
 
     it('excludes prevMonth dataset when all values are undefined', () => {
@@ -522,8 +522,8 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = UNSAFE_getByType('LineChart');
-      // Should have 2 datasets: actual + plain avg (no prevMonth since all undefined)
-      expect(lineChart.props.data.datasets).toHaveLength(2);
+      // Should have 3 datasets: actual + plain avg + zero baseline (no prevMonth since all undefined)
+      expect(lineChart.props.data.datasets).toHaveLength(3);
     });
 
     it('accepts onChartPress prop', () => {

--- a/app/services/LogService.js
+++ b/app/services/LogService.js
@@ -1,3 +1,5 @@
+import { writeTodayLogs, readAllLogs, pruneOldFiles, clearAllLogs } from './LogsFile';
+
 const MAX_ENTRIES = 500;
 
 let nextId = 1;
@@ -8,6 +10,7 @@ class LogService {
     this._listeners = new Set();
     this._installed = false;
     this._originals = {};
+    this._flushTimer = null;
   }
 
   install() {
@@ -28,6 +31,48 @@ class LogService {
         this._addEntry(level, args);
         this._originals[method].apply(console, args);
       };
+    }
+
+    this.loadFromFiles();
+  }
+
+  _scheduledFlush() {
+    if (this._flushTimer) clearTimeout(this._flushTimer);
+    this._flushTimer = setTimeout(() => {
+      this._flushTimer = null;
+      this._flushToDisk();
+    }, 1000);
+  }
+
+  _flushToDisk() {
+    writeTodayLogs(this._entries).catch(() => {
+      // Intentionally silent — must not call console.* to avoid infinite loop
+    });
+  }
+
+  async loadFromFiles() {
+    try {
+      await pruneOldFiles(7);
+      const stored = await readAllLogs();
+      if (stored.length > 0) {
+        // Merge with any entries already captured since startup, dedup by id
+        const existingIds = new Set(this._entries.map(e => e.id));
+        const newEntries = stored.filter(e => !existingIds.has(e.id));
+        const merged = [...newEntries, ...this._entries];
+        // Cap at MAX_ENTRIES keeping most recent
+        this._entries = merged.length > MAX_ENTRIES
+          ? merged.slice(merged.length - MAX_ENTRIES)
+          : merged;
+        // Ensure nextId is beyond any loaded ids to avoid collisions
+        for (const e of stored) {
+          if (typeof e.id === 'number' && e.id >= nextId) {
+            nextId = e.id + 1;
+          }
+        }
+        this._notify();
+      }
+    } catch {
+      // Intentionally silent
     }
   }
 
@@ -63,6 +108,7 @@ class LogService {
     }
 
     this._notify();
+    this._scheduledFlush();
   }
 
   getEntries(filter) {
@@ -71,8 +117,15 @@ class LogService {
   }
 
   clear() {
+    if (this._flushTimer) {
+      clearTimeout(this._flushTimer);
+      this._flushTimer = null;
+    }
     this._entries = [];
     this._notify();
+    clearAllLogs().catch(() => {
+      // Intentionally silent — must not call console.* to avoid infinite loop
+    });
   }
 
   subscribe(listener) {

--- a/app/services/LogsFile.js
+++ b/app/services/LogsFile.js
@@ -1,0 +1,109 @@
+import * as FileSystem from 'expo-file-system/legacy';
+
+const LOGS_DIR = FileSystem.documentDirectory + 'logs/';
+const FILE_PREFIX = 'penny-logs-';
+const FILE_SUFFIX = '.json';
+
+function getTodayDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getTodayPath() {
+  return LOGS_DIR + FILE_PREFIX + getTodayDate() + FILE_SUFFIX;
+}
+
+function dateFromFilename(filename) {
+  // filename: 'penny-logs-YYYY-MM-DD.json'
+  return filename.slice(FILE_PREFIX.length, filename.length - FILE_SUFFIX.length);
+}
+
+async function ensureDir() {
+  await FileSystem.makeDirectoryAsync(LOGS_DIR, { intermediates: true });
+}
+
+async function writeTodayLogs(entries) {
+  try {
+    await ensureDir();
+    const today = getTodayDate();
+    const todayEntries = entries.filter(e => e.timestamp.startsWith(today));
+    await FileSystem.writeAsStringAsync(getTodayPath(), JSON.stringify(todayEntries));
+  } catch {
+    // Intentionally silent — must not call console.* to avoid infinite loop
+  }
+}
+
+async function readAllLogs() {
+  try {
+    const dirInfo = await FileSystem.getInfoAsync(LOGS_DIR);
+    if (!dirInfo.exists) return [];
+
+    const files = await FileSystem.readDirectoryAsync(LOGS_DIR);
+    const logFiles = files.filter(f => f.startsWith(FILE_PREFIX) && f.endsWith(FILE_SUFFIX));
+
+    const allEntries = [];
+    for (const filename of logFiles) {
+      try {
+        const path = LOGS_DIR + filename;
+        const content = await FileSystem.readAsStringAsync(path);
+        const parsed = JSON.parse(content);
+        if (Array.isArray(parsed)) {
+          allEntries.push(...parsed);
+        }
+      } catch {
+        // Skip corrupt files silently
+      }
+    }
+
+    allEntries.sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
+    return allEntries;
+  } catch {
+    return [];
+  }
+}
+
+async function pruneOldFiles(retentionDays = 7) {
+  try {
+    const dirInfo = await FileSystem.getInfoAsync(LOGS_DIR);
+    if (!dirInfo.exists) return;
+
+    const files = await FileSystem.readDirectoryAsync(LOGS_DIR);
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+    const cutoffStr = cutoffDate.toISOString().slice(0, 10);
+
+    for (const filename of files) {
+      if (!filename.startsWith(FILE_PREFIX) || !filename.endsWith(FILE_SUFFIX)) continue;
+      const fileDate = dateFromFilename(filename);
+      if (fileDate < cutoffStr) {
+        try {
+          await FileSystem.deleteAsync(LOGS_DIR + filename, { idempotent: true });
+        } catch {
+          // Skip silently
+        }
+      }
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+async function clearAllLogs() {
+  try {
+    const dirInfo = await FileSystem.getInfoAsync(LOGS_DIR);
+    if (!dirInfo.exists) return;
+
+    const files = await FileSystem.readDirectoryAsync(LOGS_DIR);
+    for (const filename of files) {
+      if (!filename.startsWith(FILE_PREFIX) || !filename.endsWith(FILE_SUFFIX)) continue;
+      try {
+        await FileSystem.deleteAsync(LOGS_DIR + filename, { idempotent: true });
+      } catch {
+        // Skip silently
+      }
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+export { writeTodayLogs, readAllLogs, pruneOldFiles, clearAllLogs };


### PR DESCRIPTION
## Summary

Persists app logs through restarts and updates by writing daily JSON files to device storage.

## Changes

### New: `app/services/LogsFile.js`
- Writes one JSON file per day to `{documentDirectory}/logs/penny-logs-YYYY-MM-DD.json`
- `writeTodayLogs(entries)` — rewrites today's file with today's entries
- `readAllLogs()` — reads and merges all daily files, sorted by timestamp
- `pruneOldFiles(7)` — deletes files older than 7 days
- `clearAllLogs()` — deletes all log files

### Updated: `app/services/LogService.js`
- On `install()`: prunes old files, loads all surviving daily files into memory
- Debounced 1s flush to disk after each new log entry
- `clear()` now also deletes all log files on disk
- Deduplicates entries by id when merging from disk into memory

### Fixed: `__tests__/components/BalanceHistoryCard.test.js`
- Updated 5 dataset length assertions to account for the zero baseline dataset added in v0.71.2 (`fix: show balance graph below 0`)

## Behavior
- Logs survive app restarts and OTA updates
- Entries older than 7 days are pruned on startup
- Settings → Logs UI is unchanged — the existing panel displays persisted entries automatically
- All 46 BalanceHistoryCard tests and 25 LogService tests pass