### PR TITLE
fix(settings): fix import progress panel z-order and double-tap crash

### DIFF
--- a/__tests__/modals/SettingsModal.test.js
+++ b/__tests__/modals/SettingsModal.test.js
@@ -91,12 +91,14 @@ jest.mock('../../app/contexts/UpdateDownloadContext', () => ({
 
 // Mock BackupRestore service
 const mockExportBackup = jest.fn(() => Promise.resolve());
-const mockImportBackup = jest.fn(() => Promise.resolve());
+const mockPickImportFile = jest.fn(() => Promise.resolve({ fileUri: '/mock/file.json', filename: 'backup.json' }));
+const mockImportBackupFromFile = jest.fn(() => Promise.resolve());
 const mockRestoreBackup = jest.fn(() => Promise.resolve());
 const mockCreateBackup = jest.fn(() => Promise.resolve({ version: 1, data: {} }));
 jest.mock('../../app/services/BackupRestore', () => ({
   exportBackup: (...args) => mockExportBackup(...args),
-  importBackup: (...args) => mockImportBackup(...args),
+  pickImportFile: (...args) => mockPickImportFile(...args),
+  importBackupFromFile: (...args) => mockImportBackupFromFile(...args),
   restoreBackup: (...args) => mockRestoreBackup(...args),
   createBackup: (...args) => mockCreateBackup(...args),
 }));
@@ -162,7 +164,8 @@ describe('SettingsModal Component', () => {
     mockCancelImport.mockClear();
     mockCompleteImport.mockClear();
     mockExportBackup.mockClear();
-    mockImportBackup.mockClear();
+    mockPickImportFile.mockClear();
+    mockImportBackupFromFile.mockClear();
     mockRestoreBackup.mockClear();
     mockCreateBackup.mockClear();
     mockGetStoredBackups.mockClear();
@@ -328,11 +331,12 @@ describe('SettingsModal Component', () => {
         fireEvent.press(getByTestId('confirm-import-file-btn'));
       });
 
-      expect(mockStartImport).toHaveBeenCalled();
+      expect(mockPickImportFile).toHaveBeenCalled();
       expect(mockCancelImport).not.toHaveBeenCalled();
 
       await waitFor(() => {
-        expect(mockImportBackup).toHaveBeenCalled();
+        expect(mockImportBackupFromFile).toHaveBeenCalledWith({ fileUri: '/mock/file.json', filename: 'backup.json' });
+        expect(mockStartImport).toHaveBeenCalled();
         expect(mockOnClose).toHaveBeenCalled();
       });
     });

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -9,7 +9,7 @@ import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useImportProgress } from '../contexts/ImportProgressContext';
-import { exportBackup, importBackup, restoreBackup, createBackup } from '../services/BackupRestore';
+import { exportBackup, pickImportFile, importBackupFromFile, restoreBackup, createBackup } from '../services/BackupRestore';
 import { getStoredBackups, DAILY_BACKUP_DIR } from '../services/DailyBackupService';
 import { useLogEntries } from '../hooks/useLogEntries';
 import { File, Paths } from 'expo-file-system';
@@ -81,6 +81,7 @@ export default function SettingsModal({ visible, onClose }) {
   // Animation values
   const settingsAnim = useRef(new Animated.Value(0)).current;
   const subPanelAnim = useRef(new Animated.Value(0)).current;
+  const importPickInProgress = useRef(false);
   const toggleAnim = useRef(new Animated.Value(hideBalances ? 1 : 0)).current;
   const updateContentAnim = useRef(new Animated.Value(0)).current;
   useEffect(() => {
@@ -292,25 +293,38 @@ export default function SettingsModal({ visible, onClose }) {
   // Note: reloadApp removed because it was unused. Use expo-updates directly where needed.
 
   const confirmImportBackup = useCallback(async () => {
-    startImport();
+    if (importPickInProgress.current) return;
+    importPickInProgress.current = true;
+
+    // Phase 1: pick file while settings modal is still open (cancel returns to source picker)
+    let fileInfo;
     try {
-      await importBackup();
-      closeSubPanel();
-      onClose();
-      completeImport();
+      fileInfo = await pickImportFile();
     } catch (error) {
-      cancelImport();
+      importPickInProgress.current = false;
       if (error.message === 'Import cancelled') {
         console.info('[Import] User cancelled file selection');
         setImportStep('source');
         return;
       }
+      console.error('Import file pick error:', error);
+      showDialog(t('error') || 'Error', error.message || t('restore_error') || 'Failed to restore backup', [{ text: 'OK' }]);
+      return;
+    }
+
+    importPickInProgress.current = false;
+
+    // Phase 2: file confirmed — close settings modal, then show progress panel on top
+    closeSubPanel();
+    onClose();
+    startImport();
+    try {
+      await importBackupFromFile(fileInfo);
+      completeImport();
+    } catch (error) {
+      cancelImport();
       console.error('Import backup error:', error);
-      showDialog(
-        t('error') || 'Error',
-        error.message || t('restore_error') || 'Failed to restore backup',
-        [{ text: 'OK' }],
-      );
+      showDialog(t('error') || 'Error', error.message || t('restore_error') || 'Failed to restore backup', [{ text: 'OK' }]);
     }
   }, [closeSubPanel, onClose, startImport, completeImport, cancelImport, t, showDialog]);
 

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -1005,20 +1005,24 @@ const detectFileFormat = (filename) => {
  * Import backup from a file (auto-detects format)
  * @returns {Promise<Object>} Imported backup info
  */
-export const importBackup = async () => {
+export const pickImportFile = async () => {
+  const result = await DocumentPicker.getDocumentAsync({
+    type: '*/*',
+    copyToCacheDirectory: true,
+  });
+
+  if (result.canceled) {
+    throw new Error('Import cancelled');
+  }
+
+  return {
+    fileUri: result.assets[0].uri,
+    filename: result.assets[0].name || '',
+  };
+};
+
+export const importBackupFromFile = async ({ fileUri, filename }) => {
   try {
-    // Pick a document (allow all types)
-    const result = await DocumentPicker.getDocumentAsync({
-      type: '*/*',
-      copyToCacheDirectory: true,
-    });
-
-    if (result.canceled) {
-      throw new Error('Import cancelled');
-    }
-
-    const fileUri = result.assets[0].uri;
-    const filename = result.assets[0].name || '';
     console.log('Reading backup file:', fileUri, 'Name:', filename);
 
     // Detect format from filename
@@ -1041,7 +1045,6 @@ export const importBackup = async () => {
       break;
     case 'json':
     default: {
-      // Original JSON import
       appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'import', status: 'in_progress' });
       const fileContent = await FileSystem.readAsStringAsync(fileUri);
       try {
@@ -1060,6 +1063,11 @@ export const importBackup = async () => {
     console.error('Failed to import backup:', error);
     throw error;
   }
+};
+
+export const importBackup = async () => {
+  const fileInfo = await pickImportFile();
+  return importBackupFromFile(fileInfo);
 };
 
 /**


### PR DESCRIPTION
## Summary

- Import progress panel was rendering behind the settings modal (z-order bug)
- Tapping the Restore button twice before the native picker opened crashed with "Different document picking in progress"

## Root cause

`startImport()` was called before `await importBackup()`, so the progress modal appeared while the settings modal was still visible. Since both use react-native-paper Portal, the settings modal sat on top.

## Fix

Split `importBackup()` in BackupRestore.js into two exports:
- `pickImportFile()` — only the DocumentPicker call, throws `'Import cancelled'` on dismiss
- `importBackupFromFile(fileInfo)` — the actual format detection, parsing, and restore

`confirmImportBackup` now runs in two phases:
1. `await pickImportFile()` while settings modal is still open — cancel navigates back to source picker
2. On file confirmed: `closeSubPanel()` → `onClose()` → `startImport()` → `await importBackupFromFile()` — progress panel is now the only modal visible

Also adds an `importPickInProgress` ref guard to drop duplicate presses before the native picker opens.

`importBackup()` is kept as a one-liner combining both for any other callers.

## Changes

- **app/services/BackupRestore.js**: extract `pickImportFile` and `importBackupFromFile` exports
- **app/modals/SettingsModal.js**: two-phase `confirmImportBackup`; `importPickInProgress` ref guard
- **__tests__/modals/SettingsModal.test.js**: mock updated to `pickImportFile` + `importBackupFromFile`
