### PR TITLE
fix(graphs): correct today line x position on balance history chart

### DIFF
--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -361,21 +361,21 @@ const BalanceHistoryCard = ({
                         },
                       }}
                       decorator={() => {
-                        const chartWidth = screenWidth - 16;
-                        const paddingLeft = 40;
-                        const paddingRight = 16;
-                        const usableWidth = chartWidth - paddingLeft - paddingRight;
+                        // react-native-chart-kit places data using paddingRight (default 64) as
+                        // the left origin: x = paddingRight + i*(width-paddingRight)/(n-1)
+                        const chartWidth = screenWidth - 33; // must match width prop
+                        const chartPaddingRight = 64; // library default, acts as left margin
+                        const usableWidth = chartWidth - chartPaddingRight;
                         const dataLength = balanceHistoryData.labels.length;
                         const xStep = usableWidth / (dataLength - 1);
                         const chartTop = 12;
                         const chartBottom = 181;
-                        const chartAreaHeight = chartBottom - chartTop;
 
                         const elements = [];
 
                         if (isCurrentMonth) {
                           const todayIndex = currentDay - 1;
-                          const xPosition = paddingLeft + (todayIndex * xStep);
+                          const xPosition = chartPaddingRight + (todayIndex * xStep);
                           elements.push(
                             <Line
                               key="today-line"


### PR DESCRIPTION
The decorator calculated x positions using paddingLeft=40 as the left
origin and screenWidth-16 as chart width, but react-native-chart-kit
uses paddingRight (default 64) as the left margin for data points:
  x = paddingRight + i * (width - paddingRight) / (n - 1)

This caused a constant ~18px leftward offset (~1.8 days) making the
today vertical line appear on the previous day despite showing the
correct date label.

Fix: use chartWidth = screenWidth - 33 (matching the width prop) and
chartPaddingRight = 64 (the library's actual left origin for data).

https://claude.ai/code/session_01Rcnd6AFQP1rBVg2KQuaNtH