### PR TITLE
feat(graphs): expand income and expense cards inline instead of modal

### DIFF
--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -32,7 +32,7 @@ const ExpenseSummaryCard = ({
   return (
     <TouchableOpacity
       testID="expense-summary-card"
-      style={[styles.summaryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
+      style={styles.summaryCard}
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
@@ -82,8 +82,6 @@ const styles = StyleSheet.create({
   },
   summaryCard: {
     alignItems: 'center',
-    borderRadius: 14,
-    borderWidth: 1,
     flex: 1,
     flexDirection: 'row',
     gap: 8,

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -26,7 +26,7 @@ const ExpenseSummaryCard = ({
   totalExpenses,
   selectedCurrency,
   onPress,
-  expanded,
+  expanded = false,
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
@@ -60,10 +60,6 @@ ExpenseSummaryCard.propTypes = {
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   expanded: PropTypes.bool,
-};
-
-ExpenseSummaryCard.defaultProps = {
-  expanded: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -26,6 +26,7 @@ const ExpenseSummaryCard = ({
   totalExpenses,
   selectedCurrency,
   onPress,
+  expanded,
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
@@ -46,6 +47,7 @@ const ExpenseSummaryCard = ({
           {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
         </Text>
       </View>
+      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
     </TouchableOpacity>
   );
 };
@@ -57,6 +59,11 @@ ExpenseSummaryCard.propTypes = {
   totalExpenses: PropTypes.number.isRequired,
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
+  expanded: PropTypes.bool,
+};
+
+ExpenseSummaryCard.defaultProps = {
+  expanded: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -26,7 +26,7 @@ const IncomeSummaryCard = ({
   totalIncome,
   selectedCurrency,
   onPress,
-  expanded,
+  expanded = false,
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
@@ -60,10 +60,6 @@ IncomeSummaryCard.propTypes = {
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   expanded: PropTypes.bool,
-};
-
-IncomeSummaryCard.defaultProps = {
-  expanded: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -26,6 +26,7 @@ const IncomeSummaryCard = ({
   totalIncome,
   selectedCurrency,
   onPress,
+  expanded,
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
@@ -46,6 +47,7 @@ const IncomeSummaryCard = ({
           {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
         </Text>
       </View>
+      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
     </TouchableOpacity>
   );
 };
@@ -57,6 +59,11 @@ IncomeSummaryCard.propTypes = {
   totalIncome: PropTypes.number.isRequired,
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
+  expanded: PropTypes.bool,
+};
+
+IncomeSummaryCard.defaultProps = {
+  expanded: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -32,7 +32,7 @@ const IncomeSummaryCard = ({
   return (
     <TouchableOpacity
       testID="income-summary-card"
-      style={[styles.summaryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
+      style={styles.summaryCard}
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
@@ -82,8 +82,6 @@ const styles = StyleSheet.create({
   },
   summaryCard: {
     alignItems: 'center',
-    borderRadius: 14,
-    borderWidth: 1,
     flex: 1,
     flexDirection: 'row',
     gap: 8,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { View, StyleSheet, ScrollView, TouchableOpacity, LayoutAnimation, UIManager, Platform } from 'react-native';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { View, StyleSheet, ScrollView, TouchableOpacity, LayoutAnimation, UIManager, Platform, Animated, Easing } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -49,6 +49,8 @@ const GraphsScreen = () => {
   // Inline chart expansion state
   const [incomeChartExpanded, setIncomeChartExpanded] = useState(false);
   const [expenseChartExpanded, setExpenseChartExpanded] = useState(false);
+  const incomeChartAnim = useRef(new Animated.Value(0)).current;
+  const expenseChartAnim = useRef(new Animated.Value(0)).current;
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -366,9 +368,33 @@ const GraphsScreen = () => {
 
   // Income chart inline expansion
   const toggleIncomeChart = useCallback(() => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setIncomeChartExpanded(prev => !prev);
-  }, []);
+    if (incomeChartExpanded) {
+      Animated.timing(incomeChartAnim, {
+        toValue: 0,
+        duration: 180,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: true,
+      }).start(() => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setIncomeChartExpanded(false);
+      });
+    } else {
+      incomeChartAnim.setValue(0);
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+      setIncomeChartExpanded(true);
+    }
+  }, [incomeChartExpanded, incomeChartAnim]);
+
+  useEffect(() => {
+    if (incomeChartExpanded) {
+      Animated.timing(incomeChartAnim, {
+        toValue: 1,
+        duration: 300,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [incomeChartExpanded, incomeChartAnim]);
 
   const handleBackToIncomeParent = useCallback(() => {
     setSelectedIncomeCategory(prev => getParentCategoryId(prev));
@@ -376,9 +402,33 @@ const GraphsScreen = () => {
 
   // Expense chart inline expansion
   const toggleExpenseChart = useCallback(() => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setExpenseChartExpanded(prev => !prev);
-  }, []);
+    if (expenseChartExpanded) {
+      Animated.timing(expenseChartAnim, {
+        toValue: 0,
+        duration: 180,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: true,
+      }).start(() => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setExpenseChartExpanded(false);
+      });
+    } else {
+      expenseChartAnim.setValue(0);
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+      setExpenseChartExpanded(true);
+    }
+  }, [expenseChartExpanded, expenseChartAnim]);
+
+  useEffect(() => {
+    if (expenseChartExpanded) {
+      Animated.timing(expenseChartAnim, {
+        toValue: 1,
+        duration: 300,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [expenseChartExpanded, expenseChartAnim]);
 
   const handleBackToExpenseParent = useCallback(() => {
     setSelectedCategory(prev => getParentCategoryId(prev));
@@ -413,97 +463,116 @@ const GraphsScreen = () => {
             </View>
           </View>
 
-          {/* Income and Expenses Summary Cards - side by side */}
+          {/* Summary Cards Row — one or both cards; expanded card goes full-width */}
           <View style={styles.summaryCardsRow}>
-            <IncomeSummaryCard
-              colors={colors}
-              t={t}
-              loadingIncome={loadingIncome}
-              totalIncome={totalIncome}
-              selectedCurrency={selectedCurrency}
-              onPress={toggleIncomeChart}
-              expanded={incomeChartExpanded}
-            />
-            <ExpenseSummaryCard
-              colors={colors}
-              t={t}
-              loading={loading}
-              totalExpenses={totalExpenses}
-              selectedCurrency={selectedCurrency}
-              onPress={toggleExpenseChart}
-              expanded={expenseChartExpanded}
-            />
+            {/* Income card + chart (hidden when expense is expanded) */}
+            {!expenseChartExpanded && (
+              <View style={[styles.summaryCardContainer, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+                <IncomeSummaryCard
+                  colors={colors}
+                  t={t}
+                  loadingIncome={loadingIncome}
+                  totalIncome={totalIncome}
+                  selectedCurrency={selectedCurrency}
+                  onPress={toggleIncomeChart}
+                  expanded={incomeChartExpanded}
+                />
+                {incomeChartExpanded && (
+                  <Animated.View style={[
+                    styles.chartContent,
+                    {
+                      opacity: incomeChartAnim,
+                      transform: [{ translateY: incomeChartAnim.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }) }],
+                    },
+                  ]}>
+                    {selectedIncomeCategory !== 'all' && (
+                      <View style={styles.chartNavRow}>
+                        <TouchableOpacity
+                          onPress={handleBackToIncomeParent}
+                          style={styles.chartNavBack}
+                          accessibilityRole="button"
+                          accessibilityLabel={t('back')}
+                        >
+                          <Icon name="arrow-left" size={20} color={colors.primary} />
+                        </TouchableOpacity>
+                        <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                          <SimplePicker
+                            value={selectedIncomeCategory}
+                            onValueChange={setSelectedIncomeCategory}
+                            items={incomeCategoryItems}
+                            colors={colors}
+                          />
+                        </View>
+                      </View>
+                    )}
+                    <IncomePieChart
+                      colors={colors}
+                      t={t}
+                      loadingIncome={loadingIncome}
+                      incomeChartData={incomeChartData}
+                      selectedCurrency={selectedCurrency}
+                      onLegendItemPress={handleIncomeLegendItemPress}
+                      selectedIncomeCategory={selectedIncomeCategory}
+                    />
+                  </Animated.View>
+                )}
+              </View>
+            )}
+
+            {/* Expense card + chart (hidden when income is expanded) */}
+            {!incomeChartExpanded && (
+              <View style={[styles.summaryCardContainer, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+                <ExpenseSummaryCard
+                  colors={colors}
+                  t={t}
+                  loading={loading}
+                  totalExpenses={totalExpenses}
+                  selectedCurrency={selectedCurrency}
+                  onPress={toggleExpenseChart}
+                  expanded={expenseChartExpanded}
+                />
+                {expenseChartExpanded && (
+                  <Animated.View style={[
+                    styles.chartContent,
+                    {
+                      opacity: expenseChartAnim,
+                      transform: [{ translateY: expenseChartAnim.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }) }],
+                    },
+                  ]}>
+                    {selectedCategory !== 'all' && (
+                      <View style={styles.chartNavRow}>
+                        <TouchableOpacity
+                          onPress={handleBackToExpenseParent}
+                          style={styles.chartNavBack}
+                          accessibilityRole="button"
+                          accessibilityLabel={t('back')}
+                        >
+                          <Icon name="arrow-left" size={20} color={colors.primary} />
+                        </TouchableOpacity>
+                        <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                          <SimplePicker
+                            value={selectedCategory}
+                            onValueChange={setSelectedCategory}
+                            items={categoryItems}
+                            colors={colors}
+                          />
+                        </View>
+                      </View>
+                    )}
+                    <ExpensePieChart
+                      colors={colors}
+                      t={t}
+                      loading={loading}
+                      chartData={chartData}
+                      selectedCurrency={selectedCurrency}
+                      onLegendItemPress={handleExpenseLegendItemPress}
+                      selectedCategory={selectedCategory}
+                    />
+                  </Animated.View>
+                )}
+              </View>
+            )}
           </View>
-
-          {/* Inline Income Pie Chart (expands on card tap) */}
-          {incomeChartExpanded && (
-            <View style={[styles.incomeChartPanel, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-              {selectedIncomeCategory !== 'all' && (
-                <View style={styles.incomePanelHeader}>
-                  <TouchableOpacity
-                    onPress={handleBackToIncomeParent}
-                    style={styles.incomePanelBackButton}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('back')}
-                  >
-                    <Icon name="arrow-left" size={20} color={colors.primary} />
-                  </TouchableOpacity>
-                  <View style={[styles.incomePanelPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                    <SimplePicker
-                      value={selectedIncomeCategory}
-                      onValueChange={setSelectedIncomeCategory}
-                      items={incomeCategoryItems}
-                      colors={colors}
-                    />
-                  </View>
-                </View>
-              )}
-              <IncomePieChart
-                colors={colors}
-                t={t}
-                loadingIncome={loadingIncome}
-                incomeChartData={incomeChartData}
-                selectedCurrency={selectedCurrency}
-                onLegendItemPress={handleIncomeLegendItemPress}
-                selectedIncomeCategory={selectedIncomeCategory}
-              />
-            </View>
-          )}
-
-          {/* Inline Expense Pie Chart (expands on card tap) */}
-          {expenseChartExpanded && (
-            <View style={[styles.expenseChartPanel, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-              {selectedCategory !== 'all' && (
-                <View style={styles.expensePanelHeader}>
-                  <TouchableOpacity
-                    onPress={handleBackToExpenseParent}
-                    style={styles.expensePanelBackButton}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('back')}
-                  >
-                    <Icon name="arrow-left" size={20} color={colors.primary} />
-                  </TouchableOpacity>
-                  <View style={[styles.expensePanelPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                    <SimplePicker
-                      value={selectedCategory}
-                      onValueChange={setSelectedCategory}
-                      items={categoryItems}
-                      colors={colors}
-                    />
-                  </View>
-                </View>
-              )}
-              <ExpensePieChart
-                colors={colors}
-                t={t}
-                loading={loading}
-                chartData={chartData}
-                selectedCurrency={selectedCurrency}
-                onLegendItemPress={handleExpenseLegendItemPress}
-                selectedCategory={selectedCategory}
-              />
-            </View>
-          )}
 
           {/* Balance History Card */}
           {selectedMonth !== null && selectedAccount && (
@@ -549,6 +618,27 @@ const GraphsScreen = () => {
 };
 
 const styles = StyleSheet.create({
+  chartContent: {
+    paddingBottom: 8,
+    paddingHorizontal: 12,
+  },
+  chartNavBack: {
+    marginRight: 8,
+    padding: 4,
+  },
+  chartNavPicker: {
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 40,
+    overflow: 'hidden',
+  },
+  chartNavRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: 12,
+    marginTop: 4,
+  },
   container: {
     flex: 1,
   },
@@ -556,54 +646,10 @@ const styles = StyleSheet.create({
     padding: TOP_CONTENT_SPACING,
     paddingTop: TOP_CONTENT_SPACING + 4,
   },
-  expenseChartPanel: {
-    borderRadius: 14,
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 12,
-  },
-  expensePanelBackButton: {
-    marginRight: 8,
-    padding: 4,
-  },
-  expensePanelHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    marginBottom: 12,
-  },
-  expensePanelPicker: {
-    borderRadius: 8,
-    borderWidth: 1,
-    flex: 1,
-    height: 40,
-    overflow: 'hidden',
-  },
   filtersRow: {
     flexDirection: 'row',
     gap: 8,
     marginBottom: 16,
-  },
-  incomeChartPanel: {
-    borderRadius: 14,
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 12,
-  },
-  incomePanelBackButton: {
-    marginRight: 8,
-    padding: 4,
-  },
-  incomePanelHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    marginBottom: 12,
-  },
-  incomePanelPicker: {
-    borderRadius: 8,
-    borderWidth: 1,
-    flex: 1,
-    height: 40,
-    overflow: 'hidden',
   },
   periodPickerWrapper: {
     borderRadius: 12,
@@ -624,6 +670,12 @@ const styles = StyleSheet.create({
   },
   scrollView: {
     flex: 1,
+  },
+  summaryCardContainer: {
+    borderRadius: 14,
+    borderWidth: 1,
+    flex: 1,
+    overflow: 'hidden',
   },
   summaryCardsRow: {
     flexDirection: 'row',

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -556,10 +556,54 @@ const styles = StyleSheet.create({
     padding: TOP_CONTENT_SPACING,
     paddingTop: TOP_CONTENT_SPACING + 4,
   },
+  expenseChartPanel: {
+    borderRadius: 14,
+    borderWidth: 1,
+    marginBottom: 16,
+    padding: 12,
+  },
+  expensePanelBackButton: {
+    marginRight: 8,
+    padding: 4,
+  },
+  expensePanelHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  expensePanelPicker: {
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 40,
+    overflow: 'hidden',
+  },
   filtersRow: {
     flexDirection: 'row',
     gap: 8,
     marginBottom: 16,
+  },
+  incomeChartPanel: {
+    borderRadius: 14,
+    borderWidth: 1,
+    marginBottom: 16,
+    padding: 12,
+  },
+  incomePanelBackButton: {
+    marginRight: 8,
+    padding: 4,
+  },
+  incomePanelHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  incomePanelPicker: {
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 40,
+    overflow: 'hidden',
   },
   periodPickerWrapper: {
     borderRadius: 12,
@@ -585,50 +629,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 8,
     marginBottom: 16,
-  },
-  incomeChartPanel: {
-    borderRadius: 14,
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 12,
-  },
-  incomePanelHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    marginBottom: 12,
-  },
-  incomePanelBackButton: {
-    marginRight: 8,
-    padding: 4,
-  },
-  incomePanelPicker: {
-    borderRadius: 8,
-    borderWidth: 1,
-    flex: 1,
-    height: 40,
-    overflow: 'hidden',
-  },
-  expenseChartPanel: {
-    borderRadius: 14,
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 12,
-  },
-  expensePanelHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    marginBottom: 12,
-  },
-  expensePanelBackButton: {
-    marginRight: 8,
-    padding: 4,
-  },
-  expensePanelPicker: {
-    borderRadius: 8,
-    borderWidth: 1,
-    flex: 1,
-    height: 40,
-    overflow: 'hidden',
   },
 });
 

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -4,7 +4,7 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
-import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING } from '../styles/layout';
+import { TOP_CONTENT_SPACING } from '../styles/layout';
 import { getAvailableMonths } from '../services/OperationsDB';
 import { getAllCategories } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
@@ -16,7 +16,7 @@ import CategorySpendingCard from '../components/graphs/CategorySpendingCard';
 import ExpenseSummaryCard from '../components/graphs/ExpenseSummaryCard';
 import IncomeSummaryCard from '../components/graphs/IncomeSummaryCard';
 import IncomePieChart from '../components/graphs/IncomePieChart';
-import ChartModal from '../components/graphs/ChartModal';
+import ExpensePieChart from '../components/graphs/ExpensePieChart';
 import useExpenseData from '../hooks/useExpenseData';
 import useIncomeData from '../hooks/useIncomeData';
 import useBalanceHistory from '../hooks/useBalanceHistory';
@@ -46,12 +46,9 @@ const GraphsScreen = () => {
   // Account selection state
   const [selectedAccount, setSelectedAccount] = useState(null);
 
-  // Modal state (expense chart only)
-  const [modalVisible, setModalVisible] = useState(false);
-  const [modalType, setModalType] = useState('expense');
-
-  // Inline income chart expansion state
+  // Inline chart expansion state
   const [incomeChartExpanded, setIncomeChartExpanded] = useState(false);
+  const [expenseChartExpanded, setExpenseChartExpanded] = useState(false);
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -358,22 +355,7 @@ const GraphsScreen = () => {
     return selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
   }, [selectedYear, selectedMonth]);
 
-  // Handlers for opening modals
-  const openExpenseModal = useCallback(() => {
-    setModalType('expense');
-    setModalVisible(true);
-  }, []);
-
-  const closeModal = useCallback(() => {
-    setModalVisible(false);
-  }, []);
-
-  // Income chart inline expansion
-  const toggleIncomeChart = useCallback(() => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-    setIncomeChartExpanded(prev => !prev);
-  }, []);
-
+  // Shared category parent lookup
   const getParentCategoryId = useCallback((categoryId) => {
     if (categoryId === 'all') return 'all';
     const category = categories.find(cat => cat.id === categoryId);
@@ -382,8 +364,24 @@ const GraphsScreen = () => {
     return category.parentId;
   }, [categories]);
 
+  // Income chart inline expansion
+  const toggleIncomeChart = useCallback(() => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setIncomeChartExpanded(prev => !prev);
+  }, []);
+
   const handleBackToIncomeParent = useCallback(() => {
     setSelectedIncomeCategory(prev => getParentCategoryId(prev));
+  }, [getParentCategoryId]);
+
+  // Expense chart inline expansion
+  const toggleExpenseChart = useCallback(() => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setExpenseChartExpanded(prev => !prev);
+  }, []);
+
+  const handleBackToExpenseParent = useCallback(() => {
+    setSelectedCategory(prev => getParentCategoryId(prev));
   }, [getParentCategoryId]);
 
   return (
@@ -432,7 +430,8 @@ const GraphsScreen = () => {
               loading={loading}
               totalExpenses={totalExpenses}
               selectedCurrency={selectedCurrency}
-              onPress={openExpenseModal}
+              onPress={toggleExpenseChart}
+              expanded={expenseChartExpanded}
             />
           </View>
 
@@ -467,6 +466,41 @@ const GraphsScreen = () => {
                 selectedCurrency={selectedCurrency}
                 onLegendItemPress={handleIncomeLegendItemPress}
                 selectedIncomeCategory={selectedIncomeCategory}
+              />
+            </View>
+          )}
+
+          {/* Inline Expense Pie Chart (expands on card tap) */}
+          {expenseChartExpanded && (
+            <View style={[styles.expenseChartPanel, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+              {selectedCategory !== 'all' && (
+                <View style={styles.expensePanelHeader}>
+                  <TouchableOpacity
+                    onPress={handleBackToExpenseParent}
+                    style={styles.expensePanelBackButton}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('back')}
+                  >
+                    <Icon name="arrow-left" size={20} color={colors.primary} />
+                  </TouchableOpacity>
+                  <View style={[styles.expensePanelPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                    <SimplePicker
+                      value={selectedCategory}
+                      onValueChange={setSelectedCategory}
+                      items={categoryItems}
+                      colors={colors}
+                    />
+                  </View>
+                </View>
+              )}
+              <ExpensePieChart
+                colors={colors}
+                t={t}
+                loading={loading}
+                chartData={chartData}
+                selectedCurrency={selectedCurrency}
+                onLegendItemPress={handleExpenseLegendItemPress}
+                selectedCategory={selectedCategory}
               />
             </View>
           )}
@@ -509,29 +543,6 @@ const GraphsScreen = () => {
           />
         </View>
       </ScrollView>
-
-      {/* Chart Modal */}
-      <ChartModal
-        visible={modalVisible}
-        modalType={modalType}
-        colors={colors}
-        t={t}
-        onClose={closeModal}
-        selectedCategory={selectedCategory}
-        selectedIncomeCategory={selectedIncomeCategory}
-        categoryItems={categoryItems}
-        incomeCategoryItems={incomeCategoryItems}
-        onCategoryChange={setSelectedCategory}
-        onIncomeCategoryChange={setSelectedIncomeCategory}
-        categories={categories}
-        loading={loading}
-        chartData={chartData}
-        selectedCurrency={selectedCurrency}
-        onExpenseLegendItemPress={handleExpenseLegendItemPress}
-        loadingIncome={loadingIncome}
-        incomeChartData={incomeChartData}
-        onIncomeLegendItemPress={handleIncomeLegendItemPress}
-      />
 
     </View>
   );
@@ -591,6 +602,28 @@ const styles = StyleSheet.create({
     padding: 4,
   },
   incomePanelPicker: {
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 40,
+    overflow: 'hidden',
+  },
+  expenseChartPanel: {
+    borderRadius: 14,
+    borderWidth: 1,
+    marginBottom: 16,
+    padding: 12,
+  },
+  expensePanelHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  expensePanelBackButton: {
+    marginRight: 8,
+    padding: 4,
+  },
+  expensePanelPicker: {
     borderRadius: 8,
     borderWidth: 1,
     flex: 1,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { View, StyleSheet, ScrollView } from 'react-native';
+import { View, StyleSheet, ScrollView, TouchableOpacity, LayoutAnimation, UIManager, Platform } from 'react-native';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
@@ -14,10 +15,15 @@ import BalanceHistoryCard from '../components/graphs/BalanceHistoryCard';
 import CategorySpendingCard from '../components/graphs/CategorySpendingCard';
 import ExpenseSummaryCard from '../components/graphs/ExpenseSummaryCard';
 import IncomeSummaryCard from '../components/graphs/IncomeSummaryCard';
+import IncomePieChart from '../components/graphs/IncomePieChart';
 import ChartModal from '../components/graphs/ChartModal';
 import useExpenseData from '../hooks/useExpenseData';
 import useIncomeData from '../hooks/useIncomeData';
 import useBalanceHistory from '../hooks/useBalanceHistory';
+
+if (Platform.OS === 'android') {
+  UIManager.setLayoutAnimationEnabledExperimental?.(true);
+}
 
 const GraphsScreen = () => {
   const { colors } = useThemeColors();
@@ -40,9 +46,12 @@ const GraphsScreen = () => {
   // Account selection state
   const [selectedAccount, setSelectedAccount] = useState(null);
 
-  // Modal state
+  // Modal state (expense chart only)
   const [modalVisible, setModalVisible] = useState(false);
-  const [modalType, setModalType] = useState('expense'); // 'expense' or 'income'
+  const [modalType, setModalType] = useState('expense');
+
+  // Inline income chart expansion state
+  const [incomeChartExpanded, setIncomeChartExpanded] = useState(false);
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -355,14 +364,27 @@ const GraphsScreen = () => {
     setModalVisible(true);
   }, []);
 
-  const openIncomeModal = useCallback(() => {
-    setModalType('income');
-    setModalVisible(true);
-  }, []);
-
   const closeModal = useCallback(() => {
     setModalVisible(false);
   }, []);
+
+  // Income chart inline expansion
+  const toggleIncomeChart = useCallback(() => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setIncomeChartExpanded(prev => !prev);
+  }, []);
+
+  const getParentCategoryId = useCallback((categoryId) => {
+    if (categoryId === 'all') return 'all';
+    const category = categories.find(cat => cat.id === categoryId);
+    if (!category) return 'all';
+    if (category.parentId === null) return 'all';
+    return category.parentId;
+  }, [categories]);
+
+  const handleBackToIncomeParent = useCallback(() => {
+    setSelectedIncomeCategory(prev => getParentCategoryId(prev));
+  }, [getParentCategoryId]);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -401,7 +423,8 @@ const GraphsScreen = () => {
               loadingIncome={loadingIncome}
               totalIncome={totalIncome}
               selectedCurrency={selectedCurrency}
-              onPress={openIncomeModal}
+              onPress={toggleIncomeChart}
+              expanded={incomeChartExpanded}
             />
             <ExpenseSummaryCard
               colors={colors}
@@ -412,6 +435,41 @@ const GraphsScreen = () => {
               onPress={openExpenseModal}
             />
           </View>
+
+          {/* Inline Income Pie Chart (expands on card tap) */}
+          {incomeChartExpanded && (
+            <View style={[styles.incomeChartPanel, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+              {selectedIncomeCategory !== 'all' && (
+                <View style={styles.incomePanelHeader}>
+                  <TouchableOpacity
+                    onPress={handleBackToIncomeParent}
+                    style={styles.incomePanelBackButton}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('back')}
+                  >
+                    <Icon name="arrow-left" size={20} color={colors.primary} />
+                  </TouchableOpacity>
+                  <View style={[styles.incomePanelPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                    <SimplePicker
+                      value={selectedIncomeCategory}
+                      onValueChange={setSelectedIncomeCategory}
+                      items={incomeCategoryItems}
+                      colors={colors}
+                    />
+                  </View>
+                </View>
+              )}
+              <IncomePieChart
+                colors={colors}
+                t={t}
+                loadingIncome={loadingIncome}
+                incomeChartData={incomeChartData}
+                selectedCurrency={selectedCurrency}
+                onLegendItemPress={handleIncomeLegendItemPress}
+                selectedIncomeCategory={selectedIncomeCategory}
+              />
+            </View>
+          )}
 
           {/* Balance History Card */}
           {selectedMonth !== null && selectedAccount && (
@@ -516,6 +574,28 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 8,
     marginBottom: 16,
+  },
+  incomeChartPanel: {
+    borderRadius: 14,
+    borderWidth: 1,
+    marginBottom: 16,
+    padding: 12,
+  },
+  incomePanelHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  incomePanelBackButton: {
+    marginRight: 8,
+    padding: 4,
+  },
+  incomePanelPicker: {
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 40,
+    overflow: 'hidden',
   },
 });
 


### PR DESCRIPTION
Tapping either summary card (income or expense) now toggles an inline pie chart panel directly below the summary row, replacing the ChartModal approach.

## Changes

- **IncomeSummaryCard / ExpenseSummaryCard**: added `expanded` prop with a chevron-up/down indicator
- **GraphsScreen**: each card toggles its own `incomeChartExpanded` / `expenseChartExpanded` state, animated with `LayoutAnimation`
- Inline panels support full category drill-down — tapping a legend item navigates into a subcategory, with a back button and category picker shown inside the panel
- **ChartModal removed** — no longer needed since both charts are now inline

https://claude.ai/code/session_01KjX9BvzbLr6ppZsJ8nYvsr