### PR TITLE
feat(graphs): animate income/expense card expand with corner-drag effect

### DIFF
--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -763,5 +763,17 @@ describe('GraphsScreen', () => {
       expect(getByTestId('income-summary-card')).toBeTruthy();
       expect(getByTestId('expense-summary-card')).toBeTruthy();
     });
+
+    it('handles switching directly from income expanded to expense', () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = render(<GraphsScreen />);
+
+      fireEvent.press(getByTestId('income-summary-card')); // expand income
+      fireEvent.press(getByTestId('expense-summary-card')); // switch to expense without collapsing
+
+      // Both cards still in tree
+      expect(getByTestId('income-summary-card')).toBeTruthy();
+      expect(getByTestId('expense-summary-card')).toBeTruthy();
+    });
   });
 });

--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 
 // Mock all dependencies
 jest.mock('react-native-chart-kit', () => ({
@@ -719,6 +719,49 @@ describe('GraphsScreen', () => {
 
       // Should fallback to default when currency not in currencies.json
       expect(() => render(<GraphsScreen />)).not.toThrow();
+    });
+  });
+
+  describe('Card Expansion', () => {
+    it('renders both summary cards on mount', () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = render(<GraphsScreen />);
+
+      expect(getByTestId('income-summary-card')).toBeTruthy();
+      expect(getByTestId('expense-summary-card')).toBeTruthy();
+    });
+
+    it('keeps expense card in tree after pressing income card', () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = render(<GraphsScreen />);
+
+      fireEvent.press(getByTestId('income-summary-card'));
+
+      // With the new always-mounted design, the expense card must still be in the tree
+      expect(getByTestId('expense-summary-card')).toBeTruthy();
+      expect(getByTestId('income-summary-card')).toBeTruthy();
+    });
+
+    it('keeps income card in tree after pressing expense card', () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = render(<GraphsScreen />);
+
+      fireEvent.press(getByTestId('expense-summary-card'));
+
+      expect(getByTestId('income-summary-card')).toBeTruthy();
+      expect(getByTestId('expense-summary-card')).toBeTruthy();
+    });
+
+    it('collapses back when pressing the expanded income card again', () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = render(<GraphsScreen />);
+
+      fireEvent.press(getByTestId('income-summary-card')); // expand
+      fireEvent.press(getByTestId('income-summary-card')); // collapse
+
+      // Both cards still present after collapse too
+      expect(getByTestId('income-summary-card')).toBeTruthy();
+      expect(getByTestId('expense-summary-card')).toBeTruthy();
     });
   });
 });

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { View, StyleSheet, ScrollView, TouchableOpacity, Platform, Animated, Easing, useWindowDimensions } from 'react-native';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { View, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -53,10 +54,16 @@ const GraphsScreen = () => {
   // Inline chart expansion state
   // null = neither expanded, 'income' | 'expense' = that card is expanded/expanding
   const [expandedCard, setExpandedCard] = useState(null);
-  // animValue: 0 = collapsed, 1 = expanded (drives width, height, opacity on JS thread)
-  const animValue = useRef(new Animated.Value(0)).current;
-  // chartContentAnim: 0 = hidden, 1 = visible (drives chart content on native thread)
-  const chartContentAnim = useRef(new Animated.Value(0)).current;
+  // Reanimated shared values — all run on UI thread, immune to JS contention
+  // 0=collapsed, 1=expanded; drives width/height/opacity interpolations
+  const animProgress = useSharedValue(0);
+  // 0=hidden, 1=visible; drives chart content opacity + slide
+  const chartProgress = useSharedValue(0);
+  // 0=none, 1=income expanding, 2=expense expanding
+  const expandingCard = useSharedValue(0);
+  // Dimension values updated on orientation change
+  const halfWidthSV = useSharedValue(halfWidth);
+  const rowWidthSV = useSharedValue(rowWidth);
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -382,98 +389,94 @@ const GraphsScreen = () => {
 
   const toggleCard = useCallback((card) => {
     if (expandedCard === card) {
-      // Collapse: fade chart content first (native thread), then shrink layout (JS thread)
-      Animated.parallel([
-        Animated.timing(chartContentAnim, {
-          toValue: 0,
-          duration: 150,
-          easing: Easing.in(Easing.quad),
-          useNativeDriver: true,
-        }),
-        Animated.timing(animValue, {
-          toValue: 0,
-          duration: 220,
-          easing: Easing.in(Easing.quad),
-          useNativeDriver: false,
-        }),
-      ]).start(() => setExpandedCard(null));
+      // Collapse: fade chart content (150ms), collapse layout (220ms), then clear state
+      chartProgress.value = withTiming(0, { duration: 150, easing: Easing.in(Easing.quad) });
+      animProgress.value = withTiming(0, { duration: 220, easing: Easing.in(Easing.quad) }, (finished) => {
+        if (finished) {
+          expandingCard.value = 0;
+          runOnJS(setExpandedCard)(null);
+        }
+      });
     } else {
-      // Expand: reset anim values, set the new expanded card, let useEffect trigger animation
-      animValue.setValue(0);
-      chartContentAnim.setValue(0);
+      // Expand: set direction, reset to 0, start both animations immediately
+      animProgress.value = 0;
+      chartProgress.value = 0;
+      expandingCard.value = card === 'income' ? 1 : 2;
       setExpandedCard(card);
+      animProgress.value = withTiming(1, { duration: 300, easing: Easing.out(Easing.cubic) });
+      chartProgress.value = withTiming(1, { duration: 260, easing: Easing.out(Easing.cubic) });
     }
-  }, [expandedCard, animValue, chartContentAnim]);
+  }, [expandedCard, animProgress, chartProgress, expandingCard]);
 
   const handleToggleIncome = useCallback(() => toggleCard('income'), [toggleCard]);
   const handleToggleExpense = useCallback(() => toggleCard('expense'), [toggleCard]);
 
-  // Trigger expand animation after expandedCard state and interpolations are in place
+  // Reset expansion and update dimension shared values on orientation change
   useEffect(() => {
-    if (expandedCard !== null) {
-      Animated.parallel([
-        Animated.timing(animValue, {
-          toValue: 1,
-          duration: 300,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: false,
-        }),
-        Animated.timing(chartContentAnim, {
-          toValue: 1,
-          duration: 260,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: true,
-        }),
-      ]).start();
-    }
-  }, [expandedCard]); // intentionally omit animValue/chartContentAnim — stable refs
-
-  // Reset expansion if screen dimensions change (orientation change) to avoid stale widths
-  useEffect(() => {
-    animValue.setValue(0);
-    chartContentAnim.setValue(0);
+    halfWidthSV.value = halfWidth;
+    rowWidthSV.value = rowWidth;
+    animProgress.value = 0;
+    chartProgress.value = 0;
+    expandingCard.value = 0;
     setExpandedCard(null);
-  }, [windowWidth]); // intentionally omit animValue/chartContentAnim — stable refs
+  }, [windowWidth]); // intentionally omit stable shared value refs
 
-  // Animated style values for the two card containers
-  const incomeCardAnimStyle = {
-    width: expandedCard === 'expense'
-      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, 0] })
-      : expandedCard === 'income'
-        ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, rowWidth - CARD_GAP] })
-        : halfWidth,
-    height: expandedCard === 'income'
-      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT] })
-      : CARD_HEADER_HEIGHT,
-    opacity: expandedCard === 'expense'
-      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [1, 0] })
-      : 1,
-  };
+  // Animated styles via Reanimated — all run on UI thread, no JS contention
+  const incomeCardAnimStyle = useAnimatedStyle(() => {
+    const ev = expandingCard.value;
+    const p = animProgress.value;
+    const hw = halfWidthSV.value;
+    const rw = rowWidthSV.value;
+    if (ev === 1) {
+      return {
+        width: interpolate(p, [0, 1], [hw, rw]),
+        height: interpolate(p, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT]),
+        opacity: 1,
+      };
+    }
+    if (ev === 2) {
+      return {
+        width: interpolate(p, [0, 1], [hw, 0]),
+        height: CARD_HEADER_HEIGHT,
+        opacity: interpolate(p, [0, 1], [1, 0]),
+      };
+    }
+    return { width: hw, height: CARD_HEADER_HEIGHT, opacity: 1 };
+  });
 
-  const expenseCardAnimStyle = {
-    width: expandedCard === 'income'
-      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, 0] })
-      : expandedCard === 'expense'
-        ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, rowWidth - CARD_GAP] })
-        : halfWidth,
-    height: expandedCard === 'expense'
-      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT] })
-      : CARD_HEADER_HEIGHT,
-    opacity: expandedCard === 'income'
-      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [1, 0] })
-      : 1,
-  };
+  const expenseCardAnimStyle = useAnimatedStyle(() => {
+    const ev = expandingCard.value;
+    const p = animProgress.value;
+    const hw = halfWidthSV.value;
+    const rw = rowWidthSV.value;
+    if (ev === 2) {
+      return {
+        width: interpolate(p, [0, 1], [hw, rw]),
+        height: interpolate(p, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT]),
+        opacity: 1,
+      };
+    }
+    if (ev === 1) {
+      return {
+        width: interpolate(p, [0, 1], [hw, 0]),
+        height: CARD_HEADER_HEIGHT,
+        opacity: interpolate(p, [0, 1], [1, 0]),
+      };
+    }
+    return { width: hw, height: CARD_HEADER_HEIGHT, opacity: 1 };
+  });
 
-  const spacerAnimStyle = {
-    width: expandedCard !== null
-      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_GAP, 0] })
-      : CARD_GAP,
-  };
+  const spacerAnimStyle = useAnimatedStyle(() => {
+    if (expandingCard.value !== 0) {
+      return { width: interpolate(animProgress.value, [0, 1], [CARD_GAP, 0]) };
+    }
+    return { width: CARD_GAP };
+  });
 
-  const chartContentAnimStyle = {
-    opacity: chartContentAnim,
-    transform: [{ translateY: chartContentAnim.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }) }],
-  };
+  const chartContentAnimStyle = useAnimatedStyle(() => ({
+    opacity: chartProgress.value,
+    transform: [{ translateY: interpolate(chartProgress.value, [0, 1], [16, 0]) }],
+  }));
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -405,6 +405,9 @@ const GraphsScreen = () => {
     }
   }, [expandedCard, animValue, chartContentAnim]);
 
+  const handleToggleIncome = useCallback(() => toggleCard('income'), [toggleCard]);
+  const handleToggleExpense = useCallback(() => toggleCard('expense'), [toggleCard]);
+
   // Trigger expand animation after expandedCard state and interpolations are in place
   useEffect(() => {
     if (expandedCard !== null) {
@@ -517,7 +520,7 @@ const GraphsScreen = () => {
                 loadingIncome={loadingIncome}
                 totalIncome={totalIncome}
                 selectedCurrency={selectedCurrency}
-                onPress={() => toggleCard('income')}
+                onPress={handleToggleIncome}
                 expanded={expandedCard === 'income'}
               />
               <Animated.View
@@ -573,7 +576,7 @@ const GraphsScreen = () => {
                 loading={loading}
                 totalExpenses={totalExpenses}
                 selectedCurrency={selectedCurrency}
-                onPress={() => toggleCard('expense')}
+                onPress={handleToggleExpense}
                 expanded={expandedCard === 'expense'}
               />
               <Animated.View

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -514,15 +514,17 @@ const GraphsScreen = () => {
                 { backgroundColor: colors.surface, borderColor: colors.border },
               ]}
             >
-              <IncomeSummaryCard
-                colors={colors}
-                t={t}
-                loadingIncome={loadingIncome}
-                totalIncome={totalIncome}
-                selectedCurrency={selectedCurrency}
-                onPress={handleToggleIncome}
-                expanded={expandedCard === 'income'}
-              />
+              <View style={styles.cardHeader}>
+                <IncomeSummaryCard
+                  colors={colors}
+                  t={t}
+                  loadingIncome={loadingIncome}
+                  totalIncome={totalIncome}
+                  selectedCurrency={selectedCurrency}
+                  onPress={handleToggleIncome}
+                  expanded={expandedCard === 'income'}
+                />
+              </View>
               <Animated.View
                 testID="income-chart-content"
                 style={[styles.chartContent, chartContentAnimStyle]}
@@ -570,15 +572,17 @@ const GraphsScreen = () => {
                 { backgroundColor: colors.surface, borderColor: colors.border },
               ]}
             >
-              <ExpenseSummaryCard
-                colors={colors}
-                t={t}
-                loading={loading}
-                totalExpenses={totalExpenses}
-                selectedCurrency={selectedCurrency}
-                onPress={handleToggleExpense}
-                expanded={expandedCard === 'expense'}
-              />
+              <View style={styles.cardHeader}>
+                <ExpenseSummaryCard
+                  colors={colors}
+                  t={t}
+                  loading={loading}
+                  totalExpenses={totalExpenses}
+                  selectedCurrency={selectedCurrency}
+                  onPress={handleToggleExpense}
+                  expanded={expandedCard === 'expense'}
+                />
+              </View>
               <Animated.View
                 testID="expense-chart-content"
                 style={[styles.chartContent, chartContentAnimStyle]}
@@ -660,9 +664,17 @@ const GraphsScreen = () => {
 };
 
 const styles = StyleSheet.create({
+  cardHeader: {
+    height: CARD_HEADER_HEIGHT,
+  },
   chartContent: {
+    bottom: 0,
+    left: 0,
     paddingBottom: 8,
     paddingHorizontal: 12,
+    position: 'absolute',
+    right: 0,
+    top: CARD_HEADER_HEIGHT,
   },
   chartNavBack: {
     marginRight: 8,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -532,35 +532,42 @@ const GraphsScreen = () => {
                 testID="income-chart-content"
                 style={[styles.chartContent, chartContentAnimStyle]}
               >
-                {selectedIncomeCategory !== 'all' && (
-                  <View style={styles.chartNavRow}>
-                    <TouchableOpacity
-                      onPress={handleBackToIncomeParent}
-                      style={styles.chartNavBack}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('back')}
-                    >
-                      <Icon name="arrow-left" size={20} color={colors.primary} />
-                    </TouchableOpacity>
-                    <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                      <SimplePicker
-                        value={selectedIncomeCategory}
-                        onValueChange={setSelectedIncomeCategory}
-                        items={incomeCategoryItems}
-                        colors={colors}
-                      />
+                <ScrollView
+                  style={styles.chartScrollView}
+                  contentContainerStyle={styles.chartScrollContent}
+                  nestedScrollEnabled
+                  showsVerticalScrollIndicator={false}
+                >
+                  {selectedIncomeCategory !== 'all' && (
+                    <View style={styles.chartNavRow}>
+                      <TouchableOpacity
+                        onPress={handleBackToIncomeParent}
+                        style={styles.chartNavBack}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('back')}
+                      >
+                        <Icon name="arrow-left" size={20} color={colors.primary} />
+                      </TouchableOpacity>
+                      <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                        <SimplePicker
+                          value={selectedIncomeCategory}
+                          onValueChange={setSelectedIncomeCategory}
+                          items={incomeCategoryItems}
+                          colors={colors}
+                        />
+                      </View>
                     </View>
-                  </View>
-                )}
-                <IncomePieChart
-                  colors={colors}
-                  t={t}
-                  loadingIncome={loadingIncome}
-                  incomeChartData={incomeChartData}
-                  selectedCurrency={selectedCurrency}
-                  onLegendItemPress={handleIncomeLegendItemPress}
-                  selectedIncomeCategory={selectedIncomeCategory}
-                />
+                  )}
+                  <IncomePieChart
+                    colors={colors}
+                    t={t}
+                    loadingIncome={loadingIncome}
+                    incomeChartData={incomeChartData}
+                    selectedCurrency={selectedCurrency}
+                    onLegendItemPress={handleIncomeLegendItemPress}
+                    selectedIncomeCategory={selectedIncomeCategory}
+                  />
+                </ScrollView>
               </Animated.View>
             </Animated.View>
 
@@ -590,35 +597,42 @@ const GraphsScreen = () => {
                 testID="expense-chart-content"
                 style={[styles.chartContent, chartContentAnimStyle]}
               >
-                {selectedCategory !== 'all' && (
-                  <View style={styles.chartNavRow}>
-                    <TouchableOpacity
-                      onPress={handleBackToExpenseParent}
-                      style={styles.chartNavBack}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('back')}
-                    >
-                      <Icon name="arrow-left" size={20} color={colors.primary} />
-                    </TouchableOpacity>
-                    <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                      <SimplePicker
-                        value={selectedCategory}
-                        onValueChange={setSelectedCategory}
-                        items={categoryItems}
-                        colors={colors}
-                      />
+                <ScrollView
+                  style={styles.chartScrollView}
+                  contentContainerStyle={styles.chartScrollContent}
+                  nestedScrollEnabled
+                  showsVerticalScrollIndicator={false}
+                >
+                  {selectedCategory !== 'all' && (
+                    <View style={styles.chartNavRow}>
+                      <TouchableOpacity
+                        onPress={handleBackToExpenseParent}
+                        style={styles.chartNavBack}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('back')}
+                      >
+                        <Icon name="arrow-left" size={20} color={colors.primary} />
+                      </TouchableOpacity>
+                      <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                        <SimplePicker
+                          value={selectedCategory}
+                          onValueChange={setSelectedCategory}
+                          items={categoryItems}
+                          colors={colors}
+                        />
+                      </View>
                     </View>
-                  </View>
-                )}
-                <ExpensePieChart
-                  colors={colors}
-                  t={t}
-                  loading={loading}
-                  chartData={chartData}
-                  selectedCurrency={selectedCurrency}
-                  onLegendItemPress={handleExpenseLegendItemPress}
-                  selectedCategory={selectedCategory}
-                />
+                  )}
+                  <ExpensePieChart
+                    colors={colors}
+                    t={t}
+                    loading={loading}
+                    chartData={chartData}
+                    selectedCurrency={selectedCurrency}
+                    onLegendItemPress={handleExpenseLegendItemPress}
+                    selectedCategory={selectedCategory}
+                  />
+                </ScrollView>
               </Animated.View>
             </Animated.View>
           </View>
@@ -673,8 +687,6 @@ const styles = StyleSheet.create({
   chartContent: {
     bottom: 0,
     left: 0,
-    paddingBottom: 8,
-    paddingHorizontal: 12,
     position: 'absolute',
     right: 0,
     top: CARD_HEADER_HEIGHT,
@@ -695,6 +707,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginBottom: 12,
     marginTop: 4,
+  },
+  chartScrollContent: {
+    paddingBottom: 8,
+    paddingHorizontal: 12,
+  },
+  chartScrollView: {
+    flex: 1,
   },
   container: {
     flex: 1,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { View, StyleSheet, ScrollView, TouchableOpacity, LayoutAnimation, UIManager, Platform, Animated, Easing } from 'react-native';
+import { View, StyleSheet, ScrollView, TouchableOpacity, Platform, Animated, Easing, useWindowDimensions } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -21,14 +21,18 @@ import useExpenseData from '../hooks/useExpenseData';
 import useIncomeData from '../hooks/useIncomeData';
 import useBalanceHistory from '../hooks/useBalanceHistory';
 
-if (Platform.OS === 'android') {
-  UIManager.setLayoutAnimationEnabledExperimental?.(true);
-}
+const CARD_HEADER_HEIGHT = 56;
+const CHART_HEIGHT = 300;
+const CARD_GAP = 8;
 
 const GraphsScreen = () => {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { accounts } = useAccountsData();
+
+  const { width: windowWidth } = useWindowDimensions();
+  const rowWidth = windowWidth - TOP_CONTENT_SPACING * 2;
+  const halfWidth = (rowWidth - CARD_GAP) / 2;
 
   // Get current month and year
   const now = new Date();
@@ -47,10 +51,12 @@ const GraphsScreen = () => {
   const [selectedAccount, setSelectedAccount] = useState(null);
 
   // Inline chart expansion state
-  const [incomeChartExpanded, setIncomeChartExpanded] = useState(false);
-  const [expenseChartExpanded, setExpenseChartExpanded] = useState(false);
-  const incomeChartAnim = useRef(new Animated.Value(0)).current;
-  const expenseChartAnim = useRef(new Animated.Value(0)).current;
+  // null = neither expanded, 'income' | 'expense' = that card is expanded/expanding
+  const [expandedCard, setExpandedCard] = useState(null);
+  // animValue: 0 = collapsed, 1 = expanded (drives width, height, opacity on JS thread)
+  const animValue = useRef(new Animated.Value(0)).current;
+  // chartContentAnim: 0 = hidden, 1 = visible (drives chart content on native thread)
+  const chartContentAnim = useRef(new Animated.Value(0)).current;
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -366,73 +372,105 @@ const GraphsScreen = () => {
     return category.parentId;
   }, [categories]);
 
-  // Income chart inline expansion
-  const toggleIncomeChart = useCallback(() => {
-    if (incomeChartExpanded) {
-      Animated.timing(incomeChartAnim, {
-        toValue: 0,
-        duration: 180,
-        easing: Easing.in(Easing.quad),
-        useNativeDriver: true,
-      }).start(() => {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-        setIncomeChartExpanded(false);
-      });
-    } else {
-      incomeChartAnim.setValue(0);
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-      setIncomeChartExpanded(true);
-    }
-  }, [incomeChartExpanded, incomeChartAnim]);
-
-  useEffect(() => {
-    if (incomeChartExpanded) {
-      Animated.timing(incomeChartAnim, {
-        toValue: 1,
-        duration: 300,
-        easing: Easing.out(Easing.cubic),
-        useNativeDriver: true,
-      }).start();
-    }
-  }, [incomeChartExpanded, incomeChartAnim]);
-
   const handleBackToIncomeParent = useCallback(() => {
     setSelectedIncomeCategory(prev => getParentCategoryId(prev));
   }, [getParentCategoryId]);
 
-  // Expense chart inline expansion
-  const toggleExpenseChart = useCallback(() => {
-    if (expenseChartExpanded) {
-      Animated.timing(expenseChartAnim, {
-        toValue: 0,
-        duration: 180,
-        easing: Easing.in(Easing.quad),
-        useNativeDriver: true,
-      }).start(() => {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-        setExpenseChartExpanded(false);
-      });
-    } else {
-      expenseChartAnim.setValue(0);
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-      setExpenseChartExpanded(true);
-    }
-  }, [expenseChartExpanded, expenseChartAnim]);
-
-  useEffect(() => {
-    if (expenseChartExpanded) {
-      Animated.timing(expenseChartAnim, {
-        toValue: 1,
-        duration: 300,
-        easing: Easing.out(Easing.cubic),
-        useNativeDriver: true,
-      }).start();
-    }
-  }, [expenseChartExpanded, expenseChartAnim]);
-
   const handleBackToExpenseParent = useCallback(() => {
     setSelectedCategory(prev => getParentCategoryId(prev));
   }, [getParentCategoryId]);
+
+  const toggleCard = useCallback((card) => {
+    if (expandedCard === card) {
+      // Collapse: fade chart content first (native thread), then shrink layout (JS thread)
+      Animated.parallel([
+        Animated.timing(chartContentAnim, {
+          toValue: 0,
+          duration: 150,
+          easing: Easing.in(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(animValue, {
+          toValue: 0,
+          duration: 220,
+          easing: Easing.in(Easing.quad),
+          useNativeDriver: false,
+        }),
+      ]).start(() => setExpandedCard(null));
+    } else {
+      // Expand: reset anim values, set the new expanded card, let useEffect trigger animation
+      animValue.setValue(0);
+      chartContentAnim.setValue(0);
+      setExpandedCard(card);
+    }
+  }, [expandedCard, animValue, chartContentAnim]);
+
+  // Trigger expand animation after expandedCard state and interpolations are in place
+  useEffect(() => {
+    if (expandedCard !== null) {
+      Animated.parallel([
+        Animated.timing(animValue, {
+          toValue: 1,
+          duration: 300,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: false,
+        }),
+        Animated.timing(chartContentAnim, {
+          toValue: 1,
+          duration: 260,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+  }, [expandedCard]); // intentionally omit animValue/chartContentAnim — stable refs
+
+  // Reset expansion if screen dimensions change (orientation change) to avoid stale widths
+  useEffect(() => {
+    animValue.setValue(0);
+    chartContentAnim.setValue(0);
+    setExpandedCard(null);
+  }, [windowWidth]); // intentionally omit animValue/chartContentAnim — stable refs
+
+  // Animated style values for the two card containers
+  const incomeCardAnimStyle = {
+    width: expandedCard === 'expense'
+      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, 0] })
+      : expandedCard === 'income'
+        ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, rowWidth - CARD_GAP] })
+        : halfWidth,
+    height: expandedCard === 'income'
+      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT] })
+      : CARD_HEADER_HEIGHT,
+    opacity: expandedCard === 'expense'
+      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [1, 0] })
+      : 1,
+  };
+
+  const expenseCardAnimStyle = {
+    width: expandedCard === 'income'
+      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, 0] })
+      : expandedCard === 'expense'
+        ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, rowWidth - CARD_GAP] })
+        : halfWidth,
+    height: expandedCard === 'expense'
+      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT] })
+      : CARD_HEADER_HEIGHT,
+    opacity: expandedCard === 'income'
+      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [1, 0] })
+      : 1,
+  };
+
+  const spacerAnimStyle = {
+    width: expandedCard !== null
+      ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_GAP, 0] })
+      : CARD_GAP,
+  };
+
+  const chartContentAnimStyle = {
+    opacity: chartContentAnim,
+    transform: [{ translateY: chartContentAnim.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }) }],
+  };
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -463,115 +501,116 @@ const GraphsScreen = () => {
             </View>
           </View>
 
-          {/* Summary Cards Row — one or both cards; expanded card goes full-width */}
+          {/* Summary Cards Row — always-mounted, width/height driven by Animated */}
           <View style={styles.summaryCardsRow}>
-            {/* Income card + chart (hidden when expense is expanded) */}
-            {!expenseChartExpanded && (
-              <View style={[styles.summaryCardContainer, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-                <IncomeSummaryCard
+            {/* Income card */}
+            <Animated.View
+              style={[
+                styles.summaryCardBase,
+                incomeCardAnimStyle,
+                { backgroundColor: colors.surface, borderColor: colors.border },
+              ]}
+            >
+              <IncomeSummaryCard
+                colors={colors}
+                t={t}
+                loadingIncome={loadingIncome}
+                totalIncome={totalIncome}
+                selectedCurrency={selectedCurrency}
+                onPress={() => toggleCard('income')}
+                expanded={expandedCard === 'income'}
+              />
+              <Animated.View
+                testID="income-chart-content"
+                style={[styles.chartContent, chartContentAnimStyle]}
+              >
+                {selectedIncomeCategory !== 'all' && (
+                  <View style={styles.chartNavRow}>
+                    <TouchableOpacity
+                      onPress={handleBackToIncomeParent}
+                      style={styles.chartNavBack}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('back')}
+                    >
+                      <Icon name="arrow-left" size={20} color={colors.primary} />
+                    </TouchableOpacity>
+                    <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                      <SimplePicker
+                        value={selectedIncomeCategory}
+                        onValueChange={setSelectedIncomeCategory}
+                        items={incomeCategoryItems}
+                        colors={colors}
+                      />
+                    </View>
+                  </View>
+                )}
+                <IncomePieChart
                   colors={colors}
                   t={t}
                   loadingIncome={loadingIncome}
-                  totalIncome={totalIncome}
+                  incomeChartData={incomeChartData}
                   selectedCurrency={selectedCurrency}
-                  onPress={toggleIncomeChart}
-                  expanded={incomeChartExpanded}
+                  onLegendItemPress={handleIncomeLegendItemPress}
+                  selectedIncomeCategory={selectedIncomeCategory}
                 />
-                {incomeChartExpanded && (
-                  <Animated.View style={[
-                    styles.chartContent,
-                    {
-                      opacity: incomeChartAnim,
-                      transform: [{ translateY: incomeChartAnim.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }) }],
-                    },
-                  ]}>
-                    {selectedIncomeCategory !== 'all' && (
-                      <View style={styles.chartNavRow}>
-                        <TouchableOpacity
-                          onPress={handleBackToIncomeParent}
-                          style={styles.chartNavBack}
-                          accessibilityRole="button"
-                          accessibilityLabel={t('back')}
-                        >
-                          <Icon name="arrow-left" size={20} color={colors.primary} />
-                        </TouchableOpacity>
-                        <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                          <SimplePicker
-                            value={selectedIncomeCategory}
-                            onValueChange={setSelectedIncomeCategory}
-                            items={incomeCategoryItems}
-                            colors={colors}
-                          />
-                        </View>
-                      </View>
-                    )}
-                    <IncomePieChart
-                      colors={colors}
-                      t={t}
-                      loadingIncome={loadingIncome}
-                      incomeChartData={incomeChartData}
-                      selectedCurrency={selectedCurrency}
-                      onLegendItemPress={handleIncomeLegendItemPress}
-                      selectedIncomeCategory={selectedIncomeCategory}
-                    />
-                  </Animated.View>
-                )}
-              </View>
-            )}
+              </Animated.View>
+            </Animated.View>
 
-            {/* Expense card + chart (hidden when income is expanded) */}
-            {!incomeChartExpanded && (
-              <View style={[styles.summaryCardContainer, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-                <ExpenseSummaryCard
+            {/* Spacer that collapses as one card expands */}
+            <Animated.View style={spacerAnimStyle} />
+
+            {/* Expense card */}
+            <Animated.View
+              style={[
+                styles.summaryCardBase,
+                expenseCardAnimStyle,
+                { backgroundColor: colors.surface, borderColor: colors.border },
+              ]}
+            >
+              <ExpenseSummaryCard
+                colors={colors}
+                t={t}
+                loading={loading}
+                totalExpenses={totalExpenses}
+                selectedCurrency={selectedCurrency}
+                onPress={() => toggleCard('expense')}
+                expanded={expandedCard === 'expense'}
+              />
+              <Animated.View
+                testID="expense-chart-content"
+                style={[styles.chartContent, chartContentAnimStyle]}
+              >
+                {selectedCategory !== 'all' && (
+                  <View style={styles.chartNavRow}>
+                    <TouchableOpacity
+                      onPress={handleBackToExpenseParent}
+                      style={styles.chartNavBack}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('back')}
+                    >
+                      <Icon name="arrow-left" size={20} color={colors.primary} />
+                    </TouchableOpacity>
+                    <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+                      <SimplePicker
+                        value={selectedCategory}
+                        onValueChange={setSelectedCategory}
+                        items={categoryItems}
+                        colors={colors}
+                      />
+                    </View>
+                  </View>
+                )}
+                <ExpensePieChart
                   colors={colors}
                   t={t}
                   loading={loading}
-                  totalExpenses={totalExpenses}
+                  chartData={chartData}
                   selectedCurrency={selectedCurrency}
-                  onPress={toggleExpenseChart}
-                  expanded={expenseChartExpanded}
+                  onLegendItemPress={handleExpenseLegendItemPress}
+                  selectedCategory={selectedCategory}
                 />
-                {expenseChartExpanded && (
-                  <Animated.View style={[
-                    styles.chartContent,
-                    {
-                      opacity: expenseChartAnim,
-                      transform: [{ translateY: expenseChartAnim.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }) }],
-                    },
-                  ]}>
-                    {selectedCategory !== 'all' && (
-                      <View style={styles.chartNavRow}>
-                        <TouchableOpacity
-                          onPress={handleBackToExpenseParent}
-                          style={styles.chartNavBack}
-                          accessibilityRole="button"
-                          accessibilityLabel={t('back')}
-                        >
-                          <Icon name="arrow-left" size={20} color={colors.primary} />
-                        </TouchableOpacity>
-                        <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                          <SimplePicker
-                            value={selectedCategory}
-                            onValueChange={setSelectedCategory}
-                            items={categoryItems}
-                            colors={colors}
-                          />
-                        </View>
-                      </View>
-                    )}
-                    <ExpensePieChart
-                      colors={colors}
-                      t={t}
-                      loading={loading}
-                      chartData={chartData}
-                      selectedCurrency={selectedCurrency}
-                      onLegendItemPress={handleExpenseLegendItemPress}
-                      selectedCategory={selectedCategory}
-                    />
-                  </Animated.View>
-                )}
-              </View>
-            )}
+              </Animated.View>
+            </Animated.View>
           </View>
 
           {/* Balance History Card */}
@@ -671,15 +710,13 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
   },
-  summaryCardContainer: {
+  summaryCardBase: {
     borderRadius: 14,
     borderWidth: 1,
-    flex: 1,
     overflow: 'hidden',
   },
   summaryCardsRow: {
     flexDirection: 'row',
-    gap: 8,
     marginBottom: 16,
   },
 });

--- a/docs/superpowers/plans/2026-05-10-income-expense-card-expand-animation.md
+++ b/docs/superpowers/plans/2026-05-10-income-expense-card-expand-animation.md
@@ -1,0 +1,530 @@
+# Income/Expense Card Expansion Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the instant-disappear card expand behavior with a simultaneous width+height "corner-drag" animation, where the non-selected card fades and collapses to zero width while the selected card grows to fill the row.
+
+**Architecture:** All changes are confined to `GraphsScreen.js`. Both summary cards are always mounted (no conditional render). A single `animValue` (0→1) drives width, height, and opacity interpolations via the JS thread (required for layout properties). A second `chartContentAnim` drives the chart content fade-in on the native thread. A dedicated spacer `Animated.View` between the two cards collapses from 8→0 to keep row width consistent as one card expands.
+
+**Tech Stack:** React Native `Animated` API, `useWindowDimensions`, `Easing` — all already imported in `GraphsScreen.js`. No new dependencies.
+
+---
+
+## Constants
+
+These values are used throughout. Define them at the top of the module (outside the component):
+
+```js
+const CARD_HEADER_HEIGHT = 56; // height of summary card header row (icon + amount + chevron)
+const CHART_HEIGHT = 300;      // height of expanded chart area (tune after visual review)
+const CARD_GAP = 8;            // gap between the two cards (matches summaryCardsRow gap)
+```
+
+## Row width calculation
+
+Inside the component, after `useWindowDimensions`:
+
+```js
+const { width: windowWidth } = useWindowDimensions();
+// TOP_CONTENT_SPACING = 8 (from designTokens), applied as padding on both sides
+const rowWidth = windowWidth - TOP_CONTENT_SPACING * 2;
+const halfWidth = (rowWidth - CARD_GAP) / 2;
+```
+
+The spacer between cards animates `CARD_GAP → 0`, the selected card animates `halfWidth → rowWidth - CARD_GAP`, and the other card animates `halfWidth → 0`. At all `animValue` values: `w1 + spacer + w2 = rowWidth`.
+
+---
+
+## Files
+
+- **Modify:** `app/screens/GraphsScreen.js` — all animation logic changes
+- **Modify:** `__tests__/screens/GraphsScreen.test.js` — add behavioral regression tests
+
+---
+
+## Task 1: Write failing regression tests
+
+**Files:**
+- Modify: `__tests__/screens/GraphsScreen.test.js`
+
+The current code conditionally renders each card when the other is expanded (`{!incomeChartExpanded && ...}`). These tests assert the new always-mounted behavior — they will fail against the current code.
+
+- [ ] **Step 1.1: Add the `Card Expansion` describe block to the existing test file**
+
+Open `__tests__/screens/GraphsScreen.test.js`. Find the closing `});` of the outermost `describe('GraphsScreen', ...)` block. Insert this block just before it:
+
+```js
+describe('Card Expansion', () => {
+  it('renders both summary cards on mount', () => {
+    const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+    const { getByTestId } = render(<GraphsScreen />);
+
+    expect(getByTestId('income-summary-card')).toBeTruthy();
+    expect(getByTestId('expense-summary-card')).toBeTruthy();
+  });
+
+  it('keeps expense card in tree after pressing income card', () => {
+    const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+    const { getByTestId } = render(<GraphsScreen />);
+
+    fireEvent.press(getByTestId('income-summary-card'));
+
+    // With the new always-mounted design, the expense card must still be in the tree
+    expect(getByTestId('expense-summary-card')).toBeTruthy();
+    expect(getByTestId('income-summary-card')).toBeTruthy();
+  });
+
+  it('keeps income card in tree after pressing expense card', () => {
+    const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+    const { getByTestId } = render(<GraphsScreen />);
+
+    fireEvent.press(getByTestId('expense-summary-card'));
+
+    expect(getByTestId('income-summary-card')).toBeTruthy();
+    expect(getByTestId('expense-summary-card')).toBeTruthy();
+  });
+
+  it('collapses back when pressing the expanded income card again', () => {
+    const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+    const { getByTestId } = render(<GraphsScreen />);
+
+    fireEvent.press(getByTestId('income-summary-card')); // expand
+    fireEvent.press(getByTestId('income-summary-card')); // collapse
+
+    // Both cards still present after collapse too
+    expect(getByTestId('income-summary-card')).toBeTruthy();
+    expect(getByTestId('expense-summary-card')).toBeTruthy();
+  });
+});
+```
+
+Also add `fireEvent` to the import at the top of the test file (it's already imported — confirm it's in the destructure of `@testing-library/react-native`).
+
+- [ ] **Step 1.2: Run the new tests to confirm they fail**
+
+```bash
+npm test -- --silent --testPathPattern="GraphsScreen"
+```
+
+Expected: the two "keeps X card in tree after pressing Y card" tests fail with "Unable to find an element with testId: expense-summary-card" (or income). The "renders both" test may pass already. The "collapses back" test may pass or fail. Document the actual failures — all four should pass after implementation.
+
+---
+
+## Task 2: Replace state and animation refs
+
+**Files:**
+- Modify: `app/screens/GraphsScreen.js:50-53` (current state declarations)
+
+- [ ] **Step 2.1: Replace the two boolean states and two Animated.Values with the new unified state**
+
+Find this block (lines ~50-53):
+
+```js
+// Inline chart expansion state
+const [incomeChartExpanded, setIncomeChartExpanded] = useState(false);
+const [expenseChartExpanded, setExpenseChartExpanded] = useState(false);
+const incomeChartAnim = useRef(new Animated.Value(0)).current;
+const expenseChartAnim = useRef(new Animated.Value(0)).current;
+```
+
+Replace with:
+
+```js
+// Inline chart expansion state
+// null = neither expanded, 'income' | 'expense' = that card is expanded/expanding
+const [expandedCard, setExpandedCard] = useState(null);
+// animValue: 0 = collapsed, 1 = expanded (drives width, height, opacity on JS thread)
+const animValue = useRef(new Animated.Value(0)).current;
+// chartContentAnim: 0 = hidden, 1 = visible (drives chart content on native thread)
+const chartContentAnim = useRef(new Animated.Value(0)).current;
+```
+
+- [ ] **Step 2.2: Add `useWindowDimensions` to the React import and the hook call**
+
+Find the import line at the top:
+```js
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+```
+Add `useWindowDimensions` after `useRef`:
+```js
+import React, { useState, useEffect, useCallback, useMemo, useRef, useWindowDimensions } from 'react';
+```
+
+Then, near the top of the component body (right after the context hooks, before the `selectedPeriod` state), add:
+
+```js
+const { width: windowWidth } = useWindowDimensions();
+const rowWidth = windowWidth - TOP_CONTENT_SPACING * 2;
+const halfWidth = (rowWidth - CARD_GAP) / 2;
+```
+
+- [ ] **Step 2.3: Add the three constants above the component function**
+
+Just before `const GraphsScreen = () => {`, add:
+
+```js
+const CARD_HEADER_HEIGHT = 56;
+const CHART_HEIGHT = 300;
+const CARD_GAP = 8;
+```
+
+---
+
+## Task 3: Implement the `toggleCard` handler
+
+**Files:**
+- Modify: `app/screens/GraphsScreen.js` — replace `toggleIncomeChart` and `toggleExpenseChart`
+
+- [ ] **Step 3.1: Remove the four old handlers and their trigger useEffects**
+
+Delete these functions and their associated `useEffect`s entirely:
+- `toggleIncomeChart` (the `useCallback` block)
+- `useEffect` that watches `incomeChartExpanded` to start `incomeChartAnim`
+- `handleBackToIncomeParent` — KEEP THIS (it's independent of the animation)
+- `toggleExpenseChart` (the `useCallback` block)
+- `useEffect` that watches `expenseChartExpanded` to start `expenseChartAnim`
+- `handleBackToExpenseParent` — KEEP THIS
+
+The handlers to keep unchanged:
+```js
+const handleBackToIncomeParent = useCallback(() => {
+  setSelectedIncomeCategory(prev => getParentCategoryId(prev));
+}, [getParentCategoryId]);
+
+const handleBackToExpenseParent = useCallback(() => {
+  setSelectedCategory(prev => getParentCategoryId(prev));
+}, [getParentCategoryId]);
+```
+
+- [ ] **Step 3.2: Add the unified `toggleCard` handler and its trigger `useEffect`**
+
+Add after `handleBackToExpenseParent`:
+
+```js
+const toggleCard = useCallback((card) => {
+  if (expandedCard === card) {
+    // Collapse: fade chart content first (native thread), then shrink layout (JS thread)
+    Animated.parallel([
+      Animated.timing(chartContentAnim, {
+        toValue: 0,
+        duration: 150,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(animValue, {
+        toValue: 0,
+        duration: 220,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: false,
+      }),
+    ]).start(() => setExpandedCard(null));
+  } else {
+    // Expand: reset anim values, set the new expanded card, let useEffect trigger animation
+    animValue.setValue(0);
+    chartContentAnim.setValue(0);
+    setExpandedCard(card);
+  }
+}, [expandedCard, animValue, chartContentAnim]);
+
+// Trigger expand animation after expandedCard state and interpolations are in place
+useEffect(() => {
+  if (expandedCard !== null) {
+    Animated.parallel([
+      Animated.timing(animValue, {
+        toValue: 1,
+        duration: 300,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: false,
+      }),
+      Animated.timing(chartContentAnim, {
+        toValue: 1,
+        duration: 260,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }
+}, [expandedCard]); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+Note: `animValue` and `chartContentAnim` are refs (stable references), so omitting them from the dep array is intentional and safe. The `eslint-disable` comment suppresses the exhaustive-deps warning.
+
+---
+
+## Task 4: Handle dimension change edge case
+
+**Files:**
+- Modify: `app/screens/GraphsScreen.js`
+
+- [ ] **Step 4.1: Reset animation state when window dimensions change**
+
+Add this `useEffect` after the toggle handler (after the expand animation `useEffect`):
+
+```js
+// Reset expansion if screen dimensions change (orientation change) to avoid stale widths
+useEffect(() => {
+  animValue.setValue(0);
+  chartContentAnim.setValue(0);
+  setExpandedCard(null);
+}, [windowWidth]); // eslint-disable-line react-hooks/exhaustive-deps
+```
+
+---
+
+## Task 5: Replace card container JSX
+
+**Files:**
+- Modify: `app/screens/GraphsScreen.js:466-575` (the `summaryCardsRow` section)
+
+This is the core visual change. Replace the entire `{/* Summary Cards Row */}` section.
+
+- [ ] **Step 5.1: Compute the animated style values as local variables before the JSX return**
+
+Add these just before the `return (` statement:
+
+```js
+// Animated style values for the two card containers
+// These are computed each render; Animated.Value.interpolate() is cheap
+const incomeCardAnimStyle = {
+  width: expandedCard === 'expense'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, 0] })
+    : expandedCard === 'income'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, rowWidth - CARD_GAP] })
+    : halfWidth,
+  height: expandedCard === 'income'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT] })
+    : CARD_HEADER_HEIGHT,
+  opacity: expandedCard === 'expense'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [1, 0] })
+    : 1,
+};
+
+const expenseCardAnimStyle = {
+  width: expandedCard === 'income'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, 0] })
+    : expandedCard === 'expense'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, rowWidth - CARD_GAP] })
+    : halfWidth,
+  height: expandedCard === 'expense'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT] })
+    : CARD_HEADER_HEIGHT,
+  opacity: expandedCard === 'income'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [1, 0] })
+    : 1,
+};
+
+const spacerAnimStyle = {
+  width: expandedCard !== null
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [CARD_GAP, 0] })
+    : CARD_GAP,
+};
+
+const chartContentAnimStyle = {
+  opacity: chartContentAnim,
+  transform: [{ translateY: chartContentAnim.interpolate({ inputRange: [0, 1], outputRange: [16, 0] }) }],
+};
+```
+
+- [ ] **Step 5.2: Replace the summaryCardsRow JSX**
+
+Find the `{/* Summary Cards Row — one or both cards; expanded card goes full-width */}` comment and replace everything from that comment to the closing `</View>` of `summaryCardsRow` with:
+
+```jsx
+{/* Summary Cards Row — always-mounted, width/height driven by Animated */}
+<View style={styles.summaryCardsRow}>
+  {/* Income card */}
+  <Animated.View
+    style={[
+      styles.summaryCardBase,
+      incomeCardAnimStyle,
+      { backgroundColor: colors.surface, borderColor: colors.border },
+    ]}
+  >
+    <IncomeSummaryCard
+      colors={colors}
+      t={t}
+      loadingIncome={loadingIncome}
+      totalIncome={totalIncome}
+      selectedCurrency={selectedCurrency}
+      onPress={() => toggleCard('income')}
+      expanded={expandedCard === 'income'}
+    />
+    <Animated.View
+      testID="income-chart-content"
+      style={[styles.chartContent, chartContentAnimStyle]}
+    >
+      {selectedIncomeCategory !== 'all' && (
+        <View style={styles.chartNavRow}>
+          <TouchableOpacity
+            onPress={handleBackToIncomeParent}
+            style={styles.chartNavBack}
+            accessibilityRole="button"
+            accessibilityLabel={t('back')}
+          >
+            <Icon name="arrow-left" size={20} color={colors.primary} />
+          </TouchableOpacity>
+          <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+            <SimplePicker
+              value={selectedIncomeCategory}
+              onValueChange={setSelectedIncomeCategory}
+              items={incomeCategoryItems}
+              colors={colors}
+            />
+          </View>
+        </View>
+      )}
+      <IncomePieChart
+        colors={colors}
+        t={t}
+        loadingIncome={loadingIncome}
+        incomeChartData={incomeChartData}
+        selectedCurrency={selectedCurrency}
+        onLegendItemPress={handleIncomeLegendItemPress}
+        selectedIncomeCategory={selectedIncomeCategory}
+      />
+    </Animated.View>
+  </Animated.View>
+
+  {/* Spacer that collapses as one card expands */}
+  <Animated.View style={spacerAnimStyle} />
+
+  {/* Expense card */}
+  <Animated.View
+    style={[
+      styles.summaryCardBase,
+      expenseCardAnimStyle,
+      { backgroundColor: colors.surface, borderColor: colors.border },
+    ]}
+  >
+    <ExpenseSummaryCard
+      colors={colors}
+      t={t}
+      loading={loading}
+      totalExpenses={totalExpenses}
+      selectedCurrency={selectedCurrency}
+      onPress={() => toggleCard('expense')}
+      expanded={expandedCard === 'expense'}
+    />
+    <Animated.View
+      testID="expense-chart-content"
+      style={[styles.chartContent, chartContentAnimStyle]}
+    >
+      {selectedCategory !== 'all' && (
+        <View style={styles.chartNavRow}>
+          <TouchableOpacity
+            onPress={handleBackToExpenseParent}
+            style={styles.chartNavBack}
+            accessibilityRole="button"
+            accessibilityLabel={t('back')}
+          >
+            <Icon name="arrow-left" size={20} color={colors.primary} />
+          </TouchableOpacity>
+          <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
+            <SimplePicker
+              value={selectedCategory}
+              onValueChange={setSelectedCategory}
+              items={categoryItems}
+              colors={colors}
+            />
+          </View>
+        </View>
+      )}
+      <ExpensePieChart
+        colors={colors}
+        t={t}
+        loading={loading}
+        chartData={chartData}
+        selectedCurrency={selectedCurrency}
+        onLegendItemPress={handleExpenseLegendItemPress}
+        selectedCategory={selectedCategory}
+      />
+    </Animated.View>
+  </Animated.View>
+</View>
+```
+
+---
+
+## Task 6: Update StyleSheet
+
+**Files:**
+- Modify: `app/screens/GraphsScreen.js` — the `StyleSheet.create` block
+
+- [ ] **Step 6.1: Replace `summaryCardContainer` with `summaryCardBase` and update `summaryCardsRow`**
+
+In `StyleSheet.create`, find and replace:
+
+```js
+summaryCardContainer: {
+  borderRadius: 14,
+  borderWidth: 1,
+  flex: 1,
+  overflow: 'hidden',
+},
+summaryCardsRow: {
+  flexDirection: 'row',
+  gap: 8,
+  marginBottom: 16,
+},
+```
+
+With:
+
+```js
+summaryCardBase: {
+  borderRadius: 14,
+  borderWidth: 1,
+  overflow: 'hidden',
+  // width and height are driven by Animated.Value — no flex: 1
+},
+summaryCardsRow: {
+  flexDirection: 'row',
+  marginBottom: 16,
+  // gap removed — spacing handled by the animated spacer View between cards
+},
+```
+
+---
+
+## Task 7: Run tests and verify
+
+- [ ] **Step 7.1: Run the full test suite silently**
+
+```bash
+npm test -- --silent
+```
+
+Expected: all tests pass including the four new `Card Expansion` tests. If any test fails:
+- "Unable to find an element with testId" — check that the `Animated.View` has the correct `testID` prop
+- Animation-related errors — check that `useNativeDriver: false` is set on width/height animations
+- "expandedCard is not defined" — check the state declaration replaced correctly in Task 2
+
+- [ ] **Step 7.2: Run just the GraphsScreen tests to verify the new suite**
+
+```bash
+npm test -- --silent --testPathPattern="GraphsScreen"
+```
+
+Expected output: `Tests: 4 passed` (the new Card Expansion tests) plus all pre-existing tests passing.
+
+---
+
+## Task 8: Commit
+
+- [ ] **Step 8.1: Stage and commit**
+
+```bash
+git add app/screens/GraphsScreen.js __tests__/screens/GraphsScreen.test.js
+git commit -m "feat(graphs): animate income/expense card expand with corner-drag effect"
+```
+
+---
+
+## Self-Review Notes
+
+- `incomeChartAnim` and `expenseChartAnim` are fully removed — replaced by `animValue` and `chartContentAnim`
+- `LayoutAnimation` import removed from the `import` line (`LayoutAnimation` and `UIManager` should be removed if no longer used elsewhere in the file — check for other usages before removing)
+- `toggleIncomeChart`, `toggleExpenseChart`, and their `useEffect` triggers are removed
+- `incomeChartExpanded`, `expenseChartExpanded` are removed everywhere including the JSX conditionals
+- `expanded={expandedCard === 'income'}` / `expanded={expandedCard === 'expense'}` replace the old boolean props
+- The `income` and `expense` chart content `Animated.View`s share the same `chartContentAnim` — this is intentional since only one can be open at a time. Both always render but only the open one is visible (the other is clipped by parent `overflow: 'hidden'` and has opacity 0 from `chartContentAnim` being at 0 when `expandedCard` is not set for that card... wait — this is actually a bug: when income is expanded and expense is not, `chartContentAnim` is at 1, which means BOTH chart content views have opacity 1. But the expense chart content is clipped by the expense card's height being `CARD_HEADER_HEIGHT`, so it's invisible. This is correct behavior — `overflow: 'hidden'` on the parent clips the chart content when height is at `CARD_HEADER_HEIGHT`.)

--- a/docs/superpowers/specs/2026-05-10-income-expense-card-expand-animation-design.md
+++ b/docs/superpowers/specs/2026-05-10-income-expense-card-expand-animation-design.md
@@ -1,0 +1,168 @@
+# Income/Expense Card Expansion Animation Redesign
+
+**Date:** 2026-05-10  
+**Branch:** feat/income-expence-chart-ui-improvements  
+**Scope:** `GraphsScreen.js` only — summary card components unchanged
+
+---
+
+## Problem
+
+The current expand behavior is abrupt:
+
+- The non-selected card **instantly disappears** via conditional render
+- The selected card grows **vertically only** via `LayoutAnimation`
+- No width transition — the expanded card snaps to full width
+
+The desired feel is a **corner-drag resize**: both width and height animate simultaneously, while the other card fades and collapses out of the way.
+
+---
+
+## Design
+
+### Approach: Fade + Full Collapse (Approach C)
+
+When one card is tapped to expand:
+
+1. The **other card** fades out (`opacity: 1 → 0`) while its width collapses to `0`
+2. The **selected card** simultaneously grows in width (half-row → full row) and height (header-only → header + chart)
+3. On tap again to collapse, the animation **reverses** — selected card shrinks, other card fades back in
+
+Both cards remain **always mounted**. No conditional render during or after animation.
+
+---
+
+## Animation Values
+
+A single `animValue` (`Animated.Value`, 0=collapsed, 1=expanded) drives all four properties in one `Animated.parallel`:
+
+| Property | Collapsed (0) | Expanded (1) |
+|---|---|---|
+| Selected card `width` | `(rowWidth - GAP) / 2` | `rowWidth` |
+| Selected card `height` | `56` | `56 + CHART_HEIGHT` |
+| Other card `width` | `(rowWidth - GAP) / 2` | `0` |
+| Other card `opacity` | `1` | `0` |
+
+- `rowWidth` = `windowWidth - HORIZONTAL_PADDING * 2` (from `useWindowDimensions`, calculated once at render)
+- `GAP` = `8` (matches `summaryCardsRow` gap)
+- `CHART_HEIGHT` = `300` (fixed — pie charts are a consistent size; user can tune after seeing it)
+- `HORIZONTAL_PADDING` = value of `TOP_CONTENT_SPACING` used in `styles.content`
+
+All four properties use `useNativeDriver: false` (required for layout properties).
+
+### Timing and Easing
+
+| Direction | Duration | Easing |
+|---|---|---|
+| Expand | 300ms | `Easing.out(Easing.cubic)` |
+| Collapse | 220ms | `Easing.in(Easing.quad)` |
+
+### Chart Content (secondary animation)
+
+The chart content (pie chart + nav row inside the expanded card) gets its own `Animated.Value` (`chartContentAnim`) for `opacity` and `translateY`. This runs on **native driver** (`useNativeDriver: true`), decoupled from the layout animation.
+
+- Fade in: `opacity: 0 → 1`, `translateY: 16 → 0`, duration 260ms, `Easing.out(Easing.cubic)`
+- Fade out: `opacity: 1 → 0`, duration 150ms, `Easing.in(Easing.quad)` — kicked off at collapse start, before width shrinks
+
+To achieve visual stagger without a `delay` node (which breaks `useNativeDriver`): use asymmetric durations inside `Animated.parallel`. Chart content fade-in runs at 260ms while layout runs at 300ms — content appears to trail slightly behind the resize.
+
+---
+
+## State Changes in GraphsScreen.js
+
+### Before
+
+```js
+const [incomeChartExpanded, setIncomeChartExpanded] = useState(false);
+const [expenseChartExpanded, setExpenseChartExpanded] = useState(false);
+const incomeChartAnim = useRef(new Animated.Value(0)).current;
+const expenseChartAnim = useRef(new Animated.Value(0)).current;
+```
+
+Two booleans, two anim values, two toggle handlers, two `useEffect`s for triggering animation, conditional render for each card.
+
+### After
+
+```js
+const [expandedCard, setExpandedCard] = useState(null); // null | 'income' | 'expense'
+const animValue = useRef(new Animated.Value(0)).current;
+const chartContentAnim = useRef(new Animated.Value(0)).current;
+```
+
+One state value, two anim values (layout + content), one toggle handler, no conditional render.
+
+### Toggle Handler
+
+```js
+const toggleCard = useCallback((card) => {
+  const isExpanding = expandedCard !== card;
+
+  if (isExpanding) {
+    // Fade out chart content if switching cards (edge case: shouldn't happen with mutual exclusion)
+    chartContentAnim.setValue(0);
+    setExpandedCard(card);
+    Animated.parallel([
+      Animated.timing(animValue, { toValue: 1, duration: 300, easing: Easing.out(Easing.cubic), useNativeDriver: false }),
+      Animated.timing(chartContentAnim, { toValue: 1, duration: 260, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+    ]).start();
+  } else {
+    Animated.parallel([
+      Animated.timing(chartContentAnim, { toValue: 0, duration: 150, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+      Animated.timing(animValue, { toValue: 0, duration: 220, easing: Easing.in(Easing.quad), useNativeDriver: false }),
+    ]).start(() => setExpandedCard(null));
+  }
+}, [expandedCard, animValue, chartContentAnim]);
+```
+
+### Interpolated Styles
+
+```js
+const { width: windowWidth } = useWindowDimensions();
+const rowWidth = windowWidth - TOP_CONTENT_SPACING * 2;
+const halfWidth = (rowWidth - 8) / 2;
+const CHART_HEIGHT = 300;
+const HEADER_HEIGHT = 56;
+
+// For the income card when income is expanded:
+const incomeCardStyle = {
+  width: expandedCard === 'expense'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, 0] })
+    : expandedCard === 'income'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [halfWidth, rowWidth] })
+    : halfWidth,
+  height: expandedCard === 'income'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [HEADER_HEIGHT, HEADER_HEIGHT + CHART_HEIGHT] })
+    : HEADER_HEIGHT,
+  opacity: expandedCard === 'expense'
+    ? animValue.interpolate({ inputRange: [0, 1], outputRange: [1, 0] })
+    : 1,
+};
+// Mirror for expense card
+```
+
+---
+
+## Layout Changes
+
+- `summaryCardContainer` loses `flex: 1` — width is now driven by `Animated.Value`
+- `summaryCardsRow` keeps `flexDirection: 'row'` and `gap: 8` — but gap only applies when both cards have non-zero width
+- Both card wrappers become `Animated.View` instead of `View`
+- Chart content stays inside the same card wrapper, always rendered, visibility controlled by `chartContentAnim`
+
+---
+
+## What Doesn't Change
+
+- `ExpenseSummaryCard.js` — no changes
+- `IncomeSummaryCard.js` — no changes
+- Chart components (`IncomePieChart`, `ExpensePieChart`) — no changes
+- Category nav row (back arrow + picker) — same JSX, just wrapped differently
+- All filter/picker logic — untouched
+
+---
+
+## Edge Cases
+
+- **Switching directly from one expanded card to the other**: collapse animValue to 0 first (150ms), then expand. Keep it simple — don't try to animate the switch in one move.
+- **Window resize / orientation change**: `useWindowDimensions` re-triggers a render with updated `rowWidth`. If a card is expanded, reset `animValue` to 0 and `expandedCard` to null on dimension change to avoid stale width interpolations.
+- **hideBalances**: no impact on animation


### PR DESCRIPTION
## Summary

- Redesigns the income/expense summary card expand behavior: tapping a card now animates width + height simultaneously (corner-drag feel) while the other card fades out and collapses its width to zero
- Switches all card expansion animations from the JS-thread `Animated` API to **React Native Reanimated** (`useSharedValue` + `useAnimatedStyle` + `withTiming`), eliminating frame drops caused by chart rendering on the JS thread
- Fixes absolute positioning of chart content inside expanded cards so the card border grows correctly

## Changes

- `app/screens/GraphsScreen.js` — full animation rewrite:
  - Replaced `Animated.Value` refs with Reanimated `useSharedValue` (`animProgress`, `chartProgress`, `expandingCard`, dimension SVs)
  - Replaced computed animated style objects with `useAnimatedStyle` worklets running on the UI thread
  - Single `toggleCard` handler drives both expand (300ms cubic-out) and collapse (220ms quad-in) with correct sequencing
  - Removed `useEffect`-triggered animation; `withTiming` now starts synchronously in the handler
  - Fixed expanded card width: was `rowWidth - CARD_GAP`, now correctly `rowWidth`
  - Added `position: absolute` chart content with `cardHeader` wrapper to prevent flex layout conflict
- `__tests__/screens/GraphsScreen.test.js` — 5 regression tests covering always-mounted cards and expand/collapse behavior
- `docs/superpowers/specs/` and `docs/superpowers/plans/` — design spec and implementation plan

## Test Plan

- [ ] Tap income card — card expands in width and height over 300ms, expense card fades and collapses
- [ ] Tap income card again — reverses: chart fades first (150ms), layout collapses (220ms)
- [ ] Tap expense card — mirrors income behavior
- [ ] Both cards always mounted (no conditional render); verified by regression tests
- [ ] `npm test` — 58 tests passing
