### PR TITLE
feat(update): improve app update check to handle releases without APKs

### DIFF
--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -152,12 +152,14 @@ describe('AppUpdateService', () => {
     it('reports update availability when latest release is newer', async () => {
       const fetchImpl = jest.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({
-          tag_name: 'v0.50.4',
-          assets: [{ name: 'penny-v0.50.4.apk', browser_download_url: 'https://example.com/penny-v0.50.4.apk' }],
-          html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v0.50.4',
-          published_at: '2026-03-21T08:00:00Z',
-        }),
+        json: async () => ([
+          {
+            tag_name: 'v0.50.4',
+            assets: [{ name: 'penny-v0.50.4.apk', browser_download_url: 'https://example.com/penny-v0.50.4.apk' }],
+            html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v0.50.4',
+            published_at: '2026-03-21T08:00:00Z',
+          },
+        ]),
       });
 
       const result = await checkForAppUpdate({
@@ -174,10 +176,12 @@ describe('AppUpdateService', () => {
     it('returns no-update when versions match', async () => {
       const fetchImpl = jest.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({
-          tag_name: 'v0.50.3',
-          assets: [{ name: 'penny-v0.50.3.apk', browser_download_url: 'https://example.com/penny-v0.50.3.apk' }],
-        }),
+        json: async () => ([
+          {
+            tag_name: 'v0.50.3',
+            assets: [{ name: 'penny-v0.50.3.apk', browser_download_url: 'https://example.com/penny-v0.50.3.apk' }],
+          },
+        ]),
       });
 
       const result = await checkForAppUpdate({
@@ -202,6 +206,89 @@ describe('AppUpdateService', () => {
 
       expect(result.success).toBe(false);
       expect(result.errorCode).toBe('rate_limited');
+    });
+
+    it('skips releases without APK and uses the next one that has an APK', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([
+          {
+            tag_name: 'v0.50.5',
+            assets: [],
+          },
+          {
+            tag_name: 'v0.50.4',
+            assets: [{ name: 'penny-v0.50.4.apk', browser_download_url: 'https://example.com/penny-v0.50.4.apk' }],
+            html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v0.50.4',
+            published_at: '2026-03-20T08:00:00Z',
+          },
+        ]),
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.3',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isUpdateAvailable).toBe(true);
+      expect(result.latestVersion).toBe('0.50.4');
+      expect(result.downloadUrl).toContain('penny-v0.50.4.apk');
+    });
+
+    it('returns releases_without_apks error when all releases lack APKs', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([
+          { tag_name: 'v0.50.5', assets: [] },
+          { tag_name: 'v0.50.4', assets: [{ name: 'notes.txt', browser_download_url: 'https://example.com/notes.txt' }] },
+          { tag_name: 'v0.50.3', assets: [] },
+          { tag_name: 'v0.50.2', assets: [] },
+          { tag_name: 'v0.50.1', assets: [] },
+        ]),
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.0',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('releases_without_apks');
+    });
+
+    it('returns invalid_release_data when releases list is empty', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([]),
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.3',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe('invalid_release_data');
+    });
+
+    it('uses releases endpoint with per_page=5', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([
+          {
+            tag_name: 'v1.0.0',
+            assets: [{ name: 'penny-v1.0.0.apk', browser_download_url: 'https://example.com/penny-v1.0.0.apk' }],
+          },
+        ]),
+      });
+
+      await checkForAppUpdate({ currentVersion: '0.50.3', fetchImpl });
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        expect.stringContaining('/releases?per_page=5'),
+        expect.any(Object),
+      );
     });
   });
 });

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -362,9 +362,12 @@ export default function SettingsModal({ visible, onClose }) {
       await setPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, new Date().toISOString());
 
       if (!result.success) {
+        const errorMessage = result.errorCode === 'releases_without_apks'
+          ? (t('update_releases_without_apks') || 'Found releases but no APKs attached. Check GitHub for the latest release.')
+          : (t('update_check_failed') || 'Could not check updates right now. Please try again later.');
         showDialog(
           t('check_updates') || 'Check for updates',
-          t('update_check_failed') || 'Could not check updates right now. Please try again later.',
+          errorMessage,
           [{ text: t('ok') || 'OK' }],
         );
         return;

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -78,6 +78,8 @@ const fetchWithTimeout = async (url, options = {}, timeoutMs = UPDATE_CHECK_TIME
   }
 };
 
+const MAX_RELEASES_TO_CHECK = 5;
+
 export const checkForAppUpdate = async ({
   currentVersion = APP_VERSION,
   owner = DEFAULT_GITHUB_OWNER,
@@ -94,7 +96,7 @@ export const checkForAppUpdate = async ({
     };
   }
 
-  const endpoint = `https://api.github.com/repos/${owner}/${repo}/releases/latest`;
+  const endpoint = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=${MAX_RELEASES_TO_CHECK}`;
 
   try {
     const response = await fetchWithTimeout(
@@ -120,32 +122,47 @@ export const checkForAppUpdate = async ({
       };
     }
 
-    const release = await response.json();
-    const latestVersion = parseVersionFromRelease(release);
-    const apkAsset = extractApkAsset(release.assets);
-
-    if (!latestVersion || !apkAsset) {
+    const releases = await response.json();
+    if (!Array.isArray(releases) || releases.length === 0) {
       return {
         success: false,
         isUpdateAvailable: false,
         currentVersion: currentNormalized,
-        latestVersion,
         errorCode: 'invalid_release_data',
       };
     }
 
-    const compare = compareVersions(latestVersion, currentNormalized);
-    const isUpdateAvailable = compare > 0;
+    let foundReleasesWithoutApk = false;
+    for (const release of releases) {
+      const latestVersion = parseVersionFromRelease(release);
+      if (!latestVersion) {
+        continue;
+      }
+
+      const apkAsset = extractApkAsset(release.assets);
+      if (!apkAsset) {
+        foundReleasesWithoutApk = true;
+        continue;
+      }
+
+      const compare = compareVersions(latestVersion, currentNormalized);
+      return {
+        success: true,
+        isUpdateAvailable: compare > 0,
+        currentVersion: currentNormalized,
+        latestVersion,
+        downloadUrl: apkAsset.browser_download_url,
+        releaseUrl: release.html_url || apkAsset.browser_download_url,
+        publishedAt: release.published_at || null,
+        releaseName: release.name || release.tag_name || null,
+      };
+    }
 
     return {
-      success: true,
-      isUpdateAvailable,
+      success: false,
+      isUpdateAvailable: false,
       currentVersion: currentNormalized,
-      latestVersion,
-      downloadUrl: apkAsset.browser_download_url,
-      releaseUrl: release.html_url || apkAsset.browser_download_url,
-      publishedAt: release.published_at || null,
-      releaseName: release.name || release.tag_name || null,
+      errorCode: foundReleasesWithoutApk ? 'releases_without_apks' : 'invalid_release_data',
     };
   } catch (error) {
     const isTimeout = error?.name === 'AbortError';


### PR DESCRIPTION
## Summary
Updated the app update checking logic to handle GitHub releases that don't have APK assets by iterating through multiple releases and skipping those without APKs, rather than failing on the first release.

## Key Changes
- **API endpoint change**: Switched from `/releases/latest` to `/releases?per_page=5` to fetch multiple releases instead of just the latest one
- **Release iteration logic**: Implemented a loop to check up to 5 releases, skipping those without valid version tags or APK assets
- **Error handling**: Added new error code `releases_without_apks` to distinguish between cases where releases exist but lack APKs vs. completely invalid release data
- **User feedback**: Updated the settings modal to show a specific error message when releases are found but no APKs are attached
- **Test coverage**: Added comprehensive test cases for:
  - Skipping releases without APKs and using the next valid one
  - Handling cases where all releases lack APKs
  - Handling empty release lists
  - Verifying the correct API endpoint is called with pagination

## Implementation Details
- The service now iterates through releases in order, returning the first one that has both a valid version and an APK asset
- If no suitable release is found, it returns an appropriate error code based on whether releases without APKs were encountered
- The `MAX_RELEASES_TO_CHECK` constant (set to 5) limits the number of releases fetched to balance thoroughness with API efficiency
- Response format remains unchanged for successful cases, maintaining backward compatibility

https://claude.ai/code/session_01DjtPwXSojsG8Na7Ky8ch5w