### PR TITLE
fix: hide expand chevron for leaf categories in pie chart legends

### DIFF
--- a/__tests__/components/graphs/CustomLegend.test.js
+++ b/__tests__/components/graphs/CustomLegend.test.js
@@ -40,8 +40,8 @@ describe('CustomLegend', () => {
   };
 
   const mockData = [
-    { name: 'Food', amount: 100, color: '#FF5733', icon: 'food', categoryId: 'cat-1' },
-    { name: 'Transport', amount: 50, color: '#33FF57', icon: 'car', categoryId: 'cat-2' },
+    { name: 'Food', amount: 100, color: '#FF5733', icon: 'food', categoryId: 'cat-1', hasChildren: true },
+    { name: 'Transport', amount: 50, color: '#33FF57', icon: 'car', categoryId: 'cat-2', hasChildren: true },
   ];
 
   const defaultProps = {
@@ -218,6 +218,28 @@ describe('CustomLegend', () => {
         <CustomLegend {...defaultProps} data={dataWithoutCategoryId} isClickable={true} />,
       );
       expect(queryByTestId('icon-chevron-right')).toBeNull();
+    });
+
+    it('does not show chevron for leaf categories (hasChildren is false)', () => {
+      const leafData = [
+        { name: 'Leaf', amount: 100, color: '#000', categoryId: 'cat-leaf', hasChildren: false },
+      ];
+      const { queryByTestId } = render(
+        <CustomLegend {...defaultProps} data={leafData} isClickable={true} />,
+      );
+      expect(queryByTestId('icon-chevron-right')).toBeNull();
+    });
+
+    it('leaf category is not clickable even when isClickable is true', () => {
+      const onItemPress = jest.fn();
+      const leafData = [
+        { name: 'Leaf', amount: 100, color: '#000', categoryId: 'cat-leaf', hasChildren: false },
+      ];
+      const { getByText } = render(
+        <CustomLegend {...defaultProps} data={leafData} isClickable={true} onItemPress={onItemPress} />,
+      );
+      fireEvent.press(getByText('Leaf'));
+      expect(onItemPress).not.toHaveBeenCalled();
     });
 
     it('item without categoryId is not clickable even when isClickable is true', () => {

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -19,8 +19,9 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
     <View style={styles.legendContainer}>
       {data.map((item, index) => {
         const percentage = total > 0 ? ((item.amount / total) * 100).toFixed(1) : 0;
-        const ItemWrapper = isClickable && item.categoryId ? TouchableOpacity : View;
-        const wrapperProps = isClickable && item.categoryId ? {
+        const isExpandable = isClickable && item.categoryId && item.hasChildren;
+        const ItemWrapper = isExpandable ? TouchableOpacity : View;
+        const wrapperProps = isExpandable ? {
           onPress: () => onItemPress(item.categoryId),
           activeOpacity: 0.7,
           accessibilityRole: 'button',
@@ -34,7 +35,7 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
             style={[
               styles.legendItem,
               { borderBottomColor: colors.border },
-              isClickable && item.categoryId && styles.legendItemClickable,
+              isExpandable && styles.legendItemClickable,
             ]}
             {...wrapperProps}
           >
@@ -52,7 +53,7 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
               <Text style={[styles.legendName, { color: colors.text }]} numberOfLines={1}>
                 {item.name}
               </Text>
-              {isClickable && item.categoryId && (
+              {isExpandable && (
                 <Icon
                   name="chevron-right"
                   size={16}
@@ -93,6 +94,7 @@ CustomLegend.propTypes = {
       color: PropTypes.string,
       icon: PropTypes.string,
       categoryId: PropTypes.string,
+      hasChildren: PropTypes.bool,
     }),
   ).isRequired,
   currency: PropTypes.string.isRequired,

--- a/app/hooks/useExpenseData.js
+++ b/app/hooks/useExpenseData.js
@@ -160,6 +160,7 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
 
       // Transform aggregated data for pie chart
       const data = Object.values(aggregatedSpending).map((item, index) => {
+        const hasChildren = categories.some(cat => cat.parentId === item.category.id);
         return {
           name: item.category.name,
           amount: item.total,
@@ -167,7 +168,8 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
           legendFontColor: colors.text,
           legendFontSize: 13,
           icon: item.category.icon || null,
-          categoryId: item.category.id, // For clickable legend navigation
+          categoryId: item.category.id,
+          hasChildren,
         };
       });
 

--- a/app/hooks/useIncomeData.js
+++ b/app/hooks/useIncomeData.js
@@ -125,6 +125,7 @@ const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIn
 
       // Transform aggregated data for pie chart
       const data = Object.values(aggregatedIncome).map((item, index) => {
+        const hasChildren = categories.some(cat => cat.parentId === item.category.id);
         return {
           name: item.category.name,
           amount: item.total,
@@ -132,7 +133,8 @@ const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIn
           legendFontColor: colors.text,
           legendFontSize: 13,
           icon: item.category.icon || null,
-          categoryId: item.category.id, // For clickable legend navigation
+          categoryId: item.category.id,
+          hasChildren,
         };
       });
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-native": "^5.0.0",
     "globals": "^17.0.0",
-    "jest": "^30.3.0",
+    "jest": "30.3.0",
     "jest-expo": "~54.0.14",
     "prop-types": "^15.8.1",
     "react-test-renderer": "19.1.0"


### PR DESCRIPTION
Categories with no children showed the chevron-right expand arrow and
were tappable, but drilling into them produced "No data for this period"
because they have no subcategories to aggregate.

Now useIncomeData and useExpenseData set hasChildren on each chart data
item, and CustomLegend only renders the chevron / TouchableOpacity
wrapper when isClickable && item.hasChildren.

https://claude.ai/code/session_013c2RPNdB8nnGnEUNBuPLHW