### PR TITLE
ci: mitigate cache poisoning and untrusted checkout in emulator-screenshots

### DIFF
--- a/.github/workflows/emulator-screenshots.yml
+++ b/.github/workflows/emulator-screenshots.yml
@@ -25,6 +25,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Check commenter permissions
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const level = perm.permission;
+            if (level !== 'admin' && level !== 'write') {
+              core.setFailed(`User ${context.actor} has permission '${level}' — write or admin required to trigger screenshots`);
+            }
+
       - name: Get PR info
         if: github.event_name == 'issue_comment'
         id: pr-info
@@ -48,14 +63,6 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Cache Bun dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-
-
       - name: Install dependencies
         run: bun install
 
@@ -64,17 +71,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-
-      - name: Cache Gradle
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            android/.gradle
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
 
       - name: Enable KVM
         run: |


### PR DESCRIPTION
## Summary

- Adds collaborator permission check (write/admin required) before checking out PR head code in the privileged `issue_comment` context — runtime mitigation for CodeQL alert #4
- Removes Bun and Gradle dependency caching to prevent cache poisoning from untrusted PR code — closes CodeQL alert #6

## Test plan
- [ ] Trigger `/screenshots` as a non-collaborator — workflow should fail at permission check
- [ ] Trigger `/screenshots` as a repo collaborator — workflow should proceed normally (slower without cache)
- [ ] Verify CodeQL alert #6 closes after merge

🧀
