### PR TITLE
feat(ui): modal style standardization

### DIFF
--- a/__tests__/modals/CategoryModal.test.js
+++ b/__tests__/modals/CategoryModal.test.js
@@ -248,8 +248,8 @@ describe('CategoryModal', () => {
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
-      // Should show type selector
-      expect(getByText('select_type')).toBeTruthy();
+      // Should show type selector (label rendered uppercase)
+      expect(getByText('SELECT_TYPE')).toBeTruthy();
     });
 
     it('prevents changing folder to entry when category has children', () => {
@@ -300,7 +300,7 @@ describe('CategoryModal', () => {
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
-      expect(getByText('category_type')).toBeTruthy();
+      expect(getByText('CATEGORY_TYPE')).toBeTruthy();
       expect(getByText('expense')).toBeTruthy();
     });
 
@@ -310,7 +310,7 @@ describe('CategoryModal', () => {
       );
 
       // Parent picker should only show categories of the same type
-      expect(getByText('parent_category')).toBeTruthy();
+      expect(getByText('PARENT_CATEGORY')).toBeTruthy();
     });
   });
 

--- a/__tests__/modals/OperationModal.test.js
+++ b/__tests__/modals/OperationModal.test.js
@@ -394,11 +394,11 @@ describe('OperationModal', () => {
 
   describe('Save Operations', () => {
     it('shows save button', () => {
-      const { getByTestId } = render(
+      const { getByText } = render(
         <OperationModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
-      const saveButton = getByTestId('save-button');
+      const saveButton = getByText('save');
       expect(saveButton).toBeTruthy();
     });
 
@@ -410,11 +410,11 @@ describe('OperationModal', () => {
         handleSave: mockHandleSave,
       });
 
-      const { getByTestId } = render(
+      const { getByText } = render(
         <OperationModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
-      const saveButton = getByTestId('save-button');
+      const saveButton = getByText('save');
       fireEvent.press(saveButton);
 
       expect(mockHandleSave).toHaveBeenCalled();

--- a/__tests__/screens/AccountsScreen.test.js
+++ b/__tests__/screens/AccountsScreen.test.js
@@ -879,7 +879,7 @@ describe('AccountsScreen', () => {
 
       await waitFor(() => {
         // Find and press delete button
-        const deleteButtons = getAllByText('delete');
+        const deleteButtons = getAllByText('delete_account');
         fireEvent.press(deleteButtons[0]);
       });
 
@@ -924,7 +924,7 @@ describe('AccountsScreen', () => {
 
       await waitFor(() => {
         // Find and press delete button
-        const deleteButtons = getAllByText('delete');
+        const deleteButtons = getAllByText('delete_account');
         fireEvent.press(deleteButtons[0]);
       });
 
@@ -970,16 +970,14 @@ describe('AccountsScreen', () => {
 
       await waitFor(() => {
         // Find and press delete button
-        const deleteButtons = getAllByText('delete');
+        const deleteButtons = getAllByText('delete_account');
         fireEvent.press(deleteButtons[0]);
       });
 
       // Wait for confirmation dialog to appear and then confirm
-      await waitFor(async () => {
+      await waitFor(() => {
         const confirmDeleteButtons = getAllByText('delete');
-        if (confirmDeleteButtons.length > 1) {
-          fireEvent.press(confirmDeleteButtons[confirmDeleteButtons.length - 1]);
-        }
+        fireEvent.press(confirmDeleteButtons[0]);
       });
     });
   });

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -1,0 +1,274 @@
+// app/components/ModalShell.js
+import React from 'react';
+import {
+  View,
+  Modal as RNModal,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+  ScrollView,
+} from 'react-native';
+import { Text, TouchableRipple } from 'react-native-paper';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import ModalBlurOverlay from './ModalBlurOverlay';
+
+/**
+ * ModalShell — shared bottom-sheet wrapper for all modals.
+ *
+ * Renders: blur overlay → RNModal → KAV → overlay Pressable →
+ *   card (drag handle, header, ScrollView[children],
+ *          optional delete row, optional extraActions, cancel/save row)
+ *
+ * When onSave is omitted (shadow operations), only the cancel button is shown.
+ * When onDelete is omitted, the delete row is hidden.
+ */
+export default function ModalShell({
+  visible,
+  onDismiss,
+  title,
+  subtitle,
+  onSave,
+  onCancel,
+  saveLabel,
+  cancelLabel,
+  onDelete,
+  deleteLabel,
+  deleteDisabled,
+  extraActions,
+  scrollRef,
+  showBlurOverlay,
+  children,
+}) {
+  const { colors } = useThemeColors();
+  const { t } = useLocalization();
+
+  return (
+    <>
+      {showBlurOverlay && visible && <ModalBlurOverlay />}
+      <RNModal
+        visible={visible}
+        animationType="slide"
+        transparent={true}
+        onRequestClose={onDismiss}
+      >
+        <KeyboardAvoidingView behavior="padding" style={styles.flex1}>
+          <Pressable style={styles.overlay} onPress={onDismiss}>
+            <Pressable
+              style={[styles.card, { backgroundColor: colors.card }]}
+              onPress={() => {}}
+            >
+              {/* Drag handle */}
+              <View style={[styles.dragHandle, { backgroundColor: colors.border }]} />
+
+              {/* Header */}
+              <View style={styles.header}>
+                <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+                {subtitle ? (
+                  <Text style={[styles.subtitle, { color: colors.mutedText }]}>
+                    {subtitle}
+                  </Text>
+                ) : null}
+              </View>
+
+              {/* Scrollable form content */}
+              <ScrollView
+                ref={scrollRef}
+                style={styles.scroll}
+                contentContainerStyle={styles.scrollContent}
+                keyboardShouldPersistTaps="handled"
+                showsVerticalScrollIndicator={false}
+              >
+                {children}
+              </ScrollView>
+
+              {/* Delete row (shown only when onDelete is provided) */}
+              {onDelete ? (
+                <View style={styles.deleteWrapper}>
+                  <TouchableRipple
+                    onPress={deleteDisabled ? undefined : onDelete}
+                    disabled={deleteDisabled}
+                    rippleColor={colors.delete + '18'}
+                    style={[
+                      styles.btn,
+                      styles.deleteRow,
+                      { borderColor: colors.delete + '40' },
+                      deleteDisabled && styles.disabled,
+                    ]}
+                    borderless={false}
+                  >
+                    <View style={styles.deleteRowContent}>
+                      <Icon name="delete-outline" size={18} color={colors.delete} />
+                      <Text style={[styles.deleteRowText, { color: colors.delete }]}>
+                        {deleteLabel || t('delete')}
+                      </Text>
+                    </View>
+                  </TouchableRipple>
+                </View>
+              ) : null}
+
+              {/* Extra actions slot (e.g. Split button in OperationModal) */}
+              {extraActions || null}
+
+              {/* Cancel / Save (or full-width Cancel when onSave is absent) */}
+              <View style={[styles.actions, { borderTopColor: colors.border }]}>
+                <TouchableRipple
+                  onPress={onCancel}
+                  style={[
+                    styles.btn,
+                    styles.cancelBtn,
+                    { borderColor: colors.border },
+                    !onSave && styles.fullWidthBtn,
+                  ]}
+                  rippleColor="rgba(0,0,0,0.05)"
+                  borderless={false}
+                >
+                  <Text style={[styles.btnText, { color: colors.text }]}>
+                    {cancelLabel || t('cancel')}
+                  </Text>
+                </TouchableRipple>
+
+                {onSave ? (
+                  <TouchableRipple
+                    onPress={onSave}
+                    style={[styles.btn, { backgroundColor: colors.primary }]}
+                    rippleColor="rgba(255,255,255,0.2)"
+                    borderless={false}
+                  >
+                    <Text style={[styles.btnText, styles.saveBtnText]}>
+                      {saveLabel || t('save')}
+                    </Text>
+                  </TouchableRipple>
+                ) : null}
+              </View>
+            </Pressable>
+          </Pressable>
+        </KeyboardAvoidingView>
+      </RNModal>
+    </>
+  );
+}
+
+ModalShell.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  onSave: PropTypes.func,
+  onCancel: PropTypes.func.isRequired,
+  saveLabel: PropTypes.string,
+  cancelLabel: PropTypes.string,
+  onDelete: PropTypes.func,
+  deleteLabel: PropTypes.string,
+  deleteDisabled: PropTypes.bool,
+  extraActions: PropTypes.node,
+  scrollRef: PropTypes.object,
+  showBlurOverlay: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+ModalShell.defaultProps = {
+  subtitle: null,
+  onSave: null,
+  saveLabel: null,
+  cancelLabel: null,
+  onDelete: null,
+  deleteLabel: null,
+  deleteDisabled: false,
+  extraActions: null,
+  scrollRef: null,
+  showBlurOverlay: false,
+};
+
+const styles = StyleSheet.create({
+  actions: {
+    borderTopWidth: 1,
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingBottom: SPACING.xl,
+    paddingTop: SPACING.sm,
+  },
+  btn: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    flex: 1,
+    overflow: 'hidden',
+    paddingVertical: SPACING.sm,
+  },
+  btnText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  cancelBtn: {
+    borderWidth: 1,
+  },
+  card: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    maxHeight: '85%',
+    overflow: 'hidden',
+    paddingBottom: 0,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.sm,
+  },
+  deleteRow: {
+    borderWidth: 1,
+  },
+  deleteRowContent: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+  },
+  deleteRowText: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  deleteWrapper: {
+    flexDirection: 'row',
+    marginTop: SPACING.sm,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  dragHandle: {
+    alignSelf: 'center',
+    borderRadius: 3,
+    height: 4,
+    marginBottom: SPACING.md,
+    width: 44,
+  },
+  flex1: {
+    flex: 1,
+  },
+  fullWidthBtn: {
+    flex: 1,
+  },
+  header: {
+    marginBottom: SPACING.sm,
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  saveBtnText: {
+    color: '#fff',
+  },
+  scroll: {
+    flexShrink: 1,
+  },
+  scrollContent: {
+    paddingBottom: SPACING.sm,
+  },
+  subtitle: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+  },
+});

--- a/app/modals/CategoryModal.js
+++ b/app/modals/CategoryModal.js
@@ -2,30 +2,29 @@ import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import {
   View,
   Text,
-  TextInput,
-  Modal,
   Pressable,
   StyleSheet,
   FlatList,
   TouchableOpacity,
-  ScrollView,
-  KeyboardAvoidingView,
   Keyboard,
   Animated,
   Dimensions,
 } from 'react-native';
+import { TextInput as PaperTextInput, TouchableRipple } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useCategories } from '../contexts/CategoriesContext';
 import IconPicker from '../components/IconPicker';
-import ModalBlurOverlay from '../components/ModalBlurOverlay';
+import ModalShell from '../components/ModalShell';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
 import PropTypes from 'prop-types';
 import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
 
 export default function CategoryModal({ visible, onClose, category, isNew }) {
   const { colors } = useThemeColors();
+  const { paperInputTheme } = makeModalStyles(colors);
   const themed = useMemo(() => ({
     pickerItemText: { color: colors.text, fontSize: 18 },
     parentText: { color: colors.text, fontSize: 18, marginLeft: 12 },
@@ -153,273 +152,220 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
 
   return (
     <>
-      {visible && <ModalBlurOverlay />}
-      <Modal
+      <ModalShell
         visible={visible}
-        animationType="slide"
-        transparent={true}
-        onRequestClose={handleClose}
+        onDismiss={handleClose}
+        title={isNew ? t('add_category') : t('edit_category')}
+        onSave={handleSave}
+        onCancel={handleClose}
+        onDelete={isNew ? undefined : handleDelete}
+        deleteLabel={t('delete_category')}
+        showBlurOverlay
       >
-        <KeyboardAvoidingView behavior="padding" style={styles.keyboardAvoid}>
-          <Pressable style={styles.modalOverlay} onPress={handleClose}>
-            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-
-              {/* Drag handle */}
-              <View style={[styles.sheetDragHandle, { backgroundColor: colors.border }]} />
-
-              {/* Sheet header */}
-              <View style={styles.sheetHeader}>
-                <Text style={[styles.sheetTitle, { color: colors.text }]}>
-                  {isNew ? t('add_category') : t('edit_category')}
-                </Text>
-              </View>
-
-              <ScrollView
-                keyboardShouldPersistTaps="handled"
-                contentContainerStyle={styles.scrollContent}
-                showsVerticalScrollIndicator={false}
-                style={styles.sheetScroll}
-              >
-                {/* Name Input */}
-                <TextInput
-                  style={[
-                    styles.input,
-                    { color: colors.text, backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                  ]}
-                  value={values.name}
-                  onChangeText={text => setValues(v => ({ ...v, name: text }))}
-                  placeholder={t('category_name')}
-                  placeholderTextColor={colors.mutedText}
-                  autoFocus
-                  returnKeyType="done"
-                  onSubmitEditing={Keyboard.dismiss}
-                />
-
-                {/* Type Picker (Folder/Entry) */}
-                <Pressable
-                  style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                  onPress={() => handleOpenPicker('type')}
-                >
-                  <Text style={[styles.pickerLabel, { color: colors.mutedText }]}>
-                    {t('select_type')}
-                  </Text>
-                  <Text style={[styles.pickerValue, { color: colors.text }]}>
-                    {TYPE_OPTIONS.find(to => to.key === values.type)?.label}
-                  </Text>
-                </Pressable>
-
-                {/* Category Type Picker (Income/Expense) */}
-                <Pressable
-                  style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                  onPress={() => handleOpenPicker('categoryType')}
-                >
-                  <Text style={[styles.pickerLabel, { color: colors.mutedText }]}>
-                    {t('category_type')}
-                  </Text>
-                  <Text style={[styles.pickerValue, { color: colors.text }]}>
-                    {CATEGORY_TYPES.find(ct => ct.key === values.category_type)?.label}
-                  </Text>
-                </Pressable>
-
-                {/* Parent Picker */}
-                <Pressable
-                  style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                  onPress={() => handleOpenPicker('parent')}
-                >
-                  <Text style={[styles.pickerLabel, { color: colors.mutedText }]}>
-                    {t('parent_category')}
-                  </Text>
-                  <Text style={[styles.pickerValue, { color: colors.text }]}>
-                    {getParentName(values.parentId)}
-                  </Text>
-                </Pressable>
-
-                {/* Icon Picker */}
-                <Pressable
-                  testID="category-icon-picker"
-                  style={[styles.iconPickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                  onPress={() => setIconPickerVisible(true)}
-                >
-                  <Icon name={values.icon || 'folder'} size={32} color={colors.text} />
-                  <Text style={[styles.iconPickerText, { color: colors.mutedText }]}>
-                    {t('select_icon')}
-                  </Text>
-                </Pressable>
-
-                {errors.general && <Text style={styles.error}>{errors.general}</Text>}
-              </ScrollView>
-
-              {/* Delete zone (existing categories only) — outside ScrollView */}
-              {!isNew && (
-                <View style={styles.deleteWrapper}>
-                  <Pressable
-                    style={[styles.deleteRow, { borderColor: colors.delete + '40' }]}
-                    onPress={handleDelete}
-                  >
-                    <Icon name="delete-outline" size={18} color={colors.delete} />
-                    <Text style={[styles.deleteRowText, { color: colors.delete }]}>
-                      {t('delete_category')}
-                    </Text>
-                  </Pressable>
-                </View>
-              )}
-
-              {/* Action buttons */}
-              <View style={[styles.sheetActions, { borderTopColor: colors.border }]}>
-                <Pressable
-                  style={[styles.sheetBtn, styles.sheetBtnCancel, { borderColor: colors.border }]}
-                  onPress={handleClose}
-                >
-                  <Text style={[styles.sheetBtnText, { color: colors.text }]}>{t('cancel')}</Text>
-                </Pressable>
-                <Pressable
-                  style={[styles.sheetBtn, { backgroundColor: colors.primary }]}
-                  onPress={handleSave}
-                >
-                  <Text style={[styles.sheetBtnText, styles.sheetBtnSaveText]}>{t('save')}</Text>
-                </Pressable>
-              </View>
-
-              {/* In-sheet picker panel — slides in from the right */}
-              {activePicker && (
-                <Animated.View
-                  style={[styles.pickerPanel, { backgroundColor: colors.card, transform: [{ translateX: pickerSlideAnim }] }]}
-                >
-                  <View style={[styles.pickerPanelHeader, { borderBottomColor: colors.border }]}>
-                    <TouchableOpacity
-                      testID="picker-back-button"
-                      onPress={handleClosePicker}
-                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-                    >
-                      <Icon name="arrow-left" size={22} color={colors.text} />
-                    </TouchableOpacity>
-                    <Text style={[styles.pickerPanelTitle, { color: colors.text }]}>
-                      {pickerTitle}
-                    </Text>
-                  </View>
-
-                  {activePicker === 'type' && (
-                    <FlatList
-                      data={TYPE_OPTIONS}
-                      keyExtractor={item => item.key}
-                      renderItem={({ item }) => {
-                        const isDisabled = !isNew && hasChildren && item.key === 'entry';
-                        return (
-                          <Pressable
-                            onPress={() => {
-                              if (isDisabled) {
-                                showDialog(
-                                  t('error'),
-                                  t('cannot_change_to_entry_with_children') || 'Cannot change to entry type while category has subcategories',
-                                  [{ text: t('ok') }],
-                                );
-                                return;
-                              }
-                              setValues(v => ({ ...v, type: item.key }));
-                              handleClosePicker();
-                            }}
-                            style={({ pressed }) => [
-                              styles.pickerOption,
-                              { borderColor: colors.border },
-                              pressed && !isDisabled && { backgroundColor: colors.selected },
-                              isDisabled && { opacity: 0.5 },
-                            ]}
-                          >
-                            <Text style={[themed.pickerItemText, isDisabled && { color: colors.mutedText }]}>
-                              {item.label}
-                              {isDisabled && ' ⚠️'}
-                            </Text>
-                          </Pressable>
-                        );
-                      }}
-                    />
-                  )}
-
-                  {activePicker === 'categoryType' && (
-                    <FlatList
-                      data={CATEGORY_TYPES}
-                      keyExtractor={item => item.key}
-                      renderItem={({ item }) => (
-                        <Pressable
-                          onPress={() => {
-                            setValues(v => ({ ...v, category_type: item.key }));
-                            handleClosePicker();
-                          }}
-                          style={({ pressed }) => [
-                            styles.pickerOption,
-                            { borderColor: colors.border },
-                            pressed && { backgroundColor: colors.selected },
-                          ]}
-                        >
-                          <Text style={themed.pickerItemText}>{item.label}</Text>
-                        </Pressable>
-                      )}
-                    />
-                  )}
-
-                  {activePicker === 'parent' && (
-                    <FlatList
-                      data={[{ id: null, name: t('none'), icon: 'folder-outline' }, ...potentialParents]}
-                      keyExtractor={item => item.id || 'none'}
-                      renderItem={({ item }) => (
-                        <Pressable
-                          onPress={() => {
-                            setValues(v => ({ ...v, parentId: item.id }));
-                            handleClosePicker();
-                          }}
-                          style={({ pressed }) => [
-                            styles.pickerOption,
-                            { borderColor: colors.border },
-                            pressed && { backgroundColor: colors.selected },
-                          ]}
-                        >
-                          <View style={styles.parentOption}>
-                            <Icon name={item.icon} size={24} color={colors.text} />
-                            <Text style={themed.parentText}>
-                              {item.nameKey ? t(item.nameKey) : item.name}
-                            </Text>
-                          </View>
-                        </Pressable>
-                      )}
-                    />
-                  )}
-                </Animated.View>
-              )}
-
-            </Pressable>
-          </Pressable>
-        </KeyboardAvoidingView>
-
-        {/* Icon Picker Modal */}
-        <IconPicker
-          visible={iconPickerVisible}
-          onClose={() => setIconPickerVisible(false)}
-          onSelect={(icon) => setValues(v => ({ ...v, icon }))}
-          selectedIcon={values.icon}
+        {/* Name */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('category_name') || 'Name').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          value={values.name}
+          onChangeText={text => setValues(v => ({ ...v, name: text }))}
+          placeholder={t('category_name')}
+          autoFocus
+          returnKeyType="done"
+          onSubmitEditing={Keyboard.dismiss}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
         />
-      </Modal>
+
+        {/* Type (Folder / Entry) */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('select_type') || 'Type').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+          onPress={() => handleOpenPicker('type')}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+              {TYPE_OPTIONS.find(to => to.key === values.type)?.label}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+
+        {/* Category Type (Income / Expense) */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('category_type') || 'Category Type').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+          onPress={() => handleOpenPicker('categoryType')}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+              {CATEGORY_TYPES.find(ct => ct.key === values.category_type)?.label}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+
+        {/* Parent Category */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('parent_category') || 'Parent').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+          onPress={() => handleOpenPicker('parent')}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+              {getParentName(values.parentId)}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+
+        {/* Icon Picker (keeps its own style — icon preview) */}
+        <Pressable
+          testID="category-icon-picker"
+          style={[styles.iconPickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+          onPress={() => setIconPickerVisible(true)}
+        >
+          <Icon name={values.icon || 'folder'} size={32} color={colors.text} />
+          <Text style={[styles.iconPickerText, { color: colors.mutedText }]}>
+            {t('select_icon')}
+          </Text>
+        </Pressable>
+
+        {errors.general && <Text style={styles.error}>{errors.general}</Text>}
+
+        {/* In-sheet animated picker panel — slides in from the right */}
+        {activePicker && (
+          <Animated.View
+            style={[styles.pickerPanel, { backgroundColor: colors.card, transform: [{ translateX: pickerSlideAnim }] }]}
+          >
+            <View style={[styles.pickerPanelHeader, { borderBottomColor: colors.border }]}>
+              <TouchableOpacity
+                testID="picker-back-button"
+                onPress={handleClosePicker}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              >
+                <Icon name="arrow-left" size={22} color={colors.text} />
+              </TouchableOpacity>
+              <Text style={[styles.pickerPanelTitle, { color: colors.text }]}>
+                {pickerTitle}
+              </Text>
+            </View>
+
+            {activePicker === 'type' && (
+              <FlatList
+                data={TYPE_OPTIONS}
+                keyExtractor={item => item.key}
+                renderItem={({ item }) => {
+                  const isDisabled = !isNew && hasChildren && item.key === 'entry';
+                  return (
+                    <Pressable
+                      onPress={() => {
+                        if (isDisabled) {
+                          showDialog(
+                            t('error'),
+                            t('cannot_change_to_entry_with_children') || 'Cannot change to entry type while category has subcategories',
+                            [{ text: t('ok') }],
+                          );
+                          return;
+                        }
+                        setValues(v => ({ ...v, type: item.key }));
+                        handleClosePicker();
+                      }}
+                      style={({ pressed }) => [
+                        styles.pickerOption,
+                        { borderColor: colors.border },
+                        pressed && !isDisabled && { backgroundColor: colors.selected },
+                        isDisabled && styles.disabledOption,
+                      ]}
+                    >
+                      <Text style={[themed.pickerItemText, isDisabled && { color: colors.mutedText }]}>
+                        {item.label}{isDisabled && ' ⚠️'}
+                      </Text>
+                    </Pressable>
+                  );
+                }}
+              />
+            )}
+
+            {activePicker === 'categoryType' && (
+              <FlatList
+                data={CATEGORY_TYPES}
+                keyExtractor={item => item.key}
+                renderItem={({ item }) => (
+                  <Pressable
+                    onPress={() => {
+                      setValues(v => ({ ...v, category_type: item.key }));
+                      handleClosePicker();
+                    }}
+                    style={({ pressed }) => [
+                      styles.pickerOption,
+                      { borderColor: colors.border },
+                      pressed && { backgroundColor: colors.selected },
+                    ]}
+                  >
+                    <Text style={themed.pickerItemText}>{item.label}</Text>
+                  </Pressable>
+                )}
+              />
+            )}
+
+            {activePicker === 'parent' && (
+              <FlatList
+                data={[{ id: null, name: t('none'), icon: 'folder-outline' }, ...potentialParents]}
+                keyExtractor={item => item.id || 'none'}
+                renderItem={({ item }) => (
+                  <Pressable
+                    onPress={() => {
+                      setValues(v => ({ ...v, parentId: item.id }));
+                      handleClosePicker();
+                    }}
+                    style={({ pressed }) => [
+                      styles.pickerOption,
+                      { borderColor: colors.border },
+                      pressed && { backgroundColor: colors.selected },
+                    ]}
+                  >
+                    <View style={styles.parentOption}>
+                      <Icon name={item.icon} size={24} color={colors.text} />
+                      <Text style={themed.parentText}>
+                        {item.nameKey ? t(item.nameKey) : item.name}
+                      </Text>
+                    </View>
+                  </Pressable>
+                )}
+              />
+            )}
+          </Animated.View>
+        )}
+      </ModalShell>
+
+      {/* Icon Picker Modal — outside ModalShell */}
+      <IconPicker
+        visible={iconPickerVisible}
+        onClose={() => setIconPickerVisible(false)}
+        onSelect={(icon) => setValues(v => ({ ...v, icon }))}
+        selectedIcon={values.icon}
+      />
     </>
   );
 }
 
 const styles = StyleSheet.create({
-  deleteRow: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: 1,
-    flex: 1,
-    flexDirection: 'row',
-    gap: SPACING.sm,
-    justifyContent: 'center',
-    paddingVertical: SPACING.sm,
-  },
-  deleteRowText: {
-    fontSize: 15,
-    fontWeight: '500',
-  },
-  deleteWrapper: {
-    flexDirection: 'row',
-    marginTop: SPACING.sm,
+  disabledOption: {
+    opacity: 0.5,
   },
   error: {
     color: '#ff6b6b',
@@ -432,47 +378,15 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     flexDirection: 'row',
     marginBottom: SPACING.sm,
+    marginTop: SPACING.sm,
     padding: SPACING.md,
   },
   iconPickerText: {
     marginLeft: SPACING.md,
   },
-  input: {
-    borderRadius: BORDER_RADIUS.sm,
-    borderWidth: 1,
-    fontSize: 16,
-    marginBottom: SPACING.sm,
-    padding: SPACING.md,
-  },
-  keyboardAvoid: {
-    flex: 1,
-  },
-  modalContent: {
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    maxHeight: '85%',
-    overflow: 'hidden',
-    paddingBottom: 0,
-    paddingHorizontal: SPACING.lg,
-    paddingTop: SPACING.sm,
-  },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
   parentOption: {
     alignItems: 'center',
     flexDirection: 'row',
-  },
-  pickerButton: {
-    borderRadius: BORDER_RADIUS.sm,
-    borderWidth: 1,
-    marginBottom: SPACING.sm,
-    padding: SPACING.md,
-  },
-  pickerLabel: {
-    fontSize: 12,
-    marginBottom: 4,
   },
   pickerOption: {
     borderBottomWidth: 1,
@@ -499,54 +413,6 @@ const styles = StyleSheet.create({
   pickerPanelTitle: {
     fontSize: 17,
     fontWeight: '600',
-  },
-  pickerValue: {
-    fontSize: 16,
-  },
-  scrollContent: {
-    paddingBottom: SPACING.sm,
-  },
-  sheetActions: {
-    borderTopWidth: 1,
-    flexDirection: 'row',
-    gap: SPACING.sm,
-    paddingBottom: SPACING.xl,
-    paddingTop: SPACING.sm,
-  },
-  sheetBtn: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
-    flex: 1,
-    overflow: 'hidden',
-    paddingVertical: SPACING.sm,
-  },
-  sheetBtnCancel: {
-    borderWidth: 1,
-  },
-  sheetBtnSaveText: {
-    color: '#fff',
-  },
-  sheetBtnText: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  sheetDragHandle: {
-    alignSelf: 'center',
-    borderRadius: 3,
-    height: 4,
-    marginBottom: SPACING.md,
-    width: 44,
-  },
-  sheetHeader: {
-    marginBottom: SPACING.sm,
-  },
-  sheetScroll: {
-    flexShrink: 1,
-  },
-  sheetTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    letterSpacing: -0.3,
   },
 });
 

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -3,14 +3,10 @@ import PropTypes from 'prop-types';
 import {
   View,
   Text,
-  TextInput,
   Modal,
   Pressable,
   StyleSheet,
   FlatList,
-  ScrollView,
-  KeyboardAvoidingView,
-  Platform,
   Dimensions,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -32,8 +28,8 @@ import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
 import currencies from '../../assets/currencies.json';
 import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
 import useOperationForm from '../hooks/useOperationForm';
-import ModalBlurOverlay from '../components/ModalBlurOverlay';
-import ModalHeader from '../components/ModalHeader';
+import ModalShell from '../components/ModalShell';
+import { modalSharedStyles } from '../styles/modalStyles';
 import useOperationPicker from '../hooks/useOperationPicker';
 
 /**
@@ -352,214 +348,156 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     { key: 'transfer', label: t('transfer'), icon: 'swap-horizontal' },
   ];
 
+  const splitExtraActions = canSplit ? (
+    <View style={styles.splitDeleteRow}>
+      <Pressable
+        style={[styles.splitButtonContainer, { backgroundColor: colors.card }]}
+        onPress={() => setShowSplitModal(true)}
+        testID="split-button"
+      >
+        <Icon name="call-split" size={18} color={colors.primary} />
+        <Text style={[styles.splitButtonText, { color: colors.primary }]}>
+          {t('split_transaction')}
+        </Text>
+      </Pressable>
+    </View>
+  ) : null;
+
   return (
     <>
-      {visible && <ModalBlurOverlay />}
-      <Modal
+      <ModalShell
         visible={visible}
-        animationType="slide"
-        transparent={true}
-        onRequestClose={handleClose}
+        onDismiss={handleClose}
+        title={isNew ? t('add_operation') : t('edit_operation')}
+        onSave={isShadowOperation ? undefined : handleSave}
+        onCancel={handleClose}
+        cancelLabel={isShadowOperation ? t('close') : t('cancel')}
+        onDelete={!isNew && onDelete ? handleDelete : undefined}
+        deleteDisabled={!canDeleteShadowOperation}
+        deleteLabel={t('delete_operation')}
+        extraActions={splitExtraActions}
+        scrollRef={scrollViewRef}
+        showBlurOverlay
       >
-        <KeyboardAvoidingView behavior="padding" style={styles.fullFlex}>
-          <Pressable style={styles.modalOverlay} onPress={handleClose}>
-            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={handleStopPropagation}>
-              <View style={[styles.sheetDragHandle, { backgroundColor: colors.border }]} />
-              <ScrollView
-                ref={scrollViewRef}
-                style={styles.scrollView}
-                contentContainerStyle={styles.scrollContent}
-                keyboardShouldPersistTaps="handled"
-                showsVerticalScrollIndicator={false}
+        {/* Shared Form Fields: type selector, amount, account(s), category, multi-currency */}
+        <OperationFormFields
+          colors={colors}
+          t={t}
+          values={values}
+          setValues={setValues}
+          accounts={accounts}
+          categories={filteredCategories}
+          getAccountName={getAccountName}
+          getAccountBalance={getAccountBalance}
+          getCategoryName={getCategoryName}
+          openPicker={openPicker}
+          onAmountChange={handleAmountChange}
+          TYPES={TYPES}
+          showTypeSelector={true}
+          showAccountBalance={true}
+          showFieldIcons={true}
+          hideCategoryPicker={!isNew}
+          hideTransferTargetPicker={true}
+          transferLayout="sideBySide"
+          disabled={isShadowOperation}
+          containerBackground={colors.card}
+          onExchangeRateChange={handleExchangeRateChange}
+          onDestinationAmountChange={handleDestinationAmountChange}
+          rateSource={rateSource}
+        />
+
+        {/* Category / To Account + Date row */}
+        <View style={styles.categoryDateRow}>
+          {values.type === 'transfer' ? (
+            <View style={styles.halfFieldWrapper}>
+              <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+                {(t('to_account') || 'To').toUpperCase()}
+              </Text>
+              <Pressable
+                style={[
+                  styles.pickerButtonHalf,
+                  { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                  isShadowOperation && styles.disabledInput,
+                ]}
+                onPress={() => !isShadowOperation && openPicker('toAccount', accounts.filter(acc => acc.id !== values.accountId))}
+                disabled={isShadowOperation}
+                accessibilityRole="button"
+                accessibilityLabel={t('to_account')}
+                testID="to-account-picker"
               >
-                {isNew && <ModalHeader title={t('add_operation')} />}
-
-                {/* Shared Form Fields: Type selector, Amount, Account(s), Category, Multi-currency */}
-                <OperationFormFields
-                  colors={colors}
-                  t={t}
-                  values={values}
-                  setValues={setValues}
-                  accounts={accounts}
-                  categories={filteredCategories}
-                  getAccountName={getAccountName}
-                  getAccountBalance={getAccountBalance}
-                  getCategoryName={getCategoryName}
-                  openPicker={openPicker}
-                  onAmountChange={handleAmountChange}
-                  TYPES={TYPES}
-                  showTypeSelector={true}
-                  showAccountBalance={true}
-                  showFieldIcons={true}
-                  hideCategoryPicker={!isNew}
-                  hideTransferTargetPicker={true}
-                  transferLayout="sideBySide"
-                  disabled={isShadowOperation}
-                  containerBackground={colors.card}
-                  onExchangeRateChange={handleExchangeRateChange}
-                  onDestinationAmountChange={handleDestinationAmountChange}
-                  rateSource={rateSource}
-                />
-
-                {/* Date + Category (or To Account for transfer) row */}
-                <View style={styles.categoryDateRow}>
-                  {values.type === 'transfer' ? (
-                    <Pressable
-                      style={[
-                        styles.pickerButtonHalf,
-                        { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                        isShadowOperation && styles.disabledInput,
-                      ]}
-                      onPress={() => !isShadowOperation && openPicker('toAccount', accounts.filter(acc => acc.id !== values.accountId))}
-                      disabled={isShadowOperation}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('to_account')}
-                      testID="to-account-picker"
-                    >
-                      <Icon name="swap-horizontal" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
-                      <Text
-                        style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}
-                        numberOfLines={1}
-                      >
-                        {values.toAccountId ? getAccountName(values.toAccountId) : t('to_account')}
-                      </Text>
-                    </Pressable>
-                  ) : (
-                    <Pressable
-                      style={[
-                        styles.pickerButtonHalf,
-                        { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                        isShadowOperation && styles.disabledInput,
-                      ]}
-                      onPress={() => !isShadowOperation && openPicker('category', filteredCategories)}
-                      disabled={isShadowOperation}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('select_category')}
-                    >
-                      <Icon name="tag" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
-                      <Text
-                        style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}
-                        numberOfLines={1}
-                      >
-                        {getCategoryName(values.categoryId)}
-                      </Text>
-                    </Pressable>
-                  )}
-                  <Pressable
-                    style={[
-                      styles.pickerButtonHalf,
-                      { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                      isShadowOperation && styles.disabledInput,
-                    ]}
-                    onPress={handleOpenDatePicker}
-                    disabled={isShadowOperation}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('select_date')}
-                    testID="date-input"
-                  >
-                    <Icon name="calendar" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
-                    <Text style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}>
-                      {formatDateForDisplay(values.date)}
-                    </Text>
-                  </Pressable>
-                </View>
-
-                {/* Description Input with autocomplete suggestions */}
-                <DescriptionAutocomplete
-                  value={values.description || ''}
-                  onChangeText={handleDescriptionChange}
-                  suggestions={descriptionSuggestions}
-                  placeholder={t('description')}
-                  editable={!isShadowOperation}
-                  colors={colors}
-                  onFocus={handleDescriptionFocus}
-                />
-
-                {errors.general && <Text style={styles.error}>{errors.general}</Text>}
-              </ScrollView>
-
-              {/* Action Buttons */}
-              <View style={[styles.modalButtonRow, { backgroundColor: colors.card }]}>
-                <Pressable
-                  style={[styles.modalButton, { backgroundColor: colors.secondary }]}
-                  onPress={handleClose}
+                <Icon name="swap-horizontal" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
+                <Text
+                  style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}
+                  numberOfLines={1}
                 >
-                  <Text style={[styles.buttonText, { color: colors.text }]}>
-                    {isShadowOperation ? t('close') : t('cancel')}
-                  </Text>
-                </Pressable>
-                {!isShadowOperation && (
-                  <Pressable
-                    style={[styles.modalButton, { backgroundColor: colors.primary }]}
-                    onPress={handleSave}
-                    accessibilityLabel="Save"
-                    testID="save-button" // Added testID for Save button
-                  >
-                    <Text style={[styles.buttonText, { color: colors.text }]}>
-                      {t('save')}
-                    </Text>
-                  </Pressable>
-                )}
-              </View>
+                  {values.toAccountId ? getAccountName(values.toAccountId) : t('to_account')}
+                </Text>
+              </Pressable>
+            </View>
+          ) : (
+            <View style={styles.halfFieldWrapper}>
+              <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+                {(t('select_category') || 'Category').toUpperCase()}
+              </Text>
+              <Pressable
+                style={[
+                  styles.pickerButtonHalf,
+                  { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                  isShadowOperation && styles.disabledInput,
+                ]}
+                onPress={() => !isShadowOperation && openPicker('category', filteredCategories)}
+                disabled={isShadowOperation}
+                accessibilityRole="button"
+                accessibilityLabel={t('select_category')}
+              >
+                <Icon name="tag" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
+                <Text
+                  style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}
+                  numberOfLines={1}
+                >
+                  {getCategoryName(values.categoryId)}
+                </Text>
+              </Pressable>
+            </View>
+          )}
 
-              {/* Split & Delete Buttons Row */}
-              {(canSplit || (!isNew && onDelete)) && (
-                <View style={styles.splitDeleteRow}>
-                  {canSplit && (
-                    <Pressable
-                      style={[
-                        styles.splitButtonContainer,
-                        { backgroundColor: colors.card },
-                      ]}
-                      onPress={() => setShowSplitModal(true)}
-                      testID="split-button"
-                    >
-                      <Icon
-                        name="call-split"
-                        size={18}
-                        color={colors.primary}
-                      />
-                      <Text
-                        style={[
-                          styles.splitButtonText,
-                          { color: colors.primary },
-                        ]}
-                      >
-                        {t('split_transaction')}
-                      </Text>
-                    </Pressable>
-                  )}
-                  {!isNew && onDelete && (
-                    <Pressable
-                      style={[
-                        styles.deleteButtonContainer,
-                        { backgroundColor: colors.card },
-                        !canDeleteShadowOperation && styles.disabledButton,
-                      ]}
-                      onPress={handleDelete}
-                      disabled={!canDeleteShadowOperation}
-                    >
-                      <Icon
-                        name="delete-outline"
-                        size={18}
-                        color={canDeleteShadowOperation ? (colors.delete || '#ff6b6b') : colors.mutedText}
-                      />
-                      <Text
-                        style={[
-                          styles.deleteButtonText,
-                          { color: canDeleteShadowOperation ? (colors.delete || '#ff6b6b') : colors.mutedText },
-                        ]}
-                      >
-                        {t('delete_operation')}
-                      </Text>
-                    </Pressable>
-                  )}
-                </View>
-              )}
+          <View style={styles.halfFieldWrapper}>
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('select_date') || 'Date').toUpperCase()}
+            </Text>
+            <Pressable
+              style={[
+                styles.pickerButtonHalf,
+                { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                isShadowOperation && styles.disabledInput,
+              ]}
+              onPress={handleOpenDatePicker}
+              disabled={isShadowOperation}
+              accessibilityRole="button"
+              accessibilityLabel={t('select_date')}
+              testID="date-input"
+            >
+              <Icon name="calendar" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
+              <Text style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}>
+                {formatDateForDisplay(values.date)}
+              </Text>
             </Pressable>
-          </Pressable>
-        </KeyboardAvoidingView>
-      </Modal>
+          </View>
+        </View>
+
+        {/* Description with autocomplete */}
+        <DescriptionAutocomplete
+          value={values.description || ''}
+          onChangeText={handleDescriptionChange}
+          suggestions={descriptionSuggestions}
+          placeholder={t('description')}
+          editable={!isShadowOperation}
+          colors={colors}
+          onFocus={handleDescriptionFocus}
+        />
+
+        {errors.general && <Text style={styles.error}>{errors.general}</Text>}
+      </ModalShell>
 
       {/* Split Operation Modal */}
       <SplitOperationModal
@@ -592,7 +530,6 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
       >
         <Pressable style={styles.pickerOverlay} onPress={closePicker}>
           <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={handleStopPropagation}>
-            {/* Breadcrumb navigation for categories */}
             {pickerState.type === 'category' && categoryNavigation.breadcrumb.length > 0 && (
               <View style={[styles.breadcrumbContainer, { borderBottomColor: colors.border }]}>
                 <Pressable onPress={navigateBack} style={styles.backButton}>
@@ -603,7 +540,6 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
                 </Text>
               </View>
             )}
-
             <FlatList
               data={pickerState.data}
               keyExtractor={keyExtractor}
@@ -617,7 +553,6 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
                 </Text>
               }
             />
-            {/* Show Close button for non-category pickers OR when editing operations */}
             {(pickerState.type !== 'category' || !isNew) && (
               <Pressable style={styles.closeButton} onPress={closePicker}>
                 <Text style={[styles.closeButtonText, { color: colors.primary }]}>{t('close')}</Text>
@@ -657,10 +592,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '600',
   },
-  buttonText: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
   categoryDateRow: {
     flexDirection: 'row',
     gap: SPACING.sm,
@@ -680,22 +611,6 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-  deleteButtonContainer: {
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-    gap: SPACING.xs,
-    justifyContent: 'center',
-    minHeight: 44,
-    paddingVertical: SPACING.sm,
-  },
-  deleteButtonText: {
-    fontSize: 14,
-    fontWeight: '500',
-  },
-  disabledButton: {
-    opacity: 0.5,
-  },
   disabledInput: {
     opacity: 0.6,
   },
@@ -708,9 +623,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 4,
     top: 4,
-  },
-  fullFlex: {
-    flex: 1,
   },
   gridCell: {
     alignItems: 'center',
@@ -733,32 +645,8 @@ const styles = StyleSheet.create({
   gridRow: {
     justifyContent: 'flex-start',
   },
-  modalButton: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
+  halfFieldWrapper: {
     flex: 1,
-    marginHorizontal: SPACING.sm,
-    minHeight: 48,
-    paddingVertical: SPACING.md,
-  },
-  modalButtonRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginTop: 16,
-  },
-  modalContent: {
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    maxHeight: '85%',
-    overflow: 'hidden',
-    paddingBottom: SPACING.xxl,
-    paddingHorizontal: SPACING.lg,
-    paddingTop: SPACING.sm,
-    width: '100%',
-  },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
   },
   pickerButtonHalf: {
     alignItems: 'center',
@@ -802,20 +690,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'flex-end',
-  },
-  scrollContent: {
-    paddingBottom: SPACING.xl,
-  },
-  scrollView: {
-    flexGrow: 0,
-    flexShrink: 1,
-  },
-  sheetDragHandle: {
-    alignSelf: 'center',
-    borderRadius: 3,
-    height: 4,
-    marginBottom: SPACING.md,
-    width: 44,
   },
   splitButtonContainer: {
     alignItems: 'center',

--- a/app/modals/PlannedOperationModal.js
+++ b/app/modals/PlannedOperationModal.js
@@ -2,17 +2,14 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   View,
   Text,
-  TextInput,
   Modal,
   Pressable,
   StyleSheet,
   FlatList,
-  ScrollView,
-  KeyboardAvoidingView,
-  Platform,
   Keyboard,
   Switch,
 } from 'react-native';
+import { TextInput as PaperTextInput, TouchableRipple } from 'react-native-paper';
 import PropTypes from 'prop-types';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -23,9 +20,9 @@ import { useAccountsData } from '../contexts/AccountsDataContext';
 import { useCategories } from '../contexts/CategoriesContext';
 import useOperationPicker from '../hooks/useOperationPicker';
 import PickerModal from '../components/operations/PickerModal';
-import { SPACING, BORDER_RADIUS, HEIGHTS, FONT_SIZE } from '../styles/designTokens';
-import ModalBlurOverlay from '../components/ModalBlurOverlay';
-import ModalHeader from '../components/ModalHeader';
+import ModalShell from '../components/ModalShell';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
+import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 
 const TYPE_OPTIONS = [
   { key: 'expense', icon: 'arrow-up', colorKey: 'expense' },
@@ -35,6 +32,7 @@ const TYPE_OPTIONS = [
 
 export default function PlannedOperationModal({ visible, onClose, plannedOperation, isNew }) {
   const { colors } = useThemeColors();
+  const { paperInputTheme } = makeModalStyles(colors);
   const { t } = useLocalization();
   const { showDialog } = useDialog();
   const { addPlannedOperation, updatePlannedOperation, deletePlannedOperation } = usePlannedOperations();
@@ -235,204 +233,204 @@ export default function PlannedOperationModal({ visible, onClose, plannedOperati
 
   return (
     <>
-      {visible && <ModalBlurOverlay />}
-      <Modal visible={visible} animationType="slide" transparent onRequestClose={handleClose}>
-        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.flex1}>
-          <Pressable style={styles.modalOverlay} onPress={handleClose}>
-            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
-
-                <ModalHeader title={isNew ? t('add_planned_operation') : t('edit_planned_operation')} />
-
-                {/* Name Input */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('planned_name')}</Text>
-                  <TextInput
-                    style={[styles.input, { color: colors.text, backgroundColor: colors.inputBackground, borderColor: errors.name ? colors.error : colors.inputBorder }]}
-                    value={values.name}
-                    onChangeText={text => setValues(v => ({ ...v, name: text }))}
-                    placeholder={t('planned_operation_name_hint')}
-                    placeholderTextColor={colors.mutedText}
-                    returnKeyType="next"
-                  />
-                  {errors.name && <Text style={[styles.error, { color: colors.error }]}>{errors.name}</Text>}
-                </View>
-
-                {/* Type Selector */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('operation_type')}</Text>
-                  <View style={styles.typeRow}>
-                    {TYPE_OPTIONS.map(opt => {
-                      const isActive = values.type === opt.key;
-                      const typeLabelStyle = { color: isActive ? '#fff' : colors.mutedText };
-                      return (
-                        <Pressable
-                          key={opt.key}
-                          style={[
-                            styles.typeButton,
-                            {
-                              backgroundColor: isActive ? colors[opt.colorKey] : colors.inputBackground,
-                              borderColor: isActive ? colors[opt.colorKey] : colors.inputBorder,
-                            },
-                          ]}
-                          onPress={() => setValues(v => ({ ...v, type: opt.key, categoryId: null }))}
-                        >
-                          <Icon name={opt.icon} size={18} color={isActive ? '#fff' : colors.mutedText} />
-                          <Text style={[styles.typeLabel, typeLabelStyle]}>
-                            {t(`${opt.key}_label`) || t(opt.key)}
-                          </Text>
-                        </Pressable>
-                      );
-                    })}
-                  </View>
-                </View>
-
-                {/* Amount Input */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('amount')}</Text>
-                  <TextInput
-                    style={[styles.input, { color: colors.text, backgroundColor: colors.inputBackground, borderColor: errors.amount ? colors.error : colors.inputBorder }]}
-                    value={values.amount}
-                    onChangeText={text => setValues(v => ({ ...v, amount: text }))}
-                    placeholder="0.00"
-                    placeholderTextColor={colors.mutedText}
-                    keyboardType="decimal-pad"
-                    returnKeyType="done"
-                    onSubmitEditing={Keyboard.dismiss}
-                  />
-                  {errors.amount && <Text style={[styles.error, { color: colors.error }]}>{errors.amount}</Text>}
-                </View>
-
-                {/* Account Picker */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('select_account')}</Text>
-                  <Pressable
-                    testID="planned-account-picker"
-                    style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.accountId ? colors.error : colors.inputBorder }]}
-                    onPress={() => setAccountPickerVisible(true)}
-                  >
-                    <Text style={[styles.pickerButtonText, { color: values.accountId ? colors.text : colors.mutedText }]}>
-                      {values.accountId ? getAccountName(values.accountId) : t('select_account')}
-                    </Text>
-                    <Icon name="chevron-down" size={20} color={colors.mutedText} />
-                  </Pressable>
-                  {errors.accountId && <Text style={[styles.error, { color: colors.error }]}>{errors.accountId}</Text>}
-                </View>
-
-                {/* Category Picker (for expense/income) */}
-                {values.type !== 'transfer' && (
-                  <View style={styles.inputContainer}>
-                    <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('select_category')}</Text>
-                    <Pressable
-                      testID="planned-category-picker"
-                      style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.categoryId ? colors.error : colors.inputBorder }]}
-                      onPress={() => openCategoryPicker('category', filteredCategories)}
-                    >
-                      <Text style={[styles.pickerButtonText, { color: values.categoryId ? colors.text : colors.mutedText }]}>
-                        {values.categoryId ? getCategoryName(values.categoryId) : t('select_category')}
-                      </Text>
-                      <Icon name="chevron-down" size={20} color={colors.mutedText} />
-                    </Pressable>
-                    {errors.categoryId && <Text style={[styles.error, { color: colors.error }]}>{errors.categoryId}</Text>}
-                  </View>
-                )}
-
-                {/* To Account Picker (for transfers) */}
-                {values.type === 'transfer' && (
-                  <View style={styles.inputContainer}>
-                    <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('to_account')}</Text>
-                    <Pressable
-                      style={[styles.pickerButton, { backgroundColor: colors.inputBackground, borderColor: errors.toAccountId ? colors.error : colors.inputBorder }]}
-                      onPress={() => setToAccountPickerVisible(true)}
-                    >
-                      <Text style={[styles.pickerButtonText, { color: values.toAccountId ? colors.text : colors.mutedText }]}>
-                        {values.toAccountId ? getAccountName(values.toAccountId) : t('select_account')}
-                      </Text>
-                      <Icon name="chevron-down" size={20} color={colors.mutedText} />
-                    </Pressable>
-                    {errors.toAccountId && <Text style={[styles.error, { color: colors.error }]}>{errors.toAccountId}</Text>}
-                  </View>
-                )}
-
-                {/* Recurring Toggle */}
-                <View style={[styles.inputContainer, styles.switchRow]}>
-                  <Text style={[styles.inputLabel, styles.inputLabelNoMargin, { color: colors.mutedText }]}>
-                    {t('recurring')}
-                  </Text>
-                  <Switch
-                    value={values.isRecurring}
-                    onValueChange={val => setValues(v => ({ ...v, isRecurring: val }))}
-                    trackColor={{ false: colors.border, true: colors.primary + '66' }}
-                    thumbColor={values.isRecurring ? colors.primary : colors.mutedText}
-                  />
-                </View>
-
-                {/* Description */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>{t('description')}</Text>
-                  <TextInput
-                    style={[styles.input, styles.multilineInput, { color: colors.text, backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                    value={values.description}
-                    onChangeText={text => setValues(v => ({ ...v, description: text }))}
-                    placeholder={t('description')}
-                    placeholderTextColor={colors.mutedText}
-                    multiline
-                    numberOfLines={2}
-                  />
-                </View>
-
-                {/* Action Buttons */}
-                <View style={styles.buttonRow}>
-                  {!isNew && (
-                    <Pressable style={[styles.button, { backgroundColor: colors.danger || colors.delete }]} onPress={handleDelete}>
-                      <Text style={styles.buttonText}>{t('delete')}</Text>
-                    </Pressable>
-                  )}
-                  <Pressable style={[styles.button, { backgroundColor: colors.border }]} onPress={handleClose}>
-                    <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel')}</Text>
-                  </Pressable>
-                  <Pressable style={[styles.button, { backgroundColor: colors.primary }]} onPress={handleSave}>
-                    <Text style={styles.buttonText}>{t('save')}</Text>
-                  </Pressable>
-                </View>
-              </ScrollView>
-            </Pressable>
-          </Pressable>
-        </KeyboardAvoidingView>
-
-        {/* Account Picker Modal */}
-        {renderPickerModal(
-          accountPickerVisible,
-          setAccountPickerVisible,
-          accounts.map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
-          (id) => setValues(v => ({ ...v, accountId: id })),
-          t('select_account'),
-        )}
-
-        {/* To Account Picker Modal */}
-        {renderPickerModal(
-          toAccountPickerVisible,
-          setToAccountPickerVisible,
-          accounts.filter(a => a.id !== values.accountId).map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
-          (id) => setValues(v => ({ ...v, toAccountId: id })),
-          t('to_account'),
-        )}
-
-        {/* Category Picker Modal (hierarchical) */}
-        <PickerModal
-          visible={categoryPickerState.visible}
-          pickerType={categoryPickerState.type}
-          pickerData={categoryPickerState.data}
-          colors={colors}
-          t={t}
-          onClose={closeCategoryPicker}
-          categoryNavigation={categoryNavigation}
-          quickAddValues={{ ...values, amount: '' }}
-          onNavigateBack={navigateBack}
-          onNavigateIntoFolder={navigateIntoFolder}
-          onSelectCategory={(id) => { setValues(v => ({ ...v, categoryId: id })); closeCategoryPicker(); }}
+      <ModalShell
+        visible={visible}
+        onDismiss={handleClose}
+        title={isNew ? t('add_planned_operation') : t('edit_planned_operation')}
+        onSave={handleSave}
+        onCancel={handleClose}
+        onDelete={isNew ? undefined : handleDelete}
+        deleteLabel={t('delete_planned_operation')}
+        showBlurOverlay
+      >
+        {/* Name */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('planned_name') || 'Name').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          value={values.name}
+          onChangeText={text => setValues(v => ({ ...v, name: text }))}
+          placeholder={t('planned_operation_name_hint')}
+          returnKeyType="next"
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
         />
-      </Modal>
+        {errors.name && <Text style={[styles.error, { color: colors.error }]}>{errors.name}</Text>}
+
+        {/* Type Selector */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('operation_type') || 'Type').toUpperCase()}
+        </Text>
+        <View style={styles.typeRow}>
+          {TYPE_OPTIONS.map(opt => {
+            const isActive = values.type === opt.key;
+            return (
+              <Pressable
+                key={opt.key}
+                style={[
+                  styles.typeButton,
+                  {
+                    backgroundColor: isActive ? colors[opt.colorKey] : colors.inputBackground,
+                    borderColor: isActive ? colors[opt.colorKey] : colors.inputBorder,
+                  },
+                ]}
+                onPress={() => setValues(v => ({ ...v, type: opt.key, categoryId: null }))}
+              >
+                <Icon name={opt.icon} size={18} color={isActive ? '#fff' : colors.mutedText} />
+                <Text style={[styles.typeLabel, isActive ? styles.typeLabelActive : { color: colors.mutedText }]}>
+                  {t(`${opt.key}_label`) || t(opt.key)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {/* Amount */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('amount') || 'Amount').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          value={values.amount}
+          onChangeText={text => setValues(v => ({ ...v, amount: text }))}
+          placeholder="0.00"
+          keyboardType="decimal-pad"
+          returnKeyType="done"
+          onSubmitEditing={Keyboard.dismiss}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+        {errors.amount && <Text style={[styles.error, { color: colors.error }]}>{errors.amount}</Text>}
+
+        {/* Account */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('select_account') || 'Account').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          testID="planned-account-picker"
+          style={[modalSharedStyles.pickerRow, { borderColor: errors.accountId ? colors.error : colors.border, backgroundColor: colors.card }]}
+          onPress={() => setAccountPickerVisible(true)}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: values.accountId ? colors.text : colors.mutedText }]}>
+              {values.accountId ? getAccountName(values.accountId) : t('select_account')}
+            </Text>
+            <Icon name="chevron-down" size={20} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+        {errors.accountId && <Text style={[styles.error, { color: colors.error }]}>{errors.accountId}</Text>}
+
+        {/* Category (expense/income only) */}
+        {values.type !== 'transfer' && (
+          <>
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('select_category') || 'Category').toUpperCase()}
+            </Text>
+            <TouchableRipple
+              testID="planned-category-picker"
+              style={[modalSharedStyles.pickerRow, { borderColor: errors.categoryId ? colors.error : colors.border, backgroundColor: colors.card }]}
+              onPress={() => openCategoryPicker('category', filteredCategories)}
+              rippleColor="rgba(0,0,0,0.05)"
+              borderless={false}
+            >
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: values.categoryId ? colors.text : colors.mutedText }]}>
+                  {values.categoryId ? getCategoryName(values.categoryId) : t('select_category')}
+                </Text>
+                <Icon name="chevron-down" size={20} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+            {errors.categoryId && <Text style={[styles.error, { color: colors.error }]}>{errors.categoryId}</Text>}
+          </>
+        )}
+
+        {/* To Account (transfer only) */}
+        {values.type === 'transfer' && (
+          <>
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('to_account') || 'To Account').toUpperCase()}
+            </Text>
+            <TouchableRipple
+              style={[modalSharedStyles.pickerRow, { borderColor: errors.toAccountId ? colors.error : colors.border, backgroundColor: colors.card }]}
+              onPress={() => setToAccountPickerVisible(true)}
+              rippleColor="rgba(0,0,0,0.05)"
+              borderless={false}
+            >
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: values.toAccountId ? colors.text : colors.mutedText }]}>
+                  {values.toAccountId ? getAccountName(values.toAccountId) : t('select_account')}
+                </Text>
+                <Icon name="chevron-down" size={20} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+            {errors.toAccountId && <Text style={[styles.error, { color: colors.error }]}>{errors.toAccountId}</Text>}
+          </>
+        )}
+
+        {/* Recurring Toggle */}
+        <View style={styles.switchRow}>
+          <Text style={[modalSharedStyles.fieldLabel, styles.switchLabel, { color: colors.mutedText }]}>
+            {(t('recurring') || 'Recurring').toUpperCase()}
+          </Text>
+          <Switch
+            value={values.isRecurring}
+            onValueChange={val => setValues(v => ({ ...v, isRecurring: val }))}
+            trackColor={{ false: colors.border, true: colors.primary + '66' }}
+            thumbColor={values.isRecurring ? colors.primary : colors.mutedText}
+          />
+        </View>
+
+        {/* Description */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('description') || 'Description').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          multiline
+          numberOfLines={2}
+          value={values.description}
+          onChangeText={text => setValues(v => ({ ...v, description: text }))}
+          placeholder={t('description')}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+      </ModalShell>
+
+      {/* Account Picker Modal */}
+      {renderPickerModal(
+        accountPickerVisible,
+        setAccountPickerVisible,
+        accounts.map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
+        (id) => setValues(v => ({ ...v, accountId: id })),
+        t('select_account'),
+      )}
+
+      {/* To Account Picker Modal */}
+      {renderPickerModal(
+        toAccountPickerVisible,
+        setToAccountPickerVisible,
+        accounts.filter(a => a.id !== values.accountId).map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
+        (id) => setValues(v => ({ ...v, toAccountId: id })),
+        t('to_account'),
+      )}
+
+      {/* Category Picker Modal (hierarchical) */}
+      <PickerModal
+        visible={categoryPickerState.visible}
+        pickerType={categoryPickerState.type}
+        pickerData={categoryPickerState.data}
+        colors={colors}
+        t={t}
+        onClose={closeCategoryPicker}
+        categoryNavigation={categoryNavigation}
+        quickAddValues={{ ...values, amount: '' }}
+        onNavigateBack={navigateBack}
+        onNavigateIntoFolder={navigateIntoFolder}
+        onSelectCategory={(id) => { setValues(v => ({ ...v, categoryId: id })); closeCategoryPicker(); }}
+      />
     </>
   );
 }
@@ -451,78 +449,10 @@ PlannedOperationModal.defaultProps = {
 };
 
 const styles = StyleSheet.create({
-  button: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
-    flex: 1,
-    justifyContent: 'center',
-    marginHorizontal: SPACING.xs,
-    paddingVertical: SPACING.md,
-  },
-  buttonRow: {
-    flexDirection: 'row',
-    marginTop: SPACING.lg,
-  },
-  buttonText: {
-    color: '#fff',
-    fontSize: FONT_SIZE.md,
-    fontWeight: '600',
-  },
   error: {
     fontSize: FONT_SIZE.sm,
-    marginTop: SPACING.xs,
-  },
-  flex1: {
-    flex: 1,
-  },
-  input: {
-    borderRadius: BORDER_RADIUS.sm,
-    borderWidth: 1,
-    fontSize: FONT_SIZE.base,
-    height: HEIGHTS.input,
-    paddingHorizontal: SPACING.md,
-  },
-  inputContainer: {
-    marginBottom: SPACING.md,
-  },
-  inputLabel: {
-    fontSize: FONT_SIZE.sm,
-    fontWeight: '500',
     marginBottom: SPACING.xs,
-  },
-  inputLabelNoMargin: {
-    marginBottom: 0,
-  },
-  modalContent: {
-    borderTopLeftRadius: BORDER_RADIUS.lg,
-    borderTopRightRadius: BORDER_RADIUS.lg,
-    maxHeight: '90%',
-    paddingBottom: SPACING.xxl,
-    paddingHorizontal: SPACING.xl,
-    paddingTop: SPACING.lg,
-    width: '100%',
-  },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
-  multilineInput: {
-    height: 70,
-    paddingTop: SPACING.md,
-    textAlignVertical: 'top',
-  },
-  pickerButton: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.sm,
-    borderWidth: 1,
-    flexDirection: 'row',
-    height: HEIGHTS.input,
-    justifyContent: 'space-between',
-    paddingHorizontal: SPACING.md,
-  },
-  pickerButtonText: {
-    flex: 1,
-    fontSize: FONT_SIZE.base,
+    marginTop: SPACING.xs,
   },
   pickerCancel: {
     alignItems: 'center',
@@ -566,16 +496,14 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.md,
     paddingHorizontal: SPACING.xl,
   },
-  scrollContent: {
-    paddingBottom: SPACING.lg,
-  },
-  scrollView: {
-    flexGrow: 0,
+  switchLabel: {
+    marginTop: 0,
   },
   switchRow: {
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'space-between',
+    marginTop: SPACING.sm,
   },
   typeButton: {
     alignItems: 'center',
@@ -592,7 +520,11 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.sm,
     fontWeight: '600',
   },
+  typeLabelActive: {
+    color: '#fff',
+  },
   typeRow: {
     flexDirection: 'row',
+    marginBottom: SPACING.xs,
   },
 });

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useMemo, memo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, KeyboardAvoidingView, ScrollView, Keyboard, FlatList, TouchableOpacity, Pressable, Modal as RNModal, Animated, Dimensions } from 'react-native';
-import ModalBlurOverlay from '../components/ModalBlurOverlay';
+import { View, StyleSheet, ScrollView, Keyboard, FlatList, TouchableOpacity, Pressable, Animated, Dimensions } from 'react-native';
+import ModalShell from '../components/ModalShell';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
 import { Text, TextInput as PaperTextInput, Button, Portal, Modal, TouchableRipple, Switch } from 'react-native-paper';
 import AddFAB from '../components/AddFAB';
 import LoadingView from '../components/LoadingView';
@@ -446,6 +447,7 @@ export default function AccountsScreen() {
 
   const { colorScheme } = useThemeConfig();
   const { colors } = useThemeColors();
+  const { paperInputTheme } = makeModalStyles(colors);
   const { accounts, displayedAccounts, hiddenAccounts, showHiddenAccounts, loading, error } = useAccountsData();
   const { toggleShowHiddenAccounts, addAccount, updateAccount, deleteAccount, reorderAccounts, validateAccount, getOperationCount } = useAccountsActions();
   const { operations } = useOperationsData();
@@ -815,204 +817,141 @@ export default function AccountsScreen() {
         accessibilityHint={t('add_account_hint') || 'Opens form to create a new account'}
       />
 
-      {!!editingId && <ModalBlurOverlay />}
-      <RNModal
+      <ModalShell
         visible={!!editingId}
-        transparent={true}
-        animationType="slide"
-        onRequestClose={handleCloseModal}
+        onDismiss={handleCloseModal}
+        title={editingId === 'new' ? (t('add_account') || 'New Account') : (t('edit_account') || 'Edit Account')}
+        subtitle={editingId !== 'new' && editValues.name ? editValues.name : undefined}
+        onSave={saveEdit}
+        onCancel={handleCloseModal}
+        onDelete={editingId !== 'new' ? handleDeleteEditingAccount : undefined}
+        deleteLabel={t('delete_account') || 'Delete account'}
+        showBlurOverlay
       >
-        <KeyboardAvoidingView behavior="padding" style={styles.modalKAV}>
-          <Pressable style={styles.modalOverlay} onPress={handleCloseModal}>
-            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              {/* Drag handle */}
-              <View style={[styles.sheetDragHandle, { backgroundColor: colors.border }]} />
+        {/* Account name */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('account_name') || 'Account name').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          theme={paperInputTheme}
+          value={editValues.name}
+          onChangeText={handleNameChange}
+          error={!!errors.name}
+          autoFocus={editingId === 'new'}
+          returnKeyType="next"
+          onSubmitEditing={() => balanceInputRef.current?.focus()}
+          blurOnSubmit={false}
+          style={modalSharedStyles.textInput}
+        />
+        {errors.name && <Text variant="bodySmall" style={styles.error}>{errors.name}</Text>}
 
-              {/* Sheet header */}
-              <View style={styles.sheetHeader}>
-                <Text style={[styles.sheetTitle, { color: colors.text }]}>
-                  {editingId === 'new' ? (t('add_account') || 'New Account') : (t('edit_account') || 'Edit Account')}
+        {/* Balance */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('balance') || 'Balance').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          ref={balanceInputRef}
+          mode="outlined"
+          theme={paperInputTheme}
+          value={editValues.balance}
+          onChangeText={handleBalanceChange}
+          error={!!errors.balance}
+          keyboardType="numeric"
+          returnKeyType="done"
+          placeholder={(() => {
+            const dec = currencies[editValues.currency]?.decimal_digits ?? 2;
+            return dec === 0 ? '0' : `0.${'0'.repeat(dec)}`;
+          })()}
+          onSubmitEditing={Keyboard.dismiss}
+          style={modalSharedStyles.textInput}
+        />
+        {errors.balance && <Text variant="bodySmall" style={styles.error}>{errors.balance}</Text>}
+
+        {/* Currency selector */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('currency') || 'Currency').toUpperCase()}
+        </Text>
+        <TouchableRipple onPress={handleOpenPicker} style={[modalSharedStyles.pickerRow, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+              {editValues.currency
+                ? `${currencies[editValues.currency]?.name} · ${currencies[editValues.currency]?.symbol}`
+                : (t('select_currency') || 'Select currency')}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+        {errors.currency && <Text variant="bodySmall" style={styles.error}>{errors.currency}</Text>}
+
+        {/* Settings group */}
+        <View style={[styles.settingsGroup, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+          {editingId !== 'new' && (
+            <View style={[styles.settingItem, styles.settingItemBorder, { borderBottomColor: colors.border }]}>
+              <View style={styles.settingItemText}>
+                <Text style={[styles.settingTitle, { color: colors.text }]}>
+                  {t('create_adjustment_operation') || 'Log adjustment'}
                 </Text>
-                {editingId !== 'new' && !!editValues.name && (
-                  <Text style={[styles.sheetSubtitle, { color: colors.mutedText }]}>{editValues.name}</Text>
-                )}
+                <Text style={[styles.settingHint, { color: colors.mutedText }]}>
+                  {t('create_adjustment_operation_hint') || 'Record balance change as a transaction'}
+                </Text>
               </View>
+              <Switch
+                value={createAdjustmentOperation}
+                onValueChange={handleToggleAdjustmentSwitch}
+                color={colors.primary}
+              />
+            </View>
+          )}
+          <View style={styles.settingItem}>
+            <View style={styles.settingItemText}>
+              <Text style={[styles.settingTitle, { color: colors.text }]}>
+                {t('hidden_account') || 'Hidden account'}
+              </Text>
+              <Text style={[styles.settingHint, { color: colors.mutedText }]}>
+                {t('hidden_account_hint') || 'Hide from main list and operations'}
+              </Text>
+            </View>
+            <Switch
+              value={!!editValues.hidden}
+              onValueChange={handleToggleHiddenSwitch}
+              color={colors.primary}
+            />
+          </View>
+        </View>
 
-              <ScrollView
-                keyboardShouldPersistTaps="handled"
-                contentContainerStyle={styles.listContentContainer}
-                showsVerticalScrollIndicator={false}
-                style={styles.sheetScroll}
-              >
-                {/* Account name */}
-                <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                  {(t('account_name') || 'Account name').toUpperCase()}
-                </Text>
-                <PaperTextInput
-                  mode="outlined"
-                  value={editValues.name}
-                  onChangeText={handleNameChange}
-                  error={!!errors.name}
-                  autoFocus={editingId === 'new'}
-                  returnKeyType="next"
-                  onSubmitEditing={() => balanceInputRef.current?.focus()}
-                  blurOnSubmit={false}
-                  style={styles.textInput}
-                />
-                {errors.name && <Text variant="bodySmall" style={styles.error}>{errors.name}</Text>}
-
-                {/* Balance */}
-                <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                  {(t('balance') || 'Balance').toUpperCase()}
-                </Text>
-                <PaperTextInput
-                  ref={balanceInputRef}
-                  mode="outlined"
-                  value={editValues.balance}
-                  onChangeText={handleBalanceChange}
-                  error={!!errors.balance}
-                  keyboardType="numeric"
-                  returnKeyType="done"
-                  placeholder={(() => {
-                    const dec = currencies[editValues.currency]?.decimal_digits ?? 2;
-                    return dec === 0 ? '0' : `0.${'0'.repeat(dec)}`;
-                  })()}
-                  onSubmitEditing={Keyboard.dismiss}
-                  style={styles.textInput}
-                />
-                {errors.balance && <Text variant="bodySmall" style={styles.error}>{errors.balance}</Text>}
-
-                {/* Currency selector */}
-                <TouchableRipple onPress={handleOpenPicker} style={[styles.currencyRow, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-                  <View style={styles.currencyRowInner}>
-                    <View>
-                      <Text style={[styles.currencyRowLabel, { color: colors.mutedText }]}>
-                        {(t('currency') || 'Currency').toUpperCase()}
-                      </Text>
-                      <Text style={[styles.currencyRowValue, { color: colors.text }]}>
-                        {editValues.currency
-                          ? `${currencies[editValues.currency]?.name} · ${currencies[editValues.currency]?.symbol}`
-                          : (t('select_currency') || 'Select currency')}
-                      </Text>
-                    </View>
-                    <Icon name="chevron-right" size={22} color={colors.mutedText} />
-                  </View>
-                </TouchableRipple>
-                {errors.currency && <Text variant="bodySmall" style={styles.error}>{errors.currency}</Text>}
-
-                {/* Settings group */}
-                <View style={[styles.settingsGroup, { borderColor: colors.border, backgroundColor: colors.surface }]}>
-                  {editingId !== 'new' && (
-                    <View style={[styles.settingItem, styles.settingItemBorder, { borderBottomColor: colors.border }]}>
-                      <View style={styles.settingItemText}>
-                        <Text style={[styles.settingTitle, { color: colors.text }]}>
-                          {t('create_adjustment_operation') || 'Log adjustment'}
-                        </Text>
-                        <Text style={[styles.settingHint, { color: colors.mutedText }]}>
-                          {t('create_adjustment_operation_hint') || 'Record balance change as a transaction'}
-                        </Text>
-                      </View>
-                      <Switch
-                        value={createAdjustmentOperation}
-                        onValueChange={handleToggleAdjustmentSwitch}
-                        color={colors.primary}
-                      />
-                    </View>
-                  )}
-                  <View style={styles.settingItem}>
-                    <View style={styles.settingItemText}>
-                      <Text style={[styles.settingTitle, { color: colors.text }]}>
-                        {t('hidden_account') || 'Hidden account'}
-                      </Text>
-                      <Text style={[styles.settingHint, { color: colors.mutedText }]}>
-                        {t('hidden_account_hint') || 'Hide from main list and operations'}
-                      </Text>
-                    </View>
-                    <Switch
-                      value={!!editValues.hidden}
-                      onValueChange={handleToggleHiddenSwitch}
-                      color={colors.primary}
-                    />
-                  </View>
-                </View>
-
-              </ScrollView>
-
-              {/* Delete zone (existing accounts only) — outside ScrollView for reliable centering */}
-              {editingId !== 'new' && (
-                <View style={styles.deleteWrapper}>
-                  <TouchableRipple
-                    testID="account-delete-button"
-                    onPress={handleDeleteEditingAccount}
-                    rippleColor={colors.delete + '18'}
-                    style={[styles.sheetBtn, styles.deleteRow, { borderColor: colors.delete + '40' }]}
-                    borderless={false}
-                  >
-                    <View style={styles.deleteRowContent}>
-                      <Icon name="delete-outline" size={18} color={colors.delete} />
-                      <Text style={[styles.deleteRowText, { color: colors.delete }]}>
-                        {t('delete') || 'Delete'}
-                      </Text>
-                    </View>
-                  </TouchableRipple>
-                </View>
-              )}
-
-              {/* Action buttons */}
-              <View style={[styles.sheetActions, { borderTopColor: colors.border }]}>
+        {/* In-sheet currency picker — slides in from the right */}
+        {currencyPanelVisible && (
+          <Animated.View
+            style={[styles.currencyPanel, { backgroundColor: colors.card, transform: [{ translateX: currencySlideAnim }] }]}
+          >
+            <View style={[styles.currencyPanelHeader, { borderBottomColor: colors.border }]}>
+              <TouchableOpacity onPress={handleClosePicker} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+                <Icon name="arrow-left" size={22} color={colors.text} />
+              </TouchableOpacity>
+              <Text style={[styles.currencyPanelTitle, { color: colors.text }]}>
+                {t('select_currency') || 'Currency'}
+              </Text>
+            </View>
+            <FlatList
+              data={Object.entries(currencies)}
+              keyExtractor={([code]) => code}
+              renderItem={({ item: [code, cur] }) => (
                 <TouchableRipple
-                  onPress={handleCloseModal}
-                  style={[styles.sheetBtn, styles.sheetBtnCancel, { borderColor: colors.border }]}
-                  rippleColor="rgba(0,0,0,0.05)"
-                  borderless={false}
+                  onPress={() => handleCurrencySelect(code)}
+                  style={styles.currencyPanelItem}
+                  rippleColor="rgba(0,0,0,0.08)"
                 >
-                  <Text style={[styles.sheetBtnText, { color: colors.text }]}>{t('cancel') || 'Cancel'}</Text>
+                  <Text style={[styles.currencyPanelItemText, { color: colors.text }]}>
+                    {cur.name} ({cur.symbol})
+                  </Text>
                 </TouchableRipple>
-                <TouchableRipple
-                  onPress={saveEdit}
-                  style={[styles.sheetBtn, styles.sheetBtnSave, { backgroundColor: colors.primary }]}
-                  rippleColor="rgba(255,255,255,0.2)"
-                  borderless={false}
-                >
-                  <Text style={[styles.sheetBtnText, styles.sheetBtnSaveText]}>{t('save') || 'Save'}</Text>
-                </TouchableRipple>
-              </View>
-
-              {/* In-sheet currency picker — slides in from the right */}
-              {currencyPanelVisible && (
-                <Animated.View
-                  style={[styles.currencyPanel, { backgroundColor: colors.card, transform: [{ translateX: currencySlideAnim }] }]}
-                >
-                  <View style={[styles.currencyPanelHeader, { borderBottomColor: colors.border }]}>
-                    <TouchableOpacity onPress={handleClosePicker} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-                      <Icon name="arrow-left" size={22} color={colors.text} />
-                    </TouchableOpacity>
-                    <Text style={[styles.currencyPanelTitle, { color: colors.text }]}>
-                      {t('select_currency') || 'Currency'}
-                    </Text>
-                  </View>
-                  <FlatList
-                    data={Object.entries(currencies)}
-                    keyExtractor={([code]) => code}
-                    renderItem={({ item: [code, cur] }) => (
-                      <TouchableRipple
-                        onPress={() => handleCurrencySelect(code)}
-                        style={styles.currencyPanelItem}
-                        rippleColor="rgba(0,0,0,0.08)"
-                      >
-                        <Text style={[styles.currencyPanelItemText, { color: colors.text }]}>
-                          {cur.name} ({cur.symbol})
-                        </Text>
-                      </TouchableRipple>
-                    )}
-                    ItemSeparatorComponent={() => <View style={[styles.divider, { backgroundColor: colors.border }]} />}
-                  />
-                </Animated.View>
               )}
-            </Pressable>
-          </Pressable>
-        </KeyboardAvoidingView>
-      </RNModal>
+              ItemSeparatorComponent={() => <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+            />
+          </Animated.View>
+        )}
+      </ModalShell>
       <TransferAccountPickerModal
         visible={transferModalVisible}
         onClose={handleCloseTransferModal}
@@ -1188,48 +1127,6 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: '600',
   },
-  currencyRow: {
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: 1,
-    marginBottom: SPACING.xs,
-    marginTop: SPACING.sm,
-    overflow: 'hidden',
-  },
-  currencyRowInner: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: SPACING.md,
-    paddingVertical: SPACING.sm,
-  },
-  currencyRowLabel: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.8,
-    marginBottom: 2,
-  },
-  currencyRowValue: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
-  deleteRow: {
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: 1,
-    overflow: 'hidden',
-  },
-  deleteRowContent: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: SPACING.sm,
-  },
-  deleteRowText: {
-    fontSize: 15,
-    fontWeight: '500',
-  },
-  deleteWrapper: {
-    flexDirection: 'row',
-    marginTop: SPACING.sm,
-  },
   divider: {
     height: 1,
     marginHorizontal: SPACING.lg,
@@ -1247,13 +1144,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  fieldLabel: {
-    fontSize: 10,
-    fontWeight: '600',
-    letterSpacing: 0.8,
-    marginBottom: 2,
-    marginTop: SPACING.sm,
-  },
   hiddenBalance: {
     backgroundColor: 'rgba(120, 120, 120, 0.25)',
     borderRadius: 6,
@@ -1268,25 +1158,6 @@ const styles = StyleSheet.create({
   hiddenBalancePicker: {
     marginTop: 4,
     width: 70,
-  },
-  listContentContainer: {
-    paddingBottom: SPACING.sm,
-  },
-  modalContent: {
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    maxHeight: '85%',
-    overflow: 'hidden',
-    paddingBottom: 0,
-    paddingHorizontal: SPACING.lg,
-    paddingTop: SPACING.sm,
-  },
-  modalKAV: {
-    flex: 1,
-  },
-  modalOverlay: {
-    flex: 1,
-    justifyContent: 'flex-end',
   },
   monthlyChangeRow: {
     marginTop: SPACING.sm,
@@ -1373,52 +1244,6 @@ const styles = StyleSheet.create({
     marginTop: SPACING.sm,
     overflow: 'hidden',
   },
-  sheetActions: {
-    borderTopWidth: 1,
-    flexDirection: 'row',
-    gap: SPACING.sm,
-    paddingBottom: SPACING.xl,
-    paddingTop: SPACING.sm,
-  },
-  sheetBtn: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
-    flex: 1,
-    overflow: 'hidden',
-    paddingVertical: SPACING.sm,
-  },
-  sheetBtnCancel: {
-    borderWidth: 1,
-  },
-  sheetBtnSaveText: {
-    color: '#fff',
-  },
-  sheetBtnText: {
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  sheetDragHandle: {
-    alignSelf: 'center',
-    borderRadius: 3,
-    height: 4,
-    marginBottom: SPACING.md,
-    width: 44,
-  },
-  sheetHeader: {
-    marginBottom: SPACING.sm,
-  },
-  sheetScroll: {
-    flexShrink: 1,
-  },
-  sheetSubtitle: {
-    fontSize: 12,
-    marginTop: 2,
-  },
-  sheetTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    letterSpacing: -0.3,
-  },
   showHiddenButton: {
     borderRadius: 12,
     borderWidth: 1,
@@ -1437,8 +1262,5 @@ const styles = StyleSheet.create({
   showHiddenText: {
     fontSize: 14,
     fontWeight: '500',
-  },
-  textInput: {
-    marginBottom: SPACING.xs,
   },
 });

--- a/app/styles/modalStyles.js
+++ b/app/styles/modalStyles.js
@@ -1,0 +1,67 @@
+// app/styles/modalStyles.js
+import { StyleSheet } from 'react-native';
+import { SPACING, BORDER_RADIUS } from './designTokens';
+
+/**
+ * Static styles shared across all modal form content.
+ * Colors are applied inline since they depend on the active theme.
+ */
+export const modalSharedStyles = StyleSheet.create({
+  // Small-caps label rendered above each input or picker row
+  fieldLabel: {
+    fontSize: 10,
+    fontWeight: '600',
+    letterSpacing: 0.8,
+    marginBottom: 2,
+    marginTop: SPACING.sm,
+  },
+  // TouchableRipple container for tappable picker rows
+  pickerRow: {
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    marginBottom: SPACING.xs,
+    overflow: 'hidden',
+  },
+  // Inner row: value text + chevron
+  pickerRowInner: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+  },
+  // Selected value text inside a picker row
+  pickerRowValue: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  // Spacing below PaperTextInput
+  textInput: {
+    marginBottom: SPACING.xs,
+  },
+});
+
+/**
+ * Returns a react-native-paper theme object that maps app colors
+ * onto Paper's TextInput outlined style.
+ * Call inside the component after reading colors from ThemeColorsContext.
+ *
+ * Usage:
+ *   const { colors } = useThemeColors();
+ *   const { paperInputTheme } = makeModalStyles(colors);
+ *   <PaperTextInput mode="outlined" theme={paperInputTheme} ... />
+ */
+export function makeModalStyles(colors) {
+  return {
+    paperInputTheme: {
+      colors: {
+        primary: colors.primary,
+        outline: colors.border,
+        background: colors.card,
+        onSurfaceVariant: colors.mutedText,
+        onSurface: colors.text,
+        error: colors.error,
+      },
+    },
+  };
+}

--- a/docs/superpowers/plans/2026-05-06-modal-style-standardization.md
+++ b/docs/superpowers/plans/2026-05-06-modal-style-standardization.md
@@ -1,0 +1,1617 @@
+# Modal Style Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize all four bottom-sheet modals (Operation, Category, PlannedOperation, Account) to share a common shell component and input style matching AccountModal.
+
+**Architecture:** A new `ModalShell` component handles the outer structure (drag handle, title, scroll area, delete row, cancel/save buttons). A new `modalStyles.js` exports a static `modalSharedStyles` StyleSheet and a `makeModalStyles(colors)` function returning the Paper theme object. Each modal is refactored to use these shared pieces.
+
+**Tech Stack:** React Native, react-native-paper (`TextInput`, `TouchableRipple`), `@expo/vector-icons`
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `app/styles/modalStyles.js` | Create |
+| `app/components/ModalShell.js` | Create |
+| `app/modals/CategoryModal.js` | Modify |
+| `app/modals/PlannedOperationModal.js` | Modify |
+| `app/modals/OperationModal.js` | Modify |
+| `app/screens/AccountsScreen.js` | Modify (modal section only) |
+
+---
+
+## Task 1: Create `app/styles/modalStyles.js`
+
+**Files:**
+- Create: `app/styles/modalStyles.js`
+
+- [ ] **Step 1: Create the file**
+
+```javascript
+// app/styles/modalStyles.js
+import { StyleSheet } from 'react-native';
+import { SPACING, BORDER_RADIUS } from './designTokens';
+
+/**
+ * Static styles shared across all modal form content.
+ * Colors are applied inline since they depend on the active theme.
+ */
+export const modalSharedStyles = StyleSheet.create({
+  // Small-caps label rendered above each input or picker row
+  fieldLabel: {
+    fontSize: 10,
+    fontWeight: '600',
+    letterSpacing: 0.8,
+    marginBottom: 2,
+    marginTop: SPACING.sm,
+  },
+  // Spacing below PaperTextInput
+  textInput: {
+    marginBottom: SPACING.xs,
+  },
+  // TouchableRipple container for tappable picker rows
+  pickerRow: {
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    marginBottom: SPACING.xs,
+    overflow: 'hidden',
+  },
+  // Inner row: value text + chevron
+  pickerRowInner: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+  },
+  // Selected value text inside a picker row
+  pickerRowValue: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+});
+
+/**
+ * Returns a react-native-paper theme object that maps app colors
+ * onto Paper's TextInput outlined style.
+ * Call inside the component after reading colors from ThemeColorsContext.
+ *
+ * Usage:
+ *   const { colors } = useThemeColors();
+ *   const { paperInputTheme } = makeModalStyles(colors);
+ *   <PaperTextInput mode="outlined" theme={paperInputTheme} ... />
+ */
+export function makeModalStyles(colors) {
+  return {
+    paperInputTheme: {
+      colors: {
+        primary: colors.primary,
+        outline: colors.border,
+        background: colors.card,
+        onSurfaceVariant: colors.mutedText,
+        onSurface: colors.text,
+        error: colors.error,
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run tests to confirm nothing broken**
+
+```bash
+npm test -- --silent
+```
+Expected: all tests pass, 0 failed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/styles/modalStyles.js
+git commit -m "feat(ui): add modalStyles shared stylesheet and PaperTextInput theme helper"
+```
+
+---
+
+## Task 2: Create `app/components/ModalShell.js`
+
+**Files:**
+- Create: `app/components/ModalShell.js`
+
+- [ ] **Step 1: Create the file**
+
+```javascript
+// app/components/ModalShell.js
+import React from 'react';
+import {
+  View,
+  Modal as RNModal,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+  ScrollView,
+} from 'react-native';
+import { Text, TouchableRipple } from 'react-native-paper';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import ModalBlurOverlay from './ModalBlurOverlay';
+
+/**
+ * ModalShell — shared bottom-sheet wrapper for all modals.
+ *
+ * Renders: blur overlay → RNModal → KAV → overlay Pressable →
+ *   card (drag handle, header, ScrollView[children],
+ *          optional delete row, optional extraActions, cancel/save row)
+ *
+ * When onSave is omitted (shadow operations), only the cancel button is shown.
+ * When onDelete is omitted, the delete row is hidden.
+ */
+export default function ModalShell({
+  visible,
+  onDismiss,
+  title,
+  subtitle,
+  onSave,
+  onCancel,
+  saveLabel,
+  cancelLabel,
+  onDelete,
+  deleteLabel,
+  deleteDisabled,
+  extraActions,
+  scrollRef,
+  showBlurOverlay,
+  children,
+}) {
+  const { colors } = useThemeColors();
+  const { t } = useLocalization();
+
+  return (
+    <>
+      {showBlurOverlay && visible && <ModalBlurOverlay />}
+      <RNModal
+        visible={visible}
+        animationType="slide"
+        transparent={true}
+        onRequestClose={onDismiss}
+      >
+        <KeyboardAvoidingView behavior="padding" style={styles.flex1}>
+          <Pressable style={styles.overlay} onPress={onDismiss}>
+            <Pressable
+              style={[styles.card, { backgroundColor: colors.card }]}
+              onPress={() => {}}
+            >
+              {/* Drag handle */}
+              <View style={[styles.dragHandle, { backgroundColor: colors.border }]} />
+
+              {/* Header */}
+              <View style={styles.header}>
+                <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+                {subtitle ? (
+                  <Text style={[styles.subtitle, { color: colors.mutedText }]}>
+                    {subtitle}
+                  </Text>
+                ) : null}
+              </View>
+
+              {/* Scrollable form content */}
+              <ScrollView
+                ref={scrollRef}
+                style={styles.scroll}
+                contentContainerStyle={styles.scrollContent}
+                keyboardShouldPersistTaps="handled"
+                showsVerticalScrollIndicator={false}
+              >
+                {children}
+              </ScrollView>
+
+              {/* Delete row (shown only when onDelete is provided) */}
+              {onDelete ? (
+                <View style={styles.deleteWrapper}>
+                  <TouchableRipple
+                    onPress={deleteDisabled ? undefined : onDelete}
+                    disabled={deleteDisabled}
+                    rippleColor={colors.delete + '18'}
+                    style={[
+                      styles.btn,
+                      styles.deleteRow,
+                      { borderColor: colors.delete + '40', opacity: deleteDisabled ? 0.5 : 1 },
+                    ]}
+                    borderless={false}
+                  >
+                    <View style={styles.deleteRowContent}>
+                      <Icon name="delete-outline" size={18} color={colors.delete} />
+                      <Text style={[styles.deleteRowText, { color: colors.delete }]}>
+                        {deleteLabel || t('delete')}
+                      </Text>
+                    </View>
+                  </TouchableRipple>
+                </View>
+              ) : null}
+
+              {/* Extra actions slot (e.g. Split button in OperationModal) */}
+              {extraActions || null}
+
+              {/* Cancel / Save (or full-width Cancel when onSave is absent) */}
+              <View style={[styles.actions, { borderTopColor: colors.border }]}>
+                <TouchableRipple
+                  onPress={onCancel}
+                  style={[
+                    styles.btn,
+                    styles.cancelBtn,
+                    { borderColor: colors.border },
+                    !onSave && styles.fullWidthBtn,
+                  ]}
+                  rippleColor="rgba(0,0,0,0.05)"
+                  borderless={false}
+                >
+                  <Text style={[styles.btnText, { color: colors.text }]}>
+                    {cancelLabel || t('cancel')}
+                  </Text>
+                </TouchableRipple>
+
+                {onSave ? (
+                  <TouchableRipple
+                    onPress={onSave}
+                    style={[styles.btn, { backgroundColor: colors.primary }]}
+                    rippleColor="rgba(255,255,255,0.2)"
+                    borderless={false}
+                  >
+                    <Text style={[styles.btnText, styles.saveBtnText]}>
+                      {saveLabel || t('save')}
+                    </Text>
+                  </TouchableRipple>
+                ) : null}
+              </View>
+            </Pressable>
+          </Pressable>
+        </KeyboardAvoidingView>
+      </RNModal>
+    </>
+  );
+}
+
+ModalShell.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string,
+  onSave: PropTypes.func,
+  onCancel: PropTypes.func.isRequired,
+  saveLabel: PropTypes.string,
+  cancelLabel: PropTypes.string,
+  onDelete: PropTypes.func,
+  deleteLabel: PropTypes.string,
+  deleteDisabled: PropTypes.bool,
+  extraActions: PropTypes.node,
+  scrollRef: PropTypes.object,
+  showBlurOverlay: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+ModalShell.defaultProps = {
+  subtitle: null,
+  onSave: null,
+  saveLabel: null,
+  cancelLabel: null,
+  onDelete: null,
+  deleteLabel: null,
+  deleteDisabled: false,
+  extraActions: null,
+  scrollRef: null,
+  showBlurOverlay: false,
+};
+
+const styles = StyleSheet.create({
+  actions: {
+    borderTopWidth: 1,
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingBottom: SPACING.xl,
+    paddingTop: SPACING.sm,
+  },
+  btn: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    flex: 1,
+    overflow: 'hidden',
+    paddingVertical: SPACING.sm,
+  },
+  btnText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  cancelBtn: {
+    borderWidth: 1,
+  },
+  card: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    maxHeight: '85%',
+    overflow: 'hidden',
+    paddingBottom: 0,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.sm,
+  },
+  deleteRow: {
+    borderWidth: 1,
+  },
+  deleteRowContent: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+  },
+  deleteRowText: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  deleteWrapper: {
+    flexDirection: 'row',
+    marginTop: SPACING.sm,
+  },
+  dragHandle: {
+    alignSelf: 'center',
+    borderRadius: 3,
+    height: 4,
+    marginBottom: SPACING.md,
+    width: 44,
+  },
+  flex1: {
+    flex: 1,
+  },
+  fullWidthBtn: {
+    flex: 1,
+  },
+  header: {
+    marginBottom: SPACING.sm,
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  saveBtnText: {
+    color: '#fff',
+  },
+  scroll: {
+    flexShrink: 1,
+  },
+  scrollContent: {
+    paddingBottom: SPACING.sm,
+  },
+  subtitle: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+  },
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test -- --silent
+```
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/ModalShell.js
+git commit -m "feat(ui): add ModalShell shared bottom-sheet wrapper component"
+```
+
+---
+
+## Task 3: Refactor `CategoryModal.js`
+
+**Files:**
+- Modify: `app/modals/CategoryModal.js`
+
+**What changes:**
+- Replace `Modal + KAV + Pressable + drag handle + sheetHeader + sheetActions + deleteWrapper` with `<ModalShell>`
+- Name `TextInput` → `PaperTextInput mode="outlined"` with fieldLabel above
+- Three picker rows (Type, CategoryType, Parent) → `pickerRowStyles` with fieldLabel above
+- Icon picker row stays as-is (special — shows icon preview)
+- Import `TouchableRipple, TextInput as PaperTextInput` from `react-native-paper`
+- Remove from RN imports: `Modal`, `KeyboardAvoidingView`, `TextInput`
+
+- [ ] **Step 1: Replace imports block (lines 1–26)**
+
+```javascript
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  Pressable,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  ScrollView,
+  Keyboard,
+  Animated,
+  Dimensions,
+} from 'react-native';
+import { TextInput as PaperTextInput, TouchableRipple } from 'react-native-paper';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { useDialog } from '../contexts/DialogContext';
+import { useCategories } from '../contexts/CategoriesContext';
+import IconPicker from '../components/IconPicker';
+import ModalBlurOverlay from '../components/ModalBlurOverlay';
+import ModalShell from '../components/ModalShell';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
+import PropTypes from 'prop-types';
+import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
+```
+
+- [ ] **Step 2: Add `makeModalStyles` call inside the component, right after `const { colors } = useThemeColors();` (around line 29)**
+
+```javascript
+  const { colors } = useThemeColors();
+  const { paperInputTheme } = makeModalStyles(colors);
+```
+
+- [ ] **Step 3: Replace the entire `return (...)` block**
+
+Replace everything from `return (` through the closing `);` of the component with:
+
+```javascript
+  return (
+    <>
+      <ModalShell
+        visible={visible}
+        onDismiss={handleClose}
+        title={isNew ? t('add_category') : t('edit_category')}
+        onSave={handleSave}
+        onCancel={handleClose}
+        onDelete={isNew ? undefined : handleDelete}
+        showBlurOverlay
+      >
+        {/* Name */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('category_name') || 'Name').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          value={values.name}
+          onChangeText={text => setValues(v => ({ ...v, name: text }))}
+          autoFocus
+          returnKeyType="done"
+          onSubmitEditing={Keyboard.dismiss}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+
+        {/* Type (Folder / Entry) */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('select_type') || 'Type').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+          onPress={() => handleOpenPicker('type')}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+              {TYPE_OPTIONS.find(to => to.key === values.type)?.label}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+
+        {/* Category Type (Income / Expense) */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('category_type') || 'Category Type').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+          onPress={() => handleOpenPicker('categoryType')}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+              {CATEGORY_TYPES.find(ct => ct.key === values.category_type)?.label}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+
+        {/* Parent Category */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('parent_category') || 'Parent').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+          onPress={() => handleOpenPicker('parent')}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+              {getParentName(values.parentId)}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+
+        {/* Icon Picker (keeps its own style — icon preview) */}
+        <Pressable
+          testID="category-icon-picker"
+          style={[styles.iconPickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+          onPress={() => setIconPickerVisible(true)}
+        >
+          <Icon name={values.icon || 'folder'} size={32} color={colors.text} />
+          <Text style={[styles.iconPickerText, { color: colors.mutedText }]}>
+            {t('select_icon')}
+          </Text>
+        </Pressable>
+
+        {errors.general && <Text style={styles.error}>{errors.general}</Text>}
+
+        {/* In-sheet animated picker panel — slides in from the right */}
+        {activePicker && (
+          <Animated.View
+            style={[styles.pickerPanel, { backgroundColor: colors.card, transform: [{ translateX: pickerSlideAnim }] }]}
+          >
+            <View style={[styles.pickerPanelHeader, { borderBottomColor: colors.border }]}>
+              <TouchableOpacity
+                testID="picker-back-button"
+                onPress={handleClosePicker}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              >
+                <Icon name="arrow-left" size={22} color={colors.text} />
+              </TouchableOpacity>
+              <Text style={[styles.pickerPanelTitle, { color: colors.text }]}>
+                {pickerTitle}
+              </Text>
+            </View>
+
+            {activePicker === 'type' && (
+              <FlatList
+                data={TYPE_OPTIONS}
+                keyExtractor={item => item.key}
+                renderItem={({ item }) => {
+                  const isDisabled = !isNew && hasChildren && item.key === 'entry';
+                  return (
+                    <Pressable
+                      onPress={() => {
+                        if (isDisabled) {
+                          showDialog(
+                            t('error'),
+                            t('cannot_change_to_entry_with_children') || 'Cannot change to entry type while category has subcategories',
+                            [{ text: t('ok') }],
+                          );
+                          return;
+                        }
+                        setValues(v => ({ ...v, type: item.key }));
+                        handleClosePicker();
+                      }}
+                      style={({ pressed }) => [
+                        styles.pickerOption,
+                        { borderColor: colors.border },
+                        pressed && !isDisabled && { backgroundColor: colors.selected },
+                        isDisabled && { opacity: 0.5 },
+                      ]}
+                    >
+                      <Text style={[themed.pickerItemText, isDisabled && { color: colors.mutedText }]}>
+                        {item.label}{isDisabled && ' ⚠️'}
+                      </Text>
+                    </Pressable>
+                  );
+                }}
+              />
+            )}
+
+            {activePicker === 'categoryType' && (
+              <FlatList
+                data={CATEGORY_TYPES}
+                keyExtractor={item => item.key}
+                renderItem={({ item }) => (
+                  <Pressable
+                    onPress={() => {
+                      setValues(v => ({ ...v, category_type: item.key }));
+                      handleClosePicker();
+                    }}
+                    style={({ pressed }) => [
+                      styles.pickerOption,
+                      { borderColor: colors.border },
+                      pressed && { backgroundColor: colors.selected },
+                    ]}
+                  >
+                    <Text style={themed.pickerItemText}>{item.label}</Text>
+                  </Pressable>
+                )}
+              />
+            )}
+
+            {activePicker === 'parent' && (
+              <FlatList
+                data={[{ id: null, name: t('none'), icon: 'folder-outline' }, ...potentialParents]}
+                keyExtractor={item => item.id || 'none'}
+                renderItem={({ item }) => (
+                  <Pressable
+                    onPress={() => {
+                      setValues(v => ({ ...v, parentId: item.id }));
+                      handleClosePicker();
+                    }}
+                    style={({ pressed }) => [
+                      styles.pickerOption,
+                      { borderColor: colors.border },
+                      pressed && { backgroundColor: colors.selected },
+                    ]}
+                  >
+                    <View style={styles.parentOption}>
+                      <Icon name={item.icon} size={24} color={colors.text} />
+                      <Text style={themed.parentText}>
+                        {item.nameKey ? t(item.nameKey) : item.name}
+                      </Text>
+                    </View>
+                  </Pressable>
+                )}
+              />
+            )}
+          </Animated.View>
+        )}
+      </ModalShell>
+
+      {/* Icon Picker Modal — outside ModalShell */}
+      <IconPicker
+        visible={iconPickerVisible}
+        onClose={() => setIconPickerVisible(false)}
+        onSelect={(icon) => setValues(v => ({ ...v, icon }))}
+        selectedIcon={values.icon}
+      />
+    </>
+  );
+```
+
+- [ ] **Step 4: Replace the `StyleSheet.create` block**
+
+Keep only styles that are still used (picker panel, icon picker button, error):
+
+```javascript
+const styles = StyleSheet.create({
+  error: {
+    color: '#ff6b6b',
+    fontSize: 12,
+    marginBottom: SPACING.sm,
+  },
+  iconPickerButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
+    flexDirection: 'row',
+    marginBottom: SPACING.sm,
+    marginTop: SPACING.sm,
+    padding: SPACING.md,
+  },
+  iconPickerText: {
+    marginLeft: SPACING.md,
+  },
+  parentOption: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  pickerOption: {
+    borderBottomWidth: 1,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.md,
+  },
+  pickerPanel: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  pickerPanelHeader: {
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    gap: SPACING.md,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+  },
+  pickerPanelTitle: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test -- --silent
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/modals/CategoryModal.js
+git commit -m "feat(ui): refactor CategoryModal to use ModalShell and PaperTextInput"
+```
+
+---
+
+## Task 4: Refactor `PlannedOperationModal.js`
+
+**Files:**
+- Modify: `app/modals/PlannedOperationModal.js`
+
+**What changes:**
+- Replace outer `Modal + KAV + Pressable` boilerplate + `ModalHeader` + `buttonRow` with `<ModalShell>`
+- Name, Amount, Description `TextInput` → `PaperTextInput mode="outlined"` with fieldLabel
+- Account / Category picker `Pressable` rows → `pickerRowStyles` + `TouchableRipple`
+- Delete moves out of `buttonRow` into `ModalShell.onDelete`
+- Type selector (Expense/Income/Transfer buttons) and Recurring toggle: unchanged
+- Drag handle now provided by ModalShell (was missing)
+- Remove from RN imports: `Modal`, `KeyboardAvoidingView`, `TextInput`; keep `Platform` (still used in `renderPickerModal`)
+
+- [ ] **Step 1: Replace imports block (lines 1–28)**
+
+```javascript
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  Pressable,
+  StyleSheet,
+  FlatList,
+  ScrollView,
+  Keyboard,
+  Switch,
+} from 'react-native';
+import { TextInput as PaperTextInput, TouchableRipple } from 'react-native-paper';
+import PropTypes from 'prop-types';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { useDialog } from '../contexts/DialogContext';
+import { usePlannedOperations } from '../contexts/PlannedOperationsContext';
+import { useAccountsData } from '../contexts/AccountsDataContext';
+import { useCategories } from '../contexts/CategoriesContext';
+import useOperationPicker from '../hooks/useOperationPicker';
+import PickerModal from '../components/operations/PickerModal';
+import ModalShell from '../components/ModalShell';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
+import { SPACING, BORDER_RADIUS, FONT_SIZE, HEIGHTS } from '../styles/designTokens';
+```
+
+- [ ] **Step 2: Add `makeModalStyles` call inside component after `const { colors } = useThemeColors();`**
+
+```javascript
+  const { colors } = useThemeColors();
+  const { paperInputTheme } = makeModalStyles(colors);
+```
+
+- [ ] **Step 3: Replace entire `return (...)` block**
+
+```javascript
+  return (
+    <>
+      <ModalShell
+        visible={visible}
+        onDismiss={handleClose}
+        title={isNew ? t('add_planned_operation') : t('edit_planned_operation')}
+        onSave={handleSave}
+        onCancel={handleClose}
+        onDelete={isNew ? undefined : handleDelete}
+        showBlurOverlay
+      >
+        {/* Name */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('planned_name') || 'Name').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          value={values.name}
+          onChangeText={text => setValues(v => ({ ...v, name: text }))}
+          placeholder={t('planned_operation_name_hint')}
+          returnKeyType="next"
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+        {errors.name && <Text style={[styles.error, { color: colors.error }]}>{errors.name}</Text>}
+
+        {/* Type Selector */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('operation_type') || 'Type').toUpperCase()}
+        </Text>
+        <View style={styles.typeRow}>
+          {TYPE_OPTIONS.map(opt => {
+            const isActive = values.type === opt.key;
+            return (
+              <Pressable
+                key={opt.key}
+                style={[
+                  styles.typeButton,
+                  {
+                    backgroundColor: isActive ? colors[opt.colorKey] : colors.inputBackground,
+                    borderColor: isActive ? colors[opt.colorKey] : colors.inputBorder,
+                  },
+                ]}
+                onPress={() => setValues(v => ({ ...v, type: opt.key, categoryId: null }))}
+              >
+                <Icon name={opt.icon} size={18} color={isActive ? '#fff' : colors.mutedText} />
+                <Text style={[styles.typeLabel, { color: isActive ? '#fff' : colors.mutedText }]}>
+                  {t(`${opt.key}_label`) || t(opt.key)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {/* Amount */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('amount') || 'Amount').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          value={values.amount}
+          onChangeText={text => setValues(v => ({ ...v, amount: text }))}
+          placeholder="0.00"
+          keyboardType="decimal-pad"
+          returnKeyType="done"
+          onSubmitEditing={Keyboard.dismiss}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+        {errors.amount && <Text style={[styles.error, { color: colors.error }]}>{errors.amount}</Text>}
+
+        {/* Account */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('select_account') || 'Account').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          testID="planned-account-picker"
+          style={[modalSharedStyles.pickerRow, { borderColor: errors.accountId ? colors.error : colors.border, backgroundColor: colors.card }]}
+          onPress={() => setAccountPickerVisible(true)}
+          rippleColor="rgba(0,0,0,0.05)"
+          borderless={false}
+        >
+          <View style={modalSharedStyles.pickerRowInner}>
+            <Text style={[modalSharedStyles.pickerRowValue, { color: values.accountId ? colors.text : colors.mutedText }]}>
+              {values.accountId ? getAccountName(values.accountId) : t('select_account')}
+            </Text>
+            <Icon name="chevron-down" size={20} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+        {errors.accountId && <Text style={[styles.error, { color: colors.error }]}>{errors.accountId}</Text>}
+
+        {/* Category (expense/income only) */}
+        {values.type !== 'transfer' && (
+          <>
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('select_category') || 'Category').toUpperCase()}
+            </Text>
+            <TouchableRipple
+              testID="planned-category-picker"
+              style={[modalSharedStyles.pickerRow, { borderColor: errors.categoryId ? colors.error : colors.border, backgroundColor: colors.card }]}
+              onPress={() => openCategoryPicker('category', filteredCategories)}
+              rippleColor="rgba(0,0,0,0.05)"
+              borderless={false}
+            >
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: values.categoryId ? colors.text : colors.mutedText }]}>
+                  {values.categoryId ? getCategoryName(values.categoryId) : t('select_category')}
+                </Text>
+                <Icon name="chevron-down" size={20} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+            {errors.categoryId && <Text style={[styles.error, { color: colors.error }]}>{errors.categoryId}</Text>}
+          </>
+        )}
+
+        {/* To Account (transfer only) */}
+        {values.type === 'transfer' && (
+          <>
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('to_account') || 'To Account').toUpperCase()}
+            </Text>
+            <TouchableRipple
+              style={[modalSharedStyles.pickerRow, { borderColor: errors.toAccountId ? colors.error : colors.border, backgroundColor: colors.card }]}
+              onPress={() => setToAccountPickerVisible(true)}
+              rippleColor="rgba(0,0,0,0.05)"
+              borderless={false}
+            >
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: values.toAccountId ? colors.text : colors.mutedText }]}>
+                  {values.toAccountId ? getAccountName(values.toAccountId) : t('select_account')}
+                </Text>
+                <Icon name="chevron-down" size={20} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+            {errors.toAccountId && <Text style={[styles.error, { color: colors.error }]}>{errors.toAccountId}</Text>}
+          </>
+        )}
+
+        {/* Recurring Toggle */}
+        <View style={styles.switchRow}>
+          <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText, marginTop: 0 }]}>
+            {(t('recurring') || 'Recurring').toUpperCase()}
+          </Text>
+          <Switch
+            value={values.isRecurring}
+            onValueChange={val => setValues(v => ({ ...v, isRecurring: val }))}
+            trackColor={{ false: colors.border, true: colors.primary + '66' }}
+            thumbColor={values.isRecurring ? colors.primary : colors.mutedText}
+          />
+        </View>
+
+        {/* Description */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('description') || 'Description').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          multiline
+          numberOfLines={2}
+          value={values.description}
+          onChangeText={text => setValues(v => ({ ...v, description: text }))}
+          placeholder={t('description')}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+      </ModalShell>
+
+      {/* Account Picker Modal */}
+      {renderPickerModal(
+        accountPickerVisible,
+        setAccountPickerVisible,
+        accounts.map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
+        (id) => setValues(v => ({ ...v, accountId: id })),
+        t('select_account'),
+      )}
+
+      {/* To Account Picker Modal */}
+      {renderPickerModal(
+        toAccountPickerVisible,
+        setToAccountPickerVisible,
+        accounts.filter(a => a.id !== values.accountId).map(a => ({ id: a.id, name: `${a.name} (${a.currency})` })),
+        (id) => setValues(v => ({ ...v, toAccountId: id })),
+        t('to_account'),
+      )}
+
+      {/* Category Picker Modal (hierarchical) */}
+      <PickerModal
+        visible={categoryPickerState.visible}
+        pickerType={categoryPickerState.type}
+        pickerData={categoryPickerState.data}
+        colors={colors}
+        t={t}
+        onClose={closeCategoryPicker}
+        categoryNavigation={categoryNavigation}
+        quickAddValues={{ ...values, amount: '' }}
+        onNavigateBack={navigateBack}
+        onNavigateIntoFolder={navigateIntoFolder}
+        onSelectCategory={(id) => { setValues(v => ({ ...v, categoryId: id })); closeCategoryPicker(); }}
+      />
+    </>
+  );
+```
+
+- [ ] **Step 4: Replace `StyleSheet.create` block — keep only styles still used in the new return block**
+
+```javascript
+const styles = StyleSheet.create({
+  error: {
+    color: '#ff6b6b',
+    fontSize: FONT_SIZE.sm,
+    marginBottom: SPACING.xs,
+    marginTop: SPACING.xs,
+  },
+  pickerCancel: {
+    alignItems: 'center',
+    borderTopWidth: 1,
+    paddingVertical: SPACING.md,
+  },
+  pickerCancelText: {
+    fontSize: FONT_SIZE.base,
+    fontWeight: '600',
+  },
+  pickerContent: {
+    borderTopLeftRadius: BORDER_RADIUS.lg,
+    borderTopRightRadius: BORDER_RADIUS.lg,
+    maxHeight: '60%',
+    paddingTop: SPACING.lg,
+    width: '100%',
+  },
+  pickerItem: {
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    paddingHorizontal: SPACING.xl,
+    paddingVertical: SPACING.md,
+  },
+  pickerItemIcon: {
+    marginRight: SPACING.sm,
+  },
+  pickerItemText: {
+    fontSize: FONT_SIZE.base,
+  },
+  pickerList: {
+    maxHeight: 300,
+  },
+  pickerOverlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  pickerTitle: {
+    fontSize: FONT_SIZE.lg,
+    fontWeight: '600',
+    marginBottom: SPACING.md,
+    paddingHorizontal: SPACING.xl,
+  },
+  switchRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: SPACING.sm,
+  },
+  typeButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    flex: 1,
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    justifyContent: 'center',
+    marginHorizontal: SPACING.xs,
+    paddingVertical: SPACING.sm,
+  },
+  typeLabel: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '600',
+  },
+  typeRow: {
+    flexDirection: 'row',
+    marginBottom: SPACING.xs,
+  },
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test -- --silent
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/modals/PlannedOperationModal.js
+git commit -m "feat(ui): refactor PlannedOperationModal to use ModalShell and PaperTextInput"
+```
+
+---
+
+## Task 5: Refactor `OperationModal.js`
+
+**Files:**
+- Modify: `app/modals/OperationModal.js`
+
+**What changes:**
+- Replace `Modal + KAV + Pressable + ModalHeader + modalButtonRow + splitDeleteRow` with `<ModalShell>`
+- Title always shown: `t('add_operation')` for new, `t('edit_operation')` for edit
+- `onSave={isShadowOperation ? undefined : handleSave}` — hides Save for shadow ops
+- `cancelLabel={isShadowOperation ? t('close') : t('cancel')}`
+- `onDelete={!isNew && onDelete && canDeleteShadowOperation ? handleDelete : undefined}` (show delete only when actionable; pass `deleteDisabled` otherwise)
+- Split button → `extraActions` prop
+- Category/date picker rows → `pickerRowStyles` with fieldLabel above
+- Remove from imports: `ModalHeader`; keep everything else
+
+- [ ] **Step 1: Replace the `ModalHeader` import**
+
+Find line:
+```javascript
+import ModalHeader from '../components/ModalHeader';
+```
+Replace with:
+```javascript
+import ModalShell from '../components/ModalShell';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
+```
+
+- [ ] **Step 2: Add `makeModalStyles` call inside component after `const { colors } = useThemeColors();`**
+
+```javascript
+  const { colors } = useThemeColors();
+  const { paperInputTheme } = makeModalStyles(colors);
+```
+
+- [ ] **Step 3: Replace the `return (...)` block**
+
+Replace from `return (` through the closing `);`:
+
+```javascript
+  const splitExtraActions = (canSplit || (!isNew && onDelete)) ? (
+    <View style={styles.splitDeleteRow}>
+      {canSplit && (
+        <Pressable
+          style={[styles.splitButtonContainer, { backgroundColor: colors.card }]}
+          onPress={() => setShowSplitModal(true)}
+          testID="split-button"
+        >
+          <Icon name="call-split" size={18} color={colors.primary} />
+          <Text style={[styles.splitButtonText, { color: colors.primary }]}>
+            {t('split_transaction')}
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  ) : null;
+
+  return (
+    <>
+      <ModalShell
+        visible={visible}
+        onDismiss={handleClose}
+        title={isNew ? t('add_operation') : t('edit_operation')}
+        onSave={isShadowOperation ? undefined : handleSave}
+        onCancel={handleClose}
+        cancelLabel={isShadowOperation ? t('close') : t('cancel')}
+        onDelete={!isNew && onDelete ? handleDelete : undefined}
+        deleteDisabled={!canDeleteShadowOperation}
+        extraActions={splitExtraActions}
+        scrollRef={scrollViewRef}
+        showBlurOverlay
+      >
+        {/* Shared Form Fields: type selector, amount, account(s), category, multi-currency */}
+        <OperationFormFields
+          colors={colors}
+          t={t}
+          values={values}
+          setValues={setValues}
+          accounts={accounts}
+          categories={filteredCategories}
+          getAccountName={getAccountName}
+          getAccountBalance={getAccountBalance}
+          getCategoryName={getCategoryName}
+          openPicker={openPicker}
+          onAmountChange={handleAmountChange}
+          TYPES={TYPES}
+          showTypeSelector={true}
+          showAccountBalance={true}
+          showFieldIcons={true}
+          hideCategoryPicker={!isNew}
+          hideTransferTargetPicker={true}
+          transferLayout="sideBySide"
+          disabled={isShadowOperation}
+          containerBackground={colors.card}
+          onExchangeRateChange={handleExchangeRateChange}
+          onDestinationAmountChange={handleDestinationAmountChange}
+          rateSource={rateSource}
+        />
+
+        {/* Category / To Account + Date row */}
+        <View style={styles.categoryDateRow}>
+          {values.type === 'transfer' ? (
+            <View style={styles.halfFieldWrapper}>
+              <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+                {(t('to_account') || 'To').toUpperCase()}
+              </Text>
+              <Pressable
+                style={[
+                  styles.pickerButtonHalf,
+                  { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                  isShadowOperation && styles.disabledInput,
+                ]}
+                onPress={() => !isShadowOperation && openPicker('toAccount', accounts.filter(acc => acc.id !== values.accountId))}
+                disabled={isShadowOperation}
+                accessibilityRole="button"
+                accessibilityLabel={t('to_account')}
+                testID="to-account-picker"
+              >
+                <Icon name="swap-horizontal" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
+                <Text
+                  style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}
+                  numberOfLines={1}
+                >
+                  {values.toAccountId ? getAccountName(values.toAccountId) : t('to_account')}
+                </Text>
+              </Pressable>
+            </View>
+          ) : (
+            <View style={styles.halfFieldWrapper}>
+              <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+                {(t('select_category') || 'Category').toUpperCase()}
+              </Text>
+              <Pressable
+                style={[
+                  styles.pickerButtonHalf,
+                  { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                  isShadowOperation && styles.disabledInput,
+                ]}
+                onPress={() => !isShadowOperation && openPicker('category', filteredCategories)}
+                disabled={isShadowOperation}
+                accessibilityRole="button"
+                accessibilityLabel={t('select_category')}
+              >
+                <Icon name="tag" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
+                <Text
+                  style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}
+                  numberOfLines={1}
+                >
+                  {getCategoryName(values.categoryId)}
+                </Text>
+              </Pressable>
+            </View>
+          )}
+
+          <View style={styles.halfFieldWrapper}>
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('select_date') || 'Date').toUpperCase()}
+            </Text>
+            <Pressable
+              style={[
+                styles.pickerButtonHalf,
+                { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                isShadowOperation && styles.disabledInput,
+              ]}
+              onPress={handleOpenDatePicker}
+              disabled={isShadowOperation}
+              accessibilityRole="button"
+              accessibilityLabel={t('select_date')}
+              testID="date-input"
+            >
+              <Icon name="calendar" size={20} color={isShadowOperation ? colors.mutedText : colors.text} />
+              <Text style={[styles.pickerButtonText, { color: isShadowOperation ? colors.mutedText : colors.text }]}>
+                {formatDateForDisplay(values.date)}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {/* Description with autocomplete */}
+        <DescriptionAutocomplete
+          value={values.description || ''}
+          onChangeText={handleDescriptionChange}
+          suggestions={descriptionSuggestions}
+          placeholder={t('description')}
+          editable={!isShadowOperation}
+          colors={colors}
+          onFocus={handleDescriptionFocus}
+        />
+
+        {errors.general && <Text style={styles.error}>{errors.general}</Text>}
+      </ModalShell>
+
+      {/* Split Operation Modal */}
+      <SplitOperationModal
+        visible={showSplitModal}
+        onClose={() => setShowSplitModal(false)}
+        onConfirm={handleSplitConfirm}
+        originalAmount={values.amount}
+        operationType={values.type}
+        categories={categories}
+        colors={colors}
+        t={t}
+      />
+
+      {/* Date Picker */}
+      {showDatePicker && (
+        <DateTimePicker
+          value={new Date(values.date)}
+          mode="date"
+          display="default"
+          onChange={handleDateChange}
+        />
+      )}
+
+      {/* Unified Picker Modal */}
+      <Modal
+        visible={pickerState.visible && visible}
+        animationType="slide"
+        transparent
+        onRequestClose={closePicker}
+      >
+        <Pressable style={styles.pickerOverlay} onPress={closePicker}>
+          <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={handleStopPropagation}>
+            {pickerState.type === 'category' && categoryNavigation.breadcrumb.length > 0 && (
+              <View style={[styles.breadcrumbContainer, { borderBottomColor: colors.border }]}>
+                <Pressable onPress={navigateBack} style={styles.backButton}>
+                  <Icon name="arrow-left" size={24} color={colors.primary} />
+                </Pressable>
+                <Text style={[styles.breadcrumbText, { color: colors.text }]} numberOfLines={1}>
+                  {categoryNavigation.breadcrumb[categoryNavigation.breadcrumb.length - 1].name}
+                </Text>
+              </View>
+            )}
+            <FlatList
+              data={pickerState.data}
+              keyExtractor={keyExtractor}
+              numColumns={pickerState.type === 'category' ? 3 : 1}
+              columnWrapperStyle={pickerState.type === 'category' ? styles.gridRow : undefined}
+              contentContainerStyle={pickerState.type === 'category' ? styles.gridContent : undefined}
+              renderItem={renderPickerItem}
+              ListEmptyComponent={
+                <Text style={[styles.pickerEmptyText, { color: colors.mutedText }]}>
+                  {pickerState.type === 'category' ? t('no_categories') : t('no_accounts')}
+                </Text>
+              }
+            />
+            {(pickerState.type !== 'category' || !isNew) && (
+              <Pressable style={styles.closeButton} onPress={closePicker}>
+                <Text style={[styles.closeButtonText, { color: colors.primary }]}>{t('close')}</Text>
+              </Pressable>
+            )}
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
+  );
+```
+
+- [ ] **Step 4: Add `halfFieldWrapper` style to the existing `StyleSheet.create` block and remove unused styles**
+
+Add inside the existing `StyleSheet.create({...})`:
+```javascript
+  halfFieldWrapper: {
+    flex: 1,
+  },
+```
+
+Remove these now-unused styles from the StyleSheet: `modalButton`, `modalButtonRow`, `splitButtonContainer`, `splitButtonText`, `splitDeleteRow`, `deleteButtonContainer`, `deleteButtonText`, `disabledButton`, `fullFlex`, `modalContent`, `modalOverlay`, `sheetDragHandle`.
+
+Keep: `accountName`, `accountOption`, `backButton`, `breadcrumbContainer`, `breadcrumbText`, `buttonText`, `categoryDateRow`, `closeButton`, `closeButtonText`, `disabledInput`, `error`, `folderBadge`, `gridCell`, `gridCellName`, `gridContent`, `gridRow`, `halfFieldWrapper`, `pickerButtonHalf`, `pickerButtonText`, `pickerEmptyText`, `pickerModalContent`, `pickerOption`, `pickerOptionCurrency`, `pickerOptionText`, `pickerOverlay`, `scrollContent`, `scrollView`.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test -- --silent
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/modals/OperationModal.js
+git commit -m "feat(ui): refactor OperationModal to use ModalShell, add edit-mode title"
+```
+
+---
+
+## Task 6: Refactor `AccountsScreen.js` (AccountModal section)
+
+**Files:**
+- Modify: `app/screens/AccountsScreen.js`
+
+**What changes:**
+- Replace `{!!editingId && <ModalBlurOverlay />} + RNModal + KAV + Pressable` boilerplate with `<ModalShell>`
+- Add `theme={paperInputTheme}` to existing `PaperTextInput` fields (Name, Balance)
+- Fix Currency field: move label above the `TouchableRipple` row (out of the row's inner View)
+- Remove `ModalBlurOverlay` import (ModalShell handles it); remove `Modal as RNModal` and `KeyboardAvoidingView` from RN imports
+- Import `ModalShell` and `makeModalStyles, modalSharedStyles`
+
+- [ ] **Step 1: Update imports**
+
+In the RN import at line 3, remove `KeyboardAvoidingView` and `Modal as RNModal`:
+```javascript
+import { View, StyleSheet, ScrollView, Keyboard, FlatList, TouchableOpacity, Pressable, Animated, Dimensions } from 'react-native';
+```
+
+Remove line 4:
+```javascript
+import ModalBlurOverlay from '../components/ModalBlurOverlay';
+```
+
+After the existing imports, add:
+```javascript
+import ModalShell from '../components/ModalShell';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
+```
+
+- [ ] **Step 2: Add `makeModalStyles` call inside `AccountsScreen` component**
+
+Find `const { colors } = useThemeColors();` inside the component body and add below it:
+```javascript
+  const { paperInputTheme } = makeModalStyles(colors);
+```
+
+- [ ] **Step 3: Replace the AccountModal JSX block**
+
+Find and replace the entire block from `{!!editingId && <ModalBlurOverlay />}` through `</RNModal>` (lines ~818–1015) with:
+
+```javascript
+      <ModalShell
+        visible={!!editingId}
+        onDismiss={handleCloseModal}
+        title={editingId === 'new' ? (t('add_account') || 'New Account') : (t('edit_account') || 'Edit Account')}
+        subtitle={editingId !== 'new' && editValues.name ? editValues.name : undefined}
+        onSave={saveEdit}
+        onCancel={handleCloseModal}
+        onDelete={editingId !== 'new' ? handleDeleteEditingAccount : undefined}
+        showBlurOverlay
+      >
+        {/* Account name */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('account_name') || 'Account name').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          mode="outlined"
+          value={editValues.name}
+          onChangeText={handleNameChange}
+          error={!!errors.name}
+          autoFocus={editingId === 'new'}
+          returnKeyType="next"
+          onSubmitEditing={() => balanceInputRef.current?.focus()}
+          blurOnSubmit={false}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+        {errors.name && <Text variant="bodySmall" style={styles.error}>{errors.name}</Text>}
+
+        {/* Balance */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('balance') || 'Balance').toUpperCase()}
+        </Text>
+        <PaperTextInput
+          ref={balanceInputRef}
+          mode="outlined"
+          value={editValues.balance}
+          onChangeText={handleBalanceChange}
+          error={!!errors.balance}
+          keyboardType="numeric"
+          returnKeyType="done"
+          placeholder={(() => {
+            const dec = currencies[editValues.currency]?.decimal_digits ?? 2;
+            return dec === 0 ? '0' : `0.${'0'.repeat(dec)}`;
+          })()}
+          onSubmitEditing={Keyboard.dismiss}
+          theme={paperInputTheme}
+          style={modalSharedStyles.textInput}
+        />
+        {errors.balance && <Text variant="bodySmall" style={styles.error}>{errors.balance}</Text>}
+
+        {/* Currency — label now above the row */}
+        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+          {(t('currency') || 'Currency').toUpperCase()}
+        </Text>
+        <TouchableRipple
+          onPress={handleOpenPicker}
+          style={[styles.currencyRow, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        >
+          <View style={styles.currencyRowInner}>
+            <Text style={[styles.currencyRowValue, { color: colors.text }]}>
+              {editValues.currency
+                ? `${currencies[editValues.currency]?.name} · ${currencies[editValues.currency]?.symbol}`
+                : (t('select_currency') || 'Select currency')}
+            </Text>
+            <Icon name="chevron-right" size={22} color={colors.mutedText} />
+          </View>
+        </TouchableRipple>
+        {errors.currency && <Text variant="bodySmall" style={styles.error}>{errors.currency}</Text>}
+
+        {/* Settings group */}
+        <View style={[styles.settingsGroup, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+          {editingId !== 'new' && (
+            <View style={[styles.settingItem, styles.settingItemBorder, { borderBottomColor: colors.border }]}>
+              <View style={styles.settingItemText}>
+                <Text style={[styles.settingTitle, { color: colors.text }]}>
+                  {t('create_adjustment_operation') || 'Log adjustment'}
+                </Text>
+                <Text style={[styles.settingHint, { color: colors.mutedText }]}>
+                  {t('create_adjustment_operation_hint') || 'Record balance change as a transaction'}
+                </Text>
+              </View>
+              <Switch
+                value={createAdjustmentOperation}
+                onValueChange={handleToggleAdjustmentSwitch}
+                color={colors.primary}
+              />
+            </View>
+          )}
+          <View style={styles.settingItem}>
+            <View style={styles.settingItemText}>
+              <Text style={[styles.settingTitle, { color: colors.text }]}>
+                {t('hidden_account') || 'Hidden account'}
+              </Text>
+              <Text style={[styles.settingHint, { color: colors.mutedText }]}>
+                {t('hidden_account_hint') || 'Hide from main list and operations'}
+              </Text>
+            </View>
+            <Switch
+              value={!!editValues.hidden}
+              onValueChange={handleToggleHiddenSwitch}
+              color={colors.primary}
+            />
+          </View>
+        </View>
+
+        {/* In-sheet currency picker — slides in from the right */}
+        {currencyPanelVisible && (
+          <Animated.View
+            style={[styles.currencyPanel, { backgroundColor: colors.card, transform: [{ translateX: currencySlideAnim }] }]}
+          >
+            <View style={[styles.currencyPanelHeader, { borderBottomColor: colors.border }]}>
+              <TouchableOpacity onPress={handleClosePicker} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+                <Icon name="arrow-left" size={22} color={colors.text} />
+              </TouchableOpacity>
+              <Text style={[styles.currencyPanelTitle, { color: colors.text }]}>
+                {t('select_currency') || 'Currency'}
+              </Text>
+            </View>
+            <FlatList
+              data={Object.entries(currencies)}
+              keyExtractor={([code]) => code}
+              renderItem={({ item: [code, cur] }) => (
+                <TouchableRipple
+                  onPress={() => handleCurrencySelect(code)}
+                  style={styles.currencyPanelItem}
+                  rippleColor="rgba(0,0,0,0.08)"
+                >
+                  <Text style={[styles.currencyPanelItemText, { color: colors.text }]}>
+                    {cur.name} ({cur.symbol})
+                  </Text>
+                </TouchableRipple>
+              )}
+              ItemSeparatorComponent={() => <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+            />
+          </Animated.View>
+        )}
+      </ModalShell>
+```
+
+- [ ] **Step 4: Remove unused styles from `StyleSheet.create`**
+
+Remove: `currencyRowLabel`, `deleteRow`, `deleteRowContent`, `deleteRowText`, `deleteWrapper`, `fieldLabel`, `modalContent`, `modalKAV`, `modalOverlay`, `sheetActions`, `sheetBtn`, `sheetBtnCancel`, `sheetBtnSaveText`, `sheetBtnText`, `sheetDragHandle`, `sheetHeader`, `sheetScroll`, `sheetSubtitle`, `sheetTitle`.
+
+Update `currencyRowInner` — remove `paddingVertical: SPACING.sm` since value-only row is slightly taller now:
+```javascript
+  currencyRowInner: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+  },
+```
+(no change needed — keep as-is)
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test -- --silent
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/screens/AccountsScreen.js
+git commit -m "feat(ui): refactor AccountModal to use ModalShell, move currency label above row"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] All i18n keys exist: `add_operation`, `edit_operation`, `add_account`, `edit_account`, `add_category`, `edit_category`, `add_planned_operation`, `edit_planned_operation` — verified against `assets/i18n/en.json`
+- [x] `ModalShell` handles `onSave=null` (shadow ops) with full-width cancel button
+- [x] `deleteDisabled` prop propagated correctly — OperationModal passes it for shadow ops
+- [x] Animated currency picker panel in AccountModal stays inside ModalShell `children` — absolute-positioned, still works
+- [x] Animated picker panel in CategoryModal also inside `children` — same reasoning
+- [x] Sub-modals (SplitOperationModal, DateTimePicker, picker modals) rendered outside ModalShell as siblings in Fragment — correct, they each have their own `visible` state
+- [x] `ModalBlurOverlay` import removed from AccountsScreen (moved into ModalShell)
+- [x] `scrollRef` prop added to ModalShell and forwarded to its ScrollView; OperationModal passes `scrollRef={scrollViewRef}` so `handleDescriptionFocus` continues to work
+- [x] No TBDs, no incomplete sections

--- a/docs/superpowers/specs/2026-05-06-modal-style-standardization-design.md
+++ b/docs/superpowers/specs/2026-05-06-modal-style-standardization-design.md
@@ -1,0 +1,168 @@
+# Modal Style Standardization
+
+**Date:** 2026-05-06  
+**Scope:** OperationModal, CategoryModal, PlannedOperationModal, AccountModal
+
+## Problem
+
+The four bottom-sheet modals were built incrementally without a shared structure, producing visible inconsistencies:
+- OperationModal shows no title when editing
+- PlannedOperationModal is missing the drag handle
+- Delete/Cancel/Save button styles differ across every modal
+- Input styling differs: AccountModal uses react-native-paper `TextInput`; the others use raw RN `TextInput` with manual labels
+- The Currency picker row in AccountModal has its label inside the row instead of above it
+
+## Goal
+
+All four modals look and feel identical in terms of shell structure and input/button styling. AccountModal is the reference design.
+
+---
+
+## New Files
+
+### `app/components/ModalShell.js`
+
+Structural wrapper that replaces each modal's boilerplate outer layout. Renders:
+
+```
+RNModal (animationType="slide", transparent)
+  ├── {showBlurOverlay && <ModalBlurOverlay />}   ← outside RNModal, in Fragment
+  └── KeyboardAvoidingView (behavior="padding")
+        └── Pressable overlay (onPress=onDismiss, flex, justifyContent=flex-end)
+              └── Pressable card (stopPropagation, borderTopRadius=24, maxHeight=85%, bg=colors.card)
+                    ├── drag handle (44×4, borderRadius=3, bg=colors.border, alignSelf=center, mb=SPACING.md)
+                    ├── header View (mb=SPACING.sm)
+                    │     ├── Text title (fontSize=18, fontWeight=700, letterSpacing=-0.3)
+                    │     └── Text subtitle? (fontSize=12, color=mutedText, mt=2)
+                    ├── ScrollView (flexShrink=1, keyboardShouldPersistTaps=handled, showsVerticalScrollIndicator=false)
+                    │     └── {children}  ← form content
+                    ├── {onDelete && deleteRow}
+                    │     └── TouchableRipple (borderRadius=md, borderWidth=1, borderColor=delete+40, full width)
+                    │           └── Icon "delete-outline" + Text (color=delete, gap=SPACING.sm)
+                    ├── {extraActions}  ← optional slot, used by OperationModal for Split row
+                    └── actionRow (borderTopWidth=1, borderTopColor=border, flexDirection=row, gap=SPACING.sm, pt=SPACING.sm, pb=SPACING.xl)
+                          ├── Cancel: TouchableRipple (flex=1, borderWidth=1, borderColor=border, borderRadius=md, pv=SPACING.sm)
+                          └── Save:   TouchableRipple (flex=1, bg=colors.primary, borderRadius=md, pv=SPACING.sm, text white)
+```
+
+**Props:**
+
+| Prop | Type | Required | Default |
+|------|------|----------|---------|
+| `visible` | bool | yes | — |
+| `onDismiss` | fn | yes | — |
+| `title` | string | yes | — |
+| `subtitle` | string | no | — |
+| `onSave` | fn | yes | — |
+| `onCancel` | fn | yes | — |
+| `saveLabel` | string | no | `t('save')` |
+| `cancelLabel` | string | no | `t('cancel')` |
+| `onDelete` | fn | no | — (delete row hidden when absent) |
+| `deleteLabel` | string | no | `t('delete')` |
+| `extraActions` | node | no | — |
+| `showBlurOverlay` | bool | no | `false` |
+| `children` | node | yes | — |
+
+ModalShell uses `useContext(ThemeColorsContext)` and `useContext(LocalizationContext)` internally for colors and translations.
+
+---
+
+### `app/styles/modalStyles.js`
+
+Exports a function `makeModalStyles(colors)` returning shared styles for form content inside the shell. Does **not** duplicate shell structural styles.
+
+**`paperInputTheme`** — passed as `theme` prop to every `PaperTextInput`:
+```js
+{
+  colors: {
+    primary: colors.primary,
+    outline: colors.border,
+    background: colors.card,
+    onSurfaceVariant: colors.mutedText,
+    onSurface: colors.text,
+    error: colors.error,
+  }
+}
+```
+
+**`pickerRowStyles`** — StyleSheet for tappable picker rows (category, account, currency, icon selectors). Matches AccountModal's `currencyRow` pattern:
+```
+LABEL TEXT              ← fontSize=11, fontWeight=600, letterSpacing=0.8, color=mutedText, mb=2
+┌─── selected value ──────────────── › ──┐   ← borderRadius=md, borderWidth=1, borderColor=border
+```
+Styles: `pickerRow`, `pickerRowInner`, `pickerLabel`, `pickerValue`
+
+Usage in each modal:
+```js
+const { paperInputTheme, pickerRowStyles } = makeModalStyles(colors);
+// pass paperInputTheme to every PaperTextInput
+// apply pickerRowStyles to every tappable picker field
+```
+
+---
+
+## Modified Files
+
+### `app/modals/OperationModal.js`
+
+- Replace outer boilerplate with `<ModalShell>`:
+  - `title`: `t('add_operation')` when new, `t('edit_operation')` when editing
+  - `onDelete`: existing delete handler (shown only in edit mode, so pass `isNew ? undefined : handleDelete`)
+  - `extraActions`: existing Split button row JSX
+  - `showBlurOverlay`: true
+- Remove: `ModalHeader`, `modalButtonRow`, the split/delete bottom row, manual `Modal`/`KAV`/`Pressable` wrapper
+- Description field: `TextInput` → `PaperTextInput mode="outlined" theme={paperInputTheme}`
+- Category, Account, Date picker rows: apply `pickerRowStyles`
+- Amount stays as-is (calculator widget, not a TextInput)
+
+### `app/modals/CategoryModal.js`
+
+- Replace outer boilerplate with `<ModalShell>`:
+  - `title`: `t('add_category')` / `t('edit_category')`
+  - `onDelete`: existing delete handler (pass `isNew ? undefined : handleDelete`)
+  - `showBlurOverlay`: true
+- Remove: manual drag handle, `sheetHeader`, `sheetActions`, `deleteWrapper`, manual `Modal`/`KAV`/`Pressable` wrapper
+- Name field: `TextInput` → `PaperTextInput mode="outlined" theme={paperInputTheme}`
+- Type / Category Type / Parent Category / Icon rows: apply `pickerRowStyles`
+- Sliding `Animated.View` picker panel: stays inside `children`, no change
+
+### `app/modals/PlannedOperationModal.js`
+
+- Replace outer boilerplate with `<ModalShell>`:
+  - `title`: `t('add_planned_operation')` / `t('edit_planned_operation')`
+  - `onDelete`: existing handler (pass `isNew ? undefined : handleDelete`)
+  - `showBlurOverlay`: true
+- Drag handle now provided by ModalShell (was missing)
+- Remove: `ModalHeader`, `buttonRow` (Delete/Cancel/Save), manual `Modal`/`KAV`/`Pressable` wrapper
+- Name, Amount, Description fields: `TextInput` → `PaperTextInput mode="outlined" theme={paperInputTheme}`
+- Account / Category picker rows: apply `pickerRowStyles`
+- Type selector (Expense/Income/Transfer inline buttons): stays as-is
+- Recurring toggle: stays as-is
+
+### `app/screens/AccountsScreen.js` (AccountModal section)
+
+- Replace manual outer boilerplate with `<ModalShell>`:
+  - `title`: `t('add_account')` / `t('edit_account')`
+  - `subtitle`: account name in edit mode
+  - `onDelete`: existing handler (pass `editingId === 'new' ? undefined : handleDeleteEditingAccount`)
+  - `showBlurOverlay`: false (AccountModal currently has no blur overlay)
+- Fix CURRENCY field: replace current `currencyRow` (label inside) with `pickerRowStyles` pattern (label above)
+- Existing `PaperTextInput` fields (Name, Balance): keep as-is, add `theme={paperInputTheme}` for consistency
+- Remove: manual drag handle, `sheetHeader`, `sheetActions`, `deleteWrapper`, manual `Modal`/`KAV`/`Pressable` wrapper
+
+---
+
+## What Does NOT Change
+
+- Calculator widget in OperationModal
+- Expense/Income/Transfer type selector in PlannedOperationModal
+- Recurring toggle in PlannedOperationModal
+- Animated sliding picker panel in CategoryModal
+- All sub-picker modals (icon picker, category hierarchy picker, account picker)
+- `ModalHeader.js` component (kept for any future use, just no longer used by these modals)
+
+---
+
+## Testing
+
+All existing modal tests must pass unchanged. No new tests required — this is a visual refactor with no logic changes. Run `npm test -- --silent` before and after to confirm zero regressions.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -541,8 +541,15 @@ jest.mock('react-native-paper', () => {
   const Modal = ({ children, visible, ...props }) => visible ? React.createElement(View, props, children) : null;
   Modal.propTypes = { children: PropTypes.node, visible: PropTypes.bool };
 
-  const TextInput = ({ ...props }) => React.createElement(View, props);
-  TextInput.propTypes = { children: PropTypes.node };
+  const { TextInput: RNTextInput } = require('react-native');
+  const TextInput = ({ label, mode, theme, error, ...props }) => React.createElement(RNTextInput, props);  
+  TextInput.propTypes = {
+    children: PropTypes.node,
+    label: PropTypes.string,
+    mode: PropTypes.string,
+    theme: PropTypes.object,
+    error: PropTypes.bool,
+  };
 
   const Button = ({ children, onPress, ...props }) => React.createElement(TouchableOpacity, { onPress, ...props }, children);
   Button.propTypes = { children: PropTypes.node, onPress: PropTypes.func };


### PR DESCRIPTION
## Summary

- Add `app/styles/modalStyles.js` with shared `modalSharedStyles` StyleSheet (fieldLabel, pickerRow, pickerRowInner, pickerRowValue, textInput) and `makeModalStyles(colors)` PaperTextInput theme helper
- Add `app/components/ModalShell.js` — unified bottom-sheet wrapper with drag handle, title/subtitle, ScrollView, delete row, extraActions, cancel/save buttons, and optional blur overlay
- Refactor `CategoryModal`, `PlannedOperationModal`, `OperationModal`, and `AccountsScreen` AccountModal to use ModalShell and PaperTextInput (mode="outlined"), eliminating ~700 lines of duplicated boilerplate across the four modals
- Fix currency label position in AccountModal: moved above the picker row, consistent with other field labels

## Test Plan
- [ ] All 3015 tests pass
- [ ] Add/edit/delete works in CategoryModal
- [ ] Add/edit/delete works in PlannedOperationModal
- [ ] Add/edit/delete works in OperationModal (including split and shadow operations)
- [ ] Add/edit/delete works in AccountModal, including currency picker animated panel
