### PR TITLE
feat: redesign description suggestion row UX

### DIFF
--- a/__tests__/components/operations/DescriptionSuggestionRow.test.js
+++ b/__tests__/components/operations/DescriptionSuggestionRow.test.js
@@ -26,10 +26,9 @@ describe('DescriptionSuggestionRow', () => {
     expect(getByText('Bus fare')).toBeTruthy();
   });
 
-  it('renders hint and skip labels', () => {
+  it('renders dismiss button', () => {
     const { getByText } = render(<DescriptionSuggestionRow {...baseProps} />);
-    expect(getByText('label this?')).toBeTruthy();
-    expect(getByText('skip')).toBeTruthy();
+    expect(getByText('✕')).toBeTruthy();
   });
 
   it('calls onApply with chip text when chip is pressed', () => {
@@ -42,12 +41,12 @@ describe('DescriptionSuggestionRow', () => {
     expect(onApply).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onDismiss when skip is pressed', () => {
+  it('calls onDismiss when ✕ is pressed', () => {
     const onDismiss = jest.fn();
-    const { getByText } = render(
+    const { getByLabelText } = render(
       <DescriptionSuggestionRow {...baseProps} onDismiss={onDismiss} />,
     );
-    fireEvent.press(getByText('skip'));
+    fireEvent.press(getByLabelText('dismiss suggestion'));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 

--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -48,27 +48,26 @@ describe('OperationListItem', () => {
 
   describe('Suggestion Row Rendering', () => {
     it('renders without suggestion row when suggestionChips is not provided', () => {
-      const { queryByText } = render(<OperationListItem {...baseProps} />);
-      expect(queryByText('label this?')).toBeNull();
-      expect(queryByText('skip')).toBeNull();
+      const { queryByLabelText } = render(<OperationListItem {...baseProps} />);
+      expect(queryByLabelText('dismiss suggestion')).toBeNull();
     });
 
     it('renders without suggestion row when suggestionChips is null', () => {
-      const { queryByText } = render(
+      const { queryByLabelText } = render(
         <OperationListItem {...baseProps} suggestionChips={null} />,
       );
-      expect(queryByText('label this?')).toBeNull();
+      expect(queryByLabelText('dismiss suggestion')).toBeNull();
     });
 
     it('renders without suggestion row when suggestionChips is empty array', () => {
-      const { queryByText } = render(
+      const { queryByLabelText } = render(
         <OperationListItem {...baseProps} suggestionChips={[]} />,
       );
-      expect(queryByText('label this?')).toBeNull();
+      expect(queryByLabelText('dismiss suggestion')).toBeNull();
     });
 
     it('renders suggestion row with chips when suggestionChips is provided', () => {
-      const { getByText } = render(
+      const { getByText, getByLabelText } = render(
         <OperationListItem
           {...baseProps}
           suggestionChips={['Monthly pass', 'Bus fare']}
@@ -76,7 +75,7 @@ describe('OperationListItem', () => {
           onDismissSuggestion={jest.fn()}
         />,
       );
-      expect(getByText('label this?')).toBeTruthy();
+      expect(getByLabelText('dismiss suggestion')).toBeTruthy();
       expect(getByText('Monthly pass')).toBeTruthy();
       expect(getByText('Bus fare')).toBeTruthy();
     });
@@ -97,9 +96,9 @@ describe('OperationListItem', () => {
       expect(onApplySuggestion).toHaveBeenCalledWith('Monthly pass');
     });
 
-    it('calls onDismissSuggestion when skip is pressed', () => {
+    it('calls onDismissSuggestion when ✕ is pressed', () => {
       const onDismissSuggestion = jest.fn();
-      const { getByText } = render(
+      const { getByLabelText } = render(
         <OperationListItem
           {...baseProps}
           suggestionChips={['Monthly pass']}
@@ -107,7 +106,7 @@ describe('OperationListItem', () => {
           onDismissSuggestion={onDismissSuggestion}
         />,
       );
-      fireEvent.press(getByText('skip'));
+      fireEvent.press(getByLabelText('dismiss suggestion'));
       expect(onDismissSuggestion).toHaveBeenCalledTimes(1);
     });
 
@@ -231,7 +230,7 @@ describe('OperationListItem', () => {
 
     it('accepts default onDismissSuggestion when not provided', () => {
       // Should accept undefined onDismissSuggestion and use default
-      const { getByText } = render(
+      const { getByLabelText } = render(
         <OperationListItem
           {...baseProps}
           suggestionChips={['Test chip']}
@@ -239,7 +238,7 @@ describe('OperationListItem', () => {
           onDismissSuggestion={undefined}
         />,
       );
-      expect(getByText('skip')).toBeTruthy();
+      expect(getByLabelText('dismiss suggestion')).toBeTruthy();
     });
   });
 

--- a/app/components/operations/DescriptionSuggestionRow.js
+++ b/app/components/operations/DescriptionSuggestionRow.js
@@ -16,30 +16,32 @@ const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
 
   return (
     <Animated.View
-      style={[styles.container, { opacity: fadeAnim, borderTopColor: colors.border }]}
+      style={[styles.container, { opacity: fadeAnim }]}
     >
-      <View style={styles.hintRow}>
-        <Text style={[styles.hint, { color: colors.primary }]}>label this?</Text>
-        <TouchableOpacity
-          onPress={onDismiss}
-          accessibilityRole="button"
-          accessibilityLabel="skip suggestion"
-        >
-          <Text style={[styles.skip, { color: colors.mutedText }]}>skip</Text>
-        </TouchableOpacity>
-      </View>
-      <View style={styles.chipRow}>
-        {chips.map((chip) => (
+      <View style={styles.row}>
+        <View style={styles.xSlot}>
           <TouchableOpacity
-            key={chip}
-            onPress={() => onApply(chip)}
-            style={[styles.chip, { borderColor: colors.border, backgroundColor: colors.surface }]}
+            onPress={onDismiss}
+            style={[styles.chip, styles.dismissChip, { borderColor: colors.border, backgroundColor: colors.surface }]}
             accessibilityRole="button"
-            accessibilityLabel={`label: ${chip}`}
+            accessibilityLabel="dismiss suggestion"
           >
-            <Text style={[styles.chipText, { color: colors.primary }]}>{chip}</Text>
+            <Text style={[styles.chipText, { color: colors.mutedText }]}>✕</Text>
           </TouchableOpacity>
-        ))}
+        </View>
+        <View style={styles.chipRow}>
+          {chips.map((chip) => (
+            <TouchableOpacity
+              key={chip}
+              onPress={() => onApply(chip)}
+              style={[styles.chip, { borderColor: colors.border, backgroundColor: colors.surface }]}
+              accessibilityRole="button"
+              accessibilityLabel={`label: ${chip}`}
+            >
+              <Text style={[styles.chipText, { color: colors.primary }]}>{chip}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
       </View>
     </Animated.View>
   );
@@ -53,6 +55,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.xs,
   },
   chipRow: {
+    flex: 1,
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: SPACING.xs,
@@ -62,22 +65,22 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   container: {
-    borderTopWidth: 1,
     paddingBottom: SPACING.md,
-    paddingHorizontal: SPACING.lg,
     paddingTop: SPACING.sm,
   },
-  hint: {
-    fontSize: FONT_SIZE.sm,
+  dismissChip: {
+    paddingHorizontal: SPACING.sm,
   },
-  hintRow: {
+  row: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: SPACING.sm,
-    marginBottom: SPACING.sm,
+    paddingLeft: SPACING.lg,
+    paddingRight: SPACING.lg,
   },
-  skip: {
-    fontSize: FONT_SIZE.sm,
+  xSlot: {
+    alignItems: 'flex-start',
+    marginRight: SPACING.md,
+    width: 32,
   },
 });
 

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -443,6 +443,16 @@ const OperationsScreen = () => {
     setPendingSuggestions([]);
   }, []);
 
+  // Auto-dismiss suggestion if the pending operation gets a description (e.g. via edit modal)
+  useEffect(() => {
+    if (!pendingSuggestionId) return;
+    const op = operations.find(o => o.id === pendingSuggestionId);
+    if (op?.description) {
+      setPendingSuggestionId(null);
+      setPendingSuggestions([]);
+    }
+  }, [operations, pendingSuggestionId]);
+
   // Group operations by date into date-group objects for the list
   const groupedOperations = useMemo(() => {
     const sorted = [...operations].sort((a, b) => new Date(b.date) - new Date(a.date));


### PR DESCRIPTION
## Summary
- Replace "label this?" header + skip button with an inline ✕ chip as the first chip
- Position ✕ chip in a 32px slot aligned with row icons; suggestion chips start at the same offset as the row separator line
- Remove redundant `borderTopWidth` on the suggestion row (the previous item's separator already draws that line)
- Auto-dismiss suggestions when the operation gains a description via the edit modal

## Test plan
- [ ] QuickAdd a transaction without a description — suggestion row appears inline with ✕ first
- [ ] Tap a suggestion chip — description applied, row disappears
- [ ] Tap ✕ — row dismissed
- [ ] Open the operation via edit modal, enter a description, save — suggestion row disappears automatically
- [ ] Verify separator lines between rows look consistent (no double/heavy line above suggestion row)

🧀
