### PR TITLE
fix(useLogEntries): defer setTick to avoid setState-during-render

### DIFF
--- a/app/hooks/useLogEntries.js
+++ b/app/hooks/useLogEntries.js
@@ -8,7 +8,10 @@ export function useLogEntries(levelFilter = 'all') {
 
   useEffect(() => {
     const unsubscribe = logService.subscribe(() => {
-      setTick(t => t + 1);
+      // Defer setState to avoid updating during a render phase — LogService intercepts
+      // console.*, which React calls internally during rendering (e.g. dev warnings),
+      // so a synchronous setTick here causes "Cannot update a component while rendering".
+      setTimeout(() => setTick(t => t + 1), 0);
     });
     return unsubscribe;
   }, []);


### PR DESCRIPTION
## Summary

- Defers `setTick` in `useLogEntries` via `setTimeout(0)` to break the synchronous call chain that causes setState during a render phase

## Problem

`LogService` intercepts `console.*` methods synchronously. React calls `console.error` internally during rendering (e.g. dev warnings). This triggered: `console.error` (intercepted) → `_addEntry` → `_notify()` → `setTick()` → setState mid-render → React warning: _Cannot update a component (`SettingsModal`) while rendering a different component_.

## Solution

Wrapping `setTick(t => t + 1)` in `setTimeout(..., 0)` defers the state update out of the render phase. The logs viewer updates ~1 frame later, which is imperceptible.

🧀
