### PR TITLE
fix(modal): fix double-slide, bottom gap, and description visibility

### DIFF
--- a/__tests__/modals/CategoryModal.test.js
+++ b/__tests__/modals/CategoryModal.test.js
@@ -563,7 +563,7 @@ describe('CategoryModal', () => {
   });
 
   describe('Modal Dismissal', () => {
-    it('calls onClose when cancel button is pressed', () => {
+    it('calls onClose when cancel button is pressed', async () => {
       const { getByText } = render(
         <CategoryModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
@@ -571,7 +571,9 @@ describe('CategoryModal', () => {
       const cancelButton = getByText('cancel');
       fireEvent.press(cancelButton);
 
-      expect(mockOnClose).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled();
+      });
     });
 
     it('clears errors when modal is closed and reopened', () => {

--- a/__tests__/modals/OperationModal.test.js
+++ b/__tests__/modals/OperationModal.test.js
@@ -544,7 +544,7 @@ describe('OperationModal', () => {
   });
 
   describe('Modal Dismissal', () => {
-    it('calls handleClose when cancel button is pressed', () => {
+    it('calls handleClose when cancel button is pressed', async () => {
       const mockHandleClose = jest.fn();
       const useOperationForm = require('../../app/hooks/useOperationForm');
       useOperationForm.mockReturnValue({
@@ -560,7 +560,9 @@ describe('OperationModal', () => {
       const cancelButtons = getAllByText('cancel');
       fireEvent.press(cancelButtons[0]);
 
-      expect(mockHandleClose).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockHandleClose).toHaveBeenCalled();
+      });
     });
 
     it('shows close button instead of cancel for shadow operations', () => {

--- a/app/components/DescriptionAutocomplete.js
+++ b/app/components/DescriptionAutocomplete.js
@@ -223,7 +223,6 @@ const styles = StyleSheet.create({
   chipsWrapper: {
     marginBottom: SPACING.md,
     marginTop: SPACING.xs,
-    minHeight: 30,
   },
   container: {
     marginBottom: SPACING.md,

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -1,5 +1,5 @@
 // app/components/ModalShell.js
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import {
   View,
   Modal as RNModal,
@@ -9,10 +9,12 @@ import {
   ScrollView,
   PanResponder,
   Animated,
+  Dimensions,
 } from 'react-native';
 import { Text, TouchableRipple } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
@@ -47,15 +49,37 @@ export default function ModalShell({
 }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
+  const insets = useSafeAreaInsets();
 
   const translateY = useRef(new Animated.Value(0)).current;
   // Use a ref so the PanResponder closure always calls the latest onDismiss
   const onDismissRef = useRef(onDismiss);
   useEffect(() => { onDismissRef.current = onDismiss; }, [onDismiss]);
 
+  // Slide in from bottom when modal opens
   useEffect(() => {
-    if (visible) translateY.setValue(0);
+    if (visible) {
+      translateY.setValue(Dimensions.get('window').height * 0.6);
+      Animated.spring(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+        bounciness: 2,
+        speed: 14,
+      }).start();
+    }
   }, [visible, translateY]);
+
+  // Animate out then call callback — used for overlay tap and cancel button
+  const animateOut = useCallback((callback) => {
+    Animated.timing(translateY, {
+      toValue: Dimensions.get('window').height,
+      duration: 200,
+      useNativeDriver: true,
+    }).start(() => {
+      translateY.setValue(0);
+      callback?.();
+    });
+  }, [translateY]);
 
   const panResponder = useRef(
     PanResponder.create({
@@ -97,15 +121,15 @@ export default function ModalShell({
       {showBlurOverlay && visible && <ModalBlurOverlay />}
       <RNModal
         visible={visible}
-        animationType="slide"
+        animationType="none"
         transparent={true}
-        onRequestClose={onDismiss}
+        onRequestClose={() => animateOut(onDismiss)}
       >
         <KeyboardAvoidingView behavior="padding" style={styles.flex1}>
-          <Pressable style={styles.overlay} onPress={onDismiss}>
+          <Pressable style={styles.overlay} onPress={() => animateOut(onDismiss)}>
             <Animated.View style={{ transform: [{ translateY }] }}>
               <Pressable
-                style={[styles.card, { backgroundColor: colors.card }]}
+                style={[styles.card, { backgroundColor: colors.card, maxHeight: Dimensions.get('window').height * 0.88 }]}
                 onPress={() => {}}
               >
                 {/* Drag zone: handle + header — touch here to dismiss by dragging down */}
@@ -134,38 +158,38 @@ export default function ModalShell({
                   {children}
                 </ScrollView>
 
-                {/* Delete row (shown only when onDelete is provided) */}
-                {onDelete ? (
+                {/* Secondary actions: delete + extra actions in one compact row */}
+                {(onDelete || extraActions) ? (
                   <View style={styles.deleteWrapper}>
-                    <TouchableRipple
-                      onPress={deleteDisabled ? undefined : onDelete}
-                      disabled={deleteDisabled}
-                      rippleColor={colors.delete + '18'}
-                      style={[
-                        styles.btn,
-                        styles.deleteRow,
-                        { borderColor: colors.delete + '40' },
-                        deleteDisabled && styles.disabled,
-                      ]}
-                      borderless={false}
-                    >
-                      <View style={styles.deleteRowContent}>
-                        <Icon name="delete-outline" size={18} color={colors.delete} />
-                        <Text style={[styles.deleteRowText, { color: colors.delete }]}>
-                          {deleteLabel || t('delete')}
-                        </Text>
-                      </View>
-                    </TouchableRipple>
+                    {onDelete ? (
+                      <TouchableRipple
+                        onPress={deleteDisabled ? undefined : onDelete}
+                        disabled={deleteDisabled}
+                        rippleColor={colors.delete + '18'}
+                        style={[
+                          styles.btn,
+                          styles.deleteRow,
+                          { borderColor: colors.delete + '40' },
+                          deleteDisabled && styles.disabled,
+                        ]}
+                        borderless={false}
+                      >
+                        <View style={styles.deleteRowContent}>
+                          <Icon name="delete-outline" size={18} color={colors.delete} />
+                          <Text style={[styles.deleteRowText, { color: colors.delete }]}>
+                            {deleteLabel || t('delete')}
+                          </Text>
+                        </View>
+                      </TouchableRipple>
+                    ) : null}
+                    {extraActions || null}
                   </View>
                 ) : null}
 
-                {/* Extra actions slot (e.g. Split button in OperationModal) */}
-                {extraActions || null}
-
                 {/* Cancel / Save (or full-width Cancel when onSave is absent) */}
-                <View style={[styles.actions, { borderTopColor: colors.border }]}>
+                <View style={[styles.actions, { borderTopColor: colors.border, paddingBottom: SPACING.md + insets.bottom }]}>
                   <TouchableRipple
-                    onPress={onCancel}
+                    onPress={() => animateOut(onCancel)}
                     style={[
                       styles.btn,
                       styles.cancelBtn,
@@ -238,7 +262,6 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     flexDirection: 'row',
     gap: SPACING.sm,
-    paddingBottom: SPACING.xl,
     paddingTop: SPACING.sm,
   },
   btn: {
@@ -258,7 +281,7 @@ const styles = StyleSheet.create({
   card: {
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
-    maxHeight: '85%',
+    maxHeight: undefined,
     overflow: 'hidden',
     paddingBottom: 0,
     paddingHorizontal: SPACING.lg,
@@ -278,6 +301,7 @@ const styles = StyleSheet.create({
   },
   deleteWrapper: {
     flexDirection: 'row',
+    gap: SPACING.sm,
     marginTop: SPACING.sm,
   },
   disabled: {
@@ -310,7 +334,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   scrollContent: {
-    paddingBottom: SPACING.sm,
+    paddingBottom: 0,
   },
   subtitle: {
     fontSize: 12,

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -349,18 +349,16 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   ];
 
   const splitExtraActions = canSplit ? (
-    <View style={styles.splitDeleteRow}>
-      <Pressable
-        style={[styles.splitButtonContainer, { backgroundColor: colors.card }]}
-        onPress={() => setShowSplitModal(true)}
-        testID="split-button"
-      >
-        <Icon name="call-split" size={18} color={colors.primary} />
-        <Text style={[styles.splitButtonText, { color: colors.primary }]}>
-          {t('split_transaction')}
-        </Text>
-      </Pressable>
-    </View>
+    <Pressable
+      style={[styles.splitButtonContainer, { backgroundColor: colors.card }]}
+      onPress={() => setShowSplitModal(true)}
+      testID="split-button"
+    >
+      <Icon name="call-split" size={18} color={colors.primary} />
+      <Text style={[styles.splitButtonText, { color: colors.primary }]}>
+        {t('split_transaction')}
+      </Text>
+    </Pressable>
   ) : null;
 
   return (
@@ -399,6 +397,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
           hideCategoryPicker={!isNew}
           hideTransferTargetPicker={true}
           transferLayout="sideBySide"
+          compact={true}
           disabled={isShadowOperation}
           containerBackground={colors.card}
           onExchangeRateChange={handleExchangeRateChange}
@@ -704,10 +703,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
   },
-  splitDeleteRow: {
-    flexDirection: 'row',
-    marginTop: SPACING.sm,
-  },
+
 });
 
 OperationModal.propTypes = {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -617,6 +617,21 @@ jest.mock('@expo/vector-icons', () => {
   };
 });
 
+// Mock react-native-safe-area-context
+jest.mock('react-native-safe-area-context', () => {
+  const React = require('react');
+  const PropTypes = require('prop-types');
+  const insets = { top: 0, right: 0, bottom: 0, left: 0 };
+  const SafeAreaProvider = ({ children }) => children;
+  SafeAreaProvider.propTypes = { children: PropTypes.node };
+  return {
+    SafeAreaProvider,
+    SafeAreaView: ({ children }) => children,
+    useSafeAreaInsets: () => insets,
+    SafeAreaConsumer: ({ children }) => children(insets),
+  };
+});
+
 // Mock react-native-draggable-flatlist
 jest.mock('react-native-draggable-flatlist', () => {
   const React = require('react');


### PR DESCRIPTION
## Summary
Fix three ModalShell bugs: double-slide animation, modal floating above screen bottom, and description field requiring scroll to see in OperationModal.

## Changes
- Replace `animationType="slide"` with manual spring entry / timing exit animations
- Add `useSafeAreaInsets().bottom` to actions row padding so modal sits flush with screen edge
- Fix `maxHeight: '85%'` → `Dimensions.get('window').height * 0.88` (percentage resolved against `Animated.View` which has no explicit height — was silently broken)
- Add `compact={true}` to `OperationFormFields` in `OperationModal` to match QuickAdd calculator button sizes, recovering ~56dp for the description field
- Combine delete + split into a single shared flex row (saves one full row of chrome)
- Remove `minHeight: 30` from `DescriptionAutocomplete` chipsWrapper
- Fix cancel button tests to `await waitFor(...)` after animateOut animation
