### PR TITLE
feat(graphs): show account picker as bottom sheet with balance

### DIFF
--- a/app/components/SimplePicker.js
+++ b/app/components/SimplePicker.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, StyleSheet, TouchableOpacity, Modal, FlatList, Platform } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Pressable, Modal, FlatList, Platform } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import ModalBlurOverlay from './ModalBlurOverlay';
@@ -9,7 +9,7 @@ import ModalBlurOverlay from './ModalBlurOverlay';
  * SimplePicker - A picker component for Android
  * Uses native HTML select on web, custom modal picker on Android
  */
-const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, leftIcon }) => {
+const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, leftIcon, closeLabel }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   // Defensive check for undefined items with warning
@@ -94,38 +94,45 @@ const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, l
       <Modal
         visible={modalVisible}
         transparent={true}
-        animationType="fade"
+        animationType="slide"
         onRequestClose={() => setModalVisible(false)}
       >
-        <TouchableOpacity
+        <Pressable
           style={styles.modalOverlay}
-          activeOpacity={1}
           onPress={() => setModalVisible(false)}
         >
-          <View style={[styles.modalContent, { backgroundColor: safeColors.surface }]}>
+          <Pressable style={[styles.modalContent, { backgroundColor: safeColors.card ?? safeColors.surface }]} onPress={() => {}}>
             <FlatList
               data={safeItems}
               keyExtractor={(item) => String(item.value)}
               renderItem={({ item }) => (
-                <TouchableOpacity
-                  style={[
+                <Pressable
+                  style={({ pressed }) => [
                     styles.modalItem,
-                    { borderBottomColor: safeColors.border },
-                    item.value === value && { backgroundColor: safeColors.selected },
+                    { borderColor: safeColors.border },
+                    pressed && { backgroundColor: safeColors.selected },
                   ]}
                   onPress={() => {
                     onValueChange(item.value);
                     setModalVisible(false);
                   }}
                 >
-                  <Text style={[styles.modalItemText, { color: safeColors.text }]}>
+                  <Text style={[styles.modalItemText, { color: safeColors.text }]} numberOfLines={1}>
                     {item.label}
                   </Text>
-                </TouchableOpacity>
+                  {item.subLabel ? (
+                    <Text style={[styles.modalItemSubText, { color: safeColors.mutedText }]} numberOfLines={1}>
+                      {item.subLabel}
+                    </Text>
+                  ) : null}
+                </Pressable>
               )}
             />
-          </View>
-        </TouchableOpacity>
+            <TouchableOpacity style={styles.closeButton} onPress={() => setModalVisible(false)}>
+              <Text style={[styles.closeButtonText, { color: safeColors.primary }]}>{closeLabel}</Text>
+            </TouchableOpacity>
+          </Pressable>
+        </Pressable>
       </Modal>
     </>
   );
@@ -158,25 +165,43 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
   },
+  // Close button
+  closeButton: {
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  closeButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
   // Modal styles
   modalContent: {
-    borderRadius: 8,
-    maxHeight: '60%',
-    overflow: 'hidden',
-    width: '80%',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    maxHeight: '70%',
+    width: '100%',
   },
   modalItem: {
+    alignItems: 'center',
     borderBottomWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     paddingHorizontal: HORIZONTAL_PADDING,
-    paddingVertical: 16,
+    paddingVertical: 12,
+  },
+  modalItemSubText: {
+    fontSize: 14,
+    marginLeft: 8,
   },
   modalItemText: {
+    flex: 1,
     fontSize: 16,
+    marginRight: 4,
   },
   modalOverlay: {
     alignItems: 'center',
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-end',
   },
 });
 
@@ -201,6 +226,7 @@ SimplePicker.propTypes = {
   onValueChange: PropTypes.func,
   items: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string,
+    subLabel: PropTypes.string,
     value: PropTypes.any,
   })),
   style: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.number]),
@@ -213,10 +239,12 @@ SimplePicker.propTypes = {
     mutedText: PropTypes.string,
   }),
   leftIcon: PropTypes.string,
+  closeLabel: PropTypes.string,
 };
 
 SimplePicker.defaultProps = {
   items: [],
+  closeLabel: 'Close',
   colors: {
     text: '#000',
     surface: '#fff',

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -107,6 +107,7 @@ const BalanceHistoryCard = ({
   accounts,
   spendingPrediction,
   isCurrentMonth,
+  closeLabel,
 }) => {
   const { hideBalances } = useDisplaySettings();
 
@@ -149,6 +150,7 @@ const BalanceHistoryCard = ({
             colors={colors}
             leftIcon="bank"
             style={styles.accountPickerInner}
+            closeLabel={closeLabel}
           />
         </View>
       </View>
@@ -579,6 +581,7 @@ BalanceHistoryCard.propTypes = {
     percentElapsed: PropTypes.number,
   }),
   isCurrentMonth: PropTypes.bool,
+  closeLabel: PropTypes.string,
 };
 
 const styles = StyleSheet.create({

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -7,6 +7,8 @@ import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING } from '../styles/layout';
 import { getAvailableMonths } from '../services/OperationsDB';
 import { getAllCategories } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
+import { formatAmount } from '../services/currency';
+import currenciesJson from '../../assets/currencies.json';
 import SimplePicker from '../components/SimplePicker';
 import BalanceHistoryCard from '../components/graphs/BalanceHistoryCard';
 import CategorySpendingCard from '../components/graphs/CategorySpendingCard';
@@ -118,12 +120,13 @@ const GraphsScreen = () => {
     }
   }, [accounts, selectedCurrency]);
 
-  // Initialize default account (display_order=0)
+  // Initialize default account (display_order=0, non-hidden)
   useEffect(() => {
-    if (accounts.length > 0 && !selectedAccount) {
-      const defaultAccount = accounts.find(acc => acc.displayOrder === 0) || accounts[0];
+    const visibleAccounts = accounts.filter(acc => !acc.hidden);
+    if (visibleAccounts.length > 0 && !selectedAccount) {
+      const defaultAccount = visibleAccounts.find(acc => acc.displayOrder === 0) || visibleAccounts[0];
       setSelectedAccount(defaultAccount.id);
-    } else if (accounts.length === 0 && selectedAccount) {
+    } else if (visibleAccounts.length === 0 && selectedAccount) {
       setSelectedAccount(null);
     }
   }, [accounts, selectedAccount]);
@@ -244,7 +247,17 @@ const GraphsScreen = () => {
   );
 
   const accountItems = useMemo(() =>
-    accounts.map(acc => ({ label: acc.name, value: acc.id })),
+    accounts
+      .filter(acc => !acc.hidden)
+      .map(acc => {
+        const currencyInfo = currenciesJson[acc.currency];
+        const symbol = currencyInfo ? currencyInfo.symbol : acc.currency;
+        return {
+          label: acc.name,
+          value: acc.id,
+          subLabel: `${symbol}${formatAmount(acc.balance, acc.currency)}`,
+        };
+      }),
   [accounts],
   );
 
@@ -426,6 +439,7 @@ const GraphsScreen = () => {
               accounts={accounts}
               spendingPrediction={spendingPrediction}
               isCurrentMonth={isCurrentMonth}
+              closeLabel={t('close')}
             />
           )}
 


### PR DESCRIPTION
## Changes

- **SimplePicker**: modal now slides up as a bottom sheet (matching `PickerModal` style) — rounded top corners, blur overlay, slide animation
- **Account items**: balance shown right-aligned on the same row as account name
- **Hidden accounts**: excluded from the account picker list and default selection
- **Styling**: sheet uses `colors.card` background, `Pressable` rows with press feedback, border radius and layout match `PickerModal` exactly
- **`closeLabel` prop**: added to `SimplePicker` and `BalanceHistoryCard` for localised close button text