### PR TITLE
feat(settings): refactor sub-navigation to unified subpanel pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,63 @@ If builds hang on GitHub Actions:
 - Use secure storage libraries like `react-native-keychain` for sensitive data
 - Validate user inputs to prevent injection attacks
 
+### Modal Sub-Navigation: Subpanel Pattern
+
+**Rule: never open a new modal for secondary views inside an existing modal. Use the subpanel pattern instead.**
+
+`SettingsModal` is the reference implementation. When a settings row leads to a secondary view (language picker, export options, confirmation, logs, etc.), that view slides in over the main settings list within the same modal — no `showDialog`, no nested `Modal`, no extra screen.
+
+**Core pattern:**
+
+```javascript
+// State
+const [activeSubPanel, setActiveSubPanel] = useState(null); // null | 'language' | 'export' | ...
+const settingsAnim = useRef(new Animated.Value(0)).current;  // main list: 0=visible, 1=dimmed/shifted
+const subPanelAnim = useRef(new Animated.Value(0)).current;  // subpanel: 0=hidden, 1=visible
+
+const openSubPanel = useCallback((panel) => {
+  setActiveSubPanel(panel);
+  Animated.parallel([
+    Animated.timing(settingsAnim, { toValue: 1, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+    Animated.timing(subPanelAnim, { toValue: 1, duration: 260, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+  ]).start();
+}, [settingsAnim, subPanelAnim]);
+
+const closeSubPanel = useCallback(() => {
+  Animated.parallel([
+    Animated.timing(subPanelAnim, { toValue: 0, duration: 180, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+    Animated.timing(settingsAnim, { toValue: 0, duration: 240, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+  ]).start(() => setActiveSubPanel(null));
+}, [settingsAnim, subPanelAnim]);
+
+// JSX — single Animated.View, conditionally mounted
+{activeSubPanel && (
+  <Animated.View style={[styles.subPanelContent, { transform: [{ translateX: subPanelTranslateX }], opacity: subPanelOpacity }]}>
+    {/* header with back arrow */}
+    {activeSubPanel === 'language' && <LanguageContent />}
+    {activeSubPanel === 'export' && <ExportContent />}
+    {/* ... */}
+  </Animated.View>
+)}
+```
+
+**Easing conventions:**
+- Exit (main list fades/slides away): `Easing.in(Easing.quad)`, 200ms
+- Entry (subpanel slides in): `Easing.out(Easing.cubic)`, 260ms
+- Reverse on close: 180ms exit for subpanel, 240ms entry for main list
+
+**Critical: never use `Animated.delay` or `Animated.sequence` with `useNativeDriver: true`.** The delay node does not propagate `useNativeDriver`, breaking native-thread transform animations. Use asymmetric durations inside `Animated.parallel` to achieve visual stagger without a delay node.
+
+**Conditional mount vs always-in-tree:** Mount the `Animated.View` only when `activeSubPanel !== null`. An always-mounted view with `opacity: 0` conflicts with the animated value and causes the panel to appear without sliding.
+
+**Confirmation flows (destructive actions):** Use a centered layout inside the subpanel — warning icon + message text + destructive button. The back arrow serves as cancel; no separate cancel button needed.
+
+**Long async operations (e.g. Google Sheets export):** Keep the subpanel open during the async work. Show an `ActivityIndicator` inline on the triggering row. On success, show inline feedback (green checkmark, "Open" button) on the same row. On error, show inline error text. Never close the subpanel silently while work is in-flight.
+
+**Share-sheet exports (Expo `Sharing.shareAsync`):** Do not show a success dialog — the share sheet is the user feedback. `shareAsync` resolves when the sheet is dismissed with no cancel signal, so you cannot distinguish cancel from success.
+
+**Log/chat-style lists:** Use `FlatList` with `inverted={true}` and `data={entries.slice().reverse()}`. Newest entry is always item[0], shown at the bottom automatically — no `scrollToEnd` calls needed, and no mount cost from rendering all entries at once.
+
 ### Testing
 
 The app uses Jest with React Native Testing Library for unit, integration, and regression testing.

--- a/__tests__/integration/GoogleSheetsExport.test.js
+++ b/__tests__/integration/GoogleSheetsExport.test.js
@@ -87,11 +87,11 @@ describe('GoogleSheetsExport integration', () => {
   const renderModal = () =>
     render(<SettingsModal visible={true} onClose={jest.fn()} />);
 
-  it('shows success dialog with Open button after successful export (already signed in)', async () => {
+  it('shows inline Open button after successful export (already signed in)', async () => {
     getValidAccessToken.mockResolvedValue('access-token');
     exportToSheets.mockResolvedValue('https://docs.google.com/spreadsheets/d/sheet-123');
 
-    const { getByTestId } = renderModal();
+    const { getByTestId, getByText } = renderModal();
     fireEvent.press(getByTestId('settings-export-row'));
 
     await waitFor(() => {
@@ -99,14 +99,14 @@ describe('GoogleSheetsExport integration', () => {
     });
 
     await waitFor(() => {
-      expect(mockShowDialog).toHaveBeenCalledWith(
-        expect.stringContaining('google_sheets'),
-        expect.stringContaining('google_sheets_export_success'),
-        expect.arrayContaining([
-          expect.objectContaining({ text: 'google_sheets_open' }),
-        ]),
-      );
+      expect(getByText('google_sheets_open')).toBeTruthy();
     });
+
+    expect(mockShowDialog).not.toHaveBeenCalledWith(
+      expect.stringContaining('google_sheets'),
+      expect.stringContaining('google_sheets_export_success'),
+      expect.anything(),
+    );
   });
 
   it('falls back to signIn when not signed in, then exports successfully', async () => {
@@ -114,7 +114,7 @@ describe('GoogleSheetsExport integration', () => {
     signIn.mockResolvedValue('new-access-token');
     exportToSheets.mockResolvedValue('https://docs.google.com/spreadsheets/d/sheet-456');
 
-    const { getByTestId } = renderModal();
+    const { getByTestId, getByText } = renderModal();
     fireEvent.press(getByTestId('settings-export-row'));
 
     await waitFor(() => {
@@ -123,11 +123,7 @@ describe('GoogleSheetsExport integration', () => {
 
     await waitFor(() => {
       expect(signIn).toHaveBeenCalled();
-      expect(mockShowDialog).toHaveBeenCalledWith(
-        expect.stringContaining('google_sheets'),
-        expect.stringContaining('google_sheets_export_success'),
-        expect.anything(),
-      );
+      expect(getByText('google_sheets_open')).toBeTruthy();
     });
   });
 

--- a/__tests__/modals/SettingsModal.test.js
+++ b/__tests__/modals/SettingsModal.test.js
@@ -267,83 +267,55 @@ describe('SettingsModal Component', () => {
   });
 
   describe('Database Operations', () => {
-    it('shows dialog when reset row is pressed', () => {
+    it('shows reset confirmation subpanel when reset row is pressed', () => {
       const { getByText } = render(
         <SettingsModal visible={true} onClose={mockOnClose} />,
       );
 
       fireEvent.press(getByText('reset_database'));
 
-      expect(mockShowDialog).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        expect.arrayContaining([
-          expect.objectContaining({ text: 'cancel' }),
-          expect.objectContaining({ text: 'reset', style: 'destructive' }),
-        ]),
-      );
+      expect(getByText('reset_database_confirm')).toBeTruthy();
+      expect(getByText('reset')).toBeTruthy();
     });
 
-    it('shows dialog when import row is pressed', () => {
-      const { getByText } = render(
+    it('shows import confirmation subpanel when import row is pressed', () => {
+      const { getByText, getAllByText } = render(
         <SettingsModal visible={true} onClose={mockOnClose} />,
       );
 
       fireEvent.press(getByText('import'));
 
-      expect(mockShowDialog).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(String),
-        expect.arrayContaining([
-          expect.objectContaining({ text: 'cancel' }),
-          expect.objectContaining({ text: expect.any(String), style: 'destructive' }),
-        ]),
-      );
+      expect(getByText('restore_confirm')).toBeTruthy();
+      // restore_database appears in the subpanel title and the confirm button
+      expect(getAllByText('restore_database').length).toBeGreaterThanOrEqual(1);
     });
 
-    it('performs import when confirmed', async () => {
-      const { getByText } = render(
+    it('performs import when subpanel confirm button is pressed', async () => {
+      const { getByText, getAllByText } = render(
         <SettingsModal visible={true} onClose={mockOnClose} />,
       );
 
       fireEvent.press(getByText('import'));
 
-      const dialogCall = mockShowDialog.mock.calls[0];
-      const dialogButtons = dialogCall[2];
-      const restoreButton = dialogButtons.find(b => b.style === 'destructive');
+      // The confirm button is the last element with this text (subpanel title uses same key)
+      const confirmButtons = getAllByText('restore_database');
+      await act(async () => {
+        fireEvent.press(confirmButtons[confirmButtons.length - 1]);
+      });
 
-      expect(restoreButton.onPress).toBeDefined();
-      expect(typeof restoreButton.onPress).toBe('function');
+      expect(mockStartImport).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
     });
 
-    it('import dialog has destructive confirm button', () => {
-      const { getByText } = render(
-        <SettingsModal visible={true} onClose={mockOnClose} />,
-      );
-
-      fireEvent.press(getByText('import'));
-
-      const dialogCall = mockShowDialog.mock.calls[0];
-      const dialogButtons = dialogCall[2];
-      const restoreButton = dialogButtons.find(b => b.style === 'destructive');
-
-      expect(restoreButton).toBeTruthy();
-      expect(restoreButton.style).toBe('destructive');
-    });
-
-    it('performs reset when confirmed', async () => {
+    it('performs reset when subpanel confirm button is pressed', async () => {
       const { getByText } = render(
         <SettingsModal visible={true} onClose={mockOnClose} />,
       );
 
       fireEvent.press(getByText('reset_database'));
-
-      const dialogCall = mockShowDialog.mock.calls[0];
-      const dialogButtons = dialogCall[2];
-      const resetDialogButton = dialogButtons.find(b => b.style === 'destructive');
 
       await act(async () => {
-        await resetDialogButton.onPress();
+        fireEvent.press(getByText('reset'));
       });
 
       expect(mockResetDatabase).toHaveBeenCalled();

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -272,7 +272,7 @@ describe('AppUpdateService', () => {
       expect(result.errorCode).toBe('invalid_release_data');
     });
 
-    it('uses releases endpoint with per_page=5', async () => {
+    it('uses releases endpoint with per_page=20', async () => {
       const fetchImpl = jest.fn().mockResolvedValue({
         ok: true,
         json: async () => ([
@@ -286,7 +286,7 @@ describe('AppUpdateService', () => {
       await checkForAppUpdate({ currentVersion: '0.50.3', fetchImpl });
 
       expect(fetchImpl).toHaveBeenCalledWith(
-        expect.stringContaining('/releases?per_page=5'),
+        expect.stringContaining('/releases?per_page=20'),
         expect.any(Object),
       );
     });

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -55,6 +55,7 @@ export default function SettingsModal({ visible, onClose }) {
   const settingsAnim = useRef(new Animated.Value(0)).current;
   const subPanelAnim = useRef(new Animated.Value(0)).current;
   const toggleAnim = useRef(new Animated.Value(hideBalances ? 1 : 0)).current;
+  const updateContentAnim = useRef(new Animated.Value(0)).current;
   useEffect(() => {
     Animated.spring(toggleAnim, {
       toValue: hideBalances ? 1 : 0,
@@ -63,6 +64,17 @@ export default function SettingsModal({ visible, onClose }) {
       bounciness: 4,
     }).start();
   }, [hideBalances, toggleAnim]);
+
+  useEffect(() => {
+    if (!isCheckingUpdate && updateResult) {
+      Animated.timing(updateContentAnim, {
+        toValue: 1,
+        duration: 280,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [isCheckingUpdate, updateResult, updateContentAnim]);
 
   const { entries, clearLogs, getExportText } = useLogEntries(logFilter);
 
@@ -323,41 +335,28 @@ export default function SettingsModal({ visible, onClose }) {
   }, [showDialog, t]);
 
   const handleCheckForUpdates = useCallback(async () => {
+    updateContentAnim.setValue(0);
+    setUpdateResult(null);
     setIsCheckingUpdate(true);
+    openSubPanel('update');
     try {
       const result = await checkForAppUpdate();
       await setPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, new Date().toISOString());
 
       if (!result.success) {
-        const errorMessage = result.errorCode === 'releases_without_apks'
-          ? (t('update_releases_without_apks') || 'Found releases but no APKs attached. Check GitHub for the latest release.')
-          : (t('update_check_failed') || 'Could not check updates right now. Please try again later.');
-        showDialog(t('check_updates') || 'Check for updates', errorMessage, [{ text: t('ok') || 'OK' }]);
-        return;
+        setUpdateResult({ type: 'error', errorCode: result.errorCode });
+      } else if (!result.isUpdateAvailable) {
+        setUpdateResult({ type: 'up_to_date' });
+      } else {
+        setUpdateResult({ type: 'available', latestVersion: result.latestVersion, downloadUrl: result.downloadUrl });
       }
-
-      if (!result.isUpdateAvailable) {
-        showDialog(
-          t('check_updates') || 'Check for updates',
-          t('up_to_date') || 'You already have the latest version installed.',
-          [{ text: t('ok') || 'OK' }],
-        );
-        return;
-      }
-
-      setUpdateResult(result);
-      openSubPanel('update');
     } catch (error) {
       console.error('Manual update check failed:', error);
-      showDialog(
-        t('check_updates') || 'Check for updates',
-        t('update_check_failed') || 'Could not check updates right now. Please try again later.',
-        [{ text: t('ok') || 'OK' }],
-      );
+      setUpdateResult({ type: 'error', errorCode: null });
     } finally {
       setIsCheckingUpdate(false);
     }
-  }, [showDialog, t, openSubPanel]);
+  }, [openSubPanel, updateContentAnim]);
 
   useEffect(() => {
     if (visible) {
@@ -555,7 +554,7 @@ export default function SettingsModal({ visible, onClose }) {
               </View>
             </TouchableRipple>
 
-            <TouchableRipple onPress={handleCheckForUpdates} disabled={isCheckingUpdate} style={styles.settingsRow} testID="check-updates-row">
+            <TouchableRipple onPress={handleCheckForUpdates} style={styles.settingsRow} testID="check-updates-row">
               <View style={styles.settingsRowContent}>
                 <View style={styles.settingsRowLeft}>
                   <Ionicons name="download-outline" size={22} color={colors.text} />
@@ -563,9 +562,7 @@ export default function SettingsModal({ visible, onClose }) {
                     {t('check_updates') || 'Check for updates'}
                   </Text>
                 </View>
-                {isCheckingUpdate
-                  ? <ActivityIndicator size="small" color={colors.mutedText} />
-                  : <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />}
+                <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
               </View>
             </TouchableRipple>
 
@@ -600,7 +597,13 @@ export default function SettingsModal({ visible, onClose }) {
                   {activeSubPanel === 'import' && (t('restore_database') || 'Restore Database')}
                   {activeSubPanel === 'logs' && (t('logs') || 'Logs')}
                   {activeSubPanel === 'backups' && (t('local_backups') || 'Local Backups')}
-                  {activeSubPanel === 'update' && (t('update_available_title') || 'Update available')}
+                  {activeSubPanel === 'update' && (
+                    isCheckingUpdate
+                      ? (t('check_updates') || 'Check for updates')
+                      : updateResult?.type === 'available'
+                        ? (t('update_available_title') || 'Update available')
+                        : (t('check_updates') || 'Check for updates')
+                  )}
                   {activeSubPanel === 'reset' && (t('reset_database') || 'Reset Database')}
                 </Text>
                 {activeSubPanel === 'backups' ? (
@@ -821,38 +824,69 @@ export default function SettingsModal({ visible, onClose }) {
                 </>
               )}
 
-              {activeSubPanel === 'update' && updateResult && (
-                <View style={styles.importConfirmContent}>
-                  <Ionicons name="download-outline" size={48} color={colors.primary} style={styles.importWarningIcon} />
-                  <Text style={[styles.updateVersionText, { color: colors.text }]}>
-                    {(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
-                      .replace('{latestVersion}', updateResult.latestVersion)}
-                  </Text>
-                  <Text style={[styles.updateHintText, { color: colors.mutedText }]}>
-                    {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
-                  </Text>
-                  <TouchableRipple
-                    onPress={async () => {
-                      await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
-                      closeSubPanel();
-                      onClose();
-                      startDownload(updateResult.downloadUrl, {
-                        onError: () => {
-                          showDialog(
-                            t('error') || 'Error',
-                            t('update_download_failed') || 'Could not download the update. Please try again.',
-                            [{ text: t('ok') || 'OK' }],
-                          );
-                        },
-                      });
-                    }}
-                    style={[styles.importConfirmButton, { backgroundColor: colors.primary }]}
-                  >
-                    <Text style={styles.importConfirmButtonText}>
-                      {t('update_now') || 'Update now'}
+              {activeSubPanel === 'update' && (
+                isCheckingUpdate ? (
+                  <View style={styles.updateCheckingContainer}>
+                    <ActivityIndicator size="large" color={colors.primary} />
+                    <Text style={[styles.updateCheckingText, { color: colors.text }]}>
+                      {t('checking_for_updates') || 'Checking for available updates…'}
                     </Text>
-                  </TouchableRipple>
-                </View>
+                  </View>
+                ) : updateResult && (
+                  <Animated.View style={[styles.importConfirmContent, { opacity: updateContentAnim }]}>
+                    {updateResult.type === 'available' && (
+                      <>
+                        <Ionicons name="download-outline" size={48} color={colors.primary} style={styles.importWarningIcon} />
+                        <Text style={[styles.updateVersionText, { color: colors.text }]}>
+                          {(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
+                            .replace('{latestVersion}', updateResult.latestVersion)}
+                        </Text>
+                        <Text style={[styles.updateHintText, { color: colors.mutedText }]}>
+                          {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
+                        </Text>
+                        <TouchableRipple
+                          onPress={async () => {
+                            await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
+                            closeSubPanel();
+                            onClose();
+                            startDownload(updateResult.downloadUrl, {
+                              onError: () => {
+                                showDialog(
+                                  t('error') || 'Error',
+                                  t('update_download_failed') || 'Could not download the update. Please try again.',
+                                  [{ text: t('ok') || 'OK' }],
+                                );
+                              },
+                            });
+                          }}
+                          style={[styles.importConfirmButton, { backgroundColor: colors.primary }]}
+                        >
+                          <Text style={styles.importConfirmButtonText}>
+                            {t('update_now') || 'Update now'}
+                          </Text>
+                        </TouchableRipple>
+                      </>
+                    )}
+                    {updateResult.type === 'up_to_date' && (
+                      <>
+                        <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
+                        <Text style={[styles.updateVersionText, { color: colors.text }]}>
+                          {t('up_to_date') || 'You already have the latest version installed.'}
+                        </Text>
+                      </>
+                    )}
+                    {updateResult.type === 'error' && (
+                      <>
+                        <Ionicons name="cloud-offline-outline" size={48} color={colors.mutedText} style={styles.importWarningIcon} />
+                        <Text style={[styles.updateVersionText, { color: colors.text }]}>
+                          {updateResult.errorCode === 'releases_without_apks'
+                            ? (t('update_releases_without_apks') || 'Found releases but no APKs attached. Check GitHub for the latest release.')
+                            : (t('update_check_failed') || 'Could not check updates right now. Please try again later.')}
+                        </Text>
+                      </>
+                    )}
+                  </Animated.View>
+                )
               )}
 
               {activeSubPanel === 'backups' && (
@@ -1167,6 +1201,18 @@ const styles = StyleSheet.create({
     height: 24,
     justifyContent: 'center',
     width: 44,
+  },
+  updateCheckingContainer: {
+    alignItems: 'center',
+    flex: 1,
+    gap: SPACING.lg,
+    justifyContent: 'center',
+    paddingHorizontal: HORIZONTAL_PADDING * 2,
+  },
+  updateCheckingText: {
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
   },
   updateHintText: {
     fontSize: 13,

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, Animated, ScrollView, FlatList, Linking, ActivityIndicator } from 'react-native'; // FlatList used for backups list
+import { View, StyleSheet, TouchableOpacity, Animated, Easing, ScrollView, FlatList, Linking, ActivityIndicator } from 'react-native'; // FlatList used for backups list
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Portal, Modal, Text, Divider, TouchableRipple } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
@@ -39,23 +39,21 @@ export default function SettingsModal({ visible, onClose }) {
   const { resetDatabase } = useAccountsActions();
   const { startImport, cancelImport, completeImport } = useImportProgress();
   const { startDownload } = useUpdateDownload();
-  const [languageModalVisible, setLanguageModalVisible] = useState(false);
-  const [exportFormatModalVisible, setExportFormatModalVisible] = useState(false);
-  const [logsModalVisible, setLogsModalVisible] = useState(false);
-  const [backupsModalVisible, setBackupsModalVisible] = useState(false);
+  const [activeSubPanel, setActiveSubPanel] = useState(null); // 'language' | 'export' | 'logs' | 'backups' | null
   const [logFilter, setLogFilter] = useState('all');
   const [storedBackups, setStoredBackups] = useState([]);
   const [backupsLoading, setBackupsLoading] = useState(false);
   const [googleSheetsLoading, setGoogleSheetsLoading] = useState(false);
+  const [googleSheetsSuccessUrl, setGoogleSheetsSuccessUrl] = useState(null);
+  const [updateResult, setUpdateResult] = useState(null);
   const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
+
+  // Computed colors
+  const googleSheetsTextColor = googleSheetsSuccessUrl ? '#4caf50' : (googleSheetsLoading ? colors.mutedText : colors.text);
 
   // Animation values
   const settingsAnim = useRef(new Animated.Value(0)).current;
-  const slideAnim = useRef(new Animated.Value(0)).current;
-  const exportFormatSlideAnim = useRef(new Animated.Value(0)).current;
-  const logsSlideAnim = useRef(new Animated.Value(0)).current;
-  const backupsSlideAnim = useRef(new Animated.Value(0)).current;
-  const logsFlatListRef = useRef(null);
+  const subPanelAnim = useRef(new Animated.Value(0)).current;
   const toggleAnim = useRef(new Animated.Value(hideBalances ? 1 : 0)).current;
   useEffect(() => {
     Animated.spring(toggleAnim, {
@@ -94,25 +92,30 @@ export default function SettingsModal({ visible, onClose }) {
     // CANCELLED: do nothing silently
   }, [hideBalances, setHideBalances, t, showDialog]);
 
-  const openLanguageModal = useCallback(() => {
-    setLanguageModalVisible(true);
+  const openSubPanel = useCallback((panel) => {
+    if (panel === 'backups') loadStoredBackups();
+    setActiveSubPanel(panel);
     Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-      Animated.timing(slideAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
+      Animated.timing(settingsAnim, { toValue: 1, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+      Animated.timing(subPanelAnim, { toValue: 1, duration: 260, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
     ]).start();
-  }, [settingsAnim, slideAnim]);
+  }, [settingsAnim, subPanelAnim, loadStoredBackups]);
 
-  const closeLanguageModal = useCallback(() => {
+  const closeSubPanel = useCallback(() => {
     Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-      Animated.timing(slideAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-    ]).start(() => setLanguageModalVisible(false));
-  }, [settingsAnim, slideAnim]);
+      Animated.timing(subPanelAnim, { toValue: 0, duration: 180, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+      Animated.timing(settingsAnim, { toValue: 0, duration: 240, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+    ]).start(() => {
+      setActiveSubPanel(null);
+      setGoogleSheetsSuccessUrl(null);
+      setUpdateResult(null);
+    });
+  }, [settingsAnim, subPanelAnim]);
 
   const handleLanguageSelect = useCallback((lng) => {
     setLanguage(lng);
-    closeLanguageModal();
-  }, [setLanguage, closeLanguageModal]);
+    closeSubPanel();
+  }, [setLanguage, closeSubPanel]);
 
   // Map of language codes to their native display names
   const nativeLanguageNames = {
@@ -144,62 +147,21 @@ export default function SettingsModal({ visible, onClose }) {
     pt: '🇵🇹',
   };
 
-  const openExportFormatModal = useCallback(() => {
-    console.debug('openExportFormatModal called - showing modal');
-    setExportFormatModalVisible(true);
-    Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-      Animated.timing(exportFormatSlideAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-    ]).start();
-  }, [settingsAnim, exportFormatSlideAnim]);
-
-  const closeExportFormatModal = useCallback(() => {
-    Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-      Animated.timing(exportFormatSlideAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-    ]).start(() => setExportFormatModalVisible(false));
-  }, [settingsAnim, exportFormatSlideAnim]);
-
-  const openLogsModal = useCallback(() => {
-    setLogsModalVisible(true);
-    Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-      Animated.timing(logsSlideAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-    ]).start(() => {
-      logsFlatListRef.current?.scrollToEnd({ animated: false });
-    });
-  }, [settingsAnim, logsSlideAnim]);
-
-  const closeLogsModal = useCallback(() => {
-    Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-      Animated.timing(logsSlideAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-    ]).start(() => setLogsModalVisible(false));
-  }, [settingsAnim, logsSlideAnim]);
-
   const handleExportFormatSelect = useCallback(async (format) => {
-    closeExportFormatModal();
+    closeSubPanel();
     try {
       await exportBackup(format);
-      showDialog(
-        t('backup_database') || 'Backup Database',
-        t('backup_success') || 'Backup exported successfully',
-        [{ text: 'OK', onPress: onClose }],
-      );
     } catch (error) {
       console.error('Export backup error:', error);
       showDialog(
         t('error') || 'Error',
-        error.message === 'Import cancelled'
-          ? t('cancel') || 'Cancelled'
-          : t('backup_error') || 'Failed to create backup',
+        t('backup_error') || 'Failed to create backup',
         [{ text: 'OK' }],
       );
     }
-  }, [closeExportFormatModal, t, showDialog, onClose]);
+  }, [closeSubPanel, t, showDialog]);
 
   const handleGoogleSheetsExport = useCallback(async () => {
-    closeExportFormatModal();
     setGoogleSheetsLoading(true);
     try {
       let accessToken;
@@ -215,19 +177,13 @@ export default function SettingsModal({ visible, onClose }) {
       const backup = await createBackup();
       const sheetUrl = await exportToSheets(accessToken, backup);
       setGoogleSheetsLoading(false);
-      showDialog(
-        t('google_sheets') || 'Google Sheets',
-        t('google_sheets_export_success') || 'Exported to Google Sheets',
-        [
-          { text: t('google_sheets_open') || 'Open', onPress: () => Linking.openURL(sheetUrl) },
-          { text: t('ok') || 'OK' },
-        ],
-      );
+      setGoogleSheetsSuccessUrl(sheetUrl);
     } catch (error) {
       setGoogleSheetsLoading(false);
       if (error.message === 'sign_in_cancelled') {
-        return; // User dismissed — no error dialog
+        return; // User dismissed — stay on subpanel, no dialog
       }
+      closeSubPanel();
       let dialogMsg;
       if (error.message === 'refresh_failed') {
         dialogMsg = t('google_sheets_access_revoked') || 'Google access was revoked. Please sign in again.';
@@ -242,76 +198,39 @@ export default function SettingsModal({ visible, onClose }) {
       }
       showDialog(t('error') || 'Error', dialogMsg, [{ text: t('ok') || 'OK' }]);
     }
-  }, [closeExportFormatModal, t, showDialog]);
+  }, [closeSubPanel, t, showDialog]);
 
-  const handleResetDatabase = () => {
-    showDialog(
-      t('reset_database') || 'Reset Database',
-      t('reset_database_confirm') || 'Are you sure you want to reset the database? This will delete all data and create default accounts.',
-      [
-        { text: t('cancel') || 'Cancel', style: 'cancel' },
-        {
-          text: t('reset') || 'Reset',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await resetDatabase();
-              onClose();
-            } catch (error) {
-              // Error already handled in resetDatabase
-            }
-          },
-        },
-      ],
-    );
-  };
-
-  const handleExportBackup = () => {
-    console.debug('handleExportBackup called - opening export format modal');
-    openExportFormatModal();
-  };
+  const confirmResetDatabase = useCallback(async () => {
+    closeSubPanel();
+    try {
+      await resetDatabase();
+      onClose();
+    } catch (error) {
+      // Error already handled in resetDatabase
+    }
+  }, [closeSubPanel, resetDatabase, onClose]);
 
   // Note: reloadApp removed because it was unused. Use expo-updates directly where needed.
 
-  const handleImportBackup = () => {
-    showDialog(
-      t('restore_database') || 'Restore Database',
-      t('restore_confirm') || 'Are you sure you want to restore from backup? This will replace all current data.',
-      [
-        { text: t('cancel') || 'Cancel', style: 'cancel' },
-        {
-          text: t('restore_database') || 'Restore',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              // Close settings modal first
-              onClose();
-
-              // Start import progress tracking
-              startImport();
-
-              // Perform the import
-              await importBackup();
-
-              // Mark import as complete to enable OK button
-              completeImport();
-            } catch (error) {
-              console.error('Import backup error:', error);
-              // Cancel import progress on error
-              cancelImport();
-              showDialog(
-                t('error') || 'Error',
-                error.message === 'Import cancelled'
-                  ? t('cancel') || 'Cancelled'
-                  : error.message || t('restore_error') || 'Failed to restore backup',
-                [{ text: 'OK' }],
-              );
-            }
-          },
-        },
-      ],
-    );
-  };
+  const confirmImportBackup = useCallback(async () => {
+    closeSubPanel();
+    onClose();
+    startImport();
+    try {
+      await importBackup();
+      completeImport();
+    } catch (error) {
+      console.error('Import backup error:', error);
+      cancelImport();
+      showDialog(
+        t('error') || 'Error',
+        error.message === 'Import cancelled'
+          ? t('cancel') || 'Cancelled'
+          : error.message || t('restore_error') || 'Failed to restore backup',
+        [{ text: 'OK' }],
+      );
+    }
+  }, [closeSubPanel, onClose, startImport, completeImport, cancelImport, t, showDialog]);
 
   const handleShareLogs = useCallback(async () => {
     try {
@@ -348,22 +267,6 @@ export default function SettingsModal({ visible, onClose }) {
       setBackupsLoading(false);
     }
   }, []);
-
-  const openBackupsModal = useCallback(() => {
-    setBackupsModalVisible(true);
-    loadStoredBackups();
-    Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-      Animated.timing(backupsSlideAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-    ]).start();
-  }, [settingsAnim, backupsSlideAnim, loadStoredBackups]);
-
-  const closeBackupsModal = useCallback(() => {
-    Animated.parallel([
-      Animated.timing(settingsAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-      Animated.timing(backupsSlideAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
-    ]).start(() => setBackupsModalVisible(false));
-  }, [settingsAnim, backupsSlideAnim]);
 
   const handleRestoreLocalBackup = useCallback((uri) => {
     showDialog(
@@ -429,11 +332,7 @@ export default function SettingsModal({ visible, onClose }) {
         const errorMessage = result.errorCode === 'releases_without_apks'
           ? (t('update_releases_without_apks') || 'Found releases but no APKs attached. Check GitHub for the latest release.')
           : (t('update_check_failed') || 'Could not check updates right now. Please try again later.');
-        showDialog(
-          t('check_updates') || 'Check for updates',
-          errorMessage,
-          [{ text: t('ok') || 'OK' }],
-        );
+        showDialog(t('check_updates') || 'Check for updates', errorMessage, [{ text: t('ok') || 'OK' }]);
         return;
       }
 
@@ -446,33 +345,8 @@ export default function SettingsModal({ visible, onClose }) {
         return;
       }
 
-      showDialog(
-        t('update_available_title') || 'Update available',
-        `${(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
-          .replace('{latestVersion}', result.latestVersion)}\n\n${
-          t('update_install_hint')
-          || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'
-        }`,
-        [
-          { text: t('later') || 'Later' },
-          {
-            text: t('update_now') || 'Update now',
-            onPress: async () => {
-              await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
-              onClose();
-              startDownload(result.downloadUrl, {
-                onError: () => {
-                  showDialog(
-                    t('error') || 'Error',
-                    t('update_download_failed') || 'Could not download the update. Please try again.',
-                    [{ text: t('ok') || 'OK' }],
-                  );
-                },
-              });
-            },
-          },
-        ],
-      );
+      setUpdateResult(result);
+      openSubPanel('update');
     } catch (error) {
       console.error('Manual update check failed:', error);
       showDialog(
@@ -483,21 +357,17 @@ export default function SettingsModal({ visible, onClose }) {
     } finally {
       setIsCheckingUpdate(false);
     }
-  }, [showDialog, t, startDownload, onClose]);
+  }, [showDialog, t, openSubPanel]);
 
   useEffect(() => {
     if (visible) {
-      setLanguageModalVisible(false);
-      setExportFormatModalVisible(false);
-      setLogsModalVisible(false);
-      setBackupsModalVisible(false);
+      setActiveSubPanel(null);
+      setGoogleSheetsSuccessUrl(null);
+      setUpdateResult(null);
       settingsAnim.setValue(0);
-      slideAnim.setValue(0);
-      exportFormatSlideAnim.setValue(0);
-      logsSlideAnim.setValue(0);
-      backupsSlideAnim.setValue(0);
+      subPanelAnim.setValue(0);
     }
-  }, [visible, settingsAnim, slideAnim, exportFormatSlideAnim, logsSlideAnim, backupsSlideAnim]);
+  }, [visible, settingsAnim, subPanelAnim]);
 
   const settingsTranslateX = settingsAnim.interpolate({
     inputRange: [0, 1],
@@ -509,52 +379,17 @@ export default function SettingsModal({ visible, onClose }) {
     outputRange: [1, 0],
   });
 
-  // Interpolate animation values for language modal
-
-  const languageTranslateX = slideAnim.interpolate({
+  const subPanelTranslateX = subPanelAnim.interpolate({
     inputRange: [0, 1],
     outputRange: [50, 0],
   });
 
-  const languageOpacity = slideAnim.interpolate({
+  const subPanelOpacity = subPanelAnim.interpolate({
     inputRange: [0, 1],
     outputRange: [0, 1],
   });
 
-  // Interpolate animation values for export format modal
-  const exportFormatTranslateX = exportFormatSlideAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: [50, 0],
-  });
-
-  const exportFormatOpacity = exportFormatSlideAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: [0, 1],
-  });
-
-  // Interpolate animation values for logs modal
-  const logsTranslateX = logsSlideAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: [50, 0],
-  });
-
-  const logsOpacity = logsSlideAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: [0, 1],
-  });
-
-  // Interpolate animation values for backups modal
-  const backupsTranslateX = backupsSlideAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: [50, 0],
-  });
-
-  const backupsOpacity = backupsSlideAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: [0, 1],
-  });
-
-  const anySubModalOpen = languageModalVisible || exportFormatModalVisible || logsModalVisible || backupsModalVisible;
+  const anySubModalOpen = activeSubPanel !== null;
 
   const formatBackupLabel = useCallback((filename) => {
     if (filename.startsWith('daily_')) {
@@ -619,7 +454,7 @@ export default function SettingsModal({ visible, onClose }) {
     <Portal>
       <Modal
         visible={visible}
-        onDismiss={backupsModalVisible ? closeBackupsModal : (logsModalVisible ? closeLogsModal : (exportFormatModalVisible ? closeExportFormatModal : (languageModalVisible ? closeLanguageModal : onClose)))}
+        onDismiss={activeSubPanel ? closeSubPanel : onClose}
         dismissable={true}
       >
         <View style={[styles.modalContainer, { backgroundColor: colors.card }]}>
@@ -638,7 +473,7 @@ export default function SettingsModal({ visible, onClose }) {
               </TouchableOpacity>
             </View>
 
-            <TouchableRipple onPress={openLanguageModal} style={styles.settingsRow} testID="settings-language-row">
+            <TouchableRipple onPress={() => openSubPanel('language')} style={styles.settingsRow} testID="settings-language-row">
               <View style={styles.settingsRowContent}>
                 <View style={styles.settingsRowLeft}>
                   <Ionicons name="language-outline" size={22} color={colors.text} />
@@ -676,7 +511,7 @@ export default function SettingsModal({ visible, onClose }) {
 
             <Text variant="labelLarge" style={[styles.sectionLabel, { color: colors.mutedText }]}>{t('database') || 'Database'}</Text>
 
-            <TouchableRipple onPress={handleExportBackup} style={styles.settingsRow} testID="settings-export-row">
+            <TouchableRipple onPress={() => openSubPanel('export')} style={styles.settingsRow} testID="settings-export-row">
               <View style={styles.settingsRowContent}>
                 <View style={styles.settingsRowLeft}>
                   <Ionicons name="cloud-upload-outline" size={22} color={colors.text} />
@@ -686,7 +521,7 @@ export default function SettingsModal({ visible, onClose }) {
               </View>
             </TouchableRipple>
 
-            <TouchableRipple onPress={handleImportBackup} style={styles.settingsRow}>
+            <TouchableRipple onPress={() => openSubPanel('import')} style={styles.settingsRow}>
               <View style={styles.settingsRowContent}>
                 <View style={styles.settingsRowLeft}>
                   <Ionicons name="cloud-download-outline" size={22} color={colors.text} />
@@ -696,7 +531,7 @@ export default function SettingsModal({ visible, onClose }) {
               </View>
             </TouchableRipple>
 
-            <TouchableRipple onPress={openBackupsModal} style={styles.settingsRow} testID="settings-backups-row">
+            <TouchableRipple onPress={() => openSubPanel('backups')} style={styles.settingsRow} testID="settings-backups-row">
               <View style={styles.settingsRowContent}>
                 <View style={styles.settingsRowLeft}>
                   <Ionicons name="archive-outline" size={22} color={colors.text} />
@@ -710,7 +545,7 @@ export default function SettingsModal({ visible, onClose }) {
 
             <Text variant="labelLarge" style={[styles.sectionLabel, { color: colors.mutedText }]}>{t('developer') || 'Developer'}</Text>
 
-            <TouchableRipple onPress={openLogsModal} style={styles.settingsRow} testID="logs-row">
+            <TouchableRipple onPress={() => openSubPanel('logs')} style={styles.settingsRow} testID="logs-row">
               <View style={styles.settingsRowContent}>
                 <View style={styles.settingsRowLeft}>
                   <Ionicons name="terminal-outline" size={22} color={colors.text} />
@@ -736,7 +571,7 @@ export default function SettingsModal({ visible, onClose }) {
 
             <View style={styles.resetSpacer} />
 
-            <TouchableRipple onPress={handleResetDatabase} style={styles.settingsRow}>
+            <TouchableRipple onPress={() => openSubPanel('reset')} style={styles.settingsRow}>
               <View style={styles.settingsRowContent}>
                 <View style={styles.settingsRowLeft}>
                   <Ionicons name="trash-outline" size={22} color="#c44" />
@@ -746,277 +581,302 @@ export default function SettingsModal({ visible, onClose }) {
             </TouchableRipple>
           </Animated.View>
 
-          <Animated.View style={[
-            styles.languageModalContent,
-            { backgroundColor: colors.card },
-            {
-              transform: [{ translateX: languageTranslateX }],
-              opacity: languageOpacity,
-            },
-            !languageModalVisible && styles.invisible,
-          ]}>
-            <View style={styles.languageModalHeader}>
-              <TouchableOpacity onPress={closeLanguageModal} style={styles.backButton} testID="settings-language-back">
-                <Ionicons name="arrow-back" size={24} color={colors.text} />
-              </TouchableOpacity>
-              <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
-                {t('language')}
-              </Text>
-              <View style={styles.backButton} />
-            </View>
+          {activeSubPanel && (
+            <Animated.View style={[
+              styles.subPanelContent,
+              { backgroundColor: colors.card },
+              {
+                transform: [{ translateX: subPanelTranslateX }],
+                opacity: subPanelOpacity,
+              },
+            ]}>
+              <View style={styles.languageModalHeader}>
+                <TouchableOpacity onPress={closeSubPanel} style={styles.backButton} testID="settings-subpanel-back">
+                  <Ionicons name="arrow-back" size={24} color={colors.text} />
+                </TouchableOpacity>
+                <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
+                  {activeSubPanel === 'language' && t('language')}
+                  {activeSubPanel === 'export' && (t('export_format') || 'Export Format')}
+                  {activeSubPanel === 'import' && (t('restore_database') || 'Restore Database')}
+                  {activeSubPanel === 'logs' && (t('logs') || 'Logs')}
+                  {activeSubPanel === 'backups' && (t('local_backups') || 'Local Backups')}
+                  {activeSubPanel === 'update' && (t('update_available_title') || 'Update available')}
+                  {activeSubPanel === 'reset' && (t('reset_database') || 'Reset Database')}
+                </Text>
+                {activeSubPanel === 'backups' ? (
+                  <TouchableOpacity onPress={loadStoredBackups} style={styles.backButton}>
+                    <Ionicons name="refresh-outline" size={22} color={colors.text} />
+                  </TouchableOpacity>
+                ) : (
+                  <View style={styles.backButton} />
+                )}
+              </View>
 
-            <Divider />
+              <Divider />
 
-            <ScrollView style={styles.languageList}>
-              {availableLanguages.map(lng => {
-                return (
+              {activeSubPanel === 'language' && (
+                <ScrollView style={styles.languageList}>
+                  {availableLanguages.map(lng => (
+                    <TouchableRipple
+                      key={lng}
+                      onPress={() => handleLanguageSelect(lng)}
+                      style={styles.languageItem}
+                    >
+                      <View style={styles.languageItemContent}>
+                        <Text style={[styles.languageItemText, { color: colors.text }]}>
+                          {languageFlags[lng] ? `${languageFlags[lng]}  ${nativeLanguageNames[lng] || lng}` : (nativeLanguageNames[lng] || lng)}
+                        </Text>
+                        {language === lng && (
+                          <Ionicons name="checkmark-circle" size={24} color={colors.primary} />
+                        )}
+                      </View>
+                    </TouchableRipple>
+                  ))}
+                </ScrollView>
+              )}
+
+              {activeSubPanel === 'export' && (
+                <ScrollView style={styles.languageList}>
+                  <TouchableRipple onPress={() => handleExportFormatSelect('json')} style={styles.languageItem}>
+                    <View style={styles.languageItemContent}>
+                      <View style={styles.formatItemRow}>
+                        <Ionicons name="code-outline" size={24} color={colors.text} />
+                        <View style={styles.formatTextContainer}>
+                          <Text style={[styles.languageItemText, { color: colors.text }]}>JSON</Text>
+                          <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
+                            {t('json_description') || 'Standard format, compatible with all versions'}
+                          </Text>
+                        </View>
+                      </View>
+                      <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                    </View>
+                  </TouchableRipple>
+
+                  <TouchableRipple onPress={() => handleExportFormatSelect('csv')} style={styles.languageItem}>
+                    <View style={styles.languageItemContent}>
+                      <View style={styles.formatItemRow}>
+                        <Ionicons name="document-text-outline" size={24} color={colors.text} />
+                        <View style={styles.formatTextContainer}>
+                          <Text style={[styles.languageItemText, { color: colors.text }]}>CSV</Text>
+                          <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
+                            {t('csv_description') || 'Plain text format, easy to edit'}
+                          </Text>
+                        </View>
+                      </View>
+                      <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                    </View>
+                  </TouchableRipple>
+
+                  <TouchableRipple onPress={() => handleExportFormatSelect('sqlite')} style={styles.languageItem}>
+                    <View style={styles.languageItemContent}>
+                      <View style={styles.formatItemRow}>
+                        <Ionicons name="server-outline" size={24} color={colors.text} />
+                        <View style={styles.formatTextContainer}>
+                          <Text style={[styles.languageItemText, { color: colors.text }]}>SQLite Database</Text>
+                          <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
+                            {t('sqlite_description') || 'Raw database file, complete backup'}
+                          </Text>
+                        </View>
+                      </View>
+                      <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                    </View>
+                  </TouchableRipple>
+
                   <TouchableRipple
-                    key={lng}
-                    onPress={() => handleLanguageSelect(lng)}
+                    onPress={googleSheetsSuccessUrl ? null : handleGoogleSheetsExport}
                     style={styles.languageItem}
+                    disabled={googleSheetsLoading || !!googleSheetsSuccessUrl}
+                    testID="settings-export-google-sheets"
                   >
                     <View style={styles.languageItemContent}>
-                      <Text style={[styles.languageItemText, { color: colors.text }]}>
-                        {languageFlags[lng] ? `${languageFlags[lng]}  ${nativeLanguageNames[lng] || lng}` : (nativeLanguageNames[lng] || lng)}
-                      </Text>
-                      {language === lng && (
-                        <Ionicons name="checkmark-circle" size={24} color={colors.primary} />
+                      <View style={styles.formatItemRow}>
+                        <Ionicons
+                          name="logo-google"
+                          size={24}
+                          color={googleSheetsTextColor}
+                        />
+                        <View style={styles.formatTextContainer}>
+                          <Text style={[styles.languageItemText, { color: googleSheetsTextColor }]}>
+                            Google Sheets
+                          </Text>
+                          <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
+                            {googleSheetsLoading
+                              ? (t('google_sheets_exporting') || 'Exporting…')
+                              : googleSheetsSuccessUrl
+                                ? (t('google_sheets_export_success') || 'Exported to Google Sheets')
+                                : (t('google_sheets_description') || 'Export to a Google Sheets spreadsheet')}
+                          </Text>
+                        </View>
+                      </View>
+                      {googleSheetsLoading ? (
+                        <ActivityIndicator size="small" color={colors.primary} />
+                      ) : googleSheetsSuccessUrl ? (
+                        <View style={styles.googleSheetsSuccessTrailing}>
+                          <TouchableOpacity
+                            onPress={() => Linking.openURL(googleSheetsSuccessUrl)}
+                            style={[styles.googleSheetsOpenButton, { backgroundColor: colors.border }]}
+                          >
+                            <Text style={styles.googleSheetsOpenText}>
+                              {t('google_sheets_open') || 'Open'}
+                            </Text>
+                          </TouchableOpacity>
+                          <Ionicons name="checkmark-circle" size={22} color="#4caf50" />
+                        </View>
+                      ) : (
+                        <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
                       )}
                     </View>
                   </TouchableRipple>
-                );
-              })}
-            </ScrollView>
-          </Animated.View>
-
-          <Animated.View style={[
-            styles.languageModalContent,
-            { backgroundColor: colors.card },
-            {
-              transform: [{ translateX: exportFormatTranslateX }],
-              opacity: exportFormatOpacity,
-            },
-            !exportFormatModalVisible && styles.invisible,
-          ]}>
-            <View style={styles.languageModalHeader}>
-              <TouchableOpacity onPress={closeExportFormatModal} style={styles.backButton} testID="settings-export-back">
-                <Ionicons name="arrow-back" size={24} color={colors.text} />
-              </TouchableOpacity>
-              <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
-                {t('export_format') || 'Export Format'}
-              </Text>
-              <View style={styles.backButton} />
-            </View>
-
-            <Divider />
-
-            <ScrollView style={styles.languageList}>
-              <TouchableRipple
-                onPress={() => handleExportFormatSelect('json')}
-                style={styles.languageItem}
-              >
-                <View style={styles.languageItemContent}>
-                  <View style={styles.formatItemRow}>
-                    <Ionicons name="code-outline" size={24} color={colors.text} />
-                    <View style={styles.formatTextContainer}>
-                      <Text style={[styles.languageItemText, { color: colors.text }]}>
-                      JSON
-                      </Text>
-                      <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('json_description') || 'Standard format, compatible with all versions'}
-                      </Text>
-                    </View>
-                  </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
-                </View>
-              </TouchableRipple>
-
-              <TouchableRipple
-                onPress={() => handleExportFormatSelect('csv')}
-                style={styles.languageItem}
-              >
-                <View style={styles.languageItemContent}>
-                  <View style={styles.formatItemRow}>
-                    <Ionicons name="document-text-outline" size={24} color={colors.text} />
-                    <View style={styles.formatTextContainer}>
-                      <Text style={[styles.languageItemText, { color: colors.text }]}>
-                      CSV
-                      </Text>
-                      <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('csv_description') || 'Plain text format, easy to edit'}
-                      </Text>
-                    </View>
-                  </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
-                </View>
-              </TouchableRipple>
-
-              <TouchableRipple
-                onPress={() => handleExportFormatSelect('sqlite')}
-                style={styles.languageItem}
-              >
-                <View style={styles.languageItemContent}>
-                  <View style={styles.formatItemRow}>
-                    <Ionicons name="server-outline" size={24} color={colors.text} />
-                    <View style={styles.formatTextContainer}>
-                      <Text style={[styles.languageItemText, { color: colors.text }]}>
-                      SQLite Database
-                      </Text>
-                      <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('sqlite_description') || 'Raw database file, complete backup'}
-                      </Text>
-                    </View>
-                  </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
-                </View>
-              </TouchableRipple>
-
-              <TouchableRipple
-                onPress={handleGoogleSheetsExport}
-                style={styles.languageItem}
-                disabled={googleSheetsLoading}
-                testID="settings-export-google-sheets"
-              >
-                <View style={styles.languageItemContent}>
-                  <View style={styles.formatItemRow}>
-                    <Ionicons name="logo-google" size={24} color={colors.text} />
-                    <View style={styles.formatTextContainer}>
-                      <Text style={[styles.languageItemText, { color: colors.text }]}>
-                      Google Sheets
-                      </Text>
-                      <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('google_sheets_description') || 'Export to a Google Sheets spreadsheet'}
-                      </Text>
-                    </View>
-                  </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
-                </View>
-              </TouchableRipple>
-            </ScrollView>
-          </Animated.View>
-
-          <Animated.View style={[
-            styles.logsModalContent,
-            { backgroundColor: colors.card },
-            {
-              transform: [{ translateX: logsTranslateX }],
-              opacity: logsOpacity,
-            },
-            !logsModalVisible && styles.invisible,
-          ]}>
-            <View style={styles.languageModalHeader}>
-              <TouchableOpacity onPress={closeLogsModal} style={styles.backButton} testID="settings-logs-back">
-                <Ionicons name="arrow-back" size={24} color={colors.text} />
-              </TouchableOpacity>
-              <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
-                {t('logs') || 'Logs'}
-              </Text>
-              <View style={styles.backButton} />
-            </View>
-
-            <Divider />
-
-            <View style={styles.filterRow}>
-              {LOG_FILTERS.map(f => {
-                const isSelected = f === logFilter;
-                const filterLabelKey = `log_level_${f}`;
-                return (
-                  <TouchableOpacity
-                    key={f}
-                    onPress={() => setLogFilter(f)}
-                    style={[
-                      styles.filterChip,
-                      { borderColor: colors.border },
-                      isSelected && { backgroundColor: colors.primary },
-                    ]}
-                  >
-                    <Text style={[
-                      styles.filterChipText,
-                      isSelected ? styles.filterChipTextSelected : { color: colors.text },
-                    ]}>
-                      {t(filterLabelKey) || f}
-                    </Text>
-                  </TouchableOpacity>
-                );
-              })}
-            </View>
-
-            <ScrollView ref={logsFlatListRef} style={styles.logsList}>
-              {entries.length === 0 ? (
-                <View style={styles.logsEmptyContainer}>
-                  <Text style={[styles.logsEmptyText, { color: colors.mutedText }]}>
-                    {t('no_logs') || 'No logs yet'}
-                  </Text>
-                </View>
-              ) : (
-                entries.map(item => (
-                  <React.Fragment key={item.id}>{renderLogEntry({ item })}</React.Fragment>
-                ))
+                </ScrollView>
               )}
-            </ScrollView>
 
-            <Divider />
-
-            <View style={styles.logsActionBar}>
-              <TouchableOpacity onPress={handleShareLogs} style={styles.logsActionButton}>
-                <Ionicons name="share-outline" size={20} color={colors.primary} />
-                <Text style={[styles.logsActionText, { color: colors.primary }]}>
-                  {t('share_logs') || 'Share Logs'}
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity onPress={handleClearLogs} style={styles.logsActionButton}>
-                <Ionicons name="trash-outline" size={20} color={LOG_LEVEL_COLORS.error} />
-                <Text style={[styles.logsActionText, styles.clearLogsText]}>
-                  {t('clear_logs') || 'Clear Logs'}
-                </Text>
-              </TouchableOpacity>
-            </View>
-          </Animated.View>
-
-          <Animated.View style={[
-            styles.logsModalContent,
-            { backgroundColor: colors.card },
-            {
-              transform: [{ translateX: backupsTranslateX }],
-              opacity: backupsOpacity,
-            },
-            !backupsModalVisible && styles.invisible,
-          ]}>
-            <View style={styles.languageModalHeader}>
-              <TouchableOpacity onPress={closeBackupsModal} style={styles.backButton} testID="settings-backups-back">
-                <Ionicons name="arrow-back" size={24} color={colors.text} />
-              </TouchableOpacity>
-              <Text variant="titleLarge" style={[styles.languageModalTitle, { color: colors.text }]}>
-                {t('local_backups') || 'Local Backups'}
-              </Text>
-              <TouchableOpacity onPress={loadStoredBackups} style={styles.backButton}>
-                <Ionicons name="refresh-outline" size={22} color={colors.text} />
-              </TouchableOpacity>
-            </View>
-
-            <Divider />
-
-            {backupsLoading ? (
-              <View style={styles.logsEmptyContainer}>
-                <Text style={[styles.logsEmptyText, { color: colors.mutedText }]}>
-                  {'Loading...'}
-                </Text>
-              </View>
-            ) : (
-              <FlatList
-                data={storedBackups}
-                keyExtractor={(item) => item.uri}
-                renderItem={renderBackupItem}
-                style={styles.logsList}
-                contentContainerStyle={storedBackups.length === 0 && styles.logsEmptyContainer}
-                ListEmptyComponent={
-                  <Text style={[styles.logsEmptyText, { color: colors.mutedText }]}>
-                    {t('local_backups_empty') || 'No local backups yet'}
+              {activeSubPanel === 'reset' && (
+                <View style={styles.importConfirmContent}>
+                  <Ionicons name="warning-outline" size={48} color="#c44" style={styles.importWarningIcon} />
+                  <Text style={[styles.importConfirmText, { color: colors.text }]}>
+                    {t('reset_database_confirm') || 'Are you sure you want to reset the database? This will delete all data and create default accounts.'}
                   </Text>
-                }
-              />
-            )}
-          </Animated.View>
+                  <TouchableRipple onPress={confirmResetDatabase} style={styles.importConfirmButtonDestructive}>
+                    <Text style={styles.importConfirmButtonText}>
+                      {t('reset') || 'Reset'}
+                    </Text>
+                  </TouchableRipple>
+                </View>
+              )}
+
+              {activeSubPanel === 'import' && (
+                <View style={styles.importConfirmContent}>
+                  <Ionicons name="warning-outline" size={48} color="#c44" style={styles.importWarningIcon} />
+                  <Text style={[styles.importConfirmText, { color: colors.text }]}>
+                    {t('restore_confirm') || 'Are you sure you want to restore from backup? This will replace all current data.'}
+                  </Text>
+                  <TouchableRipple onPress={confirmImportBackup} style={styles.importConfirmButtonDestructive}>
+                    <Text style={styles.importConfirmButtonText}>
+                      {t('restore_database') || 'Restore'}
+                    </Text>
+                  </TouchableRipple>
+                </View>
+              )}
+
+              {activeSubPanel === 'logs' && (
+                <>
+                  <View style={styles.filterRow}>
+                    {LOG_FILTERS.map(f => {
+                      const isSelected = f === logFilter;
+                      const filterLabelKey = `log_level_${f}`;
+                      return (
+                        <TouchableOpacity
+                          key={f}
+                          onPress={() => setLogFilter(f)}
+                          style={[
+                            styles.filterChip,
+                            { borderColor: colors.border },
+                            isSelected && { backgroundColor: colors.primary },
+                          ]}
+                        >
+                          <Text style={[
+                            styles.filterChipText,
+                            isSelected ? styles.filterChipTextSelected : { color: colors.text },
+                          ]}>
+                            {t(filterLabelKey) || f}
+                          </Text>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
+
+                  <FlatList
+                    data={entries.slice().reverse()}
+                    keyExtractor={(item) => item.id}
+                    renderItem={renderLogEntry}
+                    style={styles.logsList}
+                    inverted
+                    initialNumToRender={20}
+                    maxToRenderPerBatch={20}
+                    windowSize={5}
+                    contentContainerStyle={entries.length === 0 && styles.logsEmptyContainer}
+                    ListEmptyComponent={
+                      <Text style={[styles.logsEmptyText, { color: colors.mutedText }]}>
+                        {t('no_logs') || 'No logs yet'}
+                      </Text>
+                    }
+                  />
+
+                  <Divider />
+
+                  <View style={styles.logsActionBar}>
+                    <TouchableOpacity onPress={handleShareLogs} style={styles.logsActionButton}>
+                      <Ionicons name="share-outline" size={20} color={colors.primary} />
+                      <Text style={[styles.logsActionText, { color: colors.primary }]}>
+                        {t('share_logs') || 'Share Logs'}
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity onPress={handleClearLogs} style={styles.logsActionButton}>
+                      <Ionicons name="trash-outline" size={20} color={LOG_LEVEL_COLORS.error} />
+                      <Text style={[styles.logsActionText, styles.clearLogsText]}>
+                        {t('clear_logs') || 'Clear Logs'}
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                </>
+              )}
+
+              {activeSubPanel === 'update' && updateResult && (
+                <View style={styles.importConfirmContent}>
+                  <Ionicons name="download-outline" size={48} color={colors.primary} style={styles.importWarningIcon} />
+                  <Text style={[styles.updateVersionText, { color: colors.text }]}>
+                    {(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
+                      .replace('{latestVersion}', updateResult.latestVersion)}
+                  </Text>
+                  <Text style={[styles.updateHintText, { color: colors.mutedText }]}>
+                    {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
+                  </Text>
+                  <TouchableRipple
+                    onPress={async () => {
+                      await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
+                      closeSubPanel();
+                      onClose();
+                      startDownload(updateResult.downloadUrl, {
+                        onError: () => {
+                          showDialog(
+                            t('error') || 'Error',
+                            t('update_download_failed') || 'Could not download the update. Please try again.',
+                            [{ text: t('ok') || 'OK' }],
+                          );
+                        },
+                      });
+                    }}
+                    style={[styles.importConfirmButton, { backgroundColor: colors.primary }]}
+                  >
+                    <Text style={styles.importConfirmButtonText}>
+                      {t('update_now') || 'Update now'}
+                    </Text>
+                  </TouchableRipple>
+                </View>
+              )}
+
+              {activeSubPanel === 'backups' && (
+                backupsLoading ? (
+                  <View style={styles.logsEmptyContainer}>
+                    <Text style={[styles.logsEmptyText, { color: colors.mutedText }]}>{'Loading...'}</Text>
+                  </View>
+                ) : (
+                  <FlatList
+                    data={storedBackups}
+                    keyExtractor={(item) => item.uri}
+                    renderItem={renderBackupItem}
+                    style={styles.logsList}
+                    contentContainerStyle={storedBackups.length === 0 && styles.logsEmptyContainer}
+                    ListEmptyComponent={
+                      <Text style={[styles.logsEmptyText, { color: colors.mutedText }]}>
+                        {t('local_backups_empty') || 'No local backups yet'}
+                      </Text>
+                    }
+                  />
+                )
+              )}
+            </Animated.View>
+          )}
         </View>
       </Modal>
     </Portal>
@@ -1120,6 +980,21 @@ const styles = StyleSheet.create({
     flex: 1,
     flexShrink: 1,
   },
+  googleSheetsOpenButton: {
+    borderRadius: BORDER_RADIUS.sm,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.xs,
+  },
+  googleSheetsOpenText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  googleSheetsSuccessTrailing: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+  },
   header: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -1130,9 +1005,39 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontWeight: '600',
   },
-  invisible: {
-    opacity: 0,
-    pointerEvents: 'none',
+  importConfirmButton: {
+    borderRadius: BORDER_RADIUS.md,
+    marginTop: SPACING.xl,
+    paddingHorizontal: SPACING.xl,
+    paddingVertical: SPACING.md,
+  },
+  importConfirmButtonDestructive: {
+    backgroundColor: '#c44',
+    borderRadius: BORDER_RADIUS.md,
+    marginTop: SPACING.xl,
+    paddingHorizontal: SPACING.xl,
+    paddingVertical: SPACING.md,
+  },
+  importConfirmButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  importConfirmContent: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: HORIZONTAL_PADDING * 2,
+    paddingVertical: SPACING.xl,
+  },
+  importConfirmText: {
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+  importWarningIcon: {
+    marginBottom: SPACING.lg,
   },
   languageItem: {
     paddingHorizontal: HORIZONTAL_PADDING,
@@ -1148,13 +1053,6 @@ const styles = StyleSheet.create({
   },
   languageList: {
     paddingVertical: SPACING.sm,
-  },
-  languageModalContent: {
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
   },
   languageModalHeader: {
     alignItems: 'center',
@@ -1212,13 +1110,6 @@ const styles = StyleSheet.create({
   logsList: {
     flex: 1,
   },
-  logsModalContent: {
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
   modalContainer: {
     ...centeredModal,
     overflow: 'hidden',
@@ -1257,6 +1148,13 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 2,
   },
+  subPanelContent: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
   switchThumb: {
     backgroundColor: '#fff',
     borderRadius: 10,
@@ -1269,6 +1167,17 @@ const styles = StyleSheet.create({
     height: 24,
     justifyContent: 'center',
     width: 44,
+  },
+  updateHintText: {
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: SPACING.md,
+    textAlign: 'center',
+  },
+  updateVersionText: {
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
   },
 });
 

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -871,9 +871,18 @@ export default function SettingsModal({ visible, onClose }) {
                               {t('whats_new') || "What's new"}
                             </Text>
                             <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
-                              <Text style={[styles.changelogText, { color: colors.text }]}>
-                                {stripMarkdown(updateResult.releaseNotes)}
-                              </Text>
+                              {updateResult.releaseNotes.map(({ version, notes }) => (
+                                <View key={version} style={styles.changelogSection}>
+                                  {updateResult.releaseNotes.length > 1 && (
+                                    <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
+                                      v{version}
+                                    </Text>
+                                  )}
+                                  <Text style={[styles.changelogText, { color: colors.text }]}>
+                                    {stripMarkdown(notes)}
+                                  </Text>
+                                </View>
+                              ))}
                             </ScrollView>
                           </>
                         ) : (
@@ -1010,6 +1019,9 @@ const styles = StyleSheet.create({
     flex: 1,
     marginTop: SPACING.xs,
   },
+  changelogSection: {
+    marginBottom: SPACING.md,
+  },
   changelogText: {
     fontSize: 13,
     lineHeight: 20,
@@ -1019,6 +1031,13 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     letterSpacing: 0.8,
     marginTop: SPACING.md,
+    textTransform: 'uppercase',
+  },
+  changelogVersion: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    marginBottom: SPACING.xs,
     textTransform: 'uppercase',
   },
   clearLogsText: {

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -32,13 +32,14 @@ const LOG_LEVEL_COLORS = {
 const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 
 const stripMarkdown = (md) => md
+  .replace(/\r\n/g, '\n')
   .replace(/#{1,6}\s+/g, '')
   .replace(/\*\*(.+?)\*\*/g, '$1')
   .replace(/\*(.+?)\*/g, '$1')
   .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
   .replace(/`([^`]+)`/g, '$1')
   .replace(/^\s*[-*+]\s+/gm, '• ')
-  .replace(/\r\n/g, '\n')
+  .replace(/\n{3,}/g, '\n\n')
   .trim();
 
 export default function SettingsModal({ visible, onClose }) {

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -31,6 +31,16 @@ const LOG_LEVEL_COLORS = {
 
 const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 
+const stripMarkdown = (md) => md
+  .replace(/#{1,6}\s+/g, '')
+  .replace(/\*\*(.+?)\*\*/g, '$1')
+  .replace(/\*(.+?)\*/g, '$1')
+  .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+  .replace(/`([^`]+)`/g, '$1')
+  .replace(/^\s*[-*+]\s+/gm, '• ')
+  .replace(/\r\n/g, '\n')
+  .trim();
+
 export default function SettingsModal({ visible, onClose }) {
   const { colors } = useThemeColors();
   const { t, language, setLanguage, availableLanguages } = useLocalization();
@@ -348,7 +358,13 @@ export default function SettingsModal({ visible, onClose }) {
       } else if (!result.isUpdateAvailable) {
         setUpdateResult({ type: 'up_to_date' });
       } else {
-        setUpdateResult({ type: 'available', latestVersion: result.latestVersion, downloadUrl: result.downloadUrl });
+        setUpdateResult({
+          type: 'available',
+          latestVersion: result.latestVersion,
+          currentVersion: result.currentVersion,
+          downloadUrl: result.downloadUrl,
+          releaseNotes: result.releaseNotes || null,
+        });
       }
     } catch (error) {
       console.error('Manual update check failed:', error);
@@ -833,57 +849,85 @@ export default function SettingsModal({ visible, onClose }) {
                     </Text>
                   </View>
                 ) : updateResult && (
-                  <Animated.View style={[styles.importConfirmContent, { opacity: updateContentAnim }]}>
+                  <Animated.View style={[styles.updateResultContainer, { opacity: updateContentAnim }]}>
                     {updateResult.type === 'available' && (
                       <>
-                        <Ionicons name="download-outline" size={48} color={colors.primary} style={styles.importWarningIcon} />
-                        <Text style={[styles.updateVersionText, { color: colors.text }]}>
-                          {(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
-                            .replace('{latestVersion}', updateResult.latestVersion)}
-                        </Text>
-                        <Text style={[styles.updateHintText, { color: colors.mutedText }]}>
-                          {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
-                        </Text>
-                        <TouchableRipple
-                          onPress={async () => {
-                            await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
-                            closeSubPanel();
-                            onClose();
-                            startDownload(updateResult.downloadUrl, {
-                              onError: () => {
-                                showDialog(
-                                  t('error') || 'Error',
-                                  t('update_download_failed') || 'Could not download the update. Please try again.',
-                                  [{ text: t('ok') || 'OK' }],
-                                );
-                              },
-                            });
-                          }}
-                          style={[styles.importConfirmButton, { backgroundColor: colors.primary }]}
-                        >
-                          <Text style={styles.importConfirmButtonText}>
-                            {t('update_now') || 'Update now'}
+                        <View style={styles.updateAvailableHeader}>
+                          <Ionicons name="download-outline" size={36} color={colors.primary} />
+                          <View style={styles.updateVersionInfo}>
+                            <Text style={[styles.updateNewVersion, { color: colors.text }]}>
+                              v{updateResult.latestVersion}
+                            </Text>
+                            <Text style={[styles.updateCurrentVersion, { color: colors.mutedText }]}>
+                              {(t('update_from_version') || 'installed: v{currentVersion}')
+                                .replace('{currentVersion}', updateResult.currentVersion)}
+                            </Text>
+                          </View>
+                        </View>
+                        {updateResult.releaseNotes ? (
+                          <>
+                            <Divider style={styles.updateDivider} />
+                            <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
+                              {t('whats_new') || "What's new"}
+                            </Text>
+                            <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
+                              <Text style={[styles.changelogText, { color: colors.text }]}>
+                                {stripMarkdown(updateResult.releaseNotes)}
+                              </Text>
+                            </ScrollView>
+                          </>
+                        ) : (
+                          <Text style={[styles.updateVersionText, { color: colors.mutedText }]}>
+                            {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
                           </Text>
-                        </TouchableRipple>
+                        )}
+                        <View style={styles.updateActions}>
+                          {updateResult.releaseNotes && (
+                            <Text style={[styles.updateHintText, { color: colors.mutedText }]}>
+                              {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
+                            </Text>
+                          )}
+                          <TouchableRipple
+                            onPress={async () => {
+                              await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
+                              closeSubPanel();
+                              onClose();
+                              startDownload(updateResult.downloadUrl, {
+                                onError: () => {
+                                  showDialog(
+                                    t('error') || 'Error',
+                                    t('update_download_failed') || 'Could not download the update. Please try again.',
+                                    [{ text: t('ok') || 'OK' }],
+                                  );
+                                },
+                              });
+                            }}
+                            style={[styles.importConfirmButton, { backgroundColor: colors.primary }]}
+                          >
+                            <Text style={styles.importConfirmButtonText}>
+                              {t('update_now') || 'Update now'}
+                            </Text>
+                          </TouchableRipple>
+                        </View>
                       </>
                     )}
                     {updateResult.type === 'up_to_date' && (
-                      <>
+                      <View style={styles.importConfirmContent}>
                         <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
                         <Text style={[styles.updateVersionText, { color: colors.text }]}>
                           {t('up_to_date') || 'You already have the latest version installed.'}
                         </Text>
-                      </>
+                      </View>
                     )}
                     {updateResult.type === 'error' && (
-                      <>
+                      <View style={styles.importConfirmContent}>
                         <Ionicons name="cloud-offline-outline" size={48} color={colors.mutedText} style={styles.importWarningIcon} />
                         <Text style={[styles.updateVersionText, { color: colors.text }]}>
                           {updateResult.errorCode === 'releases_without_apks'
                             ? (t('update_releases_without_apks') || 'Found releases but no APKs attached. Check GitHub for the latest release.')
                             : (t('update_check_failed') || 'Could not check updates right now. Please try again later.')}
                         </Text>
-                      </>
+                      </View>
                     )}
                   </Animated.View>
                 )
@@ -961,6 +1005,21 @@ const styles = StyleSheet.create({
   },
   backupItemText: {
     flex: 1,
+  },
+  changelogScroll: {
+    flex: 1,
+    marginTop: SPACING.xs,
+  },
+  changelogText: {
+    fontSize: 13,
+    lineHeight: 20,
+  },
+  changelogTitle: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.8,
+    marginTop: SPACING.md,
+    textTransform: 'uppercase',
   },
   clearLogsText: {
     color: '#e53935',
@@ -1202,6 +1261,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 44,
   },
+  updateActions: {
+    paddingTop: SPACING.md,
+  },
+  updateAvailableHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.md,
+    paddingBottom: SPACING.sm,
+  },
   updateCheckingContainer: {
     alignItems: 'center',
     flex: 1,
@@ -1214,11 +1282,30 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     textAlign: 'center',
   },
+  updateCurrentVersion: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  updateDivider: {
+    marginTop: SPACING.sm,
+  },
   updateHintText: {
     fontSize: 13,
     lineHeight: 19,
     marginTop: SPACING.md,
     textAlign: 'center',
+  },
+  updateNewVersion: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  updateResultContainer: {
+    flex: 1,
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: SPACING.lg,
+  },
+  updateVersionInfo: {
+    flex: 1,
   },
   updateVersionText: {
     fontSize: 15,

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -155,6 +155,7 @@ export const checkForAppUpdate = async ({
         releaseUrl: release.html_url || apkAsset.browser_download_url,
         publishedAt: release.published_at || null,
         releaseName: release.name || release.tag_name || null,
+        releaseNotes: release.body || null,
       };
     }
 

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -78,7 +78,7 @@ const fetchWithTimeout = async (url, options = {}, timeoutMs = UPDATE_CHECK_TIME
   }
 };
 
-const MAX_RELEASES_TO_CHECK = 5;
+const MAX_RELEASES_TO_CHECK = 20;
 
 export const checkForAppUpdate = async ({
   currentVersion = APP_VERSION,
@@ -132,39 +132,72 @@ export const checkForAppUpdate = async ({
       };
     }
 
+    // Collect all releases newer than current (GitHub returns newest first).
+    // Stop as soon as we reach a release that is not newer — everything after is older.
+    let bestRelease = null; // first (newest) release with a downloadable APK
     let foundReleasesWithoutApk = false;
+    const newerReleases = []; // all releases with version > current, for changelog
+
     for (const release of releases) {
-      const latestVersion = parseVersionFromRelease(release);
-      if (!latestVersion) {
+      const releaseVersion = parseVersionFromRelease(release);
+      if (!releaseVersion) {
         continue;
       }
+
+      if (compareVersions(releaseVersion, currentNormalized) <= 0) {
+        break; // reached current or older — stop
+      }
+
+      newerReleases.push({ version: releaseVersion, notes: release.body || null });
 
       const apkAsset = extractApkAsset(release.assets);
-      if (!apkAsset) {
+      if (apkAsset && !bestRelease) {
+        bestRelease = {
+          version: releaseVersion,
+          downloadUrl: apkAsset.browser_download_url,
+          releaseUrl: release.html_url || apkAsset.browser_download_url,
+          publishedAt: release.published_at || null,
+          releaseName: release.name || release.tag_name || null,
+        };
+      } else if (!apkAsset) {
         foundReleasesWithoutApk = true;
-        continue;
       }
+    }
 
-      const compare = compareVersions(latestVersion, currentNormalized);
+    if (newerReleases.length === 0) {
+      // Nothing newer found at all — either up to date or all releases lacked versions
       return {
         success: true,
-        isUpdateAvailable: compare > 0,
+        isUpdateAvailable: false,
         currentVersion: currentNormalized,
-        latestVersion,
-        downloadUrl: apkAsset.browser_download_url,
-        releaseUrl: release.html_url || apkAsset.browser_download_url,
-        publishedAt: release.published_at || null,
-        releaseName: release.name || release.tag_name || null,
-        releaseNotes: release.body || null,
       };
     }
 
+    if (!bestRelease) {
+      return {
+        success: false,
+        isUpdateAvailable: false,
+        currentVersion: currentNormalized,
+        errorCode: foundReleasesWithoutApk ? 'releases_without_apks' : 'invalid_release_data',
+      };
+    }
+
+    const releaseNotes = newerReleases
+      .filter((r) => r.notes)
+      .map((r) => ({ version: r.version, notes: r.notes }));
+
     return {
-      success: false,
-      isUpdateAvailable: false,
+      success: true,
+      isUpdateAvailable: true,
       currentVersion: currentNormalized,
-      errorCode: foundReleasesWithoutApk ? 'releases_without_apks' : 'invalid_release_data',
+      latestVersion: bestRelease.version,
+      downloadUrl: bestRelease.downloadUrl,
+      releaseUrl: bestRelease.releaseUrl,
+      publishedAt: bestRelease.publishedAt,
+      releaseName: bestRelease.releaseName,
+      releaseNotes: releaseNotes.length > 0 ? releaseNotes : null,
     };
+
   } catch (error) {
     const isTimeout = error?.name === 'AbortError';
     return {

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "Verfügbare Updates werden gesucht…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "installiert: v{currentVersion}",
+  "whats_new": "Was ist neu",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -255,6 +255,7 @@
   "sqlite_description": "Roh-Datenbankdatei, vollständiges Backup",
   "google_sheets": "Google Tabellen",
   "google_sheets_description": "In eine Google Tabelle exportieren",
+  "google_sheets_exporting": "Exportieren…",
   "google_sheets_export_success": "In Google Tabellen exportiert",
   "google_sheets_open": "Öffnen",
   "google_sheets_signin_failed": "Google-Anmeldung fehlgeschlagen. Bitte erneut versuchen.",

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -354,6 +354,7 @@
   "added_to_operations": "Zu Operationen hinzugefügt",
   "planned_operation_name_hint": "z.B. Miete, Netflix, Lebensmittel",
   "check_updates": "Check for updates",
+  "checking_for_updates": "Verfügbare Updates werden gesucht…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -354,6 +354,7 @@
   "added_to_operations": "Added to operations",
   "planned_operation_name_hint": "e.g. Rent, Netflix, Groceries",
   "check_updates": "Check for updates",
+  "checking_for_updates": "Checking for available updates…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -255,6 +255,7 @@
   "sqlite_description": "Raw database file, complete backup",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Export to a Google Sheets spreadsheet",
+  "google_sheets_exporting": "Exporting…",
   "google_sheets_export_success": "Exported to Google Sheets",
   "google_sheets_open": "Open",
   "google_sheets_signin_failed": "Google sign-in failed. Please try again.",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "Checking for available updates…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "installed: v{currentVersion}",
+  "whats_new": "What's new",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -255,6 +255,7 @@
   "sqlite_description": "Archivo de base de datos sin procesar, copia de seguridad completa",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Exportar a una hoja de cálculo de Google Sheets",
+  "google_sheets_exporting": "Exportando…",
   "google_sheets_export_success": "Exportado a Google Sheets",
   "google_sheets_open": "Abrir",
   "google_sheets_signin_failed": "Error al iniciar sesión en Google. Inténtalo de nuevo.",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -354,6 +354,7 @@
   "added_to_operations": "Agregada a operaciones",
   "planned_operation_name_hint": "ej. Alquiler, Netflix, Compras",
   "check_updates": "Check for updates",
+  "checking_for_updates": "Comprobando actualizaciones disponibles…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "Comprobando actualizaciones disponibles…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "instalada: v{currentVersion}",
+  "whats_new": "Novedades",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "Recherche de mises à jour disponibles…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "installée: v{currentVersion}",
+  "whats_new": "Nouveautés",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -255,6 +255,7 @@
   "sqlite_description": "Fichier de base de données brut, sauvegarde complète",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Exporter vers une feuille de calcul Google Sheets",
+  "google_sheets_exporting": "Exportation…",
   "google_sheets_export_success": "Exporté vers Google Sheets",
   "google_sheets_open": "Ouvrir",
   "google_sheets_signin_failed": "Échec de la connexion Google. Veuillez réessayer.",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -354,6 +354,7 @@
   "added_to_operations": "Ajoutée aux opérations",
   "planned_operation_name_hint": "ex. Loyer, Netflix, Courses",
   "check_updates": "Check for updates",
+  "checking_for_updates": "Recherche de mises à jour disponibles…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -254,6 +254,7 @@
   "sqlite_description": "Հում տվյալների բազայի ֆայլ, ամբողջական պահուստ",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Արտահանել Google Sheets աղյուսակ",
+  "google_sheets_exporting": "Արտահանում…",
   "google_sheets_export_success": "Արտահանվել է Google Sheets-ում",
   "google_sheets_open": "Բացել",
   "google_sheets_signin_failed": "Google-ի մուտքը ձախողվեց: Կրկին փորձեք:",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -343,6 +343,8 @@
   "checking_for_updates": "Հասանելի թարմացումների ստուգում…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "տեղադրված է: v{currentVersion}",
+  "whats_new": "Ինչ նոր կա",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -340,6 +340,7 @@
   "added_to_operations": "Ավելացվել է գործարկներին",
   "planned_operation_name_hint": "օր. Վարձակալություն, Netflix, Մսերքներ",
   "check_updates": "Check for updates",
+  "checking_for_updates": "Հասանելի թարմացումների ստուգում…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -106,6 +106,8 @@
   "checking_for_updates": "Ricerca aggiornamenti disponibili…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "installata: v{currentVersion}",
+  "whats_new": "Novità",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -120,6 +120,7 @@
   "keep_filters": "Mantieni Filtri",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Esporta in un foglio di calcolo Google Sheets",
+  "google_sheets_exporting": "Esportazione…",
   "google_sheets_export_success": "Esportato su Google Sheets",
   "google_sheets_open": "Apri",
   "google_sheets_signin_failed": "Accesso Google fallito. Riprova.",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -103,6 +103,7 @@
   "added_to_operations": "Aggiunta alle operazioni",
   "planned_operation_name_hint": "es. Affitto, Netflix, Spesa",
   "check_updates": "Check for updates",
+  "checking_for_updates": "Ricerca aggiornamenti disponibili…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "利用可能なアップデートを確認中…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "インストール済み: v{currentVersion}",
+  "whats_new": "新着情報",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -255,6 +255,7 @@
   "sqlite_description": "Raw database file, complete backup",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Export to a Google Sheets spreadsheet",
+  "google_sheets_exporting": "エクスポート中…",
   "google_sheets_export_success": "Exported to Google Sheets",
   "google_sheets_open": "Open",
   "google_sheets_signin_failed": "Google sign-in failed. Please try again.",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -354,6 +354,7 @@
   "added_to_operations": "Added to operations",
   "planned_operation_name_hint": "e.g. Rent, Netflix, Groceries",
   "check_updates": "Check for updates",
+  "checking_for_updates": "利用可能なアップデートを確認中…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -354,6 +354,7 @@
   "added_to_operations": "Added to operations",
   "planned_operation_name_hint": "e.g. Rent, Netflix, Groceries",
   "check_updates": "Check for updates",
+  "checking_for_updates": "업데이트 확인 중…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "업데이트 확인 중…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "설치됨: v{currentVersion}",
+  "whats_new": "새로운 기능",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -255,6 +255,7 @@
   "sqlite_description": "Raw database file, complete backup",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Export to a Google Sheets spreadsheet",
+  "google_sheets_exporting": "내보내는 중…",
   "google_sheets_export_success": "Exported to Google Sheets",
   "google_sheets_open": "Open",
   "google_sheets_signin_failed": "Google sign-in failed. Please try again.",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -354,6 +354,7 @@
   "added_to_operations": "Added to operations",
   "planned_operation_name_hint": "e.g. Rent, Netflix, Groceries",
   "check_updates": "Check for updates",
+  "checking_for_updates": "A verificar atualizações disponíveis…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "A verificar atualizações disponíveis…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "instalada: v{currentVersion}",
+  "whats_new": "Novidades",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -255,6 +255,7 @@
   "sqlite_description": "Raw database file, complete backup",
   "google_sheets": "Google Sheets",
   "google_sheets_description": "Export to a Google Sheets spreadsheet",
+  "google_sheets_exporting": "Exportando…",
   "google_sheets_export_success": "Exported to Google Sheets",
   "google_sheets_open": "Open",
   "google_sheets_signin_failed": "Google sign-in failed. Please try again.",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -253,6 +253,7 @@
   "sqlite_description": "Исходный файл базы данных, полная резервная копия",
   "google_sheets": "Google Таблицы",
   "google_sheets_description": "Экспорт в таблицу Google Sheets",
+  "google_sheets_exporting": "Экспорт…",
   "google_sheets_export_success": "Данные экспортированы в Google Таблицы",
   "google_sheets_open": "Открыть",
   "google_sheets_signin_failed": "Не удалось войти в Google. Попробуйте ещё раз.",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -355,6 +355,8 @@
   "checking_for_updates": "Проверка доступных обновлений…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "установлена: v{currentVersion}",
+  "whats_new": "Что нового",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -352,6 +352,7 @@
   "added_to_operations": "Добавлено в операции",
   "planned_operation_name_hint": "напр. Аренда, Netflix, Продукты",
   "check_updates": "Check for updates",
+  "checking_for_updates": "Проверка доступных обновлений…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -354,6 +354,7 @@
   "added_to_operations": "已添加到操作",
   "planned_operation_name_hint": "例如：房租、Netflix、杂货",
   "check_updates": "Check for updates",
+  "checking_for_updates": "正在检查可用更新…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
   "update_available_title": "Update available",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -255,6 +255,7 @@
   "sqlite_description": "原始数据库文件，完整备份",
   "google_sheets": "Google 表格",
   "google_sheets_description": "导出到 Google 表格电子表格",
+  "google_sheets_exporting": "正在导出…",
   "google_sheets_export_success": "已导出到 Google 表格",
   "google_sheets_open": "打开",
   "google_sheets_signin_failed": "Google 登录失败，请重试。",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -357,6 +357,8 @@
   "checking_for_updates": "正在检查可用更新…",
   "update_check_failed": "Could not check updates right now. Please try again later.",
   "up_to_date": "You already have the latest version installed.",
+  "update_from_version": "已安装: v{currentVersion}",
+  "whats_new": "新功能",
   "update_available_title": "Update available",
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",


### PR DESCRIPTION
## Summary

- Replaces all nested modals, dialogs, and stacked panels in `SettingsModal` with a single `Animated.View` subpanel that slides in over the main settings list
- Adds inline Google Sheets export feedback: loading spinner on the row while exporting, green checkmark + "Open" button on success
- Adds `google_sheets_exporting` i18n key to all 11 language files
- Documents the subpanel pattern in CLAUDE.md as a standing rule for future development

## What changed

**Sub-panels now cover:** language picker, export format, import confirmation, logs viewer, local backups, update available, reset database confirmation.

**Animation pattern:**
- Single `activeSubPanel` string state (`null | 'language' | 'export' | ...`)
- `Animated.parallel` with asymmetric durations for natural stagger — no `Animated.delay` (breaks native driver)
- Conditional mount of the `Animated.View` to avoid invisible-style vs animated-value conflicts

**Logs panel:** switched from `ScrollView + map` to `FlatList inverted={true}` with reversed data — eliminates mount lag and `scrollToEnd` race condition.

**Share-sheet exports:** removed false "success" dialog since `Sharing.shareAsync` resolves on dismiss with no cancel signal.

## Test plan

- [ ] Tap each settings row (Language, Export, Import, Logs, Local Backups, Check for Updates, Reset Database) — verify subpanel slides in smoothly
- [ ] Back arrow returns to main settings list
- [ ] Google Sheets export: loading spinner appears on row, checkmark + Open button appear on success, error message appears on failure
- [ ] Log viewer shows latest entries at bottom without delay
- [ ] Import and Reset Database confirmation subpanels show warning + destructive button
- [ ] Update available subpanel shows version info and download button
