### PR TITLE
fix: show correct currency symbol in graphs currency selector

### DIFF
--- a/app/components/SimplePicker.js
+++ b/app/components/SimplePicker.js
@@ -9,7 +9,7 @@ import ModalBlurOverlay from './ModalBlurOverlay';
  * SimplePicker - A picker component for Android
  * Uses native HTML select on web, custom modal picker on Android
  */
-const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, leftIcon, closeLabel }) => {
+const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, leftIcon, leftText, closeLabel }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   // Defensive check for undefined items with warning
@@ -65,13 +65,17 @@ const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, l
   // Android: Use custom modal picker for better control
   return (
     <>
-      {leftIcon ? (
+      {(leftIcon || leftText) ? (
         <TouchableOpacity
           style={[styles.chipButton, style]}
           onPress={() => setModalVisible(true)}
           activeOpacity={0.7}
         >
-          <Icon name={leftIcon} size={16} color={safeColors.mutedText ?? '#666666'} />
+          {leftText ? (
+            <Text style={[styles.leftText, { color: safeColors.mutedText ?? '#666666' }]}>{leftText}</Text>
+          ) : (
+            <Icon name={leftIcon} size={16} color={safeColors.mutedText ?? '#666666'} />
+          )}
           <Text style={[styles.chipButtonText, textStyle, { color: safeColors.text }]} numberOfLines={1}>
             {selectedLabel}
           </Text>
@@ -149,6 +153,13 @@ const styles = StyleSheet.create({
   androidButtonText: {
     fontSize: 16,
     fontWeight: '800',
+    textAlign: 'center',
+  },
+  // Left text label (currency symbol, etc.)
+  leftText: {
+    fontSize: 14,
+    fontWeight: '600',
+    minWidth: 16,
     textAlign: 'center',
   },
   // Chip-style button with left icon and right chevron
@@ -239,6 +250,7 @@ SimplePicker.propTypes = {
     mutedText: PropTypes.string,
   }),
   leftIcon: PropTypes.string,
+  leftText: PropTypes.string,
   closeLabel: PropTypes.string,
 };
 

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -235,6 +235,11 @@ const GraphsScreen = () => {
   [currencies],
   );
 
+  const selectedCurrencySymbol = useMemo(() => {
+    const info = currenciesJson[selectedCurrency];
+    return info ? info.symbol : selectedCurrency;
+  }, [selectedCurrency]);
+
   const accountItems = useMemo(() =>
     accounts
       .filter(acc => !acc.hidden)
@@ -372,7 +377,7 @@ const GraphsScreen = () => {
                 onValueChange={setSelectedCurrency}
                 items={currencyItems}
                 colors={colors}
-                leftIcon="currency-usd"
+                leftText={selectedCurrencySymbol}
               />
             </View>
 


### PR DESCRIPTION
The currency picker on the Graphs screen always showed a hardcoded USD icon
regardless of which currency was selected. Replace the static leftIcon="currency-usd"
with a dynamic leftText prop showing the actual symbol from currencies.json.

Also adds leftText support to SimplePicker for displaying text (symbols, etc.)
instead of a Material Community icon.

https://claude.ai/code/session_01J7PfYjofXSR2tdGVTSKfeb