### PR TITLE
fix(logging): reclassify log levels across codebase

### DIFF
--- a/__tests__/components/Header.test.js
+++ b/__tests__/components/Header.test.js
@@ -236,7 +236,7 @@ describe('Header', () => {
         eventHandler = handler;
       });
 
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
 
       render(<Header onOpenSettings={mockOnOpenSettings} />);
 

--- a/__tests__/screens/OperationsScreen.test.js
+++ b/__tests__/screens/OperationsScreen.test.js
@@ -1197,8 +1197,8 @@ describe('OperationsScreen', () => {
       const { useOperationsData } = require('../../app/contexts/OperationsDataContext');
       const { useOperationsActions } = require('../../app/contexts/OperationsActionsContext');
 
-      // Spy on console.log to verify the handler is called
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      // Spy on console.warn to verify the handler is called
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       useOperationsData.mockReturnValue({
         operations: [],

--- a/__tests__/services/BalanceHistoryDB.test.js
+++ b/__tests__/services/BalanceHistoryDB.test.js
@@ -377,7 +377,7 @@ describe('BalanceHistoryDB', () => {
     });
 
     it('handles transaction conflict errors gracefully', async () => {
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       executeTransaction.mockRejectedValue(new Error('transaction within a transaction'));
 
       await expect(BalanceHistoryDB.populateCurrentMonthHistory()).resolves.toBeUndefined();
@@ -387,7 +387,7 @@ describe('BalanceHistoryDB', () => {
     });
 
     it('handles cannot rollback errors gracefully', async () => {
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       executeTransaction.mockRejectedValue(new Error('cannot rollback'));
 
       await expect(BalanceHistoryDB.populateCurrentMonthHistory()).resolves.toBeUndefined();
@@ -397,7 +397,7 @@ describe('BalanceHistoryDB', () => {
     });
 
     it('handles no transaction is active errors gracefully', async () => {
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       executeTransaction.mockRejectedValue(new Error('no transaction is active'));
 
       await expect(BalanceHistoryDB.populateCurrentMonthHistory()).resolves.toBeUndefined();

--- a/__tests__/utils/emergencyReset.test.js
+++ b/__tests__/utils/emergencyReset.test.js
@@ -14,7 +14,7 @@ describe('emergencyReset', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    consoleLogSpy = jest.spyOn(console, 'debug').mockImplementation();
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
   });
 

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -20,14 +20,14 @@ import { useOperationsActions } from '../contexts/OperationsActionsContext';
 const APP_VERSION = require('../../package.json').version;
 
 export default function Header({ onOpenSettings, rightContent, activeScreen, operationsData }) {
-  console.log('[Header] Rendering - activeScreen:', activeScreen, ', operationsData exists:', !!operationsData);
+  console.debug('[Header] Rendering - activeScreen:', activeScreen, ', operationsData exists:', !!operationsData);
   const { colorScheme, setTheme } = useThemeConfig();
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { isDownloading, downloadProgress } = useUpdateDownload();
   const { openSearch, searchMode, closeSearch, reopenSearch, toggleFilters } = useSearch();
-  console.log('[Header] openSearch exists:', !!openSearch);
-  console.log('[Header] searchMode:', searchMode);
+  console.debug('[Header] openSearch exists:', !!openSearch);
+  console.debug('[Header] searchMode:', searchMode);
   const [dbVersion, setDbVersion] = useState(null);
 
   const { searchState, hasActiveSearch, getSearchFilterCount } = useOperationsData();
@@ -67,7 +67,7 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
     // Listen for import completion to refresh DB version
     const handleImportProgress = (event) => {
       if (event.stepId === 'complete' && event.status === 'completed') {
-        console.log('Import completed, refreshing DB version...');
+        console.debug('Import completed, refreshing DB version...');
         fetchDbVersion();
       }
     };
@@ -147,7 +147,7 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
                   <View style={styles.searchButtonContainer}>
                     <TouchableOpacity
                       onPress={() => {
-                        console.log('[Header] Search button pressed, mode:', searchMode);
+                        console.debug('[Header] Search button pressed, mode:', searchMode);
                         if (searchMode === 'collapsed') {
                           // Reopen with smart logic
                           const hasTextOnly = (searchState?.text !== '') &&
@@ -159,7 +159,7 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
                           const hasOtherFilters = !hasTextOnly && hasActiveSearch;
 
                           reopenSearch(searchState?.text !== '', hasOtherFilters, (shouldExpand) => {
-                            console.log('[Header] Should expand filters:', shouldExpand);
+                            console.debug('[Header] Should expand filters:', shouldExpand);
                             // This callback will be handled by SearchOverlay in task 10
                           });
                         } else {

--- a/app/contexts/AccountsDataContext.js
+++ b/app/contexts/AccountsDataContext.js
@@ -43,7 +43,7 @@ export const AccountsDataProvider = ({ children }) => {
       setLoading(true);
       // Load accounts from SQLite
       let accountsData = await AccountsDB.getAllAccounts();
-      console.log(`[AccountsDataContext] loadAccounts: found ${accountsData.length} accounts, createDefaultsIfEmpty=${createDefaultsIfEmpty}`);
+      console.debug(`[AccountsDataContext] loadAccounts: found ${accountsData.length} accounts, createDefaultsIfEmpty=${createDefaultsIfEmpty}`);
 
       // If no accounts exist and we should create defaults, create default ones
       if (accountsData.length === 0 && createDefaultsIfEmpty) {
@@ -68,7 +68,7 @@ export const AccountsDataProvider = ({ children }) => {
 
         // Emit RELOAD_ALL to refresh all screens with new data
         setTimeout(() => {
-          console.log('Emitting RELOAD_ALL after default data creation');
+          console.debug('Emitting RELOAD_ALL after default data creation');
           appEvents.emit(EVENTS.RELOAD_ALL);
         }, 100);
       }
@@ -107,7 +107,7 @@ export const AccountsDataProvider = ({ children }) => {
   // Listen for RELOAD_ALL event to reload accounts
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
-      console.log('AccountsDataContext: Reloading accounts due to RELOAD_ALL event');
+      console.debug('AccountsDataContext: Reloading accounts due to RELOAD_ALL event');
       loadAccounts();
     });
 

--- a/app/contexts/BudgetsContext.js
+++ b/app/contexts/BudgetsContext.js
@@ -68,7 +68,7 @@ export const BudgetsProvider = ({ children }) => {
    */
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.OPERATION_CHANGED, () => {
-      console.log('Operation changed, refreshing budget statuses...');
+      console.debug('Operation changed, refreshing budget statuses...');
       refreshBudgetStatuses();
     });
 
@@ -80,7 +80,7 @@ export const BudgetsProvider = ({ children }) => {
    */
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
-      console.log('Reloading all budgets...');
+      console.debug('Reloading all budgets...');
       reloadBudgets();
     });
 

--- a/app/contexts/CategoriesContext.js
+++ b/app/contexts/CategoriesContext.js
@@ -80,7 +80,7 @@ export const CategoriesProvider = ({ children }) => {
   // But skip if it's first launch - categories will be initialized after language selection
   useEffect(() => {
     if (!isFirstLaunch) {
-      console.log('Loading categories on mount with language:', language);
+      console.debug('Loading categories on mount with language:', language);
       reloadCategories(language);
     } else {
       console.log('Skipping initial category load - first launch detected');
@@ -91,7 +91,7 @@ export const CategoriesProvider = ({ children }) => {
   // Listen for reload events
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
-      console.log('Reloading categories due to RELOAD_ALL event with language:', language);
+      console.debug('Reloading categories due to RELOAD_ALL event with language:', language);
       reloadCategories(language);
     });
 

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -75,7 +75,7 @@ export const OperationsActionsProvider = ({ children }) => {
   // Load initial week of operations
   const loadInitialOperations = useCallback(async (filters, showLoading = true) => {
     const effectiveFilters = filters ?? activeFiltersRef.current;
-    console.log('[OperationsActionsContext] loadInitialOperations called, requestId:', loadRequestIdRef.current + 1);
+    console.debug('[OperationsActionsContext] loadInitialOperations called, requestId:', loadRequestIdRef.current + 1);
     // Increment request ID to track this specific call
     const requestId = ++loadRequestIdRef.current;
 
@@ -90,7 +90,7 @@ export const OperationsActionsProvider = ({ children }) => {
 
       // Check if this request is still the latest (ignore stale results)
       if (requestId !== loadRequestIdRef.current) {
-        console.log(`[OperationsActionsContext] Ignoring stale request ${requestId}, current is ${loadRequestIdRef.current}`);
+        console.debug(`[OperationsActionsContext] Ignoring stale request ${requestId}, current is ${loadRequestIdRef.current}`);
         return;
       }
 
@@ -265,7 +265,7 @@ export const OperationsActionsProvider = ({ children }) => {
 
   // Load operations on mount
   useEffect(() => {
-    console.log('[OperationsActionsContext] loadInitialOperations dependency changed, calling it');
+    console.debug('[OperationsActionsContext] loadInitialOperations dependency changed, calling it');
     loadInitialOperations();
   }, [loadInitialOperations]);
 
@@ -285,7 +285,7 @@ export const OperationsActionsProvider = ({ children }) => {
 
   const addOperation = useCallback(async (operation) => {
     try {
-      console.log('[OperationsContext] addOperation called with:', {
+      console.debug('[OperationsContext] addOperation called with:', {
         type: operation.type,
         amount: operation.amount,
         accountId: operation.accountId,
@@ -298,7 +298,7 @@ export const OperationsActionsProvider = ({ children }) => {
       // Create operation in DB (ID will be auto-generated, handles balance updates automatically)
       const createdOperation = await OperationsDB.createOperation(operation);
 
-      console.log('[OperationsContext] Operation created successfully:', createdOperation?.id);
+      console.debug('[OperationsContext] Operation created successfully:', createdOperation?.id);
 
       // Reload operations to include the new one (without showing loading spinner)
       // Note: We reload to ensure consistency with lazy-loaded week ranges

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -24,7 +24,7 @@ export const useOperationsData = () => {
 };
 
 export const OperationsDataProvider = ({ children }) => {
-  console.log('[OperationsDataProvider] Component rendered');
+  console.debug('[OperationsDataProvider] Component rendered');
 
   // Dependencies from other contexts
   const { accounts } = useAccountsData();
@@ -57,7 +57,7 @@ export const OperationsDataProvider = ({ children }) => {
 
   // Track searchState changes
   useEffect(() => {
-    console.log('[OperationsDataContext] searchState changed:', searchState);
+    console.debug('[OperationsDataContext] searchState changed:', searchState);
   }, [searchState]);
 
   // Legacy filter state tracking (for backwards compatibility)
@@ -93,10 +93,10 @@ export const OperationsDataProvider = ({ children }) => {
     setSearchState(prev => {
       // Don't update if text hasn't changed (prevents infinite loop)
       if (prev.text === text) {
-        console.log('[OperationsDataContext] setSearchText called but text unchanged, skipping update');
+        console.debug('[OperationsDataContext] setSearchText called but text unchanged, skipping update');
         return prev;
       }
-      console.log('[OperationsDataContext] setSearchText updating from', prev.text, 'to', text);
+      console.debug('[OperationsDataContext] setSearchText updating from', prev.text, 'to', text);
       return { ...prev, text };
     });
   }, []);

--- a/app/contexts/SearchContext.js
+++ b/app/contexts/SearchContext.js
@@ -13,23 +13,23 @@ export const SearchProvider = ({ children }) => {
       console.warn('[SearchContext] Invalid searchMode:', mode);
       return;
     }
-    console.log('[SearchContext] setSearchMode:', mode);
+    console.debug('[SearchContext] setSearchMode:', mode);
     setInternalSearchMode(mode);
   }, []);
 
   const openSearch = useCallback(() => {
-    console.log('[SearchContext] openSearch called');
+    console.debug('[SearchContext] openSearch called');
     setInternalSearchMode('open');
   }, []);
 
   const closeSearch = useCallback((hasActiveFilters) => {
-    console.log('[SearchContext] closeSearch called, hasActiveFilters:', hasActiveFilters);
+    console.debug('[SearchContext] closeSearch called, hasActiveFilters:', hasActiveFilters);
     const newMode = hasActiveFilters ? 'collapsed' : 'closed';
     setInternalSearchMode(newMode);
   }, []);
 
   const reopenSearch = useCallback((hasTextFilter, hasOtherFilters, onShouldExpandFilters) => {
-    console.log('[SearchContext] reopenSearch called, hasText:', hasTextFilter, 'hasOther:', hasOtherFilters);
+    console.debug('[SearchContext] reopenSearch called, hasText:', hasTextFilter, 'hasOther:', hasOtherFilters);
     setInternalSearchMode('open');
 
     // Auto-expand filters if other filters (non-text) are present

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -120,7 +120,7 @@ export default function SettingsModal({ visible, onClose }) {
   };
 
   const openExportFormatModal = useCallback(() => {
-    console.log('openExportFormatModal called - showing modal');
+    console.debug('openExportFormatModal called - showing modal');
     setExportFormatModalVisible(true);
     Animated.timing(exportFormatSlideAnim, {
       toValue: 1,
@@ -248,7 +248,7 @@ export default function SettingsModal({ visible, onClose }) {
   };
 
   const handleExportBackup = () => {
-    console.log('handleExportBackup called - opening export format modal');
+    console.debug('handleExportBackup called - opening export format modal');
     openExportFormatModal();
   };
 

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -657,7 +657,7 @@ const OperationsScreen = () => {
 
   // Handle scroll to index failures (when item is not rendered yet)
   const handleScrollToIndexFailed = useCallback((info) => {
-    console.log('scrollToIndex failed for index:', info.index, 'Using offset fallback');
+    console.warn('scrollToIndex failed for index:', info.index, 'Using offset fallback');
 
     // Scroll to approximate position using offset
     const estimatedItemHeight = 75;
@@ -677,7 +677,7 @@ const OperationsScreen = () => {
           viewPosition: 0,
         });
       } catch (error) {
-        console.log('Second scrollToIndex attempt failed');
+        console.warn('Second scrollToIndex attempt failed');
       }
     }, 100);
   }, []);

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -339,7 +339,7 @@ export const restoreBackup = async (backup) => {
       for (const account of backup.data.accounts) {
         // Validate required fields
         if (!account.name) {
-          console.error('Skipping account with missing name:', account);
+          console.warn('Skipping account with missing name:', account);
           continue;
         }
 
@@ -405,7 +405,7 @@ export const restoreBackup = async (backup) => {
       for (const category of backup.data.categories) {
         // Validate required fields
         if (!category.id || !category.name) {
-          console.error('Skipping category with missing id or name:', category);
+          console.warn('Skipping category with missing id or name:', category);
           continue;
         }
 
@@ -448,7 +448,7 @@ export const restoreBackup = async (backup) => {
         
         // Validate that account_id is not null/undefined
         if (mappedAccountId == null) {
-          console.error('Skipping operation with null account_id:', operation);
+          console.warn('Skipping operation with null account_id:', operation);
           continue;
         }
 
@@ -532,7 +532,7 @@ export const restoreBackup = async (backup) => {
         for (const budget of backup.data.budgets) {
           // Validate required fields
           if (!budget.id || !budget.category_id || !budget.amount || !budget.currency) {
-            console.error('Skipping budget with missing required fields:', budget);
+            console.warn('Skipping budget with missing required fields:', budget);
             continue;
           }
 
@@ -615,7 +615,7 @@ export const restoreBackup = async (backup) => {
         });
         for (const planned of backup.data.planned_operations) {
           if (!planned.id || !planned.name) {
-            console.error('Skipping planned operation with missing id or name:', planned);
+            console.warn('Skipping planned operation with missing id or name:', planned);
             continue;
           }
 
@@ -919,7 +919,7 @@ const importBackupSQLite = async (fileUri) => {
     try {
       plannedOperations = await tempDb.getAllAsync('SELECT * FROM planned_operations ORDER BY created_at ASC');
     } catch (e) {
-      console.log('No planned_operations table in imported database (older format)');
+      console.warn('No planned_operations table in imported database (older format)');
     }
 
     // Create backup object

--- a/app/services/BalanceHistoryDB.js
+++ b/app/services/BalanceHistoryDB.js
@@ -187,7 +187,7 @@ export const populateCurrentMonthHistory = async (providedDb = null) => {
       error.message.includes('cannot rollback') ||
       error.message.includes('no transaction is active')
     )) {
-      console.log('Skipping balance history population - transaction conflict detected');
+      console.warn('Skipping balance history population - transaction conflict detected');
       return;
     }
     console.error('Failed to populate current month history:', error);

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -58,7 +58,7 @@ export const initializeDefaultOperations = async () => {
     const accounts = await AccountsDB.getAllAccounts();
 
     if (!accounts || accounts.length === 0) {
-      console.log('[OperationsDB] No accounts found, skipping default operations initialization');
+      console.debug('[OperationsDB] No accounts found, skipping default operations initialization');
       return;
     }
 
@@ -66,7 +66,7 @@ export const initializeDefaultOperations = async () => {
     const visibleAccounts = accounts.filter(acc => acc.hidden === 0);
 
     if (visibleAccounts.length === 0) {
-      console.log('[OperationsDB] No visible accounts found, using first available account');
+      console.warn('[OperationsDB] No visible accounts found, using first available account');
       visibleAccounts.push(accounts[0]);
     }
 
@@ -90,7 +90,7 @@ export const initializeDefaultOperations = async () => {
     // Create each operation (this also updates account balances and balance history)
     for (const op of defaultOps) {
       await createOperation(op);
-      console.log(`[OperationsDB] Created default operation: ${op.type} - ${op.amount}`);
+      console.debug(`[OperationsDB] Created default operation: ${op.type} - ${op.amount}`);
     }
 
     console.log(`[OperationsDB] Successfully initialized ${defaultOps.length} default operations`);
@@ -254,11 +254,11 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
 
-    console.log(`Loading filtered operations from ${startDate} to ${endDate}`, filters);
+    console.debug(`Loading filtered operations from ${startDate} to ${endDate}`, filters);
 
     const operations = await queryAll(sql, params);
 
-    console.log(`Filtered operations loaded: ${operations?.length || 0} operations`);
+    console.debug(`Filtered operations loaded: ${operations?.length || 0} operations`);
 
     return (operations || []).map(mapOperationFields);
   } catch (error) {
@@ -325,18 +325,18 @@ const calculateBalanceChanges = (operation) => {
  */
 export const createOperation = async (operation) => {
   try {
-    console.log('[OperationsDB] createOperation - type:', operation.type, 'amount:', operation.amount, typeof operation.amount, 'accountId:', operation.accountId, typeof operation.accountId, 'toAccountId:', operation.toAccountId, typeof operation.toAccountId, 'categoryId:', operation.categoryId, typeof operation.categoryId, 'date:', operation.date);
+    console.debug('[OperationsDB] createOperation - type:', operation.type, 'amount:', operation.amount, typeof operation.amount, 'accountId:', operation.accountId, typeof operation.accountId, 'toAccountId:', operation.toAccountId, typeof operation.toAccountId, 'categoryId:', operation.categoryId, typeof operation.categoryId, 'date:', operation.date);
     
     const now = new Date().toISOString();
     
     // Safely extract primitive IDs (handle case where objects might be passed)
     const extractId = (value, fieldName) => {
       if (value === null || value === undefined || value === '') {
-        console.log(`[OperationsDB] ${fieldName}: null/undefined/empty`);
+        console.debug(`[OperationsDB] ${fieldName}: null/undefined/empty`);
         return null;
       }
       if (typeof value === 'object' && value !== null) {
-        console.log(`[OperationsDB] ${fieldName}: object with id=${value.id} (${typeof value.id})`);
+        console.debug(`[OperationsDB] ${fieldName}: object with id=${value.id} (${typeof value.id})`);
         if (value.id !== undefined) {
           return value.id;
         }
@@ -359,7 +359,7 @@ export const createOperation = async (operation) => {
       destination_currency: operation.destinationCurrency || null,
     };
     
-    console.log('[OperationsDB] operationData - account_id:', operationData.account_id, typeof operationData.account_id, 'to_account_id:', operationData.to_account_id, typeof operationData.to_account_id, 'category_id:', operationData.category_id, typeof operationData.category_id);
+    console.debug('[OperationsDB] operationData - account_id:', operationData.account_id, typeof operationData.account_id, 'to_account_id:', operationData.to_account_id, typeof operationData.to_account_id, 'category_id:', operationData.category_id, typeof operationData.category_id);
 
     let newOperationId;
 
@@ -380,7 +380,7 @@ export const createOperation = async (operation) => {
         operationData.destination_currency,
       ];
       
-      console.log('[OperationsDB] INSERT params:', insertParams.map((p, i) => 
+      console.debug('[OperationsDB] INSERT params:', insertParams.map((p, i) =>
         `[${i}]: ${JSON.stringify(p)} (${typeof p})`,
       ).join(', '));
       
@@ -900,14 +900,14 @@ export const getOperationsByWeekOffset = async (weekOffset) => {
     const startDateStr = formatLocalDate(startDate);
     const endDateStr = formatLocalDate(endDate);
 
-    console.log(`Loading week ${weekOffset}: ${startDateStr} to ${endDateStr}`);
+    console.debug(`Loading week ${weekOffset}: ${startDateStr} to ${endDateStr}`);
 
     const operations = await queryAll(
       'SELECT * FROM operations WHERE date >= ? AND date <= ? ORDER BY date DESC, created_at DESC',
       [startDateStr, endDateStr],
     );
 
-    console.log(`Week ${weekOffset} loaded: ${operations?.length || 0} operations`);
+    console.debug(`Week ${weekOffset} loaded: ${operations?.length || 0} operations`);
 
     return (operations || []).map(mapOperationFields);
   } catch (error) {
@@ -951,14 +951,14 @@ export const getOperationsByWeekFromDate = async (endDate) => {
     const startDateStr = formatLocalDate(start);
     const endDateStr = formatLocalDate(end);
 
-    console.log(`Loading week from ${startDateStr} to ${endDateStr}`);
+    console.debug(`Loading week from ${startDateStr} to ${endDateStr}`);
 
     const operations = await queryAll(
       'SELECT * FROM operations WHERE date >= ? AND date <= ? ORDER BY date DESC, created_at DESC',
       [startDateStr, endDateStr],
     );
 
-    console.log(`Week loaded: ${operations?.length || 0} operations`);
+    console.debug(`Week loaded: ${operations?.length || 0} operations`);
 
     return (operations || []).map(mapOperationFields);
   } catch (error) {
@@ -1062,11 +1062,11 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
 
-    console.log(`Loading filtered week from ${startDateStr} to ${endDateStr}`, filters);
+    console.debug(`Loading filtered week from ${startDateStr} to ${endDateStr}`, filters);
 
     const operations = await queryAll(sql, params);
 
-    console.log(`Filtered week loaded: ${operations?.length || 0} operations`);
+    console.debug(`Filtered week loaded: ${operations?.length || 0} operations`);
 
     return (operations || []).map(mapOperationFields);
   } catch (error) {
@@ -1221,14 +1221,14 @@ export const getOperationsByWeekToDate = async (startDate) => {
     const startDateStr = formatLocalDate(start);
     const endDateStr = formatLocalDate(end);
 
-    console.log(`Loading week from ${startDateStr} to ${endDateStr}`);
+    console.debug(`Loading week from ${startDateStr} to ${endDateStr}`);
 
     const operations = await queryAll(
       'SELECT * FROM operations WHERE date >= ? AND date <= ? ORDER BY date DESC, created_at DESC',
       [startDateStr, endDateStr],
     );
 
-    console.log(`Week loaded: ${operations?.length || 0} operations`);
+    console.debug(`Week loaded: ${operations?.length || 0} operations`);
 
     return (operations || []).map(mapOperationFields);
   } catch (error) {
@@ -1422,11 +1422,11 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
 
-    console.log(`Loading filtered week from ${startDateStr} to ${endDateStr}`, filters);
+    console.debug(`Loading filtered week from ${startDateStr} to ${endDateStr}`, filters);
 
     const operations = await queryAll(sql, params);
 
-    console.log(`Filtered week loaded: ${operations?.length || 0} operations`);
+    console.debug(`Filtered week loaded: ${operations?.length || 0} operations`);
 
     return (operations || []).map(mapOperationFields);
   } catch (error) {

--- a/app/utils/emergencyReset.js
+++ b/app/utils/emergencyReset.js
@@ -19,20 +19,20 @@ const DB_NAME = 'penny.db';
  */
 export const forceDeleteDatabase = async (baseDir = FileSystem.documentDirectory) => {
   try {
-    console.log('Emergency database deletion initiated...');
+    console.debug('Emergency database deletion initiated...');
 
     // Construct database file path
     const dbPath = `${baseDir}SQLite/${DB_NAME}`;
-    console.log('Database path:', dbPath);
+    console.debug('Database path:', dbPath);
 
     // Check if file exists
     const fileInfo = await FileSystem.getInfoAsync(dbPath);
     if (fileInfo.exists) {
-      console.log('Database file found, deleting...');
+      console.debug('Database file found, deleting...');
       await FileSystem.deleteAsync(dbPath, { idempotent: true });
-      console.log('Database file deleted successfully');
+      console.debug('Database file deleted successfully');
     } else {
-      console.log('Database file does not exist');
+      console.debug('Database file does not exist');
     }
 
     // Also try to delete WAL and SHM files if they exist
@@ -41,19 +41,19 @@ export const forceDeleteDatabase = async (baseDir = FileSystem.documentDirectory
 
     try {
       await FileSystem.deleteAsync(walPath, { idempotent: true });
-      console.log('WAL file deleted');
+      console.debug('WAL file deleted');
     } catch (e) {
-      console.log('No WAL file to delete');
+      console.debug('No WAL file to delete');
     }
 
     try {
       await FileSystem.deleteAsync(shmPath, { idempotent: true });
-      console.log('SHM file deleted');
+      console.debug('SHM file deleted');
     } catch (e) {
-      console.log('No SHM file to delete');
+      console.debug('No SHM file to delete');
     }
 
-    console.log('Emergency database deletion completed');
+    console.debug('Emergency database deletion completed');
     return true;
   } catch (error) {
     console.error('Emergency database deletion failed:', error);


### PR DESCRIPTION
## summary

the debug/info/warn/error filter in Developer > Logs was useless bc everything was either info or error. this PR fixes that by auditing every log call site and assigning the right level.

## problem

- zero console.debug calls existed — debug filter showed nothing
- hot-path traces (per-render, per-keystroke, per-scroll) cluttered info alongside meaningful lifecycle events
- graceful data-quality skips in BackupRestore were logged as errors, making restore look broken when it was fine
- actual ui failures (scrollToIndex) were silently logged as info

## changes

to console.debug (was console.log/info): per-render Header traces, SearchContext open/close/mode state, OperationsDataContext render trace and every keystroke log, OperationsActionsContext load dependency tracing and full addOperation payload dump, BudgetsContext/CategoriesContext/AccountsDataContext RELOAD_ALL event handlers, OperationsDB week-loading logs (fire on every scroll) and createOperation insert param dumps, all emergencyReset step-by-step deletion traces, SettingsModal ux action logs

to console.warn (was console.error): BackupRestore 5x Skipping entity messages (restore continues normally, data quality notices not failures); also older-format compat detection for missing planned_operations table

to console.warn (was console.log/info): both scrollToIndex failure logs in OperationsScreen, balance history transaction conflict skip, OperationsDB fallback to first account when no visible accounts

updated 4 test files to spy on the correct console method (console.debug/warn)
