### PR TITLE
refactor: extract AddFAB into reusable component with consistent styling

### DIFF
--- a/app/components/AddFAB.js
+++ b/app/components/AddFAB.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { FAB } from 'react-native-paper';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { SPACING } from '../styles/layout';
+
+const AddFAB = ({ onPress, testID, accessibilityLabel, accessibilityHint }) => {
+  const { colors } = useThemeColors();
+
+  return (
+    <FAB
+      testID={testID}
+      icon="plus"
+      style={[
+        styles.fab,
+        {
+          backgroundColor: colors.surface + 'DE',
+          borderColor: colors.border + '80',
+        },
+      ]}
+      color={colors.text}
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  fab: {
+    borderRadius: 28,
+    borderWidth: 1,
+    bottom: 100,
+    elevation: 8,
+    margin: SPACING.lg,
+    position: 'absolute',
+    right: 0,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+  },
+});
+
+export default AddFAB;

--- a/app/components/AddFAB.js
+++ b/app/components/AddFAB.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { FAB } from 'react-native-paper';
+import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { SPACING } from '../styles/layout';
 
@@ -24,6 +25,13 @@ const AddFAB = ({ onPress, testID, accessibilityLabel, accessibilityHint }) => {
       accessibilityHint={accessibilityHint}
     />
   );
+};
+
+AddFAB.propTypes = {
+  onPress: PropTypes.func.isRequired,
+  testID: PropTypes.string,
+  accessibilityLabel: PropTypes.string,
+  accessibilityHint: PropTypes.string,
 };
 
 const styles = StyleSheet.create({

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -2,7 +2,8 @@ import React, { useState, useCallback, useMemo, memo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, KeyboardAvoidingView, ScrollView, Keyboard, FlatList, TouchableOpacity, Pressable, Modal as RNModal } from 'react-native';
 import ModalBlurOverlay from '../components/ModalBlurOverlay';
-import { Text, TextInput as PaperTextInput, Button, FAB, Portal, Modal, TouchableRipple, ActivityIndicator, Switch } from 'react-native-paper';
+import { Text, TextInput as PaperTextInput, Button, Portal, Modal, TouchableRipple, ActivityIndicator, Switch } from 'react-native-paper';
+import AddFAB from '../components/AddFAB';
 import DraggableFlatList from 'react-native-draggable-flatlist';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 
@@ -751,11 +752,8 @@ export default function AccountsScreen() {
         )}
       </ScrollView>
 
-      <FAB
+      <AddFAB
         testID="accounts-add-fab"
-        icon="plus"
-        style={[styles.fab, { backgroundColor: colors.text }]}
-        color={colors.background}
         onPress={addAccountHandler}
         accessibilityLabel={t('add_account') || 'Add Account'}
         accessibilityHint={t('add_account_hint') || 'Opens form to create a new account'}
@@ -1038,14 +1036,6 @@ const styles = StyleSheet.create({
   errorContainer: {
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  fab: {
-    borderRadius: 28,
-    bottom: 100,
-    elevation: 4,
-    margin: SPACING.lg,
-    position: 'absolute',
-    right: 0,
   },
   hiddenBalance: {
     backgroundColor: 'rgba(120, 120, 120, 0.25)',

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -1,9 +1,10 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import { View, StyleSheet, FlatList, TouchableOpacity, Dimensions } from 'react-native';
-import { Text, FAB, ActivityIndicator } from 'react-native-paper';
+import { Text, ActivityIndicator } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import AddFAB from '../components/AddFAB';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useCategories } from '../contexts/CategoriesContext';
@@ -271,11 +272,8 @@ const CategoriesScreen = () => {
         />
       )}
 
-      <FAB
+      <AddFAB
         testID="categories-add-fab"
-        icon="plus"
-        style={[styles.fab, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}
-        color={colors.text}
         onPress={handleAddCategory}
         accessibilityLabel={t('add_category')}
         accessibilityHint={t('add_category_hint') || 'Opens form to create a new category'}
@@ -330,19 +328,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginRight: SPACING.xs,
     width: 32,
-  },
-  fab: {
-    borderRadius: 28,
-    borderWidth: 1,
-    bottom: 100,
-    elevation: 8,
-    margin: SPACING.lg,
-    position: 'absolute',
-    right: 0,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
   },
   gridCell: {
     alignItems: 'center',

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import { View, StyleSheet, FlatList, Pressable } from 'react-native';
-import { Text, FAB, ActivityIndicator, Snackbar } from 'react-native-paper';
+import { Text, ActivityIndicator, Snackbar } from 'react-native-paper';
+import AddFAB from '../components/AddFAB';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING } from '../styles/layout';
@@ -276,13 +277,8 @@ export default function PlannedOperationsScreen() {
         removeClippedSubviews={true}
       />
 
-      {/* FAB */}
-      <FAB
+      <AddFAB
         testID="planned-add-fab"
-        icon="plus"
-        label={t('add_planned_operation')}
-        style={[styles.fab, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}
-        color={colors.text}
         onPress={handleAdd}
         accessibilityLabel={t('add_planned_operation')}
       />
@@ -332,19 +328,6 @@ const styles = StyleSheet.create({
     height: 36,
     justifyContent: 'center',
     width: 36,
-  },
-  fab: {
-    borderRadius: 28,
-    borderWidth: 1,
-    bottom: 100,
-    elevation: 8,
-    margin: SPACING.lg,
-    position: 'absolute',
-    right: 0,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
   },
   iconContainer: {
     alignItems: 'center',


### PR DESCRIPTION
Move the floating action button used on Accounts, Categories, and Planned
screens into a shared AddFAB component. All instances now use the same
surface+border coloring from CategoriesScreen, and the Planned tab label
text is removed so the button is icon-only everywhere.

https://claude.ai/code/session_01Mi5bjJubKqsc6fSYh3gAgs