### PR TITLE
feat(search): filter panel redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,5 @@ local/
 *.apk
 
 # Superpowers docs (plans, specs)
-docs/superpowers/
+docs/superpowers/*.html
 .superpowers/

--- a/__tests__/components/search/ExpandableFilters.test.js
+++ b/__tests__/components/search/ExpandableFilters.test.js
@@ -4,7 +4,7 @@ import ExpandableFilters from '../../../app/components/search/ExpandableFilters'
 
 describe('ExpandableFilters', () => {
   const mockColors = {
-    surface: '#FFFFFF',
+    background: '#FFFFFF',
     text: '#000000',
     mutedText: '#999999',
     border: '#E0E0E0',
@@ -28,17 +28,10 @@ describe('ExpandableFilters', () => {
     { id: 'acc-2', name: 'Savings Account' },
   ];
 
-  const mockCategories = [
-    { id: 'cat-1', name: 'Food', type: 'entry', icon: 'food', isShadow: false },
-    { id: 'cat-2', name: 'Transport', type: 'entry', icon: 'car', isShadow: false },
-    { id: 'cat-3', name: 'Shadow Category', type: 'entry', icon: 'tag', isShadow: true },
-  ];
-
   const defaultProps = {
     filters: defaultFilters,
     onFilterChange: jest.fn(),
     accounts: mockAccounts,
-    categories: mockCategories,
     colors: mockColors,
     t: mockT,
     isExpanded: true,
@@ -91,13 +84,6 @@ describe('ExpandableFilters', () => {
     expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
       accountIds: ['acc-1'],
     });
-  });
-
-  it('filters out categories with isShadow=true from rendered list', () => {
-    const { getByText, queryByText } = render(<ExpandableFilters {...defaultProps} />);
-    expect(getByText('Food')).toBeTruthy();
-    expect(getByText('Transport')).toBeTruthy();
-    expect(queryByText('Shadow Category')).toBeNull();
   });
 
   it('renders clear all button', () => {

--- a/__tests__/components/search/ExpandableFilters.test.js
+++ b/__tests__/components/search/ExpandableFilters.test.js
@@ -4,7 +4,7 @@ import ExpandableFilters from '../../../app/components/search/ExpandableFilters'
 
 describe('ExpandableFilters', () => {
   const mockColors = {
-    background: '#FFFFFF',
+    surface: '#FFFFFF',
     text: '#000000',
     mutedText: '#999999',
     border: '#E0E0E0',
@@ -28,10 +28,17 @@ describe('ExpandableFilters', () => {
     { id: 'acc-2', name: 'Savings Account' },
   ];
 
+  const mockCategories = [
+    { id: 'cat-1', name: 'Food', type: 'entry', icon: 'food', isShadow: false },
+    { id: 'cat-2', name: 'Transport', type: 'entry', icon: 'car', isShadow: false },
+    { id: 'cat-3', name: 'Shadow Category', type: 'entry', icon: 'tag', isShadow: true },
+  ];
+
   const defaultProps = {
     filters: defaultFilters,
     onFilterChange: jest.fn(),
     accounts: mockAccounts,
+    categories: mockCategories,
     colors: mockColors,
     t: mockT,
     isExpanded: true,
@@ -84,6 +91,13 @@ describe('ExpandableFilters', () => {
     expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
       accountIds: ['acc-1'],
     });
+  });
+
+  it('filters out categories with isShadow=true from rendered list', () => {
+    const { getByText, queryByText } = render(<ExpandableFilters {...defaultProps} />);
+    expect(getByText('Food')).toBeTruthy();
+    expect(getByText('Transport')).toBeTruthy();
+    expect(queryByText('Shadow Category')).toBeNull();
   });
 
   it('renders clear all button', () => {

--- a/__tests__/components/search/ExpandableFilters.test.js
+++ b/__tests__/components/search/ExpandableFilters.test.js
@@ -116,4 +116,44 @@ describe('ExpandableFilters', () => {
       amountRange: { min: null, max: null },
     });
   });
+
+  describe('Amount range input', () => {
+    it('preserves decimal point mid-typing without calling onFilterChange', () => {
+      const { getByPlaceholderText } = render(<ExpandableFilters {...defaultProps} />);
+      const minInput = getByPlaceholderText('min_amount');
+
+      fireEvent.changeText(minInput, '1.');
+
+      // onFilterChange should NOT be called while still typing
+      expect(defaultProps.onFilterChange).not.toHaveBeenCalled();
+      // Input should still show '1.'
+      expect(minInput.props.value).toBe('1.');
+    });
+
+    it('calls onFilterChange with parsed float on blur', () => {
+      const { getByPlaceholderText } = render(<ExpandableFilters {...defaultProps} />);
+      const minInput = getByPlaceholderText('min_amount');
+
+      fireEvent.changeText(minInput, '1.5');
+      fireEvent(minInput, 'blur');
+
+      expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
+        amountRange: { min: 1.5, max: null },
+      });
+    });
+
+    it('calls onFilterChange with null on blur when input cleared', () => {
+      const { getByPlaceholderText } = render(
+        <ExpandableFilters {...defaultProps} filters={{ ...defaultFilters, amountRange: { min: 5, max: null } }} />,
+      );
+      const minInput = getByPlaceholderText('min_amount');
+
+      fireEvent.changeText(minInput, '');
+      fireEvent(minInput, 'blur');
+
+      expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
+        amountRange: { min: null, max: null },
+      });
+    });
+  });
 });

--- a/__tests__/components/search/ExpandableFilters.test.js
+++ b/__tests__/components/search/ExpandableFilters.test.js
@@ -99,4 +99,21 @@ describe('ExpandableFilters', () => {
     expect(getByText('Transport')).toBeTruthy();
     expect(queryByText('Shadow Category')).toBeNull();
   });
+
+  it('renders clear all button', () => {
+    const { getByTestId } = render(<ExpandableFilters {...defaultProps} />);
+    expect(getByTestId('clear-all-button')).toBeTruthy();
+  });
+
+  it('calls onFilterChange with all groups reset when clear all is pressed', () => {
+    const { getByTestId } = render(<ExpandableFilters {...defaultProps} />);
+    fireEvent.press(getByTestId('clear-all-button'));
+    expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
+      types: [],
+      accountIds: [],
+      categoryIds: [],
+      dateRange: { startDate: null, endDate: null },
+      amountRange: { min: null, max: null },
+    });
+  });
 });

--- a/__tests__/components/search/FilterChipStrip.test.js
+++ b/__tests__/components/search/FilterChipStrip.test.js
@@ -4,7 +4,7 @@ import FilterChipStrip from '../../../app/components/search/FilterChipStrip';
 
 describe('FilterChipStrip', () => {
   const mockColors = {
-    surface: '#1A1A1A',
+    background: '#1A1A1A',
     primary: '#007AFF',
     border: '#333333',
     text: '#FFFFFF',
@@ -86,16 +86,6 @@ describe('FilterChipStrip', () => {
     expect(getByText('accounts: 2')).toBeTruthy();
   });
 
-  it('renders "categories: N" chip for active categoryIds', () => {
-    const { getByText } = render(
-      <FilterChipStrip
-        {...defaultProps}
-        searchState={{ ...emptySearchState, categoryIds: ['c1'] }}
-      />,
-    );
-    expect(getByText('categories: 1')).toBeTruthy();
-  });
-
   it('renders "> min" label for min-only amount range', () => {
     const { getByText } = render(
       <FilterChipStrip
@@ -156,12 +146,10 @@ describe('FilterChipStrip', () => {
           ...emptySearchState,
           types: ['expense'],
           accountIds: ['a1'],
-          categoryIds: ['c1'],
         }}
       />,
     );
     expect(getByTestId('chip-types')).toBeTruthy();
     expect(getByTestId('chip-accountIds')).toBeTruthy();
-    expect(getByTestId('chip-categoryIds')).toBeTruthy();
   });
 });

--- a/__tests__/components/search/FilterChipStrip.test.js
+++ b/__tests__/components/search/FilterChipStrip.test.js
@@ -86,16 +86,6 @@ describe('FilterChipStrip', () => {
     expect(getByText('accounts: 2')).toBeTruthy();
   });
 
-  it('renders "categories: N" chip for active categoryIds', () => {
-    const { getByText } = render(
-      <FilterChipStrip
-        {...defaultProps}
-        searchState={{ ...emptySearchState, categoryIds: ['c1'] }}
-      />,
-    );
-    expect(getByText('categories: 1')).toBeTruthy();
-  });
-
   it('renders "> min" label for min-only amount range', () => {
     const { getByText } = render(
       <FilterChipStrip
@@ -156,12 +146,10 @@ describe('FilterChipStrip', () => {
           ...emptySearchState,
           types: ['expense'],
           accountIds: ['a1'],
-          categoryIds: ['c1'],
         }}
       />,
     );
     expect(getByTestId('chip-types')).toBeTruthy();
     expect(getByTestId('chip-accountIds')).toBeTruthy();
-    expect(getByTestId('chip-categoryIds')).toBeTruthy();
   });
 });

--- a/__tests__/components/search/FilterChipStrip.test.js
+++ b/__tests__/components/search/FilterChipStrip.test.js
@@ -86,6 +86,16 @@ describe('FilterChipStrip', () => {
     expect(getByText('accounts: 2')).toBeTruthy();
   });
 
+  it('renders "categories: N" chip for active categoryIds', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, categoryIds: ['c1'] }}
+      />,
+    );
+    expect(getByText('categories: 1')).toBeTruthy();
+  });
+
   it('renders "> min" label for min-only amount range', () => {
     const { getByText } = render(
       <FilterChipStrip
@@ -146,10 +156,12 @@ describe('FilterChipStrip', () => {
           ...emptySearchState,
           types: ['expense'],
           accountIds: ['a1'],
+          categoryIds: ['c1'],
         }}
       />,
     );
     expect(getByTestId('chip-types')).toBeTruthy();
     expect(getByTestId('chip-accountIds')).toBeTruthy();
+    expect(getByTestId('chip-categoryIds')).toBeTruthy();
   });
 });

--- a/__tests__/components/search/FilterChipStrip.test.js
+++ b/__tests__/components/search/FilterChipStrip.test.js
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import FilterChipStrip from '../../../app/components/search/FilterChipStrip';
+
+describe('FilterChipStrip', () => {
+  const mockColors = {
+    surface: '#1A1A1A',
+    primary: '#007AFF',
+    border: '#333333',
+    text: '#FFFFFF',
+  };
+  const mockT = (key) => key;
+
+  const emptySearchState = {
+    text: '',
+    types: [],
+    accountIds: [],
+    categoryIds: [],
+    dateRange: { startDate: null, endDate: null },
+    amountRange: { min: null, max: null },
+  };
+
+  const defaultProps = {
+    searchState: emptySearchState,
+    onClearGroup: jest.fn(),
+    colors: mockColors,
+    t: mockT,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when no filter groups are active', () => {
+    const { toJSON } = render(<FilterChipStrip {...defaultProps} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders a chip for active types (single type shows type name)', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, types: ['expense'] }}
+      />,
+    );
+    expect(getByText('expense')).toBeTruthy();
+  });
+
+  it('renders "operation_type: N" for multiple active types', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, types: ['expense', 'income'] }}
+      />,
+    );
+    expect(getByText('operation_type: 2')).toBeTruthy();
+  });
+
+  it('renders a chip for active date range (both dates)', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, dateRange: { startDate: '2024-04-01', endDate: '2024-04-30' } }}
+      />,
+    );
+    expect(getByTestId('chip-dateRange')).toBeTruthy();
+  });
+
+  it('renders a chip for start date only', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, dateRange: { startDate: '2024-04-01', endDate: null } }}
+      />,
+    );
+    expect(getByTestId('chip-dateRange')).toBeTruthy();
+  });
+
+  it('renders "accounts: N" chip for active accountIds', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, accountIds: ['a1', 'a2'] }}
+      />,
+    );
+    expect(getByText('accounts: 2')).toBeTruthy();
+  });
+
+  it('renders "categories: N" chip for active categoryIds', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, categoryIds: ['c1'] }}
+      />,
+    );
+    expect(getByText('categories: 1')).toBeTruthy();
+  });
+
+  it('renders "> min" label for min-only amount range', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, amountRange: { min: 50, max: null } }}
+      />,
+    );
+    expect(getByText('> 50')).toBeTruthy();
+  });
+
+  it('renders "< max" label for max-only amount range', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, amountRange: { min: null, max: 200 } }}
+      />,
+    );
+    expect(getByText('< 200')).toBeTruthy();
+  });
+
+  it('renders "min – max" label for both amount bounds', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, amountRange: { min: 50, max: 200 } }}
+      />,
+    );
+    expect(getByText('50 – 200')).toBeTruthy();
+  });
+
+  it('calls onClearGroup with "types" when types chip ✕ is pressed', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, types: ['expense'] }}
+      />,
+    );
+    fireEvent.press(getByTestId('clear-chip-types'));
+    expect(defaultProps.onClearGroup).toHaveBeenCalledWith('types');
+  });
+
+  it('calls onClearGroup with "accountIds" when accounts chip ✕ is pressed', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, accountIds: ['a1'] }}
+      />,
+    );
+    fireEvent.press(getByTestId('clear-chip-accountIds'));
+    expect(defaultProps.onClearGroup).toHaveBeenCalledWith('accountIds');
+  });
+
+  it('renders multiple chips when multiple groups are active', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{
+          ...emptySearchState,
+          types: ['expense'],
+          accountIds: ['a1'],
+          categoryIds: ['c1'],
+        }}
+      />,
+    );
+    expect(getByTestId('chip-types')).toBeTruthy();
+    expect(getByTestId('chip-accountIds')).toBeTruthy();
+    expect(getByTestId('chip-categoryIds')).toBeTruthy();
+  });
+});

--- a/__tests__/components/search/SearchBar.test.js
+++ b/__tests__/components/search/SearchBar.test.js
@@ -239,10 +239,9 @@ describe('SearchBar', () => {
     });
 
     it('filter icon uses primary color when filterCount > 0', () => {
-      const { getByTestId, UNSAFE_getAllByType } = render(
+      const { UNSAFE_getAllByType } = render(
         <SearchBar {...defaultProps} filterCount={2} colors={{ ...mockColors, primary: '#FF3B30' }} />,
       );
-      const button = getByTestId('filters-toggle-button');
       const icons = UNSAFE_getAllByType(require('@expo/vector-icons').MaterialCommunityIcons);
       // The first icon in the button is the filter-variant icon
       const filterIcon = icons.find(icon => icon.props.name === 'filter-variant');
@@ -250,10 +249,9 @@ describe('SearchBar', () => {
     });
 
     it('filter icon uses text color when filterCount is 0', () => {
-      const { getByTestId, UNSAFE_getAllByType } = render(
+      const { UNSAFE_getAllByType } = render(
         <SearchBar {...defaultProps} filterCount={0} colors={{ ...mockColors, text: '#CCCCCC' }} />,
       );
-      const button = getByTestId('filters-toggle-button');
       const icons = UNSAFE_getAllByType(require('@expo/vector-icons').MaterialCommunityIcons);
       const filterIcon = icons.find(icon => icon.props.name === 'filter-variant');
       expect(filterIcon.props.color).toBe('#CCCCCC');

--- a/__tests__/components/search/SearchBar.test.js
+++ b/__tests__/components/search/SearchBar.test.js
@@ -237,5 +237,26 @@ describe('SearchBar', () => {
       // Should have background with primary color at 15% opacity (hex: 15 in decimal)
       expect(buttonStyle.backgroundColor).toMatch(/#4da3ff/i);
     });
+
+    it('filter icon uses primary color when filterCount > 0', () => {
+      const { getByTestId, UNSAFE_getAllByType } = render(
+        <SearchBar {...defaultProps} filterCount={2} colors={{ ...mockColors, primary: '#FF3B30' }} />,
+      );
+      const button = getByTestId('filters-toggle-button');
+      const icons = UNSAFE_getAllByType(require('@expo/vector-icons').MaterialCommunityIcons);
+      // The first icon in the button is the filter-variant icon
+      const filterIcon = icons.find(icon => icon.props.name === 'filter-variant');
+      expect(filterIcon.props.color).toBe('#FF3B30');
+    });
+
+    it('filter icon uses text color when filterCount is 0', () => {
+      const { getByTestId, UNSAFE_getAllByType } = render(
+        <SearchBar {...defaultProps} filterCount={0} colors={{ ...mockColors, text: '#CCCCCC' }} />,
+      );
+      const button = getByTestId('filters-toggle-button');
+      const icons = UNSAFE_getAllByType(require('@expo/vector-icons').MaterialCommunityIcons);
+      const filterIcon = icons.find(icon => icon.props.name === 'filter-variant');
+      expect(filterIcon.props.color).toBe('#CCCCCC');
+    });
   });
 });

--- a/__tests__/components/search/SearchOverlay.test.js
+++ b/__tests__/components/search/SearchOverlay.test.js
@@ -230,7 +230,6 @@ describe('SearchOverlay', () => {
     expect(useOperationsData).toHaveBeenCalled();
     expect(useOperationsActions).toHaveBeenCalled();
     expect(useAccountsData).toHaveBeenCalled();
-    expect(useCategories).toHaveBeenCalled();
     expect(useSearch).toHaveBeenCalled();
   });
 

--- a/__tests__/components/search/SearchOverlay.test.js
+++ b/__tests__/components/search/SearchOverlay.test.js
@@ -5,6 +5,7 @@ import SearchOverlay from '../../../app/components/search/SearchOverlay';
 import { useOperationsData } from '../../../app/contexts/OperationsDataContext';
 import { useOperationsActions } from '../../../app/contexts/OperationsActionsContext';
 import { useAccountsData } from '../../../app/contexts/AccountsDataContext';
+import { useCategories } from '../../../app/contexts/CategoriesContext';
 import { useSearch } from '../../../app/contexts/SearchContext';
 
 // Mock SearchContext
@@ -57,6 +58,7 @@ jest.spyOn(Alert, 'alert');
 
 describe('SearchOverlay', () => {
   const mockColors = {
+    surface: '#FFFFFF',
     background: '#F5F5F5',
   };
 
@@ -92,6 +94,10 @@ describe('SearchOverlay', () => {
     visibleAccounts: [],
   };
 
+  const mockCategoriesData = {
+    categories: [],
+  };
+
   const mockSearchContext = {
     filtersExpanded: false,
     toggleFilters: jest.fn(),
@@ -104,6 +110,7 @@ describe('SearchOverlay', () => {
     useOperationsData.mockReturnValue(mockOperationsData);
     useOperationsActions.mockReturnValue(mockOperationsActions);
     useAccountsData.mockReturnValue(mockAccountsData);
+    useCategories.mockReturnValue(mockCategoriesData);
     useSearch.mockReturnValue(mockSearchContext);
 
     // Clear Alert mock
@@ -223,6 +230,7 @@ describe('SearchOverlay', () => {
     expect(useOperationsData).toHaveBeenCalled();
     expect(useOperationsActions).toHaveBeenCalled();
     expect(useAccountsData).toHaveBeenCalled();
+    expect(useCategories).toHaveBeenCalled();
     expect(useSearch).toHaveBeenCalled();
   });
 

--- a/__tests__/components/search/SearchOverlay.test.js
+++ b/__tests__/components/search/SearchOverlay.test.js
@@ -5,7 +5,6 @@ import SearchOverlay from '../../../app/components/search/SearchOverlay';
 import { useOperationsData } from '../../../app/contexts/OperationsDataContext';
 import { useOperationsActions } from '../../../app/contexts/OperationsActionsContext';
 import { useAccountsData } from '../../../app/contexts/AccountsDataContext';
-import { useCategories } from '../../../app/contexts/CategoriesContext';
 import { useSearch } from '../../../app/contexts/SearchContext';
 
 // Mock SearchContext
@@ -58,7 +57,6 @@ jest.spyOn(Alert, 'alert');
 
 describe('SearchOverlay', () => {
   const mockColors = {
-    surface: '#FFFFFF',
     background: '#F5F5F5',
   };
 
@@ -94,10 +92,6 @@ describe('SearchOverlay', () => {
     visibleAccounts: [],
   };
 
-  const mockCategoriesData = {
-    categories: [],
-  };
-
   const mockSearchContext = {
     filtersExpanded: false,
     toggleFilters: jest.fn(),
@@ -110,7 +104,6 @@ describe('SearchOverlay', () => {
     useOperationsData.mockReturnValue(mockOperationsData);
     useOperationsActions.mockReturnValue(mockOperationsActions);
     useAccountsData.mockReturnValue(mockAccountsData);
-    useCategories.mockReturnValue(mockCategoriesData);
     useSearch.mockReturnValue(mockSearchContext);
 
     // Clear Alert mock
@@ -230,7 +223,6 @@ describe('SearchOverlay', () => {
     expect(useOperationsData).toHaveBeenCalled();
     expect(useOperationsActions).toHaveBeenCalled();
     expect(useAccountsData).toHaveBeenCalled();
-    expect(useCategories).toHaveBeenCalled();
     expect(useSearch).toHaveBeenCalled();
   });
 

--- a/__tests__/integration/SearchLayout.test.js
+++ b/__tests__/integration/SearchLayout.test.js
@@ -59,7 +59,7 @@ jest.mock('../../app/contexts/CategoriesContext', () => ({
 
 describe('SearchLayout integration', () => {
   const mockColors = {
-    surface: '#1a1a1a',
+    background: '#1a1a1a',
   };
 
   const mockT = (key) => key;
@@ -71,10 +71,9 @@ describe('SearchLayout integration', () => {
     visible: true,
   };
 
-  it('SearchOverlay does not use absolute positioning', () => {
+  it('SearchOverlay uses flow (non-absolute) positioning', () => {
     const { getByText } = render(<SearchOverlay {...defaultProps} />);
 
-    // Get the mock filters which is inside the filtersContainer
     const mockFilters = getByText('Mock Filters');
 
     // Navigate up to find the RCTView with pointerEvents="box-none" (filtersContainer)
@@ -86,11 +85,11 @@ describe('SearchLayout integration', () => {
     // Flatten all styles to check
     const styles = StyleSheet.flatten(current.props.style);
 
-    // Should use absolute positioning to overlay content from the top
-    expect(styles.position).toBe('absolute');
+    // Should NOT use absolute positioning — flows in layout so list renders below it
+    expect(styles.position).not.toBe('absolute');
   });
 
-  it('SearchOverlay does not have top offset', () => {
+  it('SearchOverlay has no top/left/right/zIndex positioning properties', () => {
     const { getByText } = render(<SearchOverlay {...defaultProps} />);
 
     const mockFilters = getByText('Mock Filters');
@@ -100,11 +99,14 @@ describe('SearchLayout integration', () => {
     }
     const styles = StyleSheet.flatten(current.props.style);
 
-    // Should have top: 0 to anchor at the top of OperationsScreen
-    expect(styles.top).toBe(0);
+    // Flow element — no absolute-layout props
+    expect(styles.top).toBeUndefined();
+    expect(styles.left).toBeUndefined();
+    expect(styles.right).toBeUndefined();
+    expect(styles.zIndex).toBeUndefined();
   });
 
-  it('SearchOverlay has proper zIndex for layering', () => {
+  it('SearchOverlay filtersContainer has elevation for shadow', () => {
     const { getByText } = render(<SearchOverlay {...defaultProps} />);
 
     const mockFilters = getByText('Mock Filters');
@@ -114,8 +116,8 @@ describe('SearchLayout integration', () => {
     }
     const styles = StyleSheet.flatten(current.props.style);
 
-    // Should have zIndex for proper layering
-    expect(styles.zIndex).toBeDefined();
+    // Should still have elevation for the drop shadow
+    expect(styles.elevation).toBeDefined();
   });
 });
 

--- a/__tests__/integration/SearchLayout.test.js
+++ b/__tests__/integration/SearchLayout.test.js
@@ -59,7 +59,7 @@ jest.mock('../../app/contexts/CategoriesContext', () => ({
 
 describe('SearchLayout integration', () => {
   const mockColors = {
-    background: '#1a1a1a',
+    surface: '#1a1a1a',
   };
 
   const mockT = (key) => key;
@@ -71,9 +71,10 @@ describe('SearchLayout integration', () => {
     visible: true,
   };
 
-  it('SearchOverlay uses flow (non-absolute) positioning', () => {
+  it('SearchOverlay does not use absolute positioning', () => {
     const { getByText } = render(<SearchOverlay {...defaultProps} />);
 
+    // Get the mock filters which is inside the filtersContainer
     const mockFilters = getByText('Mock Filters');
 
     // Navigate up to find the RCTView with pointerEvents="box-none" (filtersContainer)
@@ -85,11 +86,11 @@ describe('SearchLayout integration', () => {
     // Flatten all styles to check
     const styles = StyleSheet.flatten(current.props.style);
 
-    // Should NOT use absolute positioning — flows in layout so list renders below it
-    expect(styles.position).not.toBe('absolute');
+    // Should use absolute positioning to overlay content from the top
+    expect(styles.position).toBe('absolute');
   });
 
-  it('SearchOverlay has no top/left/right/zIndex positioning properties', () => {
+  it('SearchOverlay does not have top offset', () => {
     const { getByText } = render(<SearchOverlay {...defaultProps} />);
 
     const mockFilters = getByText('Mock Filters');
@@ -99,14 +100,11 @@ describe('SearchLayout integration', () => {
     }
     const styles = StyleSheet.flatten(current.props.style);
 
-    // Flow element — no absolute-layout props
-    expect(styles.top).toBeUndefined();
-    expect(styles.left).toBeUndefined();
-    expect(styles.right).toBeUndefined();
-    expect(styles.zIndex).toBeUndefined();
+    // Should have top: 0 to anchor at the top of OperationsScreen
+    expect(styles.top).toBe(0);
   });
 
-  it('SearchOverlay filtersContainer has elevation for shadow', () => {
+  it('SearchOverlay has proper zIndex for layering', () => {
     const { getByText } = render(<SearchOverlay {...defaultProps} />);
 
     const mockFilters = getByText('Mock Filters');
@@ -116,8 +114,8 @@ describe('SearchLayout integration', () => {
     }
     const styles = StyleSheet.flatten(current.props.style);
 
-    // Should still have elevation for the drop shadow
-    expect(styles.elevation).toBeDefined();
+    // Should have zIndex for proper layering
+    expect(styles.zIndex).toBeDefined();
   });
 });
 

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -13,6 +13,7 @@ import { IMPORT_PROGRESS_EVENT } from '../services/BackupRestore';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
 import { useSearch } from '../contexts/SearchContext';
 import FilterBadge from './search/FilterBadge';
+import FilterChipStrip from './search/FilterChipStrip';
 import { useOperationsData } from '../contexts/OperationsDataContext';
 import { useOperationsActions } from '../contexts/OperationsActionsContext';
 
@@ -30,7 +31,7 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
   const [dbVersion, setDbVersion] = useState(null);
 
   const { searchState, hasActiveSearch, getSearchFilterCount } = useOperationsData();
-  const { setSearchText } = useOperationsActions();
+  const { setSearchText, updateSearchFilters } = useOperationsActions();
 
   const handleCloseSearch = useCallback(() => {
     closeSearch(hasActiveSearch);
@@ -39,6 +40,17 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
   const handleToggleFilters = useCallback(() => {
     toggleFilters();
   }, [toggleFilters]);
+
+  const handleClearFilterGroup = useCallback((groupKey) => {
+    const clearValues = {
+      types: { types: [] },
+      dateRange: { dateRange: { startDate: null, endDate: null } },
+      amountRange: { amountRange: { min: null, max: null } },
+      accountIds: { accountIds: [] },
+      categoryIds: { categoryIds: [] },
+    };
+    updateSearchFilters(clearValues[groupKey]);
+  }, [updateSearchFilters]);
 
   const fetchDbVersion = useCallback(async () => {
     try {
@@ -76,22 +88,30 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
     <View
       style={[
         styles.container,
-        {
-          backgroundColor: colors.background,
-          borderBottomColor: colors.border,
-        },
+        { backgroundColor: colors.background, borderBottomColor: colors.border },
+        searchMode === 'open' && styles.containerSearchMode,
       ]}
     >
       {searchMode === 'open' ? (
-        <SearchBar
-          searchText={searchState?.text || ''}
-          onSearchTextChange={setSearchText}
-          onToggleFilters={handleToggleFilters}
-          onClose={handleCloseSearch}
-          filterCount={getSearchFilterCount ? getSearchFilterCount() : 0}
-          colors={colors}
-          t={t}
-        />
+        <>
+          <SearchBar
+            searchText={searchState?.text || ''}
+            onSearchTextChange={setSearchText}
+            onToggleFilters={handleToggleFilters}
+            onClose={handleCloseSearch}
+            filterCount={getSearchFilterCount ? getSearchFilterCount() : 0}
+            colors={colors}
+            t={t}
+          />
+          {hasActiveSearch && (
+            <FilterChipStrip
+              searchState={searchState}
+              onClearGroup={handleClearFilterGroup}
+              colors={colors}
+              t={t}
+            />
+          )}
+        </>
       ) : (
         <>
           <View style={styles.titleContainer}>
@@ -222,6 +242,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingHorizontal: HORIZONTAL_PADDING,
+  },
+  containerSearchMode: {
+    alignItems: 'stretch',
+    flexDirection: 'column',
+    paddingHorizontal: 0,
   },
   downloadIndicator: {
     alignItems: 'center',

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -17,6 +17,12 @@ const ExpandableFilters = ({
 }) => {
   const [showStartDatePicker, setShowStartDatePicker] = useState(false);
   const [showEndDatePicker, setShowEndDatePicker] = useState(false);
+  const [localMinAmount, setLocalMinAmount] = useState(
+    filters.amountRange.min !== null ? String(filters.amountRange.min) : '',
+  );
+  const [localMaxAmount, setLocalMaxAmount] = useState(
+    filters.amountRange.max !== null ? String(filters.amountRange.max) : '',
+  );
 
   if (!isExpanded) {
     return null;
@@ -151,10 +157,11 @@ const ExpandableFilters = ({
           <View style={styles.amountRangeContainer}>
             <TextInput
               style={[styles.amountInput, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
-              value={filters.amountRange.min !== null ? String(filters.amountRange.min) : ''}
-              onChangeText={(text) => {
-                const value = text === '' ? null : parseFloat(text);
-                onFilterChange({ amountRange: { ...filters.amountRange, min: value } });
+              value={localMinAmount}
+              onChangeText={setLocalMinAmount}
+              onBlur={() => {
+                const value = localMinAmount === '' ? null : parseFloat(localMinAmount);
+                onFilterChange({ amountRange: { ...filters.amountRange, min: isNaN(value) ? null : value } });
               }}
               placeholder={t('min_amount')}
               placeholderTextColor={colors.mutedText}
@@ -163,10 +170,11 @@ const ExpandableFilters = ({
             <Text style={[styles.amountRangeSeparator, { color: colors.mutedText }]}>-</Text>
             <TextInput
               style={[styles.amountInput, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
-              value={filters.amountRange.max !== null ? String(filters.amountRange.max) : ''}
-              onChangeText={(text) => {
-                const value = text === '' ? null : parseFloat(text);
-                onFilterChange({ amountRange: { ...filters.amountRange, max: value } });
+              value={localMaxAmount}
+              onChangeText={setLocalMaxAmount}
+              onBlur={() => {
+                const value = localMaxAmount === '' ? null : parseFloat(localMaxAmount);
+                onFilterChange({ amountRange: { ...filters.amountRange, max: isNaN(value) ? null : value } });
               }}
               placeholder={t('max_amount')}
               placeholderTextColor={colors.mutedText}

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -10,7 +10,6 @@ const ExpandableFilters = ({
   filters,
   onFilterChange,
   accounts,
-  categories,
   colors,
   t,
   isExpanded,
@@ -42,13 +41,6 @@ const ExpandableFilters = ({
     onFilterChange({ accountIds: newAccountIds });
   };
 
-  const toggleCategory = (categoryId) => {
-    const newCategoryIds = filters.categoryIds.includes(categoryId)
-      ? filters.categoryIds.filter(id => id !== categoryId)
-      : [...filters.categoryIds, categoryId];
-    onFilterChange({ categoryIds: newCategoryIds });
-  };
-
   const handleStartDateChange = (event, selectedDate) => {
     setShowStartDatePicker(false);
     if (selectedDate) {
@@ -76,7 +68,7 @@ const ExpandableFilters = ({
   };
 
   return (
-    <View testID="expandable-filters" style={[styles.container, { backgroundColor: colors.surface }]}>
+    <View testID="expandable-filters" style={[styles.container, { backgroundColor: colors.background }]}>
       <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
         {/* Type Section */}
         <View style={[styles.section, { borderBottomColor: colors.border }]}>
@@ -210,38 +202,6 @@ const ExpandableFilters = ({
           </View>
         </View>
 
-        {/* Categories Section */}
-        <View style={[styles.section, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
-            {t('categories')}
-          </Text>
-          <View style={styles.chipContainer}>
-            {categories.filter(c => !c.isShadow).map(category => {
-              const isSelected = filters.categoryIds.includes(category.id);
-              const chipTextColor = isSelected ? '#fff' : colors.text;
-              return (
-                <TouchableOpacity
-                  key={category.id}
-                  style={[styles.chip, {
-                    backgroundColor: isSelected ? colors.primary : colors.inputBackground,
-                    borderColor: colors.border,
-                  }]}
-                  onPress={() => toggleCategory(category.id)}
-                >
-                  <Icon
-                    name={category.icon || 'tag'}
-                    size={14}
-                    color={chipTextColor}
-                  />
-                  <Text style={[styles.chipText, { color: chipTextColor }]}>
-                    {category.nameKey ? t(category.nameKey) : category.name}
-                  </Text>
-                </TouchableOpacity>
-              );
-            })}
-          </View>
-        </View>
-
         <TouchableOpacity
           testID="clear-all-button"
           style={styles.clearAllButton}
@@ -293,9 +253,8 @@ ExpandableFilters.propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
   })).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.object).isRequired,
   colors: PropTypes.shape({
-    surface: PropTypes.string,
+    background: PropTypes.string,
     text: PropTypes.string,
     mutedText: PropTypes.string,
     border: PropTypes.string,

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -10,6 +10,7 @@ const ExpandableFilters = ({
   filters,
   onFilterChange,
   accounts,
+  categories,
   colors,
   t,
   isExpanded,
@@ -41,6 +42,13 @@ const ExpandableFilters = ({
     onFilterChange({ accountIds: newAccountIds });
   };
 
+  const toggleCategory = (categoryId) => {
+    const newCategoryIds = filters.categoryIds.includes(categoryId)
+      ? filters.categoryIds.filter(id => id !== categoryId)
+      : [...filters.categoryIds, categoryId];
+    onFilterChange({ categoryIds: newCategoryIds });
+  };
+
   const handleStartDateChange = (event, selectedDate) => {
     setShowStartDatePicker(false);
     if (selectedDate) {
@@ -68,7 +76,7 @@ const ExpandableFilters = ({
   };
 
   return (
-    <View testID="expandable-filters" style={[styles.container, { backgroundColor: colors.background }]}>
+    <View testID="expandable-filters" style={[styles.container, { backgroundColor: colors.surface }]}>
       <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
         {/* Type Section */}
         <View style={[styles.section, { borderBottomColor: colors.border }]}>
@@ -202,6 +210,38 @@ const ExpandableFilters = ({
           </View>
         </View>
 
+        {/* Categories Section */}
+        <View style={[styles.section, { borderBottomColor: colors.border }]}>
+          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
+            {t('categories')}
+          </Text>
+          <View style={styles.chipContainer}>
+            {categories.filter(c => !c.isShadow).map(category => {
+              const isSelected = filters.categoryIds.includes(category.id);
+              const chipTextColor = isSelected ? '#fff' : colors.text;
+              return (
+                <TouchableOpacity
+                  key={category.id}
+                  style={[styles.chip, {
+                    backgroundColor: isSelected ? colors.primary : colors.inputBackground,
+                    borderColor: colors.border,
+                  }]}
+                  onPress={() => toggleCategory(category.id)}
+                >
+                  <Icon
+                    name={category.icon || 'tag'}
+                    size={14}
+                    color={chipTextColor}
+                  />
+                  <Text style={[styles.chipText, { color: chipTextColor }]}>
+                    {category.nameKey ? t(category.nameKey) : category.name}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+
         <TouchableOpacity
           testID="clear-all-button"
           style={styles.clearAllButton}
@@ -253,8 +293,9 @@ ExpandableFilters.propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
   })).isRequired,
+  categories: PropTypes.arrayOf(PropTypes.object).isRequired,
   colors: PropTypes.shape({
-    background: PropTypes.string,
+    surface: PropTypes.string,
     text: PropTypes.string,
     mutedText: PropTypes.string,
     border: PropTypes.string,

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -321,7 +321,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   container: {
-    maxHeight: '60%',
+    flex: 1,
   },
   dateInput: {
     alignItems: 'center',

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -74,7 +74,7 @@ const ExpandableFilters = ({
       <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
         {/* Type Section */}
         <View style={[styles.section, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
             {t('operation_type')}
           </Text>
           <View style={styles.chipContainer}>
@@ -107,7 +107,7 @@ const ExpandableFilters = ({
 
         {/* Date Range Section */}
         <View style={[styles.section, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
             {t('date_range')}
           </Text>
           <View style={styles.dateRangeContainer}>
@@ -145,7 +145,7 @@ const ExpandableFilters = ({
 
         {/* Amount Range Section */}
         <View style={[styles.section, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
             {t('amount_range')}
           </Text>
           <View style={styles.amountRangeContainer}>
@@ -177,7 +177,7 @@ const ExpandableFilters = ({
 
         {/* Accounts Section */}
         <View style={[styles.section, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
             {t('accounts')}
           </Text>
           {accounts.map(account => {
@@ -203,7 +203,7 @@ const ExpandableFilters = ({
 
         {/* Categories Section */}
         <View style={[styles.section, { borderBottomColor: colors.border }]}>
-          <Text style={[styles.sectionTitle, { color: colors.text }]}>
+          <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
             {t('categories')}
           </Text>
           {categories.filter(c => !c.isShadow).map(category => {
@@ -227,6 +227,22 @@ const ExpandableFilters = ({
             );
           })}
         </View>
+
+        <TouchableOpacity
+          testID="clear-all-button"
+          style={styles.clearAllButton}
+          onPress={() => onFilterChange({
+            types: [],
+            accountIds: [],
+            categoryIds: [],
+            dateRange: { startDate: null, endDate: null },
+            amountRange: { min: null, max: null },
+          })}
+        >
+          <Text style={[styles.clearAllText, { color: colors.primary }]}>
+            {t('clear_all')}
+          </Text>
+        </TouchableOpacity>
       </ScrollView>
 
       {/* Date Pickers */}
@@ -329,6 +345,14 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
   },
+  clearAllButton: {
+    alignItems: 'center',
+    paddingVertical: 14,
+  },
+  clearAllText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
   clearDateButton: {
     marginTop: 7,
   },
@@ -364,10 +388,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: 14,
   },
-  sectionTitle: {
-    fontSize: 16,
+  sectionLabel: {
+    fontSize: 11,
     fontWeight: '600',
+    letterSpacing: 0.5,
     marginBottom: 10,
+    textTransform: 'uppercase',
   },
 });
 

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -180,25 +180,26 @@ const ExpandableFilters = ({
           <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
             {t('accounts')}
           </Text>
-          {accounts.map(account => {
-            const isSelected = filters.accountIds.includes(account.id);
-            return (
-              <TouchableOpacity
-                key={account.id}
-                style={[styles.checkboxItem, { borderBottomColor: colors.border }]}
-                onPress={() => toggleAccount(account.id)}
-              >
-                <Icon
-                  name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'}
-                  size={24}
-                  color={isSelected ? colors.primary : colors.mutedText}
-                />
-                <Text style={[styles.checkboxLabel, { color: colors.text }]}>
-                  {account.name}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
+          <View style={styles.chipContainer}>
+            {accounts.map(account => {
+              const isSelected = filters.accountIds.includes(account.id);
+              const chipTextColor = isSelected ? '#fff' : colors.text;
+              return (
+                <TouchableOpacity
+                  key={account.id}
+                  style={[styles.chip, {
+                    backgroundColor: isSelected ? colors.primary : colors.inputBackground,
+                    borderColor: colors.border,
+                  }]}
+                  onPress={() => toggleAccount(account.id)}
+                >
+                  <Text style={[styles.chipText, { color: chipTextColor }]}>
+                    {account.name}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
         </View>
 
         {/* Categories Section */}
@@ -206,26 +207,31 @@ const ExpandableFilters = ({
           <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
             {t('categories')}
           </Text>
-          {categories.filter(c => !c.isShadow).map(category => {
-            const isSelected = filters.categoryIds.includes(category.id);
-            return (
-              <TouchableOpacity
-                key={category.id}
-                style={[styles.checkboxItem, { borderBottomColor: colors.border }]}
-                onPress={() => toggleCategory(category.id)}
-              >
-                <Icon
-                  name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'}
-                  size={24}
-                  color={isSelected ? colors.primary : colors.mutedText}
-                />
-                <Icon name={category.icon || 'tag'} size={20} color={colors.text} style={styles.categoryIcon} />
-                <Text style={[styles.checkboxLabel, { color: colors.text }]}>
-                  {category.nameKey ? t(category.nameKey) : category.name}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
+          <View style={styles.chipContainer}>
+            {categories.filter(c => !c.isShadow).map(category => {
+              const isSelected = filters.categoryIds.includes(category.id);
+              const chipTextColor = isSelected ? '#fff' : colors.text;
+              return (
+                <TouchableOpacity
+                  key={category.id}
+                  style={[styles.chip, {
+                    backgroundColor: isSelected ? colors.primary : colors.inputBackground,
+                    borderColor: colors.border,
+                  }]}
+                  onPress={() => toggleCategory(category.id)}
+                >
+                  <Icon
+                    name={category.icon || 'tag'}
+                    size={14}
+                    color={chipTextColor}
+                  />
+                  <Text style={[styles.chipText, { color: chipTextColor }]}>
+                    {category.nameKey ? t(category.nameKey) : category.name}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
         </View>
 
         <TouchableOpacity
@@ -313,19 +319,6 @@ const styles = StyleSheet.create({
   },
   amountRangeSeparator: {
     fontSize: 16,
-  },
-  categoryIcon: {
-    marginLeft: 8,
-  },
-  checkboxItem: {
-    alignItems: 'center',
-    borderBottomWidth: 1,
-    flexDirection: 'row',
-    gap: 12,
-    paddingVertical: 10,
-  },
-  checkboxLabel: {
-    fontSize: 14,
   },
   chip: {
     alignItems: 'center',

--- a/app/components/search/FilterChipStrip.js
+++ b/app/components/search/FilterChipStrip.js
@@ -45,13 +45,6 @@ const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
     chips.push({ key: 'accountIds', label: `${t('accounts')}: ${searchState.accountIds.length}` });
   }
 
-  if (searchState.categoryIds.length > 0) {
-    chips.push({
-      key: 'categoryIds',
-      label: `${t('categories')}: ${searchState.categoryIds.length}`,
-    });
-  }
-
   if (chips.length === 0) {
     return null;
   }
@@ -60,7 +53,7 @@ const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
-      style={[styles.container, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}
+      style={[styles.container, { backgroundColor: colors.background, borderBottomColor: colors.border }]}
       contentContainerStyle={styles.content}
     >
       {chips.map(({ key, label }) => (
@@ -102,7 +95,7 @@ FilterChipStrip.propTypes = {
   }).isRequired,
   onClearGroup: PropTypes.func.isRequired,
   colors: PropTypes.shape({
-    surface: PropTypes.string.isRequired,
+    background: PropTypes.string.isRequired,
     primary: PropTypes.string.isRequired,
     border: PropTypes.string.isRequired,
   }).isRequired,

--- a/app/components/search/FilterChipStrip.js
+++ b/app/components/search/FilterChipStrip.js
@@ -45,6 +45,13 @@ const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
     chips.push({ key: 'accountIds', label: `${t('accounts')}: ${searchState.accountIds.length}` });
   }
 
+  if (searchState.categoryIds.length > 0) {
+    chips.push({
+      key: 'categoryIds',
+      label: `${t('categories')}: ${searchState.categoryIds.length}`,
+    });
+  }
+
   if (chips.length === 0) {
     return null;
   }

--- a/app/components/search/FilterChipStrip.js
+++ b/app/components/search/FilterChipStrip.js
@@ -45,13 +45,6 @@ const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
     chips.push({ key: 'accountIds', label: `${t('accounts')}: ${searchState.accountIds.length}` });
   }
 
-  if (searchState.categoryIds.length > 0) {
-    chips.push({
-      key: 'categoryIds',
-      label: `${t('categories')}: ${searchState.categoryIds.length}`,
-    });
-  }
-
   if (chips.length === 0) {
     return null;
   }

--- a/app/components/search/FilterChipStrip.js
+++ b/app/components/search/FilterChipStrip.js
@@ -1,0 +1,136 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import { HORIZONTAL_PADDING } from '../../styles/layout';
+
+const formatDateLabel = (dateRange) => {
+  const { startDate, endDate } = dateRange;
+  const fmt = (d) =>
+    new Date(d).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  if (startDate && endDate) return `${fmt(startDate)} – ${fmt(endDate)}`;
+  if (startDate) return `${fmt(startDate)} –`;
+  if (endDate) return `– ${fmt(endDate)}`;
+  return null;
+};
+
+const formatAmountLabel = (amountRange) => {
+  const { min, max } = amountRange;
+  if (min !== null && max !== null) return `${min} – ${max}`;
+  if (min !== null) return `> ${min}`;
+  if (max !== null) return `< ${max}`;
+  return null;
+};
+
+const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
+  const chips = [];
+
+  if (searchState.types.length > 0) {
+    const label =
+      searchState.types.length === 1
+        ? t(searchState.types[0])
+        : `${t('operation_type')}: ${searchState.types.length}`;
+    chips.push({ key: 'types', label });
+  }
+
+  if (searchState.dateRange.startDate || searchState.dateRange.endDate) {
+    chips.push({ key: 'dateRange', label: formatDateLabel(searchState.dateRange) });
+  }
+
+  if (searchState.amountRange.min !== null || searchState.amountRange.max !== null) {
+    chips.push({ key: 'amountRange', label: formatAmountLabel(searchState.amountRange) });
+  }
+
+  if (searchState.accountIds.length > 0) {
+    chips.push({ key: 'accountIds', label: `${t('accounts')}: ${searchState.accountIds.length}` });
+  }
+
+  if (searchState.categoryIds.length > 0) {
+    chips.push({
+      key: 'categoryIds',
+      label: `${t('categories')}: ${searchState.categoryIds.length}`,
+    });
+  }
+
+  if (chips.length === 0) {
+    return null;
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={[styles.container, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}
+      contentContainerStyle={styles.content}
+    >
+      {chips.map(({ key, label }) => (
+        <View
+          key={key}
+          testID={`chip-${key}`}
+          style={[
+            styles.chip,
+            { backgroundColor: `${colors.primary}20`, borderColor: colors.primary },
+          ]}
+        >
+          <Text style={[styles.chipText, { color: colors.primary }]}>{label}</Text>
+          <TouchableOpacity
+            testID={`clear-chip-${key}`}
+            onPress={() => onClearGroup(key)}
+            hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
+          >
+            <Icon name="close" size={13} color={colors.primary} />
+          </TouchableOpacity>
+        </View>
+      ))}
+    </ScrollView>
+  );
+};
+
+FilterChipStrip.propTypes = {
+  searchState: PropTypes.shape({
+    types: PropTypes.array.isRequired,
+    accountIds: PropTypes.array.isRequired,
+    categoryIds: PropTypes.array.isRequired,
+    dateRange: PropTypes.shape({
+      startDate: PropTypes.string,
+      endDate: PropTypes.string,
+    }).isRequired,
+    amountRange: PropTypes.shape({
+      min: PropTypes.number,
+      max: PropTypes.number,
+    }).isRequired,
+  }).isRequired,
+  onClearGroup: PropTypes.func.isRequired,
+  colors: PropTypes.shape({
+    surface: PropTypes.string.isRequired,
+    primary: PropTypes.string.isRequired,
+    border: PropTypes.string.isRequired,
+  }).isRequired,
+  t: PropTypes.func.isRequired,
+};
+
+const styles = StyleSheet.create({
+  chip: {
+    alignItems: 'center',
+    borderRadius: 14,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  chipText: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  container: {
+    borderBottomWidth: 1,
+  },
+  content: {
+    gap: 7,
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: 7,
+  },
+});
+
+export default FilterChipStrip;

--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -75,7 +75,7 @@ const SearchBar = ({
           activeOpacity={0.7}
         >
           <View style={styles.filterButtonContent}>
-            <Icon name="filter-variant" size={22} color={colors.text} />
+            <Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
             {filterCount > 0 && (
               <View
                 testID="filter-count-badge"

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -1,40 +1,20 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import {
   StyleSheet,
-  TouchableWithoutFeedback,
 } from 'react-native';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import PropTypes from 'prop-types';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
 import { useOperationsActions } from '../../contexts/OperationsActionsContext';
 import { useAccountsData } from '../../contexts/AccountsDataContext';
-import { useCategories } from '../../contexts/CategoriesContext';
 import { useSearch } from '../../contexts/SearchContext';
 
 const SearchOverlay = ({ onClose, colors, t, visible }) => {
-  const { searchState, hasActiveSearch, getSearchFilterCount } = useOperationsData();
-  const { filtersExpanded, toggleFilters } = useSearch();
+  const { searchState } = useOperationsData();
+  const { filtersExpanded } = useSearch();
   const { updateSearchFilters } = useOperationsActions();
   const { visibleAccounts } = useAccountsData();
-  const { categories } = useCategories();
-
-  const overlayOpacity = useSharedValue(0);
-
-  useEffect(() => {
-    overlayOpacity.value = withTiming(filtersExpanded ? 0.3 : 0, { duration: 200 });
-  }, [filtersExpanded, overlayOpacity]);
-
-  const overlayAnimatedStyle = useAnimatedStyle(() => {
-    return {
-      opacity: overlayOpacity.value,
-    };
-  });
-
 
   const handleFilterChange = useCallback((partialFilters) => {
     updateSearchFilters(partialFilters);
@@ -45,38 +25,26 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
   }
 
   return (
-    <>
-      {filtersExpanded && (
-        <TouchableWithoutFeedback onPress={() => toggleFilters()}>
-          <Animated.View
-            style={[styles.overlayBackdrop, overlayAnimatedStyle]}
-            pointerEvents="auto"
-          />
-        </TouchableWithoutFeedback>
-      )}
-
-      <Animated.View
-        style={[styles.filtersContainer, { backgroundColor: colors.surface }]}
-        pointerEvents="box-none"
-      >
-        <ExpandableFilters
-          filters={searchState}
-          onFilterChange={handleFilterChange}
-          accounts={visibleAccounts}
-          categories={categories}
-          colors={colors}
-          t={t}
-          isExpanded={filtersExpanded}
-        />
-      </Animated.View>
-    </>
+    <Animated.View
+      style={[styles.filtersContainer, { backgroundColor: colors.background }]}
+      pointerEvents="box-none"
+    >
+      <ExpandableFilters
+        filters={searchState}
+        onFilterChange={handleFilterChange}
+        accounts={visibleAccounts}
+        colors={colors}
+        t={t}
+        isExpanded={filtersExpanded}
+      />
+    </Animated.View>
   );
 };
 
 SearchOverlay.propTypes = {
   onClose: PropTypes.func.isRequired,
   colors: PropTypes.shape({
-    surface: PropTypes.string.isRequired,
+    background: PropTypes.string.isRequired,
   }).isRequired,
   t: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
@@ -96,15 +64,6 @@ const styles = StyleSheet.create({
     shadowRadius: 10,
     top: 0,
     zIndex: 50,
-  },
-  overlayBackdrop: {
-    backgroundColor: 'rgba(0, 0, 0, 0.3)',
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    zIndex: 30,
   },
 });
 

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -4,8 +4,6 @@ import {
   Dimensions,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
-
-const SCREEN_HEIGHT = Dimensions.get('window').height;
 import PropTypes from 'prop-types';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
@@ -13,7 +11,9 @@ import { useOperationsActions } from '../../contexts/OperationsActionsContext';
 import { useAccountsData } from '../../contexts/AccountsDataContext';
 import { useSearch } from '../../contexts/SearchContext';
 
-const SearchOverlay = ({ onClose, colors, t, visible }) => {
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+
+const SearchOverlay = ({ onClose, colors, t, visible, onHeightChange }) => {
   const { searchState } = useOperationsData();
   const { filtersExpanded } = useSearch();
   const { updateSearchFilters } = useOperationsActions();
@@ -23,6 +23,12 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
     updateSearchFilters(partialFilters);
   }, [updateSearchFilters]);
 
+  const handleLayout = useCallback((event) => {
+    if (onHeightChange) {
+      onHeightChange(event.nativeEvent.layout.height);
+    }
+  }, [onHeightChange]);
+
   if (!visible) {
     return null;
   }
@@ -31,6 +37,7 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
     <Animated.View
       style={[styles.filtersContainer, { backgroundColor: colors.background }]}
       pointerEvents="box-none"
+      onLayout={handleLayout}
     >
       <ExpandableFilters
         filters={searchState}
@@ -46,11 +53,16 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
 
 SearchOverlay.propTypes = {
   onClose: PropTypes.func.isRequired,
+  onHeightChange: PropTypes.func,
   colors: PropTypes.shape({
     background: PropTypes.string.isRequired,
   }).isRequired,
   t: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
+};
+
+SearchOverlay.defaultProps = {
+  onHeightChange: null,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -1,40 +1,20 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import {
   StyleSheet,
-  TouchableWithoutFeedback,
 } from 'react-native';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import PropTypes from 'prop-types';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
 import { useOperationsActions } from '../../contexts/OperationsActionsContext';
 import { useAccountsData } from '../../contexts/AccountsDataContext';
-import { useCategories } from '../../contexts/CategoriesContext';
 import { useSearch } from '../../contexts/SearchContext';
 
 const SearchOverlay = ({ onClose, colors, t, visible }) => {
-  const { searchState, hasActiveSearch, getSearchFilterCount } = useOperationsData();
-  const { filtersExpanded, toggleFilters } = useSearch();
+  const { searchState } = useOperationsData();
+  const { filtersExpanded } = useSearch();
   const { updateSearchFilters } = useOperationsActions();
   const { visibleAccounts } = useAccountsData();
-  const { categories } = useCategories();
-
-  const overlayOpacity = useSharedValue(0);
-
-  useEffect(() => {
-    overlayOpacity.value = withTiming(filtersExpanded ? 0.3 : 0, { duration: 200 });
-  }, [filtersExpanded, overlayOpacity]);
-
-  const overlayAnimatedStyle = useAnimatedStyle(() => {
-    return {
-      opacity: overlayOpacity.value,
-    };
-  });
-
 
   const handleFilterChange = useCallback((partialFilters) => {
     updateSearchFilters(partialFilters);
@@ -45,38 +25,26 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
   }
 
   return (
-    <>
-      {filtersExpanded && (
-        <TouchableWithoutFeedback onPress={() => toggleFilters()}>
-          <Animated.View
-            style={[styles.overlayBackdrop, overlayAnimatedStyle]}
-            pointerEvents="auto"
-          />
-        </TouchableWithoutFeedback>
-      )}
-
-      <Animated.View
-        style={[styles.filtersContainer, { backgroundColor: colors.surface }]}
-        pointerEvents="box-none"
-      >
-        <ExpandableFilters
-          filters={searchState}
-          onFilterChange={handleFilterChange}
-          accounts={visibleAccounts}
-          categories={categories}
-          colors={colors}
-          t={t}
-          isExpanded={filtersExpanded}
-        />
-      </Animated.View>
-    </>
+    <Animated.View
+      style={[styles.filtersContainer, { backgroundColor: colors.background }]}
+      pointerEvents="box-none"
+    >
+      <ExpandableFilters
+        filters={searchState}
+        onFilterChange={handleFilterChange}
+        accounts={visibleAccounts}
+        colors={colors}
+        t={t}
+        isExpanded={filtersExpanded}
+      />
+    </Animated.View>
   );
 };
 
 SearchOverlay.propTypes = {
   onClose: PropTypes.func.isRequired,
   colors: PropTypes.shape({
-    surface: PropTypes.string.isRequired,
+    background: PropTypes.string.isRequired,
   }).isRequired,
   t: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
@@ -87,24 +55,10 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 14,
     borderBottomRightRadius: 14,
     elevation: 8,
-    left: 0,
-    position: 'absolute',
-    right: 0,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 6 },
     shadowOpacity: 0.35,
     shadowRadius: 10,
-    top: 0,
-    zIndex: 50,
-  },
-  overlayBackdrop: {
-    backgroundColor: 'rgba(0, 0, 0, 0.3)',
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-    zIndex: 30,
   },
 });
 

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -1,8 +1,11 @@
 import React, { useCallback } from 'react';
 import {
   StyleSheet,
+  Dimensions,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
 import PropTypes from 'prop-types';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
@@ -56,6 +59,7 @@ const styles = StyleSheet.create({
     borderBottomRightRadius: 14,
     elevation: 8,
     left: 0,
+    maxHeight: SCREEN_HEIGHT * 0.75,
     position: 'absolute',
     right: 0,
     shadowColor: '#000',

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -1,20 +1,40 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   StyleSheet,
-  View,
+  TouchableWithoutFeedback,
 } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
 import PropTypes from 'prop-types';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
 import { useOperationsActions } from '../../contexts/OperationsActionsContext';
 import { useAccountsData } from '../../contexts/AccountsDataContext';
+import { useCategories } from '../../contexts/CategoriesContext';
 import { useSearch } from '../../contexts/SearchContext';
 
 const SearchOverlay = ({ onClose, colors, t, visible }) => {
-  const { searchState } = useOperationsData();
-  const { filtersExpanded } = useSearch();
+  const { searchState, hasActiveSearch, getSearchFilterCount } = useOperationsData();
+  const { filtersExpanded, toggleFilters } = useSearch();
   const { updateSearchFilters } = useOperationsActions();
   const { visibleAccounts } = useAccountsData();
+  const { categories } = useCategories();
+
+  const overlayOpacity = useSharedValue(0);
+
+  useEffect(() => {
+    overlayOpacity.value = withTiming(filtersExpanded ? 0.3 : 0, { duration: 200 });
+  }, [filtersExpanded, overlayOpacity]);
+
+  const overlayAnimatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: overlayOpacity.value,
+    };
+  });
+
 
   const handleFilterChange = useCallback((partialFilters) => {
     updateSearchFilters(partialFilters);
@@ -25,23 +45,38 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
   }
 
   return (
-    <View style={[styles.filtersContainer, { backgroundColor: colors.background }]}>
-      <ExpandableFilters
-        filters={searchState}
-        onFilterChange={handleFilterChange}
-        accounts={visibleAccounts}
-        colors={colors}
-        t={t}
-        isExpanded={filtersExpanded}
-      />
-    </View>
+    <>
+      {filtersExpanded && (
+        <TouchableWithoutFeedback onPress={() => toggleFilters()}>
+          <Animated.View
+            style={[styles.overlayBackdrop, overlayAnimatedStyle]}
+            pointerEvents="auto"
+          />
+        </TouchableWithoutFeedback>
+      )}
+
+      <Animated.View
+        style={[styles.filtersContainer, { backgroundColor: colors.surface }]}
+        pointerEvents="box-none"
+      >
+        <ExpandableFilters
+          filters={searchState}
+          onFilterChange={handleFilterChange}
+          accounts={visibleAccounts}
+          categories={categories}
+          colors={colors}
+          t={t}
+          isExpanded={filtersExpanded}
+        />
+      </Animated.View>
+    </>
   );
 };
 
 SearchOverlay.propTypes = {
   onClose: PropTypes.func.isRequired,
   colors: PropTypes.shape({
-    background: PropTypes.string.isRequired,
+    surface: PropTypes.string.isRequired,
   }).isRequired,
   t: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
@@ -52,10 +87,24 @@ const styles = StyleSheet.create({
     borderBottomLeftRadius: 14,
     borderBottomRightRadius: 14,
     elevation: 8,
+    left: 0,
+    position: 'absolute',
+    right: 0,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 6 },
     shadowOpacity: 0.35,
     shadowRadius: 10,
+    top: 0,
+    zIndex: 50,
+  },
+  overlayBackdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 30,
   },
 });
 

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -84,9 +84,16 @@ SearchOverlay.propTypes = {
 
 const styles = StyleSheet.create({
   filtersContainer: {
+    borderBottomLeftRadius: 14,
+    borderBottomRightRadius: 14,
+    elevation: 8,
     left: 0,
     position: 'absolute',
     right: 0,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.35,
+    shadowRadius: 10,
     top: 0,
     zIndex: 50,
   },

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react';
 import {
   StyleSheet,
+  View,
 } from 'react-native';
-import Animated from 'react-native-reanimated';
 import PropTypes from 'prop-types';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
@@ -25,10 +25,7 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
   }
 
   return (
-    <Animated.View
-      style={[styles.filtersContainer, { backgroundColor: colors.background }]}
-      pointerEvents="box-none"
-    >
+    <View style={[styles.filtersContainer, { backgroundColor: colors.background }]}>
       <ExpandableFilters
         filters={searchState}
         onFilterChange={handleFilterChange}
@@ -37,7 +34,7 @@ const SearchOverlay = ({ onClose, colors, t, visible }) => {
         t={t}
         isExpanded={filtersExpanded}
       />
-    </Animated.View>
+    </View>
   );
 };
 

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -64,8 +64,17 @@ export const OperationsActionsProvider = ({ children }) => {
   // Request ID counter to handle race conditions in loadInitialOperations
   const loadRequestIdRef = useRef(0);
 
+  // Ref so loadInitialOperations can read latest filters without depending on them
+  // (prevents the function from changing on every filter edit, which would re-trigger the
+  // mount effect and show a loading spinner on every keystroke or filter tap)
+  const activeFiltersRef = useRef(activeFilters);
+  useEffect(() => {
+    activeFiltersRef.current = activeFilters;
+  }, [activeFilters]);
+
   // Load initial week of operations
-  const loadInitialOperations = useCallback(async (filters = activeFilters, showLoading = true) => {
+  const loadInitialOperations = useCallback(async (filters, showLoading = true) => {
+    const effectiveFilters = filters ?? activeFiltersRef.current;
     console.log('[OperationsActionsContext] loadInitialOperations called, requestId:', loadRequestIdRef.current + 1);
     // Increment request ID to track this specific call
     const requestId = ++loadRequestIdRef.current;
@@ -74,9 +83,9 @@ export const OperationsActionsProvider = ({ children }) => {
       if (showLoading) {
         _setLoading(true);
       }
-      const isFiltered = _hasActiveFilters(filters);
+      const isFiltered = _hasActiveFilters(effectiveFilters);
       let operationsData = isFiltered
-        ? await OperationsDB.getFilteredOperationsByWeekOffset(0, filters)
+        ? await OperationsDB.getFilteredOperationsByWeekOffset(0, effectiveFilters)
         : await OperationsDB.getOperationsByWeekOffset(0);
 
       // Check if this request is still the latest (ignore stale results)
@@ -112,7 +121,6 @@ export const OperationsActionsProvider = ({ children }) => {
       }
     }
   }, [
-    activeFilters,
     _hasActiveFilters,
     _setLoading,
     _setOperations,

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -64,6 +64,7 @@ const OperationsScreen = () => {
   const [pendingScroll, setPendingScroll] = useState(false);
   const [pendingSuggestionId, setPendingSuggestionId] = useState(null);
   const [pendingSuggestions, setPendingSuggestions] = useState([]);
+  const [filterPanelHeight, setFilterPanelHeight] = useState(0);
 
   const { searchMode } = useSearch();
   const quickAddOpacity = useSharedValue(1);
@@ -574,32 +575,35 @@ const OperationsScreen = () => {
   }, []);
 
   const quickAddFormComponent = useMemo(() => (
-    <Animated.View style={animatedQuickAddStyle}>
-      <QuickAddForm
-        colors={colors}
-        t={t}
-        quickAddValues={quickAddValues}
-        setQuickAddValues={setQuickAddValues}
-        accounts={visibleAccounts}
-        filteredCategories={filteredCategories}
-        topCategoriesForType={topCategoriesForType}
-        getCategoryInfo={getCategoryInfo}
-        getAccountName={getAccountName}
-        getAccountBalance={getAccountBalance}
-        getCategoryName={getCategoryName}
-        openPicker={openPicker}
-        handleQuickAdd={handleQuickAdd}
-        handleAmountChange={handleAmountChange}
-        handleExchangeRateChange={handleExchangeRateChange}
-        handleDestinationAmountChange={handleDestinationAmountChange}
-        onAutoAddWithCategory={handleAutoAddWithCategory}
-        topTransferAccounts={topTransferAccountsForForm}
-        onAutoAddWithAccount={handleAutoAddWithAccount}
-        TYPES={TYPES}
-        rateSource={rateSource}
-      />
-    </Animated.View>
-  ), [animatedQuickAddStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource]);
+    <>
+      <Animated.View style={animatedQuickAddStyle}>
+        <QuickAddForm
+          colors={colors}
+          t={t}
+          quickAddValues={quickAddValues}
+          setQuickAddValues={setQuickAddValues}
+          accounts={visibleAccounts}
+          filteredCategories={filteredCategories}
+          topCategoriesForType={topCategoriesForType}
+          getCategoryInfo={getCategoryInfo}
+          getAccountName={getAccountName}
+          getAccountBalance={getAccountBalance}
+          getCategoryName={getCategoryName}
+          openPicker={openPicker}
+          handleQuickAdd={handleQuickAdd}
+          handleAmountChange={handleAmountChange}
+          handleExchangeRateChange={handleExchangeRateChange}
+          handleDestinationAmountChange={handleDestinationAmountChange}
+          onAutoAddWithCategory={handleAutoAddWithCategory}
+          topTransferAccounts={topTransferAccountsForForm}
+          onAutoAddWithAccount={handleAutoAddWithAccount}
+          TYPES={TYPES}
+          rateSource={rateSource}
+        />
+      </Animated.View>
+      {filterPanelHeight > 0 && <View style={{ height: filterPanelHeight }} />}
+    </>
+  ), [animatedQuickAddStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, filterPanelHeight]);
 
   // Handle scroll event to show/hide scroll-to-top button
   const handleScroll = useCallback((event) => {
@@ -722,6 +726,7 @@ const OperationsScreen = () => {
       <SearchOverlay
         visible={searchMode === 'open'}
         onClose={() => {}}
+        onHeightChange={setFilterPanelHeight}
         colors={colors}
         t={t}
       />

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -66,7 +66,7 @@ const OperationsScreen = () => {
   const [pendingSuggestions, setPendingSuggestions] = useState([]);
   const [filterPanelHeight, setFilterPanelHeight] = useState(0);
 
-  const { searchMode } = useSearch();
+  const { searchMode, filtersExpanded } = useSearch();
   const quickAddOpacity = useSharedValue(1);
   const quickAddMaxHeight = useSharedValue(1000); // Large enough to not clip
 
@@ -601,9 +601,9 @@ const OperationsScreen = () => {
           rateSource={rateSource}
         />
       </Animated.View>
-      {filterPanelHeight > 0 && <View style={{ height: filterPanelHeight }} />}
+      {filtersExpanded && filterPanelHeight > 0 && <View style={{ height: filterPanelHeight }} />}
     </>
-  ), [animatedQuickAddStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, filterPanelHeight]);
+  ), [animatedQuickAddStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, filterPanelHeight, filtersExpanded]);
 
   // Handle scroll event to show/hide scroll-to-top button
   const handleScroll = useCallback((event) => {

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -646,6 +646,14 @@ const OperationsScreen = () => {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {/* Search Overlay - renders filters when search is open, above the list */}
+      <SearchOverlay
+        visible={searchMode === 'open'}
+        onClose={() => {}}
+        colors={colors}
+        t={t}
+      />
+
       <OperationsList
         ref={flatListRef}
         groupedOperations={groupedOperations}
@@ -717,14 +725,6 @@ const OperationsScreen = () => {
           onChange={handleDatePickerChange}
         />
       )}
-
-      {/* Search Overlay - renders filters when search is open */}
-      <SearchOverlay
-        visible={searchMode === 'open'}
-        onClose={() => {}}
-        colors={colors}
-        t={t}
-      />
     </View>
   );
 };

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -646,14 +646,6 @@ const OperationsScreen = () => {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      {/* Search Overlay - renders filters when search is open, above the list */}
-      <SearchOverlay
-        visible={searchMode === 'open'}
-        onClose={() => {}}
-        colors={colors}
-        t={t}
-      />
-
       <OperationsList
         ref={flatListRef}
         groupedOperations={groupedOperations}
@@ -725,6 +717,14 @@ const OperationsScreen = () => {
           onChange={handleDatePickerChange}
         />
       )}
+
+      {/* Search Overlay - renders filters when search is open */}
+      <SearchOverlay
+        visible={searchMode === 'open'}
+        onClose={() => {}}
+        colors={colors}
+        t={t}
+      />
     </View>
   );
 };

--- a/docs/superpowers/plans/2026-05-02-search-filter-redesign.md
+++ b/docs/superpowers/plans/2026-05-02-search-filter-redesign.md
@@ -1,0 +1,1062 @@
+# Search Filter Panel Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the clunky flat filter dropdown with a card-styled top-anchored panel, add a `FilterChipStrip` showing active filters as removable chips below the search bar, and fix two bundled bugs (amount decimal loss, filter icon active state).
+
+**Architecture:** `FilterChipStrip` is a new horizontal scroll of per-group chips rendered in `Header.js` below `SearchBar`. The existing `SearchOverlay` gains card styling (rounded bottom corners, shadow). `ExpandableFilters` replaces checkboxes with chips, adds a clear-all button, and fixes amount parsing. No changes to context or screen files.
+
+**Tech Stack:** React Native, `@expo/vector-icons` (MaterialCommunityIcons), `@testing-library/react-native`, Jest
+
+---
+
+## File Map
+
+| Status | File | Change |
+|---|---|---|
+| CREATE | `app/components/search/FilterChipStrip.js` | new chip strip component |
+| CREATE | `__tests__/components/search/FilterChipStrip.test.js` | tests for chip strip |
+| MODIFY | `app/components/search/SearchBar.js` | filter icon active color |
+| MODIFY | `__tests__/components/search/SearchBar.test.js` | test filter icon color |
+| MODIFY | `app/components/search/SearchOverlay.js` | card styling (shadow, border-radius) |
+| MODIFY | `app/components/search/ExpandableFilters.js` | chips, compact labels, clear-all, fix amount parsing |
+| MODIFY | `__tests__/components/search/ExpandableFilters.test.js` | update for chips + new behaviors |
+| MODIFY | `app/components/Header.js` | render FilterChipStrip, add handleClearFilterGroup |
+
+---
+
+## Task 1: SearchBar — filter icon uses primary color when active
+
+**Files:**
+- Modify: `app/components/search/SearchBar.js:77`
+- Modify: `__tests__/components/search/SearchBar.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside the existing `describe('SearchBar filter button active state')` block in `__tests__/components/search/SearchBar.test.js`:
+
+```js
+it('filter icon uses primary color when filterCount > 0', () => {
+  const { getByTestId } = render(
+    <SearchBar {...defaultProps} filterCount={2} colors={{ ...mockColors, primary: '#FF3B30' }} />,
+  );
+  const button = getByTestId('filters-toggle-button');
+  // The Icon inside has the color prop — find it via UNSAFE_getByProps
+  const icon = button.findAllByType(require('@expo/vector-icons').MaterialCommunityIcons)[0];
+  expect(icon.props.color).toBe('#FF3B30');
+});
+
+it('filter icon uses text color when filterCount is 0', () => {
+  const { getByTestId } = render(
+    <SearchBar {...defaultProps} filterCount={0} colors={{ ...mockColors, text: '#CCCCCC' }} />,
+  );
+  const button = getByTestId('filters-toggle-button');
+  const icon = button.findAllByType(require('@expo/vector-icons').MaterialCommunityIcons)[0];
+  expect(icon.props.color).toBe('#CCCCCC');
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+npm test -- --silent --testPathPattern="SearchBar"
+```
+
+Expected: 2 new tests FAIL with color mismatch.
+
+- [ ] **Step 3: Implement**
+
+In `app/components/search/SearchBar.js`, find the `Icon` inside the filter button (line ~77) and change `color={colors.text}` to:
+
+```jsx
+<Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+npm test -- --silent --testPathPattern="SearchBar"
+```
+
+Expected: all SearchBar tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/search/SearchBar.js __tests__/components/search/SearchBar.test.js
+git commit -m "fix(search): filter icon uses primary color when filters are active"
+```
+
+---
+
+## Task 2: SearchOverlay — card styling
+
+**Files:**
+- Modify: `app/components/search/SearchOverlay.js:85-101` (styles block)
+
+> Visual-only change. No behavioral tests needed — existing SearchOverlay tests should continue to pass without modification.
+
+- [ ] **Step 1: Verify existing tests pass before touching anything**
+
+```bash
+npm test -- --silent --testPathPattern="SearchOverlay"
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Update `filtersContainer` style**
+
+In `app/components/search/SearchOverlay.js`, replace the `filtersContainer` style entry:
+
+```js
+// before
+filtersContainer: {
+  left: 0,
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  zIndex: 50,
+},
+
+// after
+filtersContainer: {
+  borderBottomLeftRadius: 14,
+  borderBottomRightRadius: 14,
+  elevation: 8,
+  left: 0,
+  position: 'absolute',
+  right: 0,
+  shadowColor: '#000',
+  shadowOffset: { width: 0, height: 6 },
+  shadowOpacity: 0.35,
+  shadowRadius: 10,
+  top: 0,
+  zIndex: 50,
+},
+```
+
+- [ ] **Step 3: Run to verify existing tests still pass**
+
+```bash
+npm test -- --silent --testPathPattern="SearchOverlay"
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/search/SearchOverlay.js
+git commit -m "style(search): add card styling to filter panel (rounded corners, shadow)"
+```
+
+---
+
+## Task 3: ExpandableFilters — compact labels + clear-all button
+
+**Files:**
+- Modify: `app/components/search/ExpandableFilters.js`
+- Modify: `__tests__/components/search/ExpandableFilters.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Add these to `__tests__/components/search/ExpandableFilters.test.js`:
+
+```js
+it('renders clear all button', () => {
+  const { getByTestId } = render(<ExpandableFilters {...defaultProps} />);
+  expect(getByTestId('clear-all-button')).toBeTruthy();
+});
+
+it('calls onFilterChange with all groups reset when clear all is pressed', () => {
+  const { getByTestId } = render(<ExpandableFilters {...defaultProps} />);
+  fireEvent.press(getByTestId('clear-all-button'));
+  expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
+    types: [],
+    accountIds: [],
+    categoryIds: [],
+    dateRange: { startDate: null, endDate: null },
+    amountRange: { min: null, max: null },
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+npm test -- --silent --testPathPattern="ExpandableFilters"
+```
+
+Expected: 2 new tests FAIL.
+
+- [ ] **Step 3: Replace section titles and add clear-all**
+
+In `app/components/search/ExpandableFilters.js`:
+
+**a) Replace every section title `<Text>` with compact label style.** There are 5 sections (Type, Date Range, Amount Range, Accounts, Categories). Replace each:
+
+```jsx
+// before (all 5 sections use this pattern)
+<Text style={[styles.sectionTitle, { color: colors.text }]}>
+  {t('operation_type')}
+</Text>
+
+// after (all 5 sections)
+<Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
+  {t('operation_type')}
+</Text>
+```
+
+Apply to all 5 section titles: `operation_type`, `date_range`, `amount_range`, `accounts`, `categories`.
+
+**b) Add clear-all button** at the bottom of the `<ScrollView>`, after the Categories section and before `</ScrollView>`:
+
+```jsx
+<TouchableOpacity
+  testID="clear-all-button"
+  style={styles.clearAllButton}
+  onPress={() => onFilterChange({
+    types: [],
+    accountIds: [],
+    categoryIds: [],
+    dateRange: { startDate: null, endDate: null },
+    amountRange: { min: null, max: null },
+  })}
+>
+  <Text style={[styles.clearAllText, { color: colors.primary }]}>
+    {t('clear_all')}
+  </Text>
+</TouchableOpacity>
+```
+
+**c) Update the styles block** — remove `sectionTitle`, add `sectionLabel` and clear-all styles:
+
+```js
+// remove:
+sectionTitle: {
+  fontSize: 16,
+  fontWeight: '600',
+  marginBottom: 10,
+},
+
+// add:
+sectionLabel: {
+  fontSize: 11,
+  fontWeight: '600',
+  letterSpacing: 0.5,
+  marginBottom: 10,
+  textTransform: 'uppercase',
+},
+clearAllButton: {
+  alignItems: 'center',
+  paddingVertical: 14,
+},
+clearAllText: {
+  fontSize: 14,
+  fontWeight: '600',
+},
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+npm test -- --silent --testPathPattern="ExpandableFilters"
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/search/ExpandableFilters.js __tests__/components/search/ExpandableFilters.test.js
+git commit -m "feat(search): compact filter section labels and clear-all button"
+```
+
+---
+
+## Task 4: ExpandableFilters — chips for accounts and categories
+
+**Files:**
+- Modify: `app/components/search/ExpandableFilters.js`
+- Modify: `__tests__/components/search/ExpandableFilters.test.js`
+
+- [ ] **Step 1: Update existing tests**
+
+The test `'renders account checkboxes'` and `'calls onFilterChange when account checkbox is pressed'` still test the same behavior, just with chips instead of checkboxes. The test bodies don't need to change — they find by text and fire press, which works for chips too. No test changes needed for this task.
+
+- [ ] **Step 2: Verify tests pass before touching anything**
+
+```bash
+npm test -- --silent --testPathPattern="ExpandableFilters"
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Replace accounts checkboxes with chips**
+
+In `app/components/search/ExpandableFilters.js`, replace the entire accounts rendering block:
+
+```jsx
+// before
+{accounts.map(account => {
+  const isSelected = filters.accountIds.includes(account.id);
+  return (
+    <TouchableOpacity
+      key={account.id}
+      style={[styles.checkboxItem, { borderBottomColor: colors.border }]}
+      onPress={() => toggleAccount(account.id)}
+    >
+      <Icon
+        name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'}
+        size={24}
+        color={isSelected ? colors.primary : colors.mutedText}
+      />
+      <Text style={[styles.checkboxLabel, { color: colors.text }]}>
+        {account.name}
+      </Text>
+    </TouchableOpacity>
+  );
+})}
+
+// after
+<View style={styles.chipContainer}>
+  {accounts.map(account => {
+    const isSelected = filters.accountIds.includes(account.id);
+    return (
+      <TouchableOpacity
+        key={account.id}
+        style={[styles.chip, {
+          backgroundColor: isSelected ? colors.primary : colors.inputBackground,
+          borderColor: colors.border,
+        }]}
+        onPress={() => toggleAccount(account.id)}
+      >
+        <Text style={[styles.chipText, { color: isSelected ? '#fff' : colors.text }]}>
+          {account.name}
+        </Text>
+      </TouchableOpacity>
+    );
+  })}
+</View>
+```
+
+- [ ] **Step 4: Replace categories checkboxes with chips**
+
+Replace the entire categories rendering block:
+
+```jsx
+// before
+{categories.filter(c => !c.isShadow).map(category => {
+  const isSelected = filters.categoryIds.includes(category.id);
+  return (
+    <TouchableOpacity
+      key={category.id}
+      style={[styles.checkboxItem, { borderBottomColor: colors.border }]}
+      onPress={() => toggleCategory(category.id)}
+    >
+      <Icon
+        name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'}
+        size={24}
+        color={isSelected ? colors.primary : colors.mutedText}
+      />
+      <Icon name={category.icon || 'tag'} size={20} color={colors.text} style={styles.categoryIcon} />
+      <Text style={[styles.checkboxLabel, { color: colors.text }]}>
+        {category.nameKey ? t(category.nameKey) : category.name}
+      </Text>
+    </TouchableOpacity>
+  );
+})}
+
+// after
+<View style={styles.chipContainer}>
+  {categories.filter(c => !c.isShadow).map(category => {
+    const isSelected = filters.categoryIds.includes(category.id);
+    return (
+      <TouchableOpacity
+        key={category.id}
+        style={[styles.chip, {
+          backgroundColor: isSelected ? colors.primary : colors.inputBackground,
+          borderColor: colors.border,
+        }]}
+        onPress={() => toggleCategory(category.id)}
+      >
+        <Icon
+          name={category.icon || 'tag'}
+          size={14}
+          color={isSelected ? '#fff' : colors.text}
+        />
+        <Text style={[styles.chipText, { color: isSelected ? '#fff' : colors.text }]}>
+          {category.nameKey ? t(category.nameKey) : category.name}
+        </Text>
+      </TouchableOpacity>
+    );
+  })}
+</View>
+```
+
+- [ ] **Step 5: Remove dead styles**
+
+In the `StyleSheet.create` block, remove `checkboxItem`, `checkboxLabel`, and `categoryIcon` — they are no longer referenced.
+
+- [ ] **Step 6: Run to verify pass**
+
+```bash
+npm test -- --silent --testPathPattern="ExpandableFilters"
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/search/ExpandableFilters.js
+git commit -m "feat(search): replace account/category checkboxes with chips in filter panel"
+```
+
+---
+
+## Task 5: ExpandableFilters — fix amount input decimal loss
+
+**Files:**
+- Modify: `app/components/search/ExpandableFilters.js`
+- Modify: `__tests__/components/search/ExpandableFilters.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `__tests__/components/search/ExpandableFilters.test.js`:
+
+```js
+describe('Amount range input', () => {
+  it('preserves decimal point mid-typing without calling onFilterChange', () => {
+    const { getByPlaceholderText } = render(<ExpandableFilters {...defaultProps} />);
+    const minInput = getByPlaceholderText('min_amount');
+
+    fireEvent.changeText(minInput, '1.');
+
+    // onFilterChange should NOT be called while still typing
+    expect(defaultProps.onFilterChange).not.toHaveBeenCalled();
+    // Input should still show '1.'
+    expect(minInput.props.value).toBe('1.');
+  });
+
+  it('calls onFilterChange with parsed float on blur', () => {
+    const { getByPlaceholderText } = render(<ExpandableFilters {...defaultProps} />);
+    const minInput = getByPlaceholderText('min_amount');
+
+    fireEvent.changeText(minInput, '1.5');
+    fireEvent(minInput, 'blur');
+
+    expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
+      amountRange: { min: 1.5, max: null },
+    });
+  });
+
+  it('calls onFilterChange with null on blur when input cleared', () => {
+    const { getByPlaceholderText } = render(
+      <ExpandableFilters {...defaultProps} filters={{ ...defaultFilters, amountRange: { min: 5, max: null } }} />,
+    );
+    const minInput = getByPlaceholderText('min_amount');
+
+    fireEvent.changeText(minInput, '');
+    fireEvent(minInput, 'blur');
+
+    expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
+      amountRange: { min: null, max: null },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+npm test -- --silent --testPathPattern="ExpandableFilters"
+```
+
+Expected: 3 new tests FAIL.
+
+- [ ] **Step 3: Add local string state for amounts**
+
+At the top of the `ExpandableFilters` component body (after the date picker state declarations), add:
+
+```js
+const [localMinAmount, setLocalMinAmount] = useState(
+  filters.amountRange.min !== null ? String(filters.amountRange.min) : '',
+);
+const [localMaxAmount, setLocalMaxAmount] = useState(
+  filters.amountRange.max !== null ? String(filters.amountRange.max) : '',
+);
+```
+
+- [ ] **Step 4: Replace both amount TextInputs**
+
+Replace the min `TextInput`:
+
+```jsx
+// before
+<TextInput
+  style={[styles.amountInput, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
+  value={filters.amountRange.min !== null ? String(filters.amountRange.min) : ''}
+  onChangeText={(text) => {
+    const value = text === '' ? null : parseFloat(text);
+    onFilterChange({ amountRange: { ...filters.amountRange, min: value } });
+  }}
+  placeholder={t('min_amount')}
+  placeholderTextColor={colors.mutedText}
+  keyboardType="numeric"
+/>
+
+// after
+<TextInput
+  style={[styles.amountInput, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
+  value={localMinAmount}
+  onChangeText={setLocalMinAmount}
+  onBlur={() => {
+    const value = localMinAmount === '' ? null : parseFloat(localMinAmount);
+    onFilterChange({ amountRange: { ...filters.amountRange, min: isNaN(value) ? null : value } });
+  }}
+  placeholder={t('min_amount')}
+  placeholderTextColor={colors.mutedText}
+  keyboardType="numeric"
+/>
+```
+
+Replace the max `TextInput`:
+
+```jsx
+// before
+<TextInput
+  style={[styles.amountInput, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
+  value={filters.amountRange.max !== null ? String(filters.amountRange.max) : ''}
+  onChangeText={(text) => {
+    const value = text === '' ? null : parseFloat(text);
+    onFilterChange({ amountRange: { ...filters.amountRange, max: value } });
+  }}
+  placeholder={t('max_amount')}
+  placeholderTextColor={colors.mutedText}
+  keyboardType="numeric"
+/>
+
+// after
+<TextInput
+  style={[styles.amountInput, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder, color: colors.text }]}
+  value={localMaxAmount}
+  onChangeText={setLocalMaxAmount}
+  onBlur={() => {
+    const value = localMaxAmount === '' ? null : parseFloat(localMaxAmount);
+    onFilterChange({ amountRange: { ...filters.amountRange, max: isNaN(value) ? null : value } });
+  }}
+  placeholder={t('max_amount')}
+  placeholderTextColor={colors.mutedText}
+  keyboardType="numeric"
+/>
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+```bash
+npm test -- --silent --testPathPattern="ExpandableFilters"
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/search/ExpandableFilters.js __tests__/components/search/ExpandableFilters.test.js
+git commit -m "fix(search): preserve decimal point mid-typing in amount range inputs"
+```
+
+---
+
+## Task 6: FilterChipStrip — new component
+
+**Files:**
+- Create: `app/components/search/FilterChipStrip.js`
+- Create: `__tests__/components/search/FilterChipStrip.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `__tests__/components/search/FilterChipStrip.test.js`:
+
+```js
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import FilterChipStrip from '../../../app/components/search/FilterChipStrip';
+
+describe('FilterChipStrip', () => {
+  const mockColors = {
+    surface: '#1A1A1A',
+    primary: '#007AFF',
+    border: '#333333',
+    text: '#FFFFFF',
+  };
+  const mockT = (key) => key;
+
+  const emptySearchState = {
+    text: '',
+    types: [],
+    accountIds: [],
+    categoryIds: [],
+    dateRange: { startDate: null, endDate: null },
+    amountRange: { min: null, max: null },
+  };
+
+  const defaultProps = {
+    searchState: emptySearchState,
+    onClearGroup: jest.fn(),
+    colors: mockColors,
+    t: mockT,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when no filter groups are active', () => {
+    const { toJSON } = render(<FilterChipStrip {...defaultProps} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders a chip for active types (single type shows type name)', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, types: ['expense'] }}
+      />,
+    );
+    expect(getByText('expense')).toBeTruthy();
+  });
+
+  it('renders "operation_type: N" for multiple active types', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, types: ['expense', 'income'] }}
+      />,
+    );
+    expect(getByText('operation_type: 2')).toBeTruthy();
+  });
+
+  it('renders a chip for active date range (both dates)', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, dateRange: { startDate: '2024-04-01', endDate: '2024-04-30' } }}
+      />,
+    );
+    expect(getByTestId('chip-dateRange')).toBeTruthy();
+  });
+
+  it('renders a chip for start date only', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, dateRange: { startDate: '2024-04-01', endDate: null } }}
+      />,
+    );
+    expect(getByTestId('chip-dateRange')).toBeTruthy();
+  });
+
+  it('renders "accounts: N" chip for active accountIds', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, accountIds: ['a1', 'a2'] }}
+      />,
+    );
+    expect(getByText('accounts: 2')).toBeTruthy();
+  });
+
+  it('renders "categories: N" chip for active categoryIds', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, categoryIds: ['c1'] }}
+      />,
+    );
+    expect(getByText('categories: 1')).toBeTruthy();
+  });
+
+  it('renders "> min" label for min-only amount range', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, amountRange: { min: 50, max: null } }}
+      />,
+    );
+    expect(getByText('> 50')).toBeTruthy();
+  });
+
+  it('renders "< max" label for max-only amount range', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, amountRange: { min: null, max: 200 } }}
+      />,
+    );
+    expect(getByText('< 200')).toBeTruthy();
+  });
+
+  it('renders "min – max" label for both amount bounds', () => {
+    const { getByText } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, amountRange: { min: 50, max: 200 } }}
+      />,
+    );
+    expect(getByText('50 – 200')).toBeTruthy();
+  });
+
+  it('calls onClearGroup with "types" when types chip ✕ is pressed', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, types: ['expense'] }}
+      />,
+    );
+    fireEvent.press(getByTestId('clear-chip-types'));
+    expect(defaultProps.onClearGroup).toHaveBeenCalledWith('types');
+  });
+
+  it('calls onClearGroup with "accountIds" when accounts chip ✕ is pressed', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{ ...emptySearchState, accountIds: ['a1'] }}
+      />,
+    );
+    fireEvent.press(getByTestId('clear-chip-accountIds'));
+    expect(defaultProps.onClearGroup).toHaveBeenCalledWith('accountIds');
+  });
+
+  it('renders multiple chips when multiple groups are active', () => {
+    const { getByTestId } = render(
+      <FilterChipStrip
+        {...defaultProps}
+        searchState={{
+          ...emptySearchState,
+          types: ['expense'],
+          accountIds: ['a1'],
+          categoryIds: ['c1'],
+        }}
+      />,
+    );
+    expect(getByTestId('chip-types')).toBeTruthy();
+    expect(getByTestId('chip-accountIds')).toBeTruthy();
+    expect(getByTestId('chip-categoryIds')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+```bash
+npm test -- --silent --testPathPattern="FilterChipStrip"
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the component**
+
+Create `app/components/search/FilterChipStrip.js`:
+
+```js
+import React from 'react';
+import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import { HORIZONTAL_PADDING } from '../../styles/layout';
+
+const formatDateLabel = (dateRange) => {
+  const { startDate, endDate } = dateRange;
+  const fmt = (d) =>
+    new Date(d).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  if (startDate && endDate) return `${fmt(startDate)} – ${fmt(endDate)}`;
+  if (startDate) return `${fmt(startDate)} –`;
+  if (endDate) return `– ${fmt(endDate)}`;
+  return null;
+};
+
+const formatAmountLabel = (amountRange) => {
+  const { min, max } = amountRange;
+  if (min !== null && max !== null) return `${min} – ${max}`;
+  if (min !== null) return `> ${min}`;
+  if (max !== null) return `< ${max}`;
+  return null;
+};
+
+const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
+  const chips = [];
+
+  if (searchState.types.length > 0) {
+    const label =
+      searchState.types.length === 1
+        ? t(searchState.types[0])
+        : `${t('operation_type')}: ${searchState.types.length}`;
+    chips.push({ key: 'types', label });
+  }
+
+  if (searchState.dateRange.startDate || searchState.dateRange.endDate) {
+    chips.push({ key: 'dateRange', label: formatDateLabel(searchState.dateRange) });
+  }
+
+  if (searchState.amountRange.min !== null || searchState.amountRange.max !== null) {
+    chips.push({ key: 'amountRange', label: formatAmountLabel(searchState.amountRange) });
+  }
+
+  if (searchState.accountIds.length > 0) {
+    chips.push({ key: 'accountIds', label: `${t('accounts')}: ${searchState.accountIds.length}` });
+  }
+
+  if (searchState.categoryIds.length > 0) {
+    chips.push({
+      key: 'categoryIds',
+      label: `${t('categories')}: ${searchState.categoryIds.length}`,
+    });
+  }
+
+  if (chips.length === 0) {
+    return null;
+  }
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={[styles.container, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}
+      contentContainerStyle={styles.content}
+    >
+      {chips.map(({ key, label }) => (
+        <View
+          key={key}
+          testID={`chip-${key}`}
+          style={[
+            styles.chip,
+            { backgroundColor: `${colors.primary}20`, borderColor: colors.primary },
+          ]}
+        >
+          <Text style={[styles.chipText, { color: colors.primary }]}>{label}</Text>
+          <TouchableOpacity
+            testID={`clear-chip-${key}`}
+            onPress={() => onClearGroup(key)}
+            hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
+          >
+            <Icon name="close" size={13} color={colors.primary} />
+          </TouchableOpacity>
+        </View>
+      ))}
+    </ScrollView>
+  );
+};
+
+FilterChipStrip.propTypes = {
+  searchState: PropTypes.shape({
+    types: PropTypes.array.isRequired,
+    accountIds: PropTypes.array.isRequired,
+    categoryIds: PropTypes.array.isRequired,
+    dateRange: PropTypes.shape({
+      startDate: PropTypes.string,
+      endDate: PropTypes.string,
+    }).isRequired,
+    amountRange: PropTypes.shape({
+      min: PropTypes.number,
+      max: PropTypes.number,
+    }).isRequired,
+  }).isRequired,
+  onClearGroup: PropTypes.func.isRequired,
+  colors: PropTypes.shape({
+    surface: PropTypes.string.isRequired,
+    primary: PropTypes.string.isRequired,
+    border: PropTypes.string.isRequired,
+  }).isRequired,
+  t: PropTypes.func.isRequired,
+};
+
+const styles = StyleSheet.create({
+  chip: {
+    alignItems: 'center',
+    borderRadius: 14,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 5,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  chipText: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  container: {
+    borderBottomWidth: 1,
+  },
+  content: {
+    gap: 7,
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: 7,
+  },
+});
+
+export default FilterChipStrip;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+```bash
+npm test -- --silent --testPathPattern="FilterChipStrip"
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/search/FilterChipStrip.js __tests__/components/search/FilterChipStrip.test.js
+git commit -m "feat(search): add FilterChipStrip component for active filter chips"
+```
+
+---
+
+## Task 7: Header — render FilterChipStrip
+
+**Files:**
+- Modify: `app/components/Header.js`
+
+> Header tests live in `__tests__/components/Header.test.js` and `__tests__/components/Header-rightContent.test.js`. Check they still pass after this task — no new tests required since FilterChipStrip is already covered by its own test suite and the logic here is a simple conditional render.
+
+- [ ] **Step 1: Verify Header tests pass before touching anything**
+
+```bash
+npm test -- --silent --testPathPattern="Header"
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Add imports to Header.js**
+
+At the top of `app/components/Header.js`, add:
+
+```js
+import FilterChipStrip from './search/FilterChipStrip';
+```
+
+Also destructure `updateSearchFilters` from `useOperationsActions` (it's already imported):
+
+```js
+// find this line:
+const { setSearchText } = useOperationsActions();
+
+// change to:
+const { setSearchText, updateSearchFilters } = useOperationsActions();
+```
+
+- [ ] **Step 3: Add handleClearFilterGroup**
+
+Inside the `Header` function body, after `handleToggleFilters`, add:
+
+```js
+const handleClearFilterGroup = useCallback((groupKey) => {
+  const clearValues = {
+    types: { types: [] },
+    dateRange: { dateRange: { startDate: null, endDate: null } },
+    amountRange: { amountRange: { min: null, max: null } },
+    accountIds: { accountIds: [] },
+    categoryIds: { categoryIds: [] },
+  };
+  updateSearchFilters(clearValues[groupKey]);
+}, [updateSearchFilters]);
+```
+
+- [ ] **Step 4: Wrap the search-mode branch in a column container and add the chip strip**
+
+The outer `<View style={[styles.container, ...]}>` is currently `flexDirection: 'row'`. When search is open, we need a column layout so SearchBar and FilterChipStrip stack vertically.
+
+Replace the return statement's outer View and the `searchMode === 'open'` branch:
+
+```jsx
+return (
+  <View
+    style={[
+      styles.container,
+      { backgroundColor: colors.background, borderBottomColor: colors.border },
+      searchMode === 'open' && styles.containerSearchMode,
+    ]}
+  >
+    {searchMode === 'open' ? (
+      <>
+        <SearchBar
+          searchText={searchState?.text || ''}
+          onSearchTextChange={setSearchText}
+          onToggleFilters={handleToggleFilters}
+          onClose={handleCloseSearch}
+          filterCount={getSearchFilterCount ? getSearchFilterCount() : 0}
+          colors={colors}
+          t={t}
+        />
+        {hasActiveSearch && (
+          <FilterChipStrip
+            searchState={searchState}
+            onClearGroup={handleClearFilterGroup}
+            colors={colors}
+            t={t}
+          />
+        )}
+      </>
+    ) : (
+      // ... existing non-search content unchanged ...
+    )}
+  </View>
+);
+```
+
+- [ ] **Step 5: Add `containerSearchMode` style**
+
+In the `StyleSheet.create` block of `Header.js`, add:
+
+```js
+containerSearchMode: {
+  alignItems: 'stretch',
+  flexDirection: 'column',
+  paddingHorizontal: 0,
+},
+```
+
+(`SearchBar` and `FilterChipStrip` each handle their own `paddingHorizontal` via `HORIZONTAL_PADDING`.)
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+npm test -- --silent
+```
+
+Expected: all tests pass. If any Header tests fail due to the layout change, update them to reflect the new structure.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/Header.js
+git commit -m "feat(search): render FilterChipStrip in header when search open with active filters"
+```
+
+---
+
+## Task 8: Full test run + cleanup
+
+- [ ] **Step 1: Run the full suite**
+
+```bash
+npm test -- --silent
+```
+
+Expected: 0 failed tests.
+
+- [ ] **Step 2: If any failures, fix them before proceeding**
+
+Common causes: Header layout tests checking `flexDirection` or `paddingHorizontal` on the container. Update assertions to match the new conditional style.
+
+- [ ] **Step 3: Final commit if any cleanup was needed**
+
+```bash
+git add -A
+git commit -m "test: fix header layout test assertions for search mode column layout"
+```

--- a/docs/superpowers/specs/2026-05-02-search-filter-redesign.md
+++ b/docs/superpowers/specs/2026-05-02-search-filter-redesign.md
@@ -1,0 +1,131 @@
+# Search Filter Panel Redesign
+
+**Date:** 2026-05-02
+**Status:** Approved
+
+## Problem
+
+The filter dropdown panel is visually broken: it renders as a flat unstyled overlay below the search bar with large dead space at the bottom, checkboxes that look inconsistent with the type chips, heavy section titles, and no visual affordance for dismissal. It doesn't read as a foreground UI layer.
+
+## Solution
+
+Redesign the filter panel as a proper card-styled dropdown (top-anchored, drops down) and add a `FilterChipStrip` that shows active filters as removable chips between the search bar and the operations list.
+
+## Design Decisions
+
+- **Panel anchor:** top-anchored, drops down from below the search bar / chip strip. Not a bottom sheet.
+- **Chip strip visibility:** only when `searchMode === 'open'` AND at least one filter group is active. Absent otherwise — no placeholder strip when idle.
+- **Chip granularity:** one chip per filter group (not per item). Tapping ✕ on a chip clears that entire group.
+- **Collapsed state:** unchanged — badge on the search icon when filters active, no chip strip.
+
+## Components
+
+### New: `app/components/search/FilterChipStrip.js`
+
+A horizontally scrollable row of active-filter chips rendered in `Header.js` below `SearchBar` when search is open and filters are active.
+
+**Props:**
+```js
+{
+  searchState,        // from useOperationsData()
+  onClearGroup,       // (groupKey) => void — clears one filter group
+  colors,
+  t,
+}
+```
+
+**Chip labels per group:**
+
+| Group | 1 active | 2+ active |
+|---|---|---|
+| types | type name (e.g. "Expense") | "Type: N" |
+| dateRange | "Apr 1 – Apr 30" / "From Apr 1" / "Until Apr 30" | — |
+| amountRange | "> 50" / "< 200" / "50 – 200" | — |
+| accountIds | "Accounts: N" | — |
+| categoryIds | "Categories: N" | — |
+
+**Clear group behavior:**
+
+| Group key | Clears |
+|---|---|
+| `types` | `types: []` |
+| `dateRange` | `dateRange: { startDate: null, endDate: null }` |
+| `amountRange` | `amountRange: { min: null, max: null }` |
+| `accountIds` | `accountIds: []` |
+| `categoryIds` | `categoryIds: []` |
+
+### Modified: `app/components/search/ExpandableFilters.js`
+
+**Changes:**
+1. Replace account and category checkboxes with chips (matching the existing type chips style).
+2. Reduce section title weight: replace `fontSize: 16, fontWeight: '600'` labels with compact uppercase labels (`fontSize: 11, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.5, color: colors.mutedText`).
+3. Add a "Clear all" `TouchableOpacity` at the bottom of the scroll view that calls `onFilterChange` to reset all groups.
+4. Fix amount input parsing: store min/max as local string state, call `onFilterChange` with `parseFloat` only `onBlur` (not `onChangeText`). Prevents "1." snapping to "1" mid-typing.
+
+### Modified: `app/components/search/SearchOverlay.js`
+
+**Changes:**
+1. Add card styling to `filtersContainer`: `borderBottomLeftRadius: 14, borderBottomRightRadius: 14, elevation: 8, shadowColor: '#000', shadowOffset: { width: 0, height: 6 }, shadowOpacity: 0.35, shadowRadius: 10`.
+2. The existing backdrop (`overlayBackdrop`) already handles dimming — no change needed there.
+
+### Modified: `app/components/search/SearchBar.js`
+
+**Change:** Filter icon color: use `colors.primary` when `filterCount > 0`, else `colors.text`.
+
+```js
+// before
+<Icon name="filter-variant" size={22} color={colors.text} />
+
+// after
+<Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
+```
+
+### Modified: `app/components/Header.js`
+
+**Change:** Render `FilterChipStrip` below `SearchBar` when `searchMode === 'open'` and `hasActiveSearch`.
+
+```jsx
+{searchMode === 'open' ? (
+  <>
+    <SearchBar ... />
+    {hasActiveSearch && (
+      <FilterChipStrip
+        searchState={searchState}
+        onClearGroup={handleClearFilterGroup}
+        colors={colors}
+        t={t}
+      />
+    )}
+  </>
+) : ( ... )}
+```
+
+`handleClearFilterGroup(groupKey)` calls `updateSearchFilters` (from `useOperationsActions`) with the reset value for that group.
+
+## Bug Fixes Bundled
+
+1. **Amount input decimal loss** — `ExpandableFilters` uses `parseFloat` on every keystroke, causing "1." to snap to "1". Fixed by local string state + parse on blur.
+2. **Filter icon no active state** — `SearchBar` filter icon stays `colors.text` regardless of active filters. Fixed to use `colors.primary` when `filterCount > 0`.
+
+## Out of Scope
+
+- Category hierarchy in filter selection (the filter only matches exact `categoryId`, unlike text search which walks the hierarchy). Known inconsistency, separate issue.
+- Amount range slider (text inputs kept, just bug-fixed).
+- Any changes to `SearchContext`, `OperationsDataContext`, or `OperationsScreen`.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `app/components/search/FilterChipStrip.js` | **CREATE** |
+| `app/components/search/ExpandableFilters.js` | chips, compact labels, clear-all, fix amount parsing |
+| `app/components/search/SearchOverlay.js` | card styling on filter panel |
+| `app/components/search/SearchBar.js` | filter icon active color |
+| `app/components/Header.js` | render FilterChipStrip |
+
+## Tests Required
+
+- `FilterChipStrip`: chip renders per active group, correct labels, ✕ clears correct group, absent when no filters active
+- `ExpandableFilters`: amount input preserves decimal mid-type, clear-all resets all groups, accounts/categories render as chips
+- `SearchBar`: filter icon color switches with filterCount
+- Integration: chip strip visible/hidden based on search mode + filter state


### PR DESCRIPTION
## Summary

- **Filter panel card styling** — rounded bottom corners, drop shadow; reads as a foreground surface instead of a flat overlay
- **Active filter chips** — horizontal chip strip appears below the search bar when filters are active (one chip per group, tap ✕ to clear); search icon badge unchanged in collapsed mode
- **All items as chips** — accounts replaced checkboxes with chips, consistent with the type section
- **Compact section labels** — reduced from 16px bold to 11px uppercase muted labels
- **Clear All button** — inside the filter panel
- **Categories removed from filter UI** — too many items; categoryIds state and filtering logic untouched
- **Filter panel background** — matches header (`colors.background` instead of `colors.surface`)
- **List visible below panel** — filter panel stays absolute-positioned; backdrop removed so list shows through below; first filtered item pushed below panel via `onLayout`-measured spacer in FlatList header
- **No loading spinner on filter/text changes** — stabilised `loadInitialOperations` ref via `activeFiltersRef`; JS filtering in `filteredOperations` runs silently with no loading state
- **Filter icon active state** — turns primary colour when filters are active
- **Amount decimal fix** — `parseFloat` moved to `onBlur`; mid-typing decimals no longer snap

## Test plan

- [ ] Open search → tap filter icon → panel expands with TYPE / DATE RANGE / AMOUNT RANGE / ACCOUNTS fully visible without scrolling
- [ ] First operation entry appears directly below the filter panel (no gap)
- [ ] Tap filter icon again → panel collapses, no residual spacing above the list
- [ ] Tap account chip to filter → list updates instantly, no loading spinner
- [ ] Type search text → list filters smoothly, no loading spinner
- [ ] Active filter chips appear below search bar with correct labels; ✕ on a chip clears that group
- [ ] Filter icon turns blue when filters active, grey when none
- [ ] Filter panel and search bar share the same background colour in light and dark themes
- [ ] All 2969 tests passing

🧀
