### PR TITLE
fix(operations): prevent layout slide when switching operation types

### DIFF
--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -314,26 +314,24 @@ const OperationFormFields = memo(({
           </View>
 
           {/* Row 2: always 4 flex-1 slots to match row 1 widths; invisible spacers for empty slots */}
-          {secondRowCats.length > 0 && (
-            <View style={styles.categoryButtonsContainer}>
-              {Array.from({ length: 4 }, (_, i) => {
-                const category = secondRowCats[i];
-                if (!category) {
-                  return (
-                    <View
-                      key={`cat-spacer-${i}`}
-                      style={[
-                        styles.categoryShortcutButton,
-                        compact && styles.categoryShortcutButtonCompact,
-                        styles.invisible,
-                      ]}
-                    />
-                  );
-                }
-                return renderCategoryChip(category, i, true);
-              })}
-            </View>
-          )}
+          <View style={[styles.categoryButtonsContainer, secondRowCats.length === 0 && styles.invisible]}>
+            {Array.from({ length: 4 }, (_, i) => {
+              const category = secondRowCats[i];
+              if (!category) {
+                return (
+                  <View
+                    key={`cat-spacer-${i}`}
+                    style={[
+                      styles.categoryShortcutButton,
+                      compact && styles.categoryShortcutButtonCompact,
+                      styles.invisible,
+                    ]}
+                  />
+                );
+              }
+              return renderCategoryChip(category, i, true);
+            })}
+          </View>
         </View>
       );
     }
@@ -442,26 +440,24 @@ const OperationFormFields = memo(({
           </View>
 
           {/* Row 2: always 4 flex-1 slots to match row 1 widths; invisible spacers for empty slots */}
-          {secondRowAccounts.length > 0 && (
-            <View style={styles.categoryButtonsContainer}>
-              {Array.from({ length: 4 }, (_, i) => {
-                const account = secondRowAccounts[i];
-                if (!account) {
-                  return (
-                    <View
-                      key={`acc-spacer-${i}`}
-                      style={[
-                        styles.accountShortcutButton,
-                        compact && styles.accountShortcutButtonCompact,
-                        styles.invisible,
-                      ]}
-                    />
-                  );
-                }
-                return renderAccountChip(account);
-              })}
-            </View>
-          )}
+          <View style={[styles.categoryButtonsContainer, secondRowAccounts.length === 0 && styles.invisible]}>
+            {Array.from({ length: 4 }, (_, i) => {
+              const account = secondRowAccounts[i];
+              if (!account) {
+                return (
+                  <View
+                    key={`acc-spacer-${i}`}
+                    style={[
+                      styles.accountShortcutButton,
+                      compact && styles.accountShortcutButtonCompact,
+                      styles.invisible,
+                    ]}
+                  />
+                );
+              }
+              return renderAccountChip(account);
+            })}
+          </View>
         </View>
       );
     }


### PR DESCRIPTION
fix(operations): prevent layout slide when switching operation types with different category row counts

Always render the second row container for category/account shortcuts, using invisible spacers when empty, so the QuickAdd panel height stays constant across type switches.

🧀
