### PR TITLE
Change emulator screenshots workflow to trigger on PR comments

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -1,8 +1,8 @@
 name: Emulator Screenshots
 
 on:
-  pull_request:
-    branches: ['**']
+  issue_comment:
+    types: [created]
   workflow_dispatch:
 
 permissions:
@@ -11,18 +11,39 @@ permissions:
   actions: read
 
 concurrency:
-  group: screenshots-${{ github.head_ref || github.ref }}
+  group: screenshots-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   screenshots:
-    if: "!startsWith(github.head_ref, 'release')"
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/screenshots'))
     name: Capture App Screenshots
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Get PR info
+        if: github.event_name == 'issue_comment'
+        id: pr-info
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('head_sha', pr.data.head.sha);
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('pr_number', String(pr.data.number));
+
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && steps.pr-info.outputs.head_sha || github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -118,10 +139,22 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+      - name: Resolve PR number
+        if: always()
+        id: resolve-pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              core.setOutput('pr_number', String(context.issue.number));
+            } else {
+              core.setOutput('pr_number', '');
+            }
+
       - name: Push screenshots to ci-screenshots branch
-        if: github.event_name == 'pull_request' && always()
+        if: steps.resolve-pr.outputs.pr_number != '' && always()
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
+          PR_NUMBER=${{ steps.resolve-pr.outputs.pr_number }}
           SCREENSHOT_DIR="pr-${PR_NUMBER}"
           BACKUP_DIR="/tmp/screenshots-backup"
 
@@ -165,13 +198,13 @@ jobs:
           cp "$BACKUP_DIR"/*.png screenshots/
 
       - name: Build PR comment body
-        if: github.event_name == 'pull_request' && always()
+        if: steps.resolve-pr.outputs.pr_number != '' && always()
         uses: actions/github-script@v9
         id: set-screenshot-results
         with:
           script: |
             const fs = require('fs');
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = ${{ steps.resolve-pr.outputs.pr_number }};
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const rawBase = `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/ci-screenshots/pr-${prNumber}`;
 
@@ -245,9 +278,10 @@ jobs:
             core.setOutput('message', lines.join('\n'));
 
       - uses: marocchino/sticky-pull-request-comment@v3.0.4
-        if: github.event_name == 'pull_request' && always()
+        if: steps.resolve-pr.outputs.pr_number != '' && always()
         with:
           header: "App Screenshots"
+          number: ${{ steps.resolve-pr.outputs.pr_number }}
           message: ${{ steps.set-screenshot-results.outputs.message }}
           hide_and_recreate: true
           hide_classify: "OUTDATED"


### PR DESCRIPTION
## Summary
Modified the emulator screenshots workflow to be triggered by issue comments (specifically PR comments containing `/screenshots`) instead of automatically on every pull request. This allows for on-demand screenshot generation rather than running on every PR.

## Key Changes
- **Trigger mechanism**: Changed from `pull_request` event to `issue_comment` event with a filter for the `/screenshots` command
- **Conditional logic**: Updated the job condition to check for either `workflow_dispatch` or issue comments on PRs containing `/screenshots`
- **PR information retrieval**: Added a new "Get PR info" step that uses the GitHub API to fetch PR details (head SHA, ref, and number) when triggered by issue comments, since this information isn't directly available in the issue_comment event
- **Checkout step**: Modified to use the correct ref based on the trigger type (PR head SHA for issue comments, default SHA for workflow dispatch)
- **PR number resolution**: Added a "Resolve PR number" step to consistently determine the PR number regardless of trigger type
- **Screenshot push and commenting**: Updated conditions and variable references to work with the new PR number resolution logic
- **Sticky comment**: Added explicit `number` parameter to ensure the comment is posted to the correct PR

## Implementation Details
- The workflow now supports both manual triggers (`workflow_dispatch`) and on-demand PR comment triggers
- PR information is fetched dynamically for issue_comment events to ensure the correct commit is checked out
- The PR number is resolved at the end of the workflow to handle both trigger types consistently
- All downstream steps that depend on PR context have been updated to use the resolved PR number

https://claude.ai/code/session_01M6fTkDM3hVgpyEqX3uKTPm