### PR TITLE
fix(calendar): improve edit row UX in balance history calendar

### DIFF
--- a/app/components/graphs/BalanceHistoryCalendarView.js
+++ b/app/components/graphs/BalanceHistoryCalendarView.js
@@ -152,6 +152,9 @@ const BalanceHistoryCalendarView = ({
           testID="calendar-edit-row"
           style={[styles.editRow, { borderColor: colors.primary, backgroundColor: colors.surface }]}
         >
+          <TouchableOpacity testID="calendar-cancel-btn" onPress={handleCancel} style={styles.cancelBtn}>
+            <Text style={[styles.cancelBtnText, { color: colors.mutedText }]}>↩</Text>
+          </TouchableOpacity>
           <Text style={[styles.editDateLabel, { color: colors.mutedText }]}>
             {selectedDay}
           </Text>
@@ -164,7 +167,6 @@ const BalanceHistoryCalendarView = ({
             value={editingBalanceValue}
             onChangeText={onEditingBalanceValueChange}
             keyboardType="decimal-pad"
-            autoFocus
             placeholder={(0).toFixed(decimalDigits)}
             placeholderTextColor={colors.mutedText}
           />
@@ -181,12 +183,9 @@ const BalanceHistoryCalendarView = ({
               style={[styles.editBtn, styles.deleteBtn]}
               onPress={handleDelete}
             >
-              <Text style={styles.editBtnText}>✕</Text>
+              <Text style={styles.editBtnText}>🗑</Text>
             </TouchableOpacity>
           )}
-          <TouchableOpacity testID="calendar-cancel-btn" onPress={handleCancel} style={styles.cancelBtn}>
-            <Text style={[styles.cancelBtnText, { color: colors.mutedText }]}>×</Text>
-          </TouchableOpacity>
         </View>
       )}
     </View>


### PR DESCRIPTION
- Remove autoFocus from edit input to prevent keyboard from auto-popping up when selecting a day
- Move cancel button to the left side of the edit row for better layout flow
- Change cancel icon from × to ↩ (undo) to distinguish it from the delete action
- Change delete button icon from ✕ to 🗑 (trash) to avoid confusion with cancel ×

https://claude.ai/code/session_01LHKv3eGvQHkixRHrFFGT93