### PR TITLE
feat(quickadd): add second suggested row for categories and transfer accounts

### DIFF
--- a/__tests__/hooks/useQuickAddForm.test.js
+++ b/__tests__/hooks/useQuickAddForm.test.js
@@ -319,15 +319,17 @@ describe('useQuickAddForm', () => {
       );
 
       await waitFor(() => {
-        expect(result.current.topCategoriesForType).toHaveLength(3);
+        // history: cat-e2, cat-e4 (2). fillers: cat-e1, cat-e3 (2 remaining). total: 4
+        expect(result.current.topCategoriesForType).toHaveLength(4);
         expect(result.current.topCategoriesForType[0].id).toBe('cat-e2');
         expect(result.current.topCategoriesForType[1].id).toBe('cat-e4');
         // Filled from remaining leaf categories by id order
         expect(result.current.topCategoriesForType[2].id).toBe('cat-e1');
+        expect(result.current.topCategoriesForType[3].id).toBe('cat-e3');
       });
     });
 
-    it('should fall back to first 3 leaf categories when no history for expense', async () => {
+    it('should fall back to up to 7 leaf categories when no history for expense', async () => {
       mockGetTopCategories.mockResolvedValue([]);
 
       const { result } = renderHook(() =>
@@ -335,14 +337,16 @@ describe('useQuickAddForm', () => {
       );
 
       await waitFor(() => {
-        expect(result.current.topCategoriesForType).toHaveLength(3);
+        // 4 expense leaf categories available, all returned (< 7 limit)
+        expect(result.current.topCategoriesForType).toHaveLength(4);
         expect(result.current.topCategoriesForType[0].id).toBe('cat-e1');
         expect(result.current.topCategoriesForType[1].id).toBe('cat-e2');
         expect(result.current.topCategoriesForType[2].id).toBe('cat-e3');
+        expect(result.current.topCategoriesForType[3].id).toBe('cat-e4');
       });
     });
 
-    it('should fall back to first 3 leaf categories when no history for income', async () => {
+    it('should fall back to up to 7 leaf categories when no history for income', async () => {
       mockGetTopCategories.mockResolvedValue([]);
 
       const { result } = renderHook(() =>
@@ -353,10 +357,12 @@ describe('useQuickAddForm', () => {
         result.current.setQuickAddValues(prev => ({ ...prev, type: 'income' }));
       });
 
-      expect(result.current.topCategoriesForType).toHaveLength(3);
+      // 4 income leaf categories available (cat-i1..i4), all returned (< 7 limit)
+      expect(result.current.topCategoriesForType).toHaveLength(4);
       expect(result.current.topCategoriesForType[0].id).toBe('cat-i1');
       expect(result.current.topCategoriesForType[1].id).toBe('cat-i2');
       expect(result.current.topCategoriesForType[2].id).toBe('cat-i3');
+      expect(result.current.topCategoriesForType[3].id).toBe('cat-i4');
     });
 
     it('should exclude shadow and folder categories from fallback', async () => {
@@ -392,7 +398,8 @@ describe('useQuickAddForm', () => {
 
       const ids = result.current.topCategoriesForType.map(c => c.id);
       expect(ids).not.toContain('cat-folder');
-      expect(result.current.topCategoriesForType).toHaveLength(3);
+      // history: cat-i1, cat-i2 (2). fillers: cat-i3, cat-i4 (2 remaining). total: 4
+      expect(result.current.topCategoriesForType).toHaveLength(4);
       expect(result.current.topCategoriesForType[0].id).toBe('cat-i1');
       expect(result.current.topCategoriesForType[1].id).toBe('cat-i2');
     });
@@ -432,11 +439,13 @@ describe('useQuickAddForm', () => {
         result.current.setQuickAddValues(prev => ({ ...prev, type: 'income' }));
       });
 
-      expect(result.current.topCategoriesForType).toHaveLength(3);
+      // history: cat-i3, cat-i1 (2). fillers: cat-i2, cat-i4 (2 remaining). total: 4
+      expect(result.current.topCategoriesForType).toHaveLength(4);
       expect(result.current.topCategoriesForType[0].id).toBe('cat-i3');
       expect(result.current.topCategoriesForType[1].id).toBe('cat-i1');
       // Filled from remaining leaf categories by id order
       expect(result.current.topCategoriesForType[2].id).toBe('cat-i2');
+      expect(result.current.topCategoriesForType[3].id).toBe('cat-i4');
     });
   });
 
@@ -635,20 +644,30 @@ describe('useQuickAddForm', () => {
       expect(ids).toContain('acc-2');
     });
 
-    it('should limit to 3 accounts', async () => {
+    it('should limit to 8 accounts', async () => {
       const manyAccounts = [
         { id: 'acc-1', name: 'A1', currency: 'USD', balance: '100' },
         { id: 'acc-2', name: 'A2', currency: 'USD', balance: '200' },
         { id: 'acc-3', name: 'A3', currency: 'USD', balance: '300' },
         { id: 'acc-4', name: 'A4', currency: 'USD', balance: '400' },
         { id: 'acc-5', name: 'A5', currency: 'USD', balance: '500' },
+        { id: 'acc-6', name: 'A6', currency: 'USD', balance: '600' },
+        { id: 'acc-7', name: 'A7', currency: 'USD', balance: '700' },
+        { id: 'acc-8', name: 'A8', currency: 'USD', balance: '800' },
+        { id: 'acc-9', name: 'A9', currency: 'USD', balance: '900' },
+        { id: 'acc-10', name: 'A10', currency: 'USD', balance: '1000' },
       ];
 
       mockGetTopTransferTargets.mockResolvedValue([
         { accountId: 'acc-2', count: 10 },
         { accountId: 'acc-3', count: 8 },
         { accountId: 'acc-4', count: 5 },
-        { accountId: 'acc-5', count: 3 },
+        { accountId: 'acc-5', count: 4 },
+        { accountId: 'acc-6', count: 3 },
+        { accountId: 'acc-7', count: 2 },
+        { accountId: 'acc-8', count: 2 },
+        { accountId: 'acc-9', count: 1 },
+        { accountId: 'acc-10', count: 1 },
       ]);
 
       const { result } = renderHook(() =>
@@ -663,7 +682,7 @@ describe('useQuickAddForm', () => {
         result.current.setQuickAddValues(prev => ({ ...prev, type: 'transfer', accountId: 'acc-1' }));
       });
 
-      expect(result.current.topTransferAccountsForForm).toHaveLength(3);
+      expect(result.current.topTransferAccountsForForm).toHaveLength(8);
     });
   });
 

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -253,60 +253,87 @@ const OperationFormFields = memo(({
         }
       };
 
-      return (
-        <View style={[styles.categoryButtonsContainer, compact && styles.categoryButtonsContainerCompact]}>
-          {/* Button to open picker */}
+      // Show "all" button only when there are more than 8 categories (not all fit in two rows)
+      const showAllButton = categories.length > 8;
+      const firstRowCats = showAllButton ? topCategoriesForType.slice(0, 3) : topCategoriesForType.slice(0, 4);
+      const secondRowCats = showAllButton ? topCategoriesForType.slice(3) : topCategoriesForType.slice(4);
+
+      const renderCategoryChip = (category, index, isSecondRow = false) => {
+        const categoryInfo = getCategoryInfo ? getCategoryInfo(category.id) : { name: category.name, icon: category.icon, parentName: null };
+        const isSelected = values.categoryId === category.id;
+        const textColor = isSelected ? '#fff' : (disabled ? colors.mutedText : colors.text);
+
+        return (
           <Pressable
-            style={[styles.categoryPickerButton, inputStyle, groupBorderStyle, disabledStyle]}
-            onPress={() => !disabled && openPicker('category', categories)}
+            key={category.id}
+            testID={`category-shortcut-${isSecondRow ? 'r2-' : ''}${index}`}
+            style={[
+              styles.categoryShortcutButton,
+              compact && styles.categoryShortcutButtonCompact,
+              {
+                backgroundColor: isSelected ? colors.primary : colors.inputBackground,
+                borderColor: colors.border,
+              },
+              disabledStyle,
+            ]}
+            onPress={() => handleCategoryPress(category.id)}
             disabled={disabled}
           >
-            <Icon name="menu" size={16} color={disabled ? colors.mutedText : colors.text} />
+            <Icon name={categoryInfo.icon} size={18} color={textColor} />
             <Text
-              style={[styles.categoryPickerText, { color: disabled ? colors.mutedText : colors.text }]}
-              numberOfLines={2}
+              style={[styles.categoryShortcutText, { color: textColor }]}
+              numberOfLines={isSecondRow ? 1 : 2}
+              ellipsizeMode="tail"
             >
-              {t('all_categories')}
+              {categoryInfo.name}
             </Text>
           </Pressable>
+        );
+      };
 
-          {/* Top 3 category shortcut buttons */}
-          {topCategoriesForType.map((category, index) => {
-            const categoryInfo = getCategoryInfo ? getCategoryInfo(category.id) : { name: category.name, icon: category.icon, parentName: null };
-            const isSelected = values.categoryId === category.id;
-            const textColor = isSelected ? '#fff' : (disabled ? colors.mutedText : colors.text);
-            const parentColor = isSelected ? 'rgba(255,255,255,0.7)' : colors.mutedText;
-
-            return (
+      return (
+        <View style={[styles.categoryRowsWrapper, compact && styles.categoryRowsWrapperCompact]}>
+          {/* Row 1: "All categories" button (if > 8 total) + first 3 or 4 shortcuts */}
+          <View style={styles.categoryButtonsContainer}>
+            {showAllButton && (
               <Pressable
-                key={category.id}
-                testID={`category-shortcut-${index}`}
-                style={[
-                  styles.categoryShortcutButton,
-                  compact && styles.categoryShortcutButtonCompact,
-                  {
-                    backgroundColor: isSelected ? colors.primary : colors.inputBackground,
-                    borderColor: colors.border,
-                  },
-                  disabledStyle,
-                ]}
-                onPress={() => handleCategoryPress(category.id)}
+                style={[styles.categoryPickerButton, inputStyle, groupBorderStyle, disabledStyle]}
+                onPress={() => !disabled && openPicker('category', categories)}
                 disabled={disabled}
               >
-                <Icon name={categoryInfo.icon} size={18} color={textColor} />
+                <Icon name="menu" size={16} color={disabled ? colors.mutedText : colors.text} />
                 <Text
-                  style={[
-                    styles.categoryShortcutText,
-                    { color: textColor },
-                  ]}
+                  style={[styles.categoryPickerText, { color: disabled ? colors.mutedText : colors.text }]}
                   numberOfLines={2}
-                  ellipsizeMode="tail"
                 >
-                  {categoryInfo.name}
+                  {t('all_categories')}
                 </Text>
               </Pressable>
-            );
-          })}
+            )}
+            {firstRowCats.map((category, index) => renderCategoryChip(category, index, false))}
+          </View>
+
+          {/* Row 2: always 4 flex-1 slots to match row 1 widths; invisible spacers for empty slots */}
+          {secondRowCats.length > 0 && (
+            <View style={styles.categoryButtonsContainer}>
+              {Array.from({ length: 4 }, (_, i) => {
+                const category = secondRowCats[i];
+                if (!category) {
+                  return (
+                    <View
+                      key={`cat-spacer-${i}`}
+                      style={[
+                        styles.categoryShortcutButton,
+                        compact && styles.categoryShortcutButtonCompact,
+                        styles.invisible,
+                      ]}
+                    />
+                  );
+                }
+                return renderCategoryChip(category, i, true);
+              })}
+            </View>
+          )}
         </View>
       );
     }
@@ -343,64 +370,98 @@ const OperationFormFields = memo(({
         }
       };
 
-      return (
-        <View style={[styles.categoryButtonsContainer, compact && styles.categoryButtonsContainerCompact]}>
+      // Show "all" button only when there are more than 8 available target accounts
+      const availableAccountCount = accounts.filter(acc => acc.id !== values.accountId).length;
+      const showAllAccountsButton = availableAccountCount > 8;
+      const firstRowAccounts = showAllAccountsButton ? topTransferAccounts.slice(0, 3) : topTransferAccounts.slice(0, 4);
+      const secondRowAccounts = showAllAccountsButton ? topTransferAccounts.slice(3) : topTransferAccounts.slice(4);
+
+      const renderAccountChip = (account) => {
+        const isSelected = values.toAccountId === account.id;
+        const textColor = isSelected ? '#fff' : (disabled ? colors.mutedText : colors.text);
+        const balanceColor = isSelected ? 'rgba(255,255,255,0.7)' : colors.mutedText;
+
+        return (
           <Pressable
-            style={[styles.categoryPickerButton, inputStyle, groupBorderStyle, disabledStyle]}
-            onPress={() => !disabled && openPicker('toAccount', accounts.filter(acc => acc.id !== values.accountId))}
+            key={account.id}
+            style={[
+              styles.accountShortcutButton,
+              compact && styles.accountShortcutButtonCompact,
+              {
+                backgroundColor: isSelected ? colors.primary : colors.inputBackground,
+                borderColor: colors.border,
+              },
+              disabledStyle,
+            ]}
+            onPress={() => handleTargetPress(account.id)}
             disabled={disabled}
           >
-            <Icon name="menu" size={16} color={disabled ? colors.mutedText : colors.text} />
+            {getAccountBalance && (
+              hideBalances ? (
+                <View style={styles.hiddenBalanceSmall} />
+              ) : (
+                <Text
+                  style={[styles.accountShortcutBalance, { color: balanceColor }]}
+                  numberOfLines={1}
+                >
+                  {getAccountBalance(account.id)}
+                </Text>
+              )
+            )}
             <Text
-              style={[styles.categoryPickerText, { color: disabled ? colors.mutedText : colors.text }]}
-              numberOfLines={2}
+              style={[styles.accountShortcutName, { color: textColor }]}
+              numberOfLines={1}
+              ellipsizeMode="tail"
             >
-              {t('all_accounts')}
+              {account.name}
             </Text>
           </Pressable>
+        );
+      };
 
-          {topTransferAccounts.map((account) => {
-            const isSelected = values.toAccountId === account.id;
-            const textColor = isSelected ? '#fff' : (disabled ? colors.mutedText : colors.text);
-            const balanceColor = isSelected ? 'rgba(255,255,255,0.7)' : colors.mutedText;
-
-            return (
+      return (
+        <View style={[styles.categoryRowsWrapper, compact && styles.categoryRowsWrapperCompact]}>
+          {/* Row 1: "All accounts" button (if > 8 total) + first 3 or 4 shortcuts */}
+          <View style={styles.categoryButtonsContainer}>
+            {showAllAccountsButton && (
               <Pressable
-                key={account.id}
-                style={[
-                  styles.accountShortcutButton,
-                  compact && styles.accountShortcutButtonCompact,
-                  {
-                    backgroundColor: isSelected ? colors.primary : colors.inputBackground,
-                    borderColor: colors.border,
-                  },
-                  disabledStyle,
-                ]}
-                onPress={() => handleTargetPress(account.id)}
+                style={[styles.categoryPickerButton, inputStyle, groupBorderStyle, disabledStyle]}
+                onPress={() => !disabled && openPicker('toAccount', accounts.filter(acc => acc.id !== values.accountId))}
                 disabled={disabled}
               >
-                {getAccountBalance && (
-                  hideBalances ? (
-                    <View style={styles.hiddenBalanceSmall} />
-                  ) : (
-                    <Text
-                      style={[styles.accountShortcutBalance, { color: balanceColor }]}
-                      numberOfLines={1}
-                    >
-                      {getAccountBalance(account.id)}
-                    </Text>
-                  )
-                )}
+                <Icon name="menu" size={16} color={disabled ? colors.mutedText : colors.text} />
                 <Text
-                  style={[styles.accountShortcutName, { color: textColor }]}
-                  numberOfLines={1}
-                  ellipsizeMode="tail"
+                  style={[styles.categoryPickerText, { color: disabled ? colors.mutedText : colors.text }]}
+                  numberOfLines={2}
                 >
-                  {account.name}
+                  {t('all_accounts')}
                 </Text>
               </Pressable>
-            );
-          })}
+            )}
+            {firstRowAccounts.map((account) => renderAccountChip(account))}
+          </View>
+
+          {/* Row 2: always 4 flex-1 slots to match row 1 widths; invisible spacers for empty slots */}
+          {secondRowAccounts.length > 0 && (
+            <View style={styles.categoryButtonsContainer}>
+              {Array.from({ length: 4 }, (_, i) => {
+                const account = secondRowAccounts[i];
+                if (!account) {
+                  return (
+                    <View
+                      key={`acc-spacer-${i}`}
+                      style={[
+                        styles.accountShortcutButton,
+                        compact && styles.accountShortcutButtonCompact,
+                        styles.invisible,
+                      ]}
+                    />
+                  );
+                }
+                return renderAccountChip(account);
+              })}
+            </View>
+          )}
         </View>
       );
     }
@@ -524,10 +585,6 @@ const styles = StyleSheet.create({
   categoryButtonsContainer: {
     flexDirection: 'row',
     gap: SPACING.xs,
-    marginBottom: SPACING.md,
-  },
-  categoryButtonsContainerCompact: {
-    marginBottom: SPACING.xs,
   },
   categoryPickerButton: {
     alignItems: 'center',
@@ -545,6 +602,13 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     marginTop: 2,
     textAlign: 'center',
+  },
+  categoryRowsWrapper: {
+    gap: SPACING.xs,
+    marginBottom: SPACING.md,
+  },
+  categoryRowsWrapperCompact: {
+    marginBottom: SPACING.xs,
   },
   categoryShortcutButton: {
     alignItems: 'center',
@@ -601,6 +665,9 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     height: 8,
     width: 40,
+  },
+  invisible: {
+    opacity: 0,
   },
   typeButton: {
     alignItems: 'center',

--- a/app/hooks/useQuickAddForm.js
+++ b/app/hooks/useQuickAddForm.js
@@ -93,7 +93,7 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
   useEffect(() => {
     async function loadTopCategories() {
       try {
-        const topCats = await OperationsDB.getTopCategoriesFromLastMonth(5);
+        const topCats = await OperationsDB.getTopCategoriesFromLastMonth(10);
         setTopCategories(topCats);
       } catch (error) {
         console.error('Failed to load top categories:', error);
@@ -102,7 +102,7 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
     }
     async function loadTopTransferTargets() {
       try {
-        const targets = await OperationsDB.getTopTransferTargetAccounts(5);
+        const targets = await OperationsDB.getTopTransferTargetAccounts(10);
         setTopTransferTargets(targets);
       } catch (error) {
         console.error('Failed to load top transfer targets:', error);
@@ -124,8 +124,8 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
     });
   }, [categories, quickAddValues.type]);
 
-  // Get top 3 categories matching current operation type (expense/income)
-  // Fills remaining slots with leaf categories by id order when history has fewer than 3
+  // Get top 8 categories matching current operation type (expense/income)
+  // Fills remaining slots with leaf categories by id order when history has fewer than 8
   const topCategoriesForType = useMemo(() => {
     if (quickAddValues.type === 'transfer') return [];
 
@@ -133,15 +133,15 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
     const fromHistory = topCategories
       .map(tc => categories.find(cat => cat.id === tc.categoryId))
       .filter(cat => cat && cat.categoryType === quickAddValues.type && !cat.isShadow && cat.type !== 'folder')
-      .slice(0, 3);
+      .slice(0, 8);
 
-    if (fromHistory.length >= 3) return fromHistory;
+    if (fromHistory.length >= 8) return fromHistory;
 
     // Fill remaining slots from leaf categories by id order, excluding already-selected
     const historyIds = new Set(fromHistory.map(cat => cat.id));
     const fillers = categories
       .filter(cat => cat.categoryType === quickAddValues.type && !cat.isShadow && cat.type !== 'folder' && !historyIds.has(cat.id))
-      .slice(0, 3 - fromHistory.length);
+      .slice(0, 8 - fromHistory.length);
 
     return [...fromHistory, ...fillers];
   }, [topCategories, categories, quickAddValues.type]);
@@ -156,14 +156,14 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
     const fromHistory = topTransferTargets
       .map(tt => accounts.find(acc => acc.id === tt.accountId))
       .filter(acc => acc && acc.id !== sourceId)
-      .slice(0, 3);
+      .slice(0, 8);
 
     if (fromHistory.length > 0) return fromHistory;
 
-    // Fallback: first 3 visible accounts excluding current source
+    // Fallback: first 8 visible accounts excluding current source
     return visibleAccounts
       .filter(acc => acc.id !== sourceId)
-      .slice(0, 3);
+      .slice(0, 8);
   }, [topTransferTargets, accounts, visibleAccounts, quickAddValues.type, quickAddValues.accountId]);
 
   // Reset form but keep account and type


### PR DESCRIPTION
## Summary

- Adds a second row of suggested categories/accounts in quickadd, bringing the total to 8 shortcuts across two rows of 4
- Hides the "All categories"/"All accounts" button when total items ≤ 8 (all fit in the two rows already)
- Second row uses 4-slot layout with invisible spacers to match first row item widths exactly
- Second row chips truncate to 1 line to prevent height variation from long category names

## Test plan

- [ ] Expense type: verify 2 rows of 4 category chips appear; "All categories" hidden when ≤ 8 categories exist
- [ ] Income type: same verification
- [ ] Transfer type: verify 2 rows of 4 account chips appear; "All accounts" hidden when ≤ 8 accounts available
- [ ] With > 8 items: verify "All" button reappears in row 1 (row 1 = all + 3, row 2 = 4)
- [ ] Row 2 items with fewer than 4 visible: verify empty space on right, no stretching
- [ ] Long category names (e.g. multi-word) in row 2: verify height matches row 1

🧀
