### PR TITLE
featI(settings): Add update check progress indicator

### DIFF
--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -89,7 +89,7 @@ export default function ModalShell({
           bounciness: 0,
         }).start();
       },
-    })
+    }),
   ).current;
 
   return (
@@ -104,96 +104,96 @@ export default function ModalShell({
         <KeyboardAvoidingView behavior="padding" style={styles.flex1}>
           <Pressable style={styles.overlay} onPress={onDismiss}>
             <Animated.View style={{ transform: [{ translateY }] }}>
-            <Pressable
-              style={[styles.card, { backgroundColor: colors.card }]}
-              onPress={() => {}}
-            >
-              {/* Drag zone: handle + header — touch here to dismiss by dragging down */}
-              <View {...panResponder.panHandlers}>
-                <View style={[styles.dragHandle, { backgroundColor: colors.border }]} />
-
-                {/* Header */}
-                <View style={styles.header}>
-                  <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
-                  {subtitle ? (
-                    <Text style={[styles.subtitle, { color: colors.mutedText }]}>
-                      {subtitle}
-                    </Text>
-                  ) : null}
-                </View>
-              </View>
-
-              {/* Scrollable form content */}
-              <ScrollView
-                ref={scrollRef}
-                style={styles.scroll}
-                contentContainerStyle={styles.scrollContent}
-                keyboardShouldPersistTaps="handled"
-                showsVerticalScrollIndicator={false}
+              <Pressable
+                style={[styles.card, { backgroundColor: colors.card }]}
+                onPress={() => {}}
               >
-                {children}
-              </ScrollView>
+                {/* Drag zone: handle + header — touch here to dismiss by dragging down */}
+                <View {...panResponder.panHandlers}>
+                  <View style={[styles.dragHandle, { backgroundColor: colors.border }]} />
 
-              {/* Delete row (shown only when onDelete is provided) */}
-              {onDelete ? (
-                <View style={styles.deleteWrapper}>
+                  {/* Header */}
+                  <View style={styles.header}>
+                    <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+                    {subtitle ? (
+                      <Text style={[styles.subtitle, { color: colors.mutedText }]}>
+                        {subtitle}
+                      </Text>
+                    ) : null}
+                  </View>
+                </View>
+
+                {/* Scrollable form content */}
+                <ScrollView
+                  ref={scrollRef}
+                  style={styles.scroll}
+                  contentContainerStyle={styles.scrollContent}
+                  keyboardShouldPersistTaps="handled"
+                  showsVerticalScrollIndicator={false}
+                >
+                  {children}
+                </ScrollView>
+
+                {/* Delete row (shown only when onDelete is provided) */}
+                {onDelete ? (
+                  <View style={styles.deleteWrapper}>
+                    <TouchableRipple
+                      onPress={deleteDisabled ? undefined : onDelete}
+                      disabled={deleteDisabled}
+                      rippleColor={colors.delete + '18'}
+                      style={[
+                        styles.btn,
+                        styles.deleteRow,
+                        { borderColor: colors.delete + '40' },
+                        deleteDisabled && styles.disabled,
+                      ]}
+                      borderless={false}
+                    >
+                      <View style={styles.deleteRowContent}>
+                        <Icon name="delete-outline" size={18} color={colors.delete} />
+                        <Text style={[styles.deleteRowText, { color: colors.delete }]}>
+                          {deleteLabel || t('delete')}
+                        </Text>
+                      </View>
+                    </TouchableRipple>
+                  </View>
+                ) : null}
+
+                {/* Extra actions slot (e.g. Split button in OperationModal) */}
+                {extraActions || null}
+
+                {/* Cancel / Save (or full-width Cancel when onSave is absent) */}
+                <View style={[styles.actions, { borderTopColor: colors.border }]}>
                   <TouchableRipple
-                    onPress={deleteDisabled ? undefined : onDelete}
-                    disabled={deleteDisabled}
-                    rippleColor={colors.delete + '18'}
+                    onPress={onCancel}
                     style={[
                       styles.btn,
-                      styles.deleteRow,
-                      { borderColor: colors.delete + '40' },
-                      deleteDisabled && styles.disabled,
+                      styles.cancelBtn,
+                      { borderColor: colors.border },
+                      !onSave && styles.fullWidthBtn,
                     ]}
+                    rippleColor="rgba(0,0,0,0.05)"
                     borderless={false}
                   >
-                    <View style={styles.deleteRowContent}>
-                      <Icon name="delete-outline" size={18} color={colors.delete} />
-                      <Text style={[styles.deleteRowText, { color: colors.delete }]}>
-                        {deleteLabel || t('delete')}
-                      </Text>
-                    </View>
-                  </TouchableRipple>
-                </View>
-              ) : null}
-
-              {/* Extra actions slot (e.g. Split button in OperationModal) */}
-              {extraActions || null}
-
-              {/* Cancel / Save (or full-width Cancel when onSave is absent) */}
-              <View style={[styles.actions, { borderTopColor: colors.border }]}>
-                <TouchableRipple
-                  onPress={onCancel}
-                  style={[
-                    styles.btn,
-                    styles.cancelBtn,
-                    { borderColor: colors.border },
-                    !onSave && styles.fullWidthBtn,
-                  ]}
-                  rippleColor="rgba(0,0,0,0.05)"
-                  borderless={false}
-                >
-                  <Text style={[styles.btnText, { color: colors.text }]}>
-                    {cancelLabel || t('cancel')}
-                  </Text>
-                </TouchableRipple>
-
-                {onSave ? (
-                  <TouchableRipple
-                    onPress={onSave}
-                    style={[styles.btn, { backgroundColor: colors.primary }]}
-                    rippleColor="rgba(255,255,255,0.2)"
-                    borderless={false}
-                  >
-                    <Text style={[styles.btnText, styles.saveBtnText]}>
-                      {saveLabel || t('save')}
+                    <Text style={[styles.btnText, { color: colors.text }]}>
+                      {cancelLabel || t('cancel')}
                     </Text>
                   </TouchableRipple>
-                ) : null}
-              </View>
-            </Pressable>
+
+                  {onSave ? (
+                    <TouchableRipple
+                      onPress={onSave}
+                      style={[styles.btn, { backgroundColor: colors.primary }]}
+                      rippleColor="rgba(255,255,255,0.2)"
+                      borderless={false}
+                    >
+                      <Text style={[styles.btnText, styles.saveBtnText]}>
+                        {saveLabel || t('save')}
+                      </Text>
+                    </TouchableRipple>
+                  ) : null}
+                </View>
+              </Pressable>
             </Animated.View>
           </Pressable>
         </KeyboardAvoidingView>

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, Animated, ScrollView, FlatList, Linking } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Animated, ScrollView, FlatList, Linking, ActivityIndicator } from 'react-native';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Portal, Modal, Text, Divider, TouchableRipple } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
@@ -47,6 +47,7 @@ export default function SettingsModal({ visible, onClose }) {
   const [storedBackups, setStoredBackups] = useState([]);
   const [backupsLoading, setBackupsLoading] = useState(false);
   const [googleSheetsLoading, setGoogleSheetsLoading] = useState(false);
+  const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
 
   // Animation values
   const slideAnim = useRef(new Animated.Value(0)).current;
@@ -438,6 +439,7 @@ export default function SettingsModal({ visible, onClose }) {
   }, [showDialog, t]);
 
   const handleCheckForUpdates = useCallback(async () => {
+    setIsCheckingUpdate(true);
     try {
       const result = await checkForAppUpdate();
       await setPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, new Date().toISOString());
@@ -497,6 +499,8 @@ export default function SettingsModal({ visible, onClose }) {
         t('update_check_failed') || 'Could not check updates right now. Please try again later.',
         [{ text: t('ok') || 'OK' }],
       );
+    } finally {
+      setIsCheckingUpdate(false);
     }
   }, [showDialog, t, startDownload, onClose]);
 
@@ -735,7 +739,7 @@ export default function SettingsModal({ visible, onClose }) {
             </View>
           </TouchableRipple>
 
-          <TouchableRipple onPress={handleCheckForUpdates} style={styles.settingsRow} testID="check-updates-row">
+          <TouchableRipple onPress={handleCheckForUpdates} disabled={isCheckingUpdate} style={styles.settingsRow} testID="check-updates-row">
             <View style={styles.settingsRowContent}>
               <View style={styles.settingsRowLeft}>
                 <Ionicons name="download-outline" size={22} color={colors.text} />
@@ -743,7 +747,9 @@ export default function SettingsModal({ visible, onClose }) {
                   {t('check_updates') || 'Check for updates'}
                 </Text>
               </View>
-              <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+              {isCheckingUpdate
+                ? <ActivityIndicator size="small" color={colors.mutedText} />
+                : <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />}
             </View>
           </TouchableRipple>
 


### PR DESCRIPTION
Show a small `ActivityIndicator` spinner on the "Check for updates" settings row while the network request is in progress, replacing the chevron icon. The row is also disabled during the check to prevent double-taps. The spinner clears via a `finally` block so it always resets regardless of outcome.

BEGIN_COMMIT_OVERRIDE
feat: show spinner on update check row while check is in progress
END_COMMIT_OVERRIDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRmi9XaP9RveQws5yy1thJ)_