### PR TITLE
fix: prev month balance graph drops to 0 on last day of longer months

### DIFF
--- a/__tests__/hooks/useBalanceHistory.test.js
+++ b/__tests__/hooks/useBalanceHistory.test.js
@@ -455,6 +455,38 @@ describe('useBalanceHistory', () => {
       });
     });
 
+    it('should not produce undefined/null at end of prevMonth when current month has more days than previous month', async () => {
+      // May has 31 days, April has 30 — day 31 previously returned undefined which
+      // react-native-chart-kit rendered as 0, making the purple line drop to zero.
+      const mayYear = 2026;
+      const mayMonthIndex = 4; // May (0-based)
+
+      const mockMayHistory = [];
+      const mockAprilHistory = [
+        { date: '2026-04-01', balance: '-250000' },
+        { date: '2026-04-30', balance: '-262000' },
+      ];
+
+      BalanceHistoryDB.getBalanceHistory
+        .mockResolvedValueOnce(mockMayHistory)
+        .mockResolvedValueOnce(mockAprilHistory);
+
+      const { result } = renderHook(() => useBalanceHistory(mockAccountId, mayYear, mayMonthIndex));
+
+      await act(async () => {
+        await result.current.loadBalanceHistory();
+      });
+
+      await waitFor(() => {
+        const prevMonth = result.current.balanceHistoryData.prevMonth;
+        expect(prevMonth).toBeDefined();
+        // May has 31 elements; the last element (day 31) must NOT be undefined/null
+        // It should forward-fill from April's last known value (-262000)
+        expect(prevMonth[30]).toBe(-262000);
+        expect(prevMonth[30]).not.toBeUndefined();
+      });
+    });
+
     it('should include prevMonthTotalExpenses and prevMonthDaysCount in balance history data', async () => {
       BalanceHistoryDB.getBalanceHistory
         .mockResolvedValueOnce([])

--- a/app/hooks/useBalanceHistory.js
+++ b/app/hooks/useBalanceHistory.js
@@ -141,18 +141,26 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
       });
 
       // Create previous month data line (forward-filled for all available days)
+      // lastKnownPrevValue is carried forward so that days beyond the previous
+      // month's length (e.g. day 31 when prev month is April) keep the final
+      // balance instead of falling back to null/0 in the chart library.
+      let lastKnownPrevValue;
       const prevMonthData = allDays.map(day => {
-        // Only include data if the day exists in previous month
-        if (day > prevMonthDays) return undefined;
+        if (day > prevMonthDays) {
+          // Current month has more days than prev month — hold the last value flat
+          return lastKnownPrevValue;
+        }
 
         if (prevBalanceByDay[day] !== undefined) {
-          return prevBalanceByDay[day];
+          lastKnownPrevValue = prevBalanceByDay[day];
+          return lastKnownPrevValue;
         }
 
         // Forward fill: use the most recent balance before this day
         for (let d = day - 1; d >= 1; d--) {
           if (prevBalanceByDay[d] !== undefined) {
-            return prevBalanceByDay[d];
+            lastKnownPrevValue = prevBalanceByDay[d];
+            return lastKnownPrevValue;
           }
         }
 


### PR DESCRIPTION
When the current month has more days than the previous month (e.g. May
with 31 days vs April with 30 days), day 31 in the prevMonth dataset was
returning undefined. react-native-chart-kit treats null/undefined as 0,
causing the purple "Prev Month" line to plummet to zero on the final day.

Fix: track lastKnownPrevValue while building the prevMonth array and
forward-fill that value for any days that don't exist in the shorter
previous month, keeping the line flat at the last real balance.

Adds a regression test covering the May (31d) / April (30d) scenario.

https://claude.ai/code/session_01QyQ2iX6ZtqFSbX9b3wquWu