### PR TITLE
fix: eliminate search bar flicker by moving text state into SearchBar

### DIFF
--- a/__tests__/components/search/SearchBar.test.js
+++ b/__tests__/components/search/SearchBar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import SearchBar from '../../../app/components/search/SearchBar';
 
 describe('SearchBar', () => {
@@ -25,6 +25,11 @@ describe('SearchBar', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('renders search input with placeholder', () => {
@@ -32,19 +37,34 @@ describe('SearchBar', () => {
     expect(getByPlaceholderText('search_operations_placeholder')).toBeTruthy();
   });
 
-  it('calls onSearchTextChange when typing', async () => {
+  it('calls onSearchTextChange after debounce when typing', () => {
     const { getByPlaceholderText } = render(<SearchBar {...defaultProps} />);
     const input = getByPlaceholderText('search_operations_placeholder');
 
     fireEvent.changeText(input, 'coffee');
 
-    await waitFor(() => {
-      expect(defaultProps.onSearchTextChange).toHaveBeenCalledWith('coffee');
+    // Should not be called immediately
+    expect(defaultProps.onSearchTextChange).not.toHaveBeenCalledWith('coffee');
+
+    // Should be called after the 300ms debounce
+    act(() => {
+      jest.advanceTimersByTime(300);
     });
+
+    expect(defaultProps.onSearchTextChange).toHaveBeenCalledWith('coffee');
   });
 
-  it('shows clear button when searchText is not empty', () => {
+  it('shows clear button when searchText prop initializes with text', () => {
     const { getByTestId } = render(<SearchBar {...defaultProps} searchText="coffee" />);
+    expect(getByTestId('clear-search-button')).toBeTruthy();
+  });
+
+  it('shows clear button after typing text', () => {
+    const { getByPlaceholderText, getByTestId } = render(<SearchBar {...defaultProps} />);
+    const input = getByPlaceholderText('search_operations_placeholder');
+
+    fireEvent.changeText(input, 'coffee');
+
     expect(getByTestId('clear-search-button')).toBeTruthy();
   });
 
@@ -53,12 +73,21 @@ describe('SearchBar', () => {
     expect(queryByTestId('clear-search-button')).toBeNull();
   });
 
-  it('calls onSearchTextChange with empty string when clear button pressed', () => {
+  it('calls onSearchTextChange with empty string immediately when clear button pressed', () => {
     const { getByTestId } = render(<SearchBar {...defaultProps} searchText="coffee" />);
 
     fireEvent.press(getByTestId('clear-search-button'));
 
+    // Clear is immediate, no debounce
     expect(defaultProps.onSearchTextChange).toHaveBeenCalledWith('');
+  });
+
+  it('hides clear button after pressing clear', () => {
+    const { getByTestId, queryByTestId } = render(<SearchBar {...defaultProps} searchText="coffee" />);
+
+    fireEvent.press(getByTestId('clear-search-button'));
+
+    expect(queryByTestId('clear-search-button')).toBeNull();
   });
 
   it('calls onToggleFilters when filters button pressed', () => {
@@ -85,5 +114,24 @@ describe('SearchBar', () => {
   it('does not show filter count badge when filterCount is 0', () => {
     const { queryByTestId } = render(<SearchBar {...defaultProps} filterCount={0} />);
     expect(queryByTestId('filter-count-badge')).toBeNull();
+  });
+
+  it('debounces rapid typing and only calls onSearchTextChange once with final value', () => {
+    const { getByPlaceholderText } = render(<SearchBar {...defaultProps} />);
+    const input = getByPlaceholderText('search_operations_placeholder');
+
+    fireEvent.changeText(input, 'c');
+    fireEvent.changeText(input, 'co');
+    fireEvent.changeText(input, 'cof');
+    fireEvent.changeText(input, 'coff');
+    fireEvent.changeText(input, 'coffe');
+    fireEvent.changeText(input, 'coffee');
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(defaultProps.onSearchTextChange).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onSearchTextChange).toHaveBeenCalledWith('coffee');
   });
 });

--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { View, TextInput, TouchableOpacity, StyleSheet, Text } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
@@ -13,24 +13,38 @@ const SearchBar = ({
   colors,
   t,
 }) => {
+  const [localText, setLocalText] = useState(searchText);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearchTextChange(localText);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [localText, onSearchTextChange]);
+
+  const handleClear = useCallback(() => {
+    setLocalText('');
+    onSearchTextChange('');
+  }, [onSearchTextChange]);
+
   return (
     <View style={[styles.container, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
       <View style={styles.searchInputContainer}>
         <Icon name="magnify" size={20} color={colors.mutedText} />
         <TextInput
           style={[styles.searchInput, { color: colors.text }]}
-          value={searchText}
-          onChangeText={onSearchTextChange}
+          value={localText}
+          onChangeText={setLocalText}
           placeholder={t('search_operations_placeholder')}
           placeholderTextColor={colors.mutedText}
           autoFocus
           autoCorrect={false}
           autoCapitalize="none"
         />
-        {searchText.length > 0 && (
+        {localText.length > 0 && (
           <TouchableOpacity
             testID="clear-search-button"
-            onPress={() => onSearchTextChange('')}
+            onPress={handleClear}
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >
             <Icon name="close-circle" size={20} color={colors.mutedText} />

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -19,13 +19,9 @@ import { useAccountsData } from '../../contexts/AccountsDataContext';
 import { useCategories } from '../../contexts/CategoriesContext';
 
 const SearchOverlay = ({ onClose, colors, t, visible }) => {
-  console.log('[SearchOverlay] Component rendered, visible:', visible);
-
   const { searchState, hasActiveSearch, getSearchFilterCount } = useOperationsData();
 
   const [filtersExpanded, setFiltersExpanded] = useState(false);
-  // Initialize localSearchText from searchState so it persists across remounts
-  const [localSearchText, setLocalSearchText] = useState(searchState?.text || '');
   const { setSearchText, updateSearchFilters, clearAllSearch } = useOperationsActions();
   const { visibleAccounts } = useAccountsData();
   const { categories } = useCategories();
@@ -33,26 +29,13 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
   const slideAnim = useSharedValue(visible ? 0 : -100);
   const overlayOpacity = useSharedValue(0);
 
-  // Animate in/out when visibility changes
   useEffect(() => {
-    console.log('[SearchOverlay] Visibility changed to:', visible);
     if (visible) {
       slideAnim.value = withTiming(0, { duration: 200 });
     } else {
       slideAnim.value = withTiming(-100, { duration: 200 });
     }
   }, [visible]);
-
-  useEffect(() => {
-    console.log('[SearchOverlay] localSearchText changed to:', localSearchText);
-    // Debounce search text input
-    const timer = setTimeout(() => {
-      console.log('[SearchOverlay] Setting search text after debounce:', localSearchText);
-      setSearchText(localSearchText);
-    }, 300);
-
-    return () => clearTimeout(timer);
-  }, [localSearchText, setSearchText]);
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
@@ -141,8 +124,8 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
         pointerEvents="box-none"
       >
         <SearchBar
-          searchText={localSearchText}
-          onSearchTextChange={setLocalSearchText}
+          searchText={searchState?.text || ''}
+          onSearchTextChange={setSearchText}
           onToggleFilters={handleToggleFilters}
           onClose={handleCloseOverlay}
           filterCount={filterCount}


### PR DESCRIPTION
Each keystroke was causing SearchOverlay (the parent) to re-render because
localSearchText lived there. That round-trip — native input → parent state
update → child re-render → TextInput value update — produced a visible
flicker on every character.

Text state now lives in SearchBar itself, so only SearchBar re-renders per
keystroke. The 300ms debounce propagates the value up to the context, and
the clear button bypasses the debounce for an instant response. SearchOverlay
passes setSearchText directly, eliminating the intermediate local state layer.

https://claude.ai/code/session_01JzqRzkd9uhbfbA2y1MKUAy