### PR TITLE
fix: no error when biometrics not configured for hide balances toggle

### DIFF
--- a/__tests__/modals/SettingsModal.test.js
+++ b/__tests__/modals/SettingsModal.test.js
@@ -14,6 +14,11 @@ const mockResetDatabase = jest.fn(() => Promise.resolve());
 const mockStartImport = jest.fn();
 const mockCancelImport = jest.fn();
 const mockCompleteImport = jest.fn();
+const mockSetHideBalances = jest.fn();
+const mockAuthenticateWithBiometrics = jest.fn();
+
+// Mutable state so individual tests can control hideBalances
+const displaySettingsMockState = { hideBalances: false };
 
 // Mock all context dependencies
 jest.mock('../../app/contexts/ThemeColorsContext', () => ({
@@ -60,9 +65,20 @@ jest.mock('../../app/contexts/ImportProgressContext', () => ({
 
 jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
   useDisplaySettings: () => ({
-    hideBalances: false,
-    setHideBalances: jest.fn(),
+    hideBalances: displaySettingsMockState.hideBalances,
+    setHideBalances: mockSetHideBalances,
   }),
+}));
+
+jest.mock('../../app/services/BiometricService', () => ({
+  authenticateWithBiometrics: (...args) => mockAuthenticateWithBiometrics(...args),
+  BiometricResult: {
+    SUCCESS: 'success',
+    FAILED: 'failed',
+    CANCELLED: 'cancelled',
+    NOT_AVAILABLE: 'not_available',
+    NOT_ENROLLED: 'not_enrolled',
+  },
 }));
 
 jest.mock('../../app/contexts/UpdateDownloadContext', () => ({
@@ -125,6 +141,9 @@ describe('SettingsModal Component', () => {
     mockCompleteImport.mockClear();
     mockExportBackup.mockClear();
     mockImportBackup.mockClear();
+    mockSetHideBalances.mockClear();
+    mockAuthenticateWithBiometrics.mockClear();
+    displaySettingsMockState.hideBalances = false;
   });
 
   describe('Basic Rendering', () => {
@@ -473,6 +492,52 @@ describe('SettingsModal Component', () => {
 
       expect(modalInstance).toBeTruthy();
       expect(modalInstance.props.visible).toBe(true);
+    });
+  });
+
+  describe('Hide Balances Toggle', () => {
+    it('silently allows unhide and calls setHideBalances(false) when biometrics NOT_AVAILABLE', async () => {
+      displaySettingsMockState.hideBalances = true;
+      mockAuthenticateWithBiometrics.mockResolvedValue('not_available');
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { getByText } = render(
+        <SettingsModal visible={true} onClose={mockOnClose} />,
+      );
+
+      await act(async () => {
+        fireEvent.press(getByText('hide_balances'));
+      });
+
+      expect(mockShowDialog).not.toHaveBeenCalled();
+      expect(mockSetHideBalances).toHaveBeenCalledWith(false);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('biometric not available'),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('silently allows unhide and calls setHideBalances(false) when biometrics NOT_ENROLLED', async () => {
+      displaySettingsMockState.hideBalances = true;
+      mockAuthenticateWithBiometrics.mockResolvedValue('not_enrolled');
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const { getByText } = render(
+        <SettingsModal visible={true} onClose={mockOnClose} />,
+      );
+
+      await act(async () => {
+        fireEvent.press(getByText('hide_balances'));
+      });
+
+      expect(mockShowDialog).not.toHaveBeenCalled();
+      expect(mockSetHideBalances).toHaveBeenCalledWith(false);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('biometric not enrolled'),
+      );
+
+      consoleWarnSpy.mockRestore();
     });
   });
 });

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -79,17 +79,11 @@ export default function SettingsModal({ visible, onClose }) {
     if (result === BiometricResult.SUCCESS) {
       setHideBalances(false);
     } else if (result === BiometricResult.NOT_AVAILABLE) {
-      showDialog(
-        t('error') || 'Error',
-        t('biometric_unavailable') || 'Biometric authentication is not available on this device',
-        [{ text: t('ok') || 'OK' }],
-      );
+      console.warn('biometric not available, allowing hide balances toggle without auth');
+      setHideBalances(false);
     } else if (result === BiometricResult.NOT_ENROLLED) {
-      showDialog(
-        t('error') || 'Error',
-        t('biometric_not_enrolled') || 'No biometrics enrolled. Please set up biometrics in device settings.',
-        [{ text: t('ok') || 'OK' }],
-      );
+      console.warn('biometric not enrolled, allowing hide balances toggle without auth');
+      setHideBalances(false);
     } else if (result === BiometricResult.FAILED) {
       showDialog(
         t('error') || 'Error',


### PR DESCRIPTION
## Summary
- when biometrics are not enrolled or not available, silently allow the hide balances toggle instead of showing an error dialog
- logs a console.warn so the event is visible in the in-app logs viewer

## Problem
toggling hide balances off with no biometric configured showed a blocking error dialog. nothing to authenticate against, so the action should just proceed.

## Changes
- app/modals/SettingsModal.js: NOT_AVAILABLE and NOT_ENROLLED branches now call console.warn + setHideBalances(false) instead of showDialog(error)
- __tests__/modals/SettingsModal.test.js: two new test cases; all 3026 tests pass
