### PR TITLE
fix: replace startup update dialog with rich UpdateAvailableModal

### DIFF
--- a/app/modals/UpdateAvailableModal.js
+++ b/app/modals/UpdateAvailableModal.js
@@ -1,0 +1,235 @@
+import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { View, StyleSheet, TouchableOpacity, Animated, Easing, ScrollView } from 'react-native';
+import { Portal, Modal, Text, Divider, TouchableRipple } from 'react-native-paper';
+import { Ionicons } from '@expo/vector-icons';
+import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+
+const stripMarkdown = (md) => md
+  .replace(/\r\n/g, '\n')
+  .replace(/#{1,6}\s+/g, '')
+  .replace(/\*\*(.+?)\*\*/g, '$1')
+  .replace(/\*(.+?)\*/g, '$1')
+  .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+  .replace(/`([^`]+)`/g, '$1')
+  .replace(/^\s*[-*+]\s+/gm, '• ')
+  .replace(/\n{3,}/g, '\n\n')
+  .trim();
+
+export default function UpdateAvailableModal({ visible, onDismiss, onUpdate, updateData }) {
+  const { colors } = useThemeColors();
+  const { t } = useLocalization();
+  const contentAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      contentAnim.setValue(0);
+      Animated.timing(contentAnim, {
+        toValue: 1,
+        duration: 280,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [visible, contentAnim]);
+
+  if (!updateData) return null;
+
+  const { latestVersion, currentVersion, downloadUrl, releaseNotes } = updateData;
+
+  return (
+    <Portal>
+      <Modal visible={visible} onDismiss={onDismiss} dismissable>
+        <View style={[styles.modalContainer, { backgroundColor: colors.card }]}>
+          <View style={styles.header}>
+            <TouchableOpacity onPress={onDismiss} style={styles.backButton}>
+              <Ionicons name="arrow-back" size={24} color={colors.text} />
+            </TouchableOpacity>
+            <Text variant="titleLarge" style={[styles.headerTitle, { color: colors.text }]}>
+              {t('update_available_title') || 'Update available'}
+            </Text>
+            <View style={styles.backButton} />
+          </View>
+
+          <Divider />
+
+          <Animated.View style={[styles.resultContainer, { opacity: contentAnim }]}>
+            <View style={styles.updateAvailableHeader}>
+              <Ionicons name="download-outline" size={36} color={colors.primary} />
+              <View style={styles.updateVersionInfo}>
+                <Text style={[styles.updateNewVersion, { color: colors.text }]}>
+                  v{latestVersion}
+                </Text>
+                <Text style={[styles.updateCurrentVersion, { color: colors.mutedText }]}>
+                  {(t('update_from_version') || 'installed: v{currentVersion}')
+                    .replace('{currentVersion}', currentVersion)}
+                </Text>
+              </View>
+            </View>
+
+            {releaseNotes ? (
+              <>
+                <Divider style={styles.updateDivider} />
+                <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
+                  {t('whats_new') || "What's new"}
+                </Text>
+                <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
+                  {releaseNotes.map(({ version, notes }) => (
+                    <View key={version} style={styles.changelogSection}>
+                      {releaseNotes.length > 1 && (
+                        <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
+                          v{version}
+                        </Text>
+                      )}
+                      <Text style={[styles.changelogText, { color: colors.text }]}>
+                        {stripMarkdown(notes)}
+                      </Text>
+                    </View>
+                  ))}
+                </ScrollView>
+              </>
+            ) : (
+              <Text style={[styles.updateVersionText, { color: colors.mutedText }]}>
+                {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
+              </Text>
+            )}
+
+            <View style={styles.updateActions}>
+              {releaseNotes && (
+                <Text style={[styles.updateHintText, { color: colors.mutedText }]}>
+                  {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
+                </Text>
+              )}
+              <TouchableRipple
+                onPress={() => onUpdate(downloadUrl)}
+                style={[styles.updateButton, { backgroundColor: colors.primary }]}
+              >
+                <Text style={styles.updateButtonText}>
+                  {t('update_now') || 'Update now'}
+                </Text>
+              </TouchableRipple>
+            </View>
+          </Animated.View>
+        </View>
+      </Modal>
+    </Portal>
+  );
+}
+
+UpdateAvailableModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
+  updateData: PropTypes.shape({
+    latestVersion: PropTypes.string.isRequired,
+    currentVersion: PropTypes.string.isRequired,
+    downloadUrl: PropTypes.string.isRequired,
+    releaseNotes: PropTypes.arrayOf(PropTypes.shape({
+      version: PropTypes.string,
+      notes: PropTypes.string,
+    })),
+  }),
+};
+
+const styles = StyleSheet.create({
+  backButton: {
+    alignItems: 'center',
+    height: 40,
+    justifyContent: 'center',
+    width: 40,
+  },
+  changelogScroll: {
+    flex: 1,
+    marginTop: SPACING.xs,
+  },
+  changelogSection: {
+    marginBottom: SPACING.md,
+  },
+  changelogText: {
+    fontSize: 13,
+    lineHeight: 20,
+  },
+  changelogTitle: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.8,
+    marginTop: SPACING.md,
+    textTransform: 'uppercase',
+  },
+  changelogVersion: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    marginBottom: SPACING.xs,
+    textTransform: 'uppercase',
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: SPACING.lg,
+  },
+  headerTitle: {
+    fontWeight: '600',
+  },
+  modalContainer: {
+    borderRadius: BORDER_RADIUS.lg,
+    margin: SPACING.md,
+    maxHeight: '95%',
+    overflow: 'hidden',
+  },
+  resultContainer: {
+    flex: 1,
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: SPACING.lg,
+  },
+  updateActions: {
+    paddingTop: SPACING.md,
+  },
+  updateAvailableHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.md,
+    paddingBottom: SPACING.sm,
+  },
+  updateButton: {
+    borderRadius: BORDER_RADIUS.md,
+    marginTop: SPACING.xl,
+    paddingHorizontal: SPACING.xl,
+    paddingVertical: SPACING.md,
+  },
+  updateButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  updateCurrentVersion: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  updateDivider: {
+    marginTop: SPACING.sm,
+  },
+  updateHintText: {
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: SPACING.md,
+    textAlign: 'center',
+  },
+  updateNewVersion: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  updateVersionInfo: {
+    flex: 1,
+  },
+  updateVersionText: {
+    fontSize: 15,
+    lineHeight: 22,
+    textAlign: 'center',
+  },
+});

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { useLocalization } from '../contexts/LocalizationContext';
 import LanguageSelectionScreen from './LanguageSelectionScreen';
@@ -9,6 +9,7 @@ import { useDialog } from '../contexts/DialogContext';
 import { checkForAppUpdate } from '../services/AppUpdateService';
 import { getPreference, setPreference, PREF_KEYS } from '../services/PreferencesDB';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
+import UpdateAvailableModal from '../modals/UpdateAvailableModal';
 
 const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const UPDATE_REMINDER_DELAY_DAYS = 3;
@@ -23,6 +24,7 @@ const AppInitializer = () => {
   const { showDialog } = useDialog();
   const { startDownload } = useUpdateDownload();
   const [isInitializing, setIsInitializing] = useState(false);
+  const [pendingUpdate, setPendingUpdate] = useState(null);
 
   // Run once on every app open (after first launch is complete)
   useEffect(() => {
@@ -52,41 +54,12 @@ const AppInitializer = () => {
             return;
           }
 
-          showDialog(
-            t('update_available_title') || 'Update available',
-            `${(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Install it from GitHub release APK.')
-              .replace('{latestVersion}', result.latestVersion)}\n\n${
-              t('update_install_hint')
-              || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'
-            }`,
-            [
-              {
-                text: t('later') || 'Later',
-                onPress: async () => {
-                  const suppressUntil = new Date(
-                    Date.now() + UPDATE_REMINDER_DELAY_DAYS * 24 * 60 * 60 * 1000,
-                  ).toISOString();
-                  await setPreference(PREF_KEYS.UPDATE_SKIP_UNTIL, suppressUntil);
-                  await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
-                },
-              },
-              {
-                text: t('update_now') || 'Update now',
-                onPress: async () => {
-                  await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, result.latestVersion);
-                  startDownload(result.downloadUrl, {
-                    onError: () => {
-                      showDialog(
-                        t('error') || 'Error',
-                        t('update_download_failed') || 'Could not download the update. Please try again.',
-                        [{ text: t('ok') || 'OK' }],
-                      );
-                    },
-                  });
-                },
-              },
-            ],
-          );
+          setPendingUpdate({
+            latestVersion: result.latestVersion,
+            currentVersion: result.currentVersion,
+            downloadUrl: result.downloadUrl,
+            releaseNotes: result.releaseNotes || null,
+          });
         } catch (error) {
           console.warn('[AppInitializer] Failed to auto-check updates:', error);
         }
@@ -94,7 +67,34 @@ const AppInitializer = () => {
 
       runUpdateCheck();
     }
-  }, [isFirstLaunch, showDialog, t, startDownload]);
+  }, [isFirstLaunch]);
+
+  const handleUpdateDismiss = useCallback(async () => {
+    if (pendingUpdate) {
+      const suppressUntil = new Date(
+        Date.now() + UPDATE_REMINDER_DELAY_DAYS * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      await setPreference(PREF_KEYS.UPDATE_SKIP_UNTIL, suppressUntil);
+      await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, pendingUpdate.latestVersion);
+    }
+    setPendingUpdate(null);
+  }, [pendingUpdate]);
+
+  const handleUpdateNow = useCallback(async (downloadUrl) => {
+    if (pendingUpdate) {
+      await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, pendingUpdate.latestVersion);
+    }
+    setPendingUpdate(null);
+    startDownload(downloadUrl, {
+      onError: () => {
+        showDialog(
+          t('error') || 'Error',
+          t('update_download_failed') || 'Could not download the update. Please try again.',
+          [{ text: t('ok') || 'OK' }],
+        );
+      },
+    });
+  }, [pendingUpdate, startDownload, showDialog, t]);
 
   const handleLanguageSelected = async (selectedLanguage) => {
     try {
@@ -125,7 +125,17 @@ const AppInitializer = () => {
   }
 
   // Normal app flow - not first launch
-  return <SimpleTabs />;
+  return (
+    <>
+      <SimpleTabs />
+      <UpdateAvailableModal
+        visible={!!pendingUpdate}
+        onDismiss={handleUpdateDismiss}
+        onUpdate={handleUpdateNow}
+        updateData={pendingUpdate}
+      />
+    </>
+  );
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
The automatic update check on app startup used showDialog() which
produced a plain text alert. This replaces it with a new
UpdateAvailableModal that matches the settings update subpanel exactly:
back-arrow header, version info with download icon, scrollable changelog,
installation hint, and a primary-coloured "Update now" button.

Later/dismiss still snoozes for 3 days via UPDATE_SKIP_UNTIL preference.

https://claude.ai/code/session_01XrSmoNXpcdyPjwXvn18nLf