### PR TITLE
fix(search): support category hierarchy in operations search

### DIFF
--- a/__tests__/contexts/OperationsContext.test.js
+++ b/__tests__/contexts/OperationsContext.test.js
@@ -51,6 +51,7 @@ jest.mock('../../app/contexts/CategoriesContext', () => ({
   CategoriesProvider: ({ children }) => children,
   useCategories: () => ({
     categories: [],
+    getCategoryPath: () => [],
     loading: false,
   }),
 }));

--- a/__tests__/contexts/OperationsDataContext-search.test.js
+++ b/__tests__/contexts/OperationsDataContext-search.test.js
@@ -32,9 +32,10 @@ const mockAccounts = [
 ];
 
 const mockCategories = [
-  { id: 'cat-1', name: 'Food', nameKey: 'category.food', type: 'expense' },
-  { id: 'cat-2', name: 'Salary', nameKey: 'category.salary', type: 'income' },
-  { id: 'cat-3', name: 'Transport', nameKey: 'category.transport', type: 'expense' },
+  { id: 'cat-1', name: 'Food', nameKey: 'category.food', type: 'expense', parentId: null },
+  { id: 'cat-2', name: 'Salary', nameKey: 'category.salary', type: 'income', parentId: null },
+  { id: 'cat-3', name: 'Transport', nameKey: 'category.transport', type: 'expense', parentId: null },
+  { id: 'cat-4', name: 'Restaurants', nameKey: null, type: 'expense', parentId: 'cat-1' },
 ];
 
 const mockOperations = [
@@ -104,10 +105,21 @@ jest.mock('../../app/contexts/AccountsActionsContext', () => ({
 }));
 
 // Mock CategoriesContext
+const mockGetCategoryPath = (categoryId) => {
+  const path = [];
+  let current = mockCategories.find(cat => cat.id === categoryId);
+  while (current) {
+    path.unshift(current);
+    current = mockCategories.find(cat => cat.id === current.parentId);
+  }
+  return path;
+};
+
 jest.mock('../../app/contexts/CategoriesContext', () => ({
   CategoriesProvider: ({ children }) => children,
   useCategories: () => ({
     categories: mockCategories,
+    getCategoryPath: mockGetCategoryPath,
     loading: false,
   }),
 }));
@@ -380,6 +392,45 @@ describe('OperationsDataContext - Search API', () => {
           const filtered = result.current.data.operations;
           expect(filtered).toHaveLength(2);
           expect(filtered.map(op => op.id).sort()).toEqual(['op-1', 'op-5']);
+        });
+      });
+
+      it('filters by parent category name match (hierarchy traversal)', async () => {
+        // Add an operation categorized under 'Restaurants' (child of 'Food')
+        OperationsDB.getOperationsByWeekOffset.mockResolvedValue([
+          ...mockOperations,
+          {
+            id: 'op-6',
+            type: 'expense',
+            accountId: 'acc-1',
+            categoryId: 'cat-4', // Restaurants, child of Food
+            amount: '30',
+            description: 'Dinner out',
+            date: '2026-04-12',
+          },
+        ]);
+
+        const { result } = renderHook(
+          () => ({
+            data: useOperationsData(),
+            actions: useOperationsActions(),
+          }),
+          { wrapper },
+        );
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(6);
+        });
+
+        act(() => {
+          result.current.actions.setSearchText('food');
+        });
+
+        await waitFor(() => {
+          const filtered = result.current.data.operations;
+          // op-1, op-5 have cat-1 (Food), op-6 has cat-4 (Restaurants, child of Food)
+          expect(filtered).toHaveLength(3);
+          expect(filtered.map(op => op.id).sort()).toEqual(['op-1', 'op-5', 'op-6']);
         });
       });
 

--- a/__tests__/integration/OperationManagement.test.js
+++ b/__tests__/integration/OperationManagement.test.js
@@ -46,6 +46,7 @@ jest.mock('../../app/contexts/CategoriesContext', () => ({
   CategoriesProvider: ({ children }) => children,
   useCategories: () => ({
     categories: [],
+    getCategoryPath: () => [],
     loading: false,
   }),
 }));

--- a/__tests__/integration/OperationsFiltering.test.js
+++ b/__tests__/integration/OperationsFiltering.test.js
@@ -42,6 +42,7 @@ jest.mock('../../app/contexts/CategoriesContext', () => ({
   CategoriesProvider: ({ children }) => children,
   useCategories: () => ({
     categories: [],
+    getCategoryPath: () => [],
     loading: false,
   }),
 }));

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -28,7 +28,7 @@ export const OperationsDataProvider = ({ children }) => {
 
   // Dependencies from other contexts
   const { accounts } = useAccountsData();
-  const { categories } = useCategories();
+  const { categories, getCategoryPath } = useCategories();
   const { t } = useLocalization();
 
   // Core data state
@@ -157,13 +157,13 @@ export const OperationsDataProvider = ({ children }) => {
           return true;
         }
 
-        // match category name
-        const category = categories.find(cat => cat.id === op.categoryId);
-        if (category) {
-          const categoryName = category.nameKey ? t(category.nameKey) : category.name;
-          if (categoryName.toLowerCase().includes(searchLower)) {
-            return true;
-          }
+        // match category name (including parent categories in hierarchy)
+        const categoryPath = getCategoryPath(op.categoryId);
+        if (categoryPath.some(cat => {
+          const name = cat.nameKey ? t(cat.nameKey) : cat.name;
+          return name && name.toLowerCase().includes(searchLower);
+        })) {
+          return true;
         }
 
         // match amount (as string)
@@ -238,7 +238,7 @@ export const OperationsDataProvider = ({ children }) => {
     }
 
     return result;
-  }, [operations, searchState, accounts, categories, t]);
+  }, [operations, searchState, accounts, getCategoryPath, t]);
 
   // Count active filter groups (excluding text search)
   const getSearchFilterCount = useCallback(() => {


### PR DESCRIPTION
## Summary
Enhanced the operations search functionality to support hierarchical category matching. When searching for operations by category name, the search now traverses the category hierarchy and matches operations categorized under child categories if their parent category name matches the search term.

## Key Changes
- Updated `OperationsDataContext` to use the `getCategoryPath` function from `CategoriesContext` to retrieve the full category hierarchy for each operation
- Modified the category search filter to check all categories in the hierarchy path, not just the direct category assignment
- Updated the dependency array in the `useMemo` hook to include `getCategoryPath` instead of `categories`
- Added test data with a hierarchical category structure (e.g., "Restaurants" as a child of "Food")
- Added comprehensive test case verifying that searching for "food" returns operations categorized under both "Food" and its child category "Restaurants"

## Implementation Details
- The `getCategoryPath` function builds an array of categories from the leaf node up to the root by following `parentId` references
- Search matching now uses `categoryPath.some()` to check if any category in the hierarchy matches the search term
- Both translated category names (via `nameKey`) and fallback names are supported in the hierarchy traversal

https://claude.ai/code/session_01WcvZdkp1p7LdsG693qHWKM