### PR TITLE
feat: apply basic filters to all sheets after Google Sheets export

### DIFF
--- a/__tests__/services/GoogleSheetsService.test.js
+++ b/__tests__/services/GoogleSheetsService.test.js
@@ -204,6 +204,17 @@ describe('GoogleSheetsService', () => {
       },
     };
 
+    const mockMetadata = {
+      sheets: [
+        { properties: { title: 'Accounts', sheetId: 0 } },
+        { properties: { title: 'Operations', sheetId: 1 } },
+        { properties: { title: 'Categories', sheetId: 2 } },
+        { properties: { title: 'Budgets', sheetId: 3 } },
+        { properties: { title: 'Planned Operations', sheetId: 4 } },
+        { properties: { title: 'Balance History', sheetId: 5 } },
+      ],
+    };
+
     it('creates a new spreadsheet and stores its ID on first export', async () => {
       getPreference.mockResolvedValue(null);
       setPreference.mockResolvedValue(undefined);
@@ -212,6 +223,8 @@ describe('GoogleSheetsService', () => {
         json: async () => ({ spreadsheetId: 'new-sheet-id' }),
       });
       mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata });
       mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
       const url = await exportToSheets('access-token', mockBackup);
@@ -224,12 +237,30 @@ describe('GoogleSheetsService', () => {
       getPreference.mockResolvedValue('existing-sheet-id');
       mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
       mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
       const url = await exportToSheets('access-token', mockBackup);
 
       expect(url).toBe('https://docs.google.com/spreadsheets/d/existing-sheet-id');
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(4);
       expect(setPreference).not.toHaveBeenCalled();
+    });
+
+    it('applies basic filters to all 6 sheets after writing data', async () => {
+      getPreference.mockResolvedValue('sheet-id');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // clearSheets
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // writeSheets
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIds
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // applyFilters
+
+      await exportToSheets('access-token', mockBackup);
+
+      const applyFiltersCall = mockFetch.mock.calls[3];
+      const body = JSON.parse(applyFiltersCall[1].body);
+      expect(body.requests).toHaveLength(6);
+      expect(body.requests[0].setBasicFilter.filter.range.sheetId).toBe(0);
+      expect(body.requests[5].setBasicFilter.filter.range.sheetId).toBe(5);
     });
 
     it('throws refresh_failed and signs out when clearSheets returns 401', async () => {

--- a/app/services/GoogleSheetsService.js
+++ b/app/services/GoogleSheetsService.js
@@ -181,6 +181,45 @@ const createSpreadsheet = async (accessToken) => {
   return data.spreadsheetId;
 };
 
+const getSheetIds = async (accessToken, spreadsheetId, sheetNames) => {
+  const response = await fetch(
+    `${SHEETS_API}/${spreadsheetId}?fields=sheets.properties`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (!response.ok) {
+    const data = await response.json();
+    throw new Error(data.error?.message || 'get_sheet_ids_failed');
+  }
+  const data = await response.json();
+  const nameToId = new Map(data.sheets.map(s => [s.properties.title, s.properties.sheetId]));
+  return sheetNames.map(name => nameToId.get(name)).filter(id => id !== undefined);
+};
+
+const applyFilters = async (accessToken, spreadsheetId, sheetIds) => {
+  const requests = sheetIds.map(sheetId => ({
+    setBasicFilter: {
+      filter: { range: { sheetId, startRowIndex: 0, startColumnIndex: 0 } },
+    },
+  }));
+  const response = await fetch(`${SHEETS_API}/${spreadsheetId}:batchUpdate`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ requests }),
+  });
+  if (!response.ok) {
+    const data = await response.json();
+    if (response.status === 401) {
+      await signOut();
+      throw new Error('refresh_failed');
+    }
+    throw new Error(data.error?.message || 'apply_filters_failed');
+  }
+  await response.json().catch(() => {});
+};
+
 const clearSheets = async (accessToken, spreadsheetId, ranges) => {
   const response = await fetch(`${SHEETS_API}/${spreadsheetId}/values:batchClear`, {
     method: 'POST',
@@ -240,8 +279,11 @@ export const exportToSheets = async (accessToken, backup) => {
   }
 
   const sheets = buildSheetsData(backup);
-  await clearSheets(accessToken, spreadsheetId, sheets.map(s => s.range.split('!')[0]));
+  const sheetNames = sheets.map(s => s.range.split('!')[0]);
+  await clearSheets(accessToken, spreadsheetId, sheetNames);
   await writeSheets(accessToken, spreadsheetId, sheets);
+  const sheetIds = await getSheetIds(accessToken, spreadsheetId, sheetNames);
+  await applyFilters(accessToken, spreadsheetId, sheetIds);
 
   return `https://docs.google.com/spreadsheets/d/${spreadsheetId}`;
 };


### PR DESCRIPTION
After writing data, fetch sheet metadata to resolve numeric sheet IDs,
then send a setBasicFilter request for each of the 6 exported sheets so
header-row dropdowns are ready without manual setup.

https://claude.ai/code/session_01KjFQS2HHzc2WSHCpcUoe8J