### PR TITLE
feat(categories): bottom sheet modal with animated picker panels

### DIFF
--- a/__tests__/modals/CategoryModal.test.js
+++ b/__tests__/modals/CategoryModal.test.js
@@ -601,8 +601,8 @@ describe('CategoryModal', () => {
   });
 
   describe('Picker Modal Interactions', () => {
-    it('opens type picker modal when type button is pressed', async () => {
-      const { queryByText, queryAllByText } = render(
+    it('opens type picker panel when type button is pressed', async () => {
+      const { queryByTestId, queryAllByText } = render(
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
@@ -612,14 +612,14 @@ describe('CategoryModal', () => {
         fireEvent.press(folderTexts[0]);
       }
 
-      // Type picker modal should show close button
+      // Type picker panel should show back button
       await waitFor(() => {
-        expect(queryByText('close')).toBeTruthy();
+        expect(queryByTestId('picker-back-button')).toBeTruthy();
       });
     });
 
-    it('opens category type picker modal when category type button is pressed', async () => {
-      const { queryByText, queryAllByText } = render(
+    it('opens category type picker panel when category type button is pressed', async () => {
+      const { queryByTestId, queryAllByText } = render(
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
@@ -629,14 +629,14 @@ describe('CategoryModal', () => {
         fireEvent.press(expenseTexts[0]);
       }
 
-      // Category type picker modal should show close button
+      // Category type picker panel should show back button
       await waitFor(() => {
-        expect(queryByText('close')).toBeTruthy();
+        expect(queryByTestId('picker-back-button')).toBeTruthy();
       });
     });
 
-    it('opens parent picker modal when parent button is pressed', async () => {
-      const { queryByText, queryAllByText } = render(
+    it('opens parent picker panel when parent button is pressed', async () => {
+      const { queryByTestId, queryAllByText } = render(
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
@@ -646,9 +646,9 @@ describe('CategoryModal', () => {
         fireEvent.press(noneTexts[0]);
       }
 
-      // Parent picker modal should show close button
+      // Parent picker panel should show back button
       await waitFor(() => {
-        expect(queryByText('close')).toBeTruthy();
+        expect(queryByTestId('picker-back-button')).toBeTruthy();
       });
     });
 
@@ -729,8 +729,8 @@ describe('CategoryModal', () => {
       });
     });
 
-    it('closes type picker via close button', async () => {
-      const { queryAllByText, queryByText } = render(
+    it('closes type picker via back button', async () => {
+      const { queryAllByText, queryByTestId } = render(
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
@@ -740,17 +740,17 @@ describe('CategoryModal', () => {
         fireEvent.press(folderTexts[0]);
       }
 
-      // Press close button
+      // Press back button
       await waitFor(() => {
-        const closeButton = queryByText('close');
-        if (closeButton) {
-          fireEvent.press(closeButton);
+        const backButton = queryByTestId('picker-back-button');
+        if (backButton) {
+          fireEvent.press(backButton);
         }
       });
     });
 
-    it('closes category type picker via close button', async () => {
-      const { queryAllByText, queryByText } = render(
+    it('closes category type picker via back button', async () => {
+      const { queryAllByText, queryByTestId } = render(
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
@@ -760,17 +760,17 @@ describe('CategoryModal', () => {
         fireEvent.press(expenseTexts[0]);
       }
 
-      // Press close button
+      // Press back button
       await waitFor(() => {
-        const closeButton = queryByText('close');
-        if (closeButton) {
-          fireEvent.press(closeButton);
+        const backButton = queryByTestId('picker-back-button');
+        if (backButton) {
+          fireEvent.press(backButton);
         }
       });
     });
 
-    it('closes parent picker via close button', async () => {
-      const { queryAllByText, queryByText } = render(
+    it('closes parent picker via back button', async () => {
+      const { queryAllByText, queryByTestId } = render(
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
@@ -780,11 +780,11 @@ describe('CategoryModal', () => {
         fireEvent.press(noneTexts[0]);
       }
 
-      // Press close button
+      // Press back button
       await waitFor(() => {
-        const closeButton = queryByText('close');
-        if (closeButton) {
-          fireEvent.press(closeButton);
+        const backButton = queryByTestId('picker-back-button');
+        if (backButton) {
+          fireEvent.press(backButton);
         }
       });
     });

--- a/app/modals/CategoryModal.js
+++ b/app/modals/CategoryModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -10,8 +10,9 @@ import {
   TouchableOpacity,
   ScrollView,
   KeyboardAvoidingView,
-  Platform,
   Keyboard,
+  Animated,
+  Dimensions,
 } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -20,15 +21,14 @@ import { useDialog } from '../contexts/DialogContext';
 import { useCategories } from '../contexts/CategoriesContext';
 import IconPicker from '../components/IconPicker';
 import ModalBlurOverlay from '../components/ModalBlurOverlay';
-import ModalHeader from '../components/ModalHeader';
 import PropTypes from 'prop-types';
+import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
 
 export default function CategoryModal({ visible, onClose, category, isNew }) {
   const { colors } = useThemeColors();
   const themed = useMemo(() => ({
-    closeText: { color: colors.primary },
-    parentText: { color: colors.text, fontSize: 18, marginLeft: 12 },
     pickerItemText: { color: colors.text, fontSize: 18 },
+    parentText: { color: colors.text, fontSize: 18, marginLeft: 12 },
   }), [colors]);
   const { t } = useLocalization();
   const { showDialog } = useDialog();
@@ -43,9 +43,10 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
   });
   const [errors, setErrors] = useState({});
   const [iconPickerVisible, setIconPickerVisible] = useState(false);
-  const [parentPickerVisible, setParentPickerVisible] = useState(false);
-  const [categoryTypePickerVisible, setCategoryTypePickerVisible] = useState(false);
-  const [typePickerVisible, setTypePickerVisible] = useState(false);
+
+  // Single animated panel for all pickers — only one open at a time
+  const [activePicker, setActivePicker] = useState(null); // null | 'type' | 'categoryType' | 'parent'
+  const pickerSlideAnim = useRef(new Animated.Value(Dimensions.get('window').width)).current;
 
   useEffect(() => {
     if (category && !isNew) {
@@ -105,7 +106,17 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
     );
   }, [category, deleteCategory, onClose, t, showDialog]);
 
-  // Get potential parents - all folders of the same category_type
+  const handleOpenPicker = useCallback((pickerKey) => {
+    pickerSlideAnim.setValue(Dimensions.get('window').width);
+    setActivePicker(pickerKey);
+    Animated.timing(pickerSlideAnim, { toValue: 0, duration: 260, useNativeDriver: true }).start();
+  }, [pickerSlideAnim]);
+
+  const handleClosePicker = useCallback(() => {
+    Animated.timing(pickerSlideAnim, { toValue: Dimensions.get('window').width, duration: 260, useNativeDriver: true })
+      .start(() => setActivePicker(null));
+  }, [pickerSlideAnim]);
+
   const potentialParents = useMemo(() => {
     return categories.filter(c => {
       const catType = c.category_type || c.categoryType;
@@ -129,11 +140,16 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
     { key: 'entry', label: t('entry') },
   ];
 
-  // Check if category has children
   const hasChildren = useMemo(() => {
     if (!category?.id) return false;
     return categories.some(cat => cat.parentId === category.id);
   }, [category, categories]);
+
+  const pickerTitle = activePicker === 'type'
+    ? t('select_type')
+    : activePicker === 'categoryType'
+      ? t('category_type')
+      : t('parent_category');
 
   return (
     <>
@@ -144,24 +160,30 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
         transparent={true}
         onRequestClose={handleClose}
       >
-        <KeyboardAvoidingView
-          behavior="height"
-          style={styles.keyboardAvoid}
-        >
+        <KeyboardAvoidingView behavior="padding" style={styles.keyboardAvoid}>
           <Pressable style={styles.modalOverlay} onPress={handleClose}>
             <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <ScrollView
-                style={styles.scrollView}
-                contentContainerStyle={styles.scrollContent}
-                keyboardShouldPersistTaps="handled"
-              >
-                <ModalHeader title={isNew ? t('add_category') : t('edit_category')} />
 
+              {/* Drag handle */}
+              <View style={[styles.sheetDragHandle, { backgroundColor: colors.border }]} />
+
+              {/* Sheet header */}
+              <View style={styles.sheetHeader}>
+                <Text style={[styles.sheetTitle, { color: colors.text }]}>
+                  {isNew ? t('add_category') : t('edit_category')}
+                </Text>
+              </View>
+
+              <ScrollView
+                keyboardShouldPersistTaps="handled"
+                contentContainerStyle={styles.scrollContent}
+                showsVerticalScrollIndicator={false}
+                style={styles.sheetScroll}
+              >
                 {/* Name Input */}
                 <TextInput
                   style={[
                     styles.input,
-                    styles.inputThemed,
                     { color: colors.text, backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
                   ]}
                   value={values.name}
@@ -175,96 +197,195 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
 
                 {/* Type Picker (Folder/Entry) */}
                 <Pressable
-                  style={[styles.pickerButton, styles.pickerButtonThemed, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                  onPress={() => setTypePickerVisible(true)}
+                  style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                  onPress={() => handleOpenPicker('type')}
                 >
                   <Text style={[styles.pickerLabel, { color: colors.mutedText }]}>
                     {t('select_type')}
                   </Text>
-                  <View style={styles.pickerRow}>
-                    <Text style={[styles.pickerValue, { color: colors.text }]}>
-                      {TYPE_OPTIONS.find(to => to.key === values.type)?.label}
-                    </Text>
-                  </View>
+                  <Text style={[styles.pickerValue, { color: colors.text }]}>
+                    {TYPE_OPTIONS.find(to => to.key === values.type)?.label}
+                  </Text>
                 </Pressable>
 
                 {/* Category Type Picker (Income/Expense) */}
                 <Pressable
-                  style={[styles.pickerButton, styles.pickerButtonThemed, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                  onPress={() => setCategoryTypePickerVisible(true)}
+                  style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                  onPress={() => handleOpenPicker('categoryType')}
                 >
                   <Text style={[styles.pickerLabel, { color: colors.mutedText }]}>
                     {t('category_type')}
                   </Text>
-                  <View style={styles.pickerRow}>
-                    <Text style={[styles.pickerValue, { color: colors.text }]}>
-                      {CATEGORY_TYPES.find(ct => ct.key === values.category_type)?.label}
-                    </Text>
-                  </View>
+                  <Text style={[styles.pickerValue, { color: colors.text }]}>
+                    {CATEGORY_TYPES.find(ct => ct.key === values.category_type)?.label}
+                  </Text>
                 </Pressable>
 
                 {/* Parent Picker */}
                 <Pressable
-                  style={[styles.pickerButton, styles.pickerButtonThemed, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                  onPress={() => setParentPickerVisible(true)}
+                  style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                  onPress={() => handleOpenPicker('parent')}
                 >
                   <Text style={[styles.pickerLabel, { color: colors.mutedText }]}>
                     {t('parent_category')}
                   </Text>
-                  <View style={styles.pickerRow}>
-                    <Text style={[styles.pickerValue, { color: colors.text }]}>
-                      {getParentName(values.parentId)}
-                    </Text>
-                  </View>
+                  <Text style={[styles.pickerValue, { color: colors.text }]}>
+                    {getParentName(values.parentId)}
+                  </Text>
                 </Pressable>
 
                 {/* Icon Picker */}
                 <Pressable
                   testID="category-icon-picker"
-                  style={[styles.iconPickerButton, styles.iconPickerButtonThemed, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                  style={[styles.iconPickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
                   onPress={() => setIconPickerVisible(true)}
                 >
                   <Icon name={values.icon || 'folder'} size={32} color={colors.text} />
-                  <Text style={[styles.iconPickerText, { color: colors.mutedText }]}> 
+                  <Text style={[styles.iconPickerText, { color: colors.mutedText }]}>
                     {t('select_icon')}
                   </Text>
                 </Pressable>
 
                 {errors.general && <Text style={styles.error}>{errors.general}</Text>}
+              </ScrollView>
 
-                {/* Delete Button (only for existing categories) */}
-                {!isNew && (
+              {/* Delete zone (existing categories only) — outside ScrollView */}
+              {!isNew && (
+                <View style={styles.deleteWrapper}>
                   <Pressable
-                    style={[styles.deleteButtonContainer, { borderTopColor: colors.border }]}
+                    style={[styles.deleteRow, { borderColor: colors.delete + '40' }]}
                     onPress={handleDelete}
                   >
-                    <Icon name="delete-outline" size={20} color={colors.delete} />
-                    <Text style={[styles.deleteButtonText, { color: colors.delete }]}>
+                    <Icon name="delete-outline" size={18} color={colors.delete} />
+                    <Text style={[styles.deleteRowText, { color: colors.delete }]}>
                       {t('delete_category')}
                     </Text>
                   </Pressable>
-                )}
-              </ScrollView>
+                </View>
+              )}
 
-              {/* Action Buttons */}
-              <View style={[styles.modalButtonRow, { backgroundColor: colors.card }]}>
+              {/* Action buttons */}
+              <View style={[styles.sheetActions, { borderTopColor: colors.border }]}>
                 <Pressable
-                  style={[styles.modalButton, { backgroundColor: colors.secondary }]}
+                  style={[styles.sheetBtn, styles.sheetBtnCancel, { borderColor: colors.border }]}
                   onPress={handleClose}
                 >
-                  <Text style={[styles.buttonText, { color: colors.text }]}>
-                    {t('cancel')}
-                  </Text>
+                  <Text style={[styles.sheetBtnText, { color: colors.text }]}>{t('cancel')}</Text>
                 </Pressable>
                 <Pressable
-                  style={[styles.modalButton, { backgroundColor: colors.primary }]}
+                  style={[styles.sheetBtn, { backgroundColor: colors.primary }]}
                   onPress={handleSave}
                 >
-                  <Text style={[styles.buttonText, { color: colors.text }]}>
-                    {t('save')}
-                  </Text>
+                  <Text style={[styles.sheetBtnText, styles.sheetBtnSaveText]}>{t('save')}</Text>
                 </Pressable>
               </View>
+
+              {/* In-sheet picker panel — slides in from the right */}
+              {activePicker && (
+                <Animated.View
+                  style={[styles.pickerPanel, { backgroundColor: colors.card, transform: [{ translateX: pickerSlideAnim }] }]}
+                >
+                  <View style={[styles.pickerPanelHeader, { borderBottomColor: colors.border }]}>
+                    <TouchableOpacity
+                      testID="picker-back-button"
+                      onPress={handleClosePicker}
+                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                    >
+                      <Icon name="arrow-left" size={22} color={colors.text} />
+                    </TouchableOpacity>
+                    <Text style={[styles.pickerPanelTitle, { color: colors.text }]}>
+                      {pickerTitle}
+                    </Text>
+                  </View>
+
+                  {activePicker === 'type' && (
+                    <FlatList
+                      data={TYPE_OPTIONS}
+                      keyExtractor={item => item.key}
+                      renderItem={({ item }) => {
+                        const isDisabled = !isNew && hasChildren && item.key === 'entry';
+                        return (
+                          <Pressable
+                            onPress={() => {
+                              if (isDisabled) {
+                                showDialog(
+                                  t('error'),
+                                  t('cannot_change_to_entry_with_children') || 'Cannot change to entry type while category has subcategories',
+                                  [{ text: t('ok') }],
+                                );
+                                return;
+                              }
+                              setValues(v => ({ ...v, type: item.key }));
+                              handleClosePicker();
+                            }}
+                            style={({ pressed }) => [
+                              styles.pickerOption,
+                              { borderColor: colors.border },
+                              pressed && !isDisabled && { backgroundColor: colors.selected },
+                              isDisabled && { opacity: 0.5 },
+                            ]}
+                          >
+                            <Text style={[themed.pickerItemText, isDisabled && { color: colors.mutedText }]}>
+                              {item.label}
+                              {isDisabled && ' ⚠️'}
+                            </Text>
+                          </Pressable>
+                        );
+                      }}
+                    />
+                  )}
+
+                  {activePicker === 'categoryType' && (
+                    <FlatList
+                      data={CATEGORY_TYPES}
+                      keyExtractor={item => item.key}
+                      renderItem={({ item }) => (
+                        <Pressable
+                          onPress={() => {
+                            setValues(v => ({ ...v, category_type: item.key }));
+                            handleClosePicker();
+                          }}
+                          style={({ pressed }) => [
+                            styles.pickerOption,
+                            { borderColor: colors.border },
+                            pressed && { backgroundColor: colors.selected },
+                          ]}
+                        >
+                          <Text style={themed.pickerItemText}>{item.label}</Text>
+                        </Pressable>
+                      )}
+                    />
+                  )}
+
+                  {activePicker === 'parent' && (
+                    <FlatList
+                      data={[{ id: null, name: t('none'), icon: 'folder-outline' }, ...potentialParents]}
+                      keyExtractor={item => item.id || 'none'}
+                      renderItem={({ item }) => (
+                        <Pressable
+                          onPress={() => {
+                            setValues(v => ({ ...v, parentId: item.id }));
+                            handleClosePicker();
+                          }}
+                          style={({ pressed }) => [
+                            styles.pickerOption,
+                            { borderColor: colors.border },
+                            pressed && { backgroundColor: colors.selected },
+                          ]}
+                        >
+                          <View style={styles.parentOption}>
+                            <Icon name={item.icon} size={24} color={colors.text} />
+                            <Text style={themed.parentText}>
+                              {item.nameKey ? t(item.nameKey) : item.name}
+                            </Text>
+                          </View>
+                        </Pressable>
+                      )}
+                    />
+                  )}
+                </Animated.View>
+              )}
+
             </Pressable>
           </Pressable>
         </KeyboardAvoidingView>
@@ -276,266 +397,156 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
           onSelect={(icon) => setValues(v => ({ ...v, icon }))}
           selectedIcon={values.icon}
         />
-
-        {/* Type Picker Modal (Folder/Entry) */}
-        <Modal
-          visible={typePickerVisible}
-          animationType="slide"
-          transparent
-          onRequestClose={() => setTypePickerVisible(false)}
-        >
-          <Pressable style={styles.modalOverlay} onPress={() => setTypePickerVisible(false)}>
-            <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <FlatList
-                data={TYPE_OPTIONS}
-                keyExtractor={item => item.key}
-                renderItem={({ item }) => {
-                // Disable changing to 'entry' if category has children
-                  const isDisabled = !isNew && hasChildren && item.key === 'entry';
-
-                  return (
-                    <Pressable
-                      onPress={() => {
-                        if (isDisabled) {
-                          showDialog(
-                            t('error'),
-                            t('cannot_change_to_entry_with_children') || 'Cannot change to entry type while category has subcategories',
-                            [{ text: t('ok') }],
-                          );
-                          return;
-                        }
-                        setValues(v => ({ ...v, type: item.key }));
-                        setTypePickerVisible(false);
-                      }}
-                      style={({ pressed }) => [
-                        styles.pickerOption,
-                        { borderColor: colors.border },
-                        pressed && !isDisabled && { backgroundColor: colors.selected },
-                        isDisabled && { opacity: 0.5 },
-                      ]}
-                      disabled={isDisabled}
-                    >
-                      <Text style={[themed.pickerItemText, isDisabled && { color: colors.mutedText }]}>
-                        {item.label}
-                        {isDisabled && ' ⚠️'}
-                      </Text>
-                    </Pressable>
-                  );
-                }}
-              />
-              <Pressable style={styles.closeButton} onPress={() => setTypePickerVisible(false)}>
-                <Text style={themed.closeText}>{t('close')}</Text>
-              </Pressable>
-            </Pressable>
-          </Pressable>
-        </Modal>
-
-        {/* Category Type Picker Modal */}
-        <Modal
-          visible={categoryTypePickerVisible}
-          animationType="slide"
-          transparent
-          onRequestClose={() => setCategoryTypePickerVisible(false)}
-        >
-          <Pressable style={styles.modalOverlay} onPress={() => setCategoryTypePickerVisible(false)}>
-            <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <FlatList
-                data={CATEGORY_TYPES}
-                keyExtractor={item => item.key}
-                renderItem={({ item }) => (
-                  <Pressable
-                    onPress={() => {
-                      setValues(v => ({ ...v, category_type: item.key }));
-                      setCategoryTypePickerVisible(false);
-                    }}
-                    style={({ pressed }) => [
-                      styles.pickerOption,
-                      { borderColor: colors.border },
-                      pressed && { backgroundColor: colors.selected },
-                    ]}
-                  >
-                    <Text style={themed.pickerItemText}>{item.label}</Text>
-                  </Pressable>
-                )}
-              />
-              <Pressable style={styles.closeButton} onPress={() => setCategoryTypePickerVisible(false)}>
-                <Text style={themed.closeText}>{t('close')}</Text>
-              </Pressable>
-            </Pressable>
-          </Pressable>
-        </Modal>
-
-        {/* Parent Picker Modal */}
-        <Modal
-          visible={parentPickerVisible}
-          animationType="slide"
-          transparent
-          onRequestClose={() => setParentPickerVisible(false)}
-        >
-          <Pressable style={styles.modalOverlay} onPress={() => setParentPickerVisible(false)}>
-            <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <FlatList
-                data={[{ id: null, name: t('none'), icon: 'folder-outline' }, ...potentialParents]}
-                keyExtractor={item => item.id || 'none'}
-                renderItem={({ item }) => (
-                  <Pressable
-                    onPress={() => {
-                      setValues(v => ({ ...v, parentId: item.id }));
-                      setParentPickerVisible(false);
-                    }}
-                    style={({ pressed }) => [
-                      styles.pickerOption,
-                      { borderColor: colors.border },
-                      pressed && { backgroundColor: colors.selected },
-                    ]}
-                  >
-                    <View style={styles.parentOption}>
-                      <Icon name={item.icon} size={24} color={colors.text} />
-                      <Text style={themed.parentText}>
-                        {item.nameKey ? t(item.nameKey) : item.name}
-                      </Text>
-                    </View>
-                  </Pressable>
-                )}
-              />
-              <Pressable style={styles.closeButton} onPress={() => setParentPickerVisible(false)}>
-                <Text style={themed.closeText}>{t('close')}</Text>
-              </Pressable>
-            </Pressable>
-          </Pressable>
-        </Modal>
       </Modal>
     </>
   );
 }
 
 const styles = StyleSheet.create({
-  buttonText: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  closeButton: {
-    alignSelf: 'center',
-    marginTop: 8,
-    padding: 10,
-  },
-  deleteButtonContainer: {
+  deleteRow: {
     alignItems: 'center',
-    borderTopWidth: 1,
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    flex: 1,
     flexDirection: 'row',
+    gap: SPACING.sm,
     justifyContent: 'center',
-    marginTop: 20,
-    paddingVertical: 12,
+    paddingVertical: SPACING.sm,
   },
-  deleteButtonText: {
-    fontSize: 16,
+  deleteRowText: {
+    fontSize: 15,
     fontWeight: '500',
-    marginLeft: 8,
+  },
+  deleteWrapper: {
+    flexDirection: 'row',
+    marginTop: SPACING.sm,
   },
   error: {
     color: '#ff6b6b',
     fontSize: 12,
-    marginBottom: 8,
+    marginBottom: SPACING.sm,
   },
   iconPickerButton: {
     alignItems: 'center',
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.sm,
     borderWidth: 1,
     flexDirection: 'row',
-    marginBottom: 12,
-    padding: 12,
-  },
-  // Previously added themed/static helpers (placed near related styles)
-  iconPickerButtonThemed: {
-    padding: 12,
+    marginBottom: SPACING.sm,
+    padding: SPACING.md,
   },
   iconPickerText: {
-    marginLeft: 12,
+    marginLeft: SPACING.md,
   },
   input: {
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.sm,
     borderWidth: 1,
     fontSize: 16,
-    marginBottom: 12,
-    padding: 12,
+    marginBottom: SPACING.sm,
+    padding: SPACING.md,
   },
-  inputThemed: {},
   keyboardAvoid: {
     flex: 1,
   },
-  modalButton: {
-    alignItems: 'center',
-    borderRadius: 6,
-    flex: 1,
-    marginHorizontal: 8,
-    paddingVertical: 12,
-  },
-  modalButtonRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginTop: 16,
-  },
   modalContent: {
-    borderRadius: 12,
-    elevation: 5,
-    flexDirection: 'column',
-    maxHeight: '80%',
-    minHeight: '60%',
-    padding: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    width: '90%',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    maxHeight: '85%',
+    overflow: 'hidden',
+    paddingBottom: 0,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.sm,
   },
   modalOverlay: {
-    alignItems: 'center',
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-end',
   },
   parentOption: {
     alignItems: 'center',
     flexDirection: 'row',
   },
   pickerButton: {
-    alignItems: 'flex-start',
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.sm,
     borderWidth: 1,
-    flexDirection: 'column',
-    marginBottom: 12,
-    padding: 12,
+    marginBottom: SPACING.sm,
+    padding: SPACING.md,
   },
-  pickerButtonThemed: {},
   pickerLabel: {
     fontSize: 12,
     marginBottom: 4,
   },
-  pickerModalContent: {
-    borderRadius: 12,
-    maxHeight: '70%',
-    padding: 12,
-    width: '90%',
-  },
   pickerOption: {
     borderBottomWidth: 1,
-    paddingHorizontal: 8,
-    paddingVertical: 12,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.md,
   },
-  pickerRow: {
+  pickerPanel: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  pickerPanelHeader: {
     alignItems: 'center',
+    borderBottomWidth: 1,
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    width: '100%',
+    gap: SPACING.md,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+  },
+  pickerPanelTitle: {
+    fontSize: 17,
+    fontWeight: '600',
   },
   pickerValue: {
     fontSize: 16,
   },
   scrollContent: {
-    paddingBottom: 20,
+    paddingBottom: SPACING.sm,
   },
-  scrollView: {
-    flexGrow: 0,
+  sheetActions: {
+    borderTopWidth: 1,
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingBottom: SPACING.xl,
+    paddingTop: SPACING.sm,
+  },
+  sheetBtn: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    flex: 1,
+    overflow: 'hidden',
+    paddingVertical: SPACING.sm,
+  },
+  sheetBtnCancel: {
+    borderWidth: 1,
+  },
+  sheetBtnSaveText: {
+    color: '#fff',
+  },
+  sheetBtnText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  sheetDragHandle: {
+    alignSelf: 'center',
+    borderRadius: 3,
+    height: 4,
+    marginBottom: SPACING.md,
+    width: 44,
+  },
+  sheetHeader: {
+    marginBottom: SPACING.sm,
+  },
+  sheetScroll: {
     flexShrink: 1,
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: -0.3,
   },
 });
 


### PR DESCRIPTION
## Summary
- convert CategoryModal from centered dialog to bottom sheet, matching accounts screen pattern from #469
- replace 3 nested Modal picker components (type, category type, parent) with a single animated slide-in panel
- move delete button outside ScrollView
- add drag handle and inline sheet header

## Changes
- app/modals/CategoryModal.js: full bottom sheet conversion
- tests/modals/CategoryModal.test.js: update picker tests to use testID picker-back-button

