### PR TITLE
fix(header): hide search bar when navigating away from operations screen

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -89,10 +89,10 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
       style={[
         styles.container,
         { backgroundColor: colors.background, borderBottomColor: colors.border },
-        searchMode === 'open' && styles.containerSearchMode,
+        searchMode === 'open' && activeScreen === 'Operations' && styles.containerSearchMode,
       ]}
     >
-      {searchMode === 'open' ? (
+      {searchMode === 'open' && activeScreen === 'Operations' ? (
         <>
           <SearchBar
             searchText={searchState?.text || ''}


### PR DESCRIPTION
## Summary
- Search bar and search mode styling now only render when `activeScreen === 'Operations'`
- Switching to any other tab shows the regular header, regardless of search state

## Test plan
- [ ] Open search on Operations screen
- [ ] Switch to another tab (Accounts, Categories, Graphs)
- [ ] Verify regular header is shown (no search bar)
- [ ] Switch back to Operations — search state should still be preserved (collapsed/open)

🧀
