### PR TITLE
feat: replace month and currency pickers on GraphsScreen with WheelPicker

### DIFF
--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -62,6 +62,16 @@ jest.mock('../../app/components/SimplePicker', () => {
   };
 });
 
+jest.mock('@quidone/react-native-wheel-picker', () => {
+  const React = require('react');
+  return {
+    __esModule: true,
+    default: function MockWheelPicker() {
+      return React.createElement('WheelPicker', null);
+    },
+  };
+});
+
 jest.mock('../../assets/currencies.json', () => ({
   USD: { symbol: '$', decimal_digits: 2 },
   EUR: { symbol: '€', decimal_digits: 2 },

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -727,8 +727,8 @@ const GraphsScreen = () => {
               onValueChanged={({ item }) => setSelectedCurrency(item.value)}
               itemHeight={48}
               visibleItemCount={5}
-              itemTextStyle={{ color: colors.text, fontSize: 16 }}
-              overlayItemStyle={{ backgroundColor: colors.selected, borderRadius: 8 }}
+              itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
+              overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
               enableScrollByTapOnItem
               keyExtractor={(item, index) => `currency-${index}`}
             />
@@ -760,8 +760,8 @@ const GraphsScreen = () => {
               onValueChanged={({ item }) => setSelectedPeriod(item.value)}
               itemHeight={48}
               visibleItemCount={5}
-              itemTextStyle={{ color: colors.text, fontSize: 16 }}
-              overlayItemStyle={{ backgroundColor: colors.selected, borderRadius: 8 }}
+              itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
+              overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
               enableScrollByTapOnItem
               keyExtractor={(item, index) => `period-${index}`}
             />
@@ -776,11 +776,6 @@ const GraphsScreen = () => {
 const styles = StyleSheet.create({
   cardHeader: {
     height: CARD_HEADER_HEIGHT,
-  },
-  currencySymbol: {
-    fontSize: 15,
-    fontWeight: '600',
-    marginRight: 6,
   },
   chartContent: {
     bottom: 0,
@@ -819,6 +814,11 @@ const styles = StyleSheet.create({
   content: {
     padding: TOP_CONTENT_SPACING,
     paddingTop: TOP_CONTENT_SPACING + 4,
+  },
+  currencySymbol: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginRight: 6,
   },
   filtersRow: {
     flexDirection: 'row',
@@ -894,6 +894,12 @@ const styles = StyleSheet.create({
   summaryCardsRow: {
     flexDirection: 'row',
     marginBottom: 16,
+  },
+  wheelItemText: {
+    fontSize: 16,
+  },
+  wheelOverlayItem: {
+    borderRadius: 8,
   },
 });
 

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { View, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
+import { View, Text, Modal, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import WheelPicker from '@quidone/react-native-wheel-picker';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
@@ -47,6 +48,9 @@ const GraphsScreen = () => {
   const [topLevelIncomeCategories, setTopLevelIncomeCategories] = useState([]);
   const [availableMonths, setAvailableMonths] = useState([]);
   const [selectedCategoryForTrend, setSelectedCategoryForTrend] = useState(null);
+
+  const [showPeriodPicker, setShowPeriodPicker] = useState(false);
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false);
 
   // Account selection state
   const [selectedAccount, setSelectedAccount] = useState(null);
@@ -500,26 +504,34 @@ const GraphsScreen = () => {
           {/* Filters Row */}
           <View style={styles.filtersRow}>
             {/* Currency Picker */}
-            <View style={[styles.pickerWrapper, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-              <SimplePicker
-                value={selectedCurrency}
-                onValueChange={setSelectedCurrency}
-                items={currencyItems}
-                colors={colors}
-                leftText={selectedCurrencySymbol}
-              />
-            </View>
+            <TouchableOpacity
+              style={[styles.pickerWrapper, { backgroundColor: colors.surface, borderColor: colors.border }]}
+              onPress={() => setShowCurrencyPicker(true)}
+              activeOpacity={0.7}
+            >
+              <View style={styles.periodPickerButton}>
+                <Text style={[styles.currencySymbol, { color: colors.primary }]}>{selectedCurrencySymbol}</Text>
+                <Text style={[styles.periodPickerText, { color: colors.text }]} numberOfLines={1}>
+                  {selectedCurrency}
+                </Text>
+                <Icon name="chevron-down" size={18} color={colors.mutedText} />
+              </View>
+            </TouchableOpacity>
 
             {/* Period Picker (Combined Month + Year) */}
-            <View style={[styles.periodPickerWrapper, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-              <SimplePicker
-                value={selectedPeriod}
-                onValueChange={setSelectedPeriod}
-                items={periodItems}
-                colors={colors}
-                leftIcon="calendar-month"
-              />
-            </View>
+            <TouchableOpacity
+              style={[styles.periodPickerWrapper, { backgroundColor: colors.surface, borderColor: colors.border }]}
+              onPress={() => setShowPeriodPicker(true)}
+              activeOpacity={0.7}
+            >
+              <View style={styles.periodPickerButton}>
+                <Icon name="calendar-month" size={18} color={colors.primary} style={styles.periodPickerIcon} />
+                <Text style={[styles.periodPickerText, { color: colors.text }]} numberOfLines={1}>
+                  {periodItems.find(item => item.value === selectedPeriod)?.label ?? ''}
+                </Text>
+                <Icon name="chevron-down" size={18} color={colors.mutedText} />
+              </View>
+            </TouchableOpacity>
           </View>
 
           {/* Summary Cards Row — always-mounted, width/height driven by Animated */}
@@ -691,6 +703,72 @@ const GraphsScreen = () => {
         </View>
       </ScrollView>
 
+      <Modal
+        visible={showCurrencyPicker}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowCurrencyPicker(false)}
+      >
+        <TouchableOpacity
+          style={styles.pickerModalOverlay}
+          activeOpacity={1}
+          onPress={() => setShowCurrencyPicker(false)}
+        >
+          <TouchableOpacity activeOpacity={1} style={[styles.pickerModalSheet, { backgroundColor: colors.surface }]}>
+            <View style={[styles.pickerModalHeader, { borderBottomColor: colors.border }]}>
+              <Text style={[styles.pickerModalTitle, { color: colors.text }]}>{t('select_currency')}</Text>
+              <TouchableOpacity onPress={() => setShowCurrencyPicker(false)}>
+                <Text style={[styles.pickerModalDone, { color: colors.primary }]}>{t('done')}</Text>
+              </TouchableOpacity>
+            </View>
+            <WheelPicker
+              data={currencyItems}
+              value={selectedCurrency}
+              onValueChanged={({ item }) => setSelectedCurrency(item.value)}
+              itemHeight={48}
+              visibleItemCount={5}
+              itemTextStyle={{ color: colors.text, fontSize: 16 }}
+              overlayItemStyle={{ backgroundColor: colors.selected, borderRadius: 8 }}
+              enableScrollByTapOnItem
+              keyExtractor={(item, index) => `currency-${index}`}
+            />
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </Modal>
+
+      <Modal
+        visible={showPeriodPicker}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowPeriodPicker(false)}
+      >
+        <TouchableOpacity
+          style={styles.pickerModalOverlay}
+          activeOpacity={1}
+          onPress={() => setShowPeriodPicker(false)}
+        >
+          <TouchableOpacity activeOpacity={1} style={[styles.pickerModalSheet, { backgroundColor: colors.surface }]}>
+            <View style={[styles.pickerModalHeader, { borderBottomColor: colors.border }]}>
+              <Text style={[styles.pickerModalTitle, { color: colors.text }]}>{t('select_month')}</Text>
+              <TouchableOpacity onPress={() => setShowPeriodPicker(false)}>
+                <Text style={[styles.pickerModalDone, { color: colors.primary }]}>{t('done')}</Text>
+              </TouchableOpacity>
+            </View>
+            <WheelPicker
+              data={periodItems}
+              value={selectedPeriod}
+              onValueChanged={({ item }) => setSelectedPeriod(item.value)}
+              itemHeight={48}
+              visibleItemCount={5}
+              itemTextStyle={{ color: colors.text, fontSize: 16 }}
+              overlayItemStyle={{ backgroundColor: colors.selected, borderRadius: 8 }}
+              enableScrollByTapOnItem
+              keyExtractor={(item, index) => `period-${index}`}
+            />
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </Modal>
+
     </View>
   );
 };
@@ -698,6 +776,11 @@ const GraphsScreen = () => {
 const styles = StyleSheet.create({
   cardHeader: {
     height: CARD_HEADER_HEIGHT,
+  },
+  currencySymbol: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginRight: 6,
   },
   chartContent: {
     bottom: 0,
@@ -742,17 +825,58 @@ const styles = StyleSheet.create({
     gap: 8,
     marginBottom: 16,
   },
+  periodPickerButton: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    paddingHorizontal: 12,
+  },
+  periodPickerIcon: {
+    marginRight: 6,
+  },
+  periodPickerText: {
+    flex: 1,
+    fontSize: 14,
+  },
   periodPickerWrapper: {
     borderRadius: 12,
     borderWidth: 1,
     flex: 1,
     height: 44,
+    justifyContent: 'center',
     overflow: 'hidden',
+  },
+  pickerModalDone: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  pickerModalHeader: {
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  pickerModalOverlay: {
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  pickerModalSheet: {
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingBottom: 32,
+  },
+  pickerModalTitle: {
+    fontSize: 16,
+    fontWeight: '600',
   },
   pickerWrapper: {
     borderRadius: 12,
     borderWidth: 1,
     height: 44,
+    justifyContent: 'center',
     minWidth: 110,
     overflow: 'hidden',
   },

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "penny",
       "dependencies": {
+        "@quidone/react-native-wheel-picker": "^1.6.4",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "8.5.1",
         "@react-native-google-signin/google-signin": "^16.1.2",
@@ -47,7 +48,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-native": "^5.0.0",
         "globals": "^17.0.0",
-        "jest": "^30.3.0",
+        "jest": "30.3.0",
         "jest-expo": "~54.0.14",
         "prop-types": "^15.8.1",
         "react-test-renderer": "19.1.0",
@@ -493,6 +494,8 @@
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
+    "@quidone/react-native-wheel-picker": ["@quidone/react-native-wheel-picker@1.6.4", "", { "dependencies": { "@rozhkov/react-useful-hooks": "^1.0.10", "date-fns": "^4.1.0" }, "peerDependencies": { "react": ">=16.8", "react-native": ">=0.71.6" } }, "sha512-K2w9JPwk0Gsmg/8VIljoXdstxV7SMbvzU2yqwZcHvEy0+/cMFltph2Lz2ek6lKMQuhYQJzw/HxAe1LZh45ppjQ=="],
+
     "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@2.2.0", "", { "dependencies": { "merge-options": "^3.0.4" }, "peerDependencies": { "react-native": "^0.0.0-0 || >=0.65 <1.0" } }, "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw=="],
 
     "@react-native-community/datetimepicker": ["@react-native-community/datetimepicker@8.5.1", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": ">=52.0.0", "react": "*", "react-native": "*", "react-native-windows": "*" }, "optionalPeers": ["expo", "react-native-windows"] }, "sha512-TuwM1ORbxCjOp1GOtONj0QnpDpVfq0F4UlfKZYPxL/vmriaLHt2Kgvw63Bv0Bpep4eOkslVVSS1IRfRI6d392g=="],
@@ -520,6 +523,8 @@
     "@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
 
     "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.5", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw=="],
+
+    "@rozhkov/react-useful-hooks": ["@rozhkov/react-useful-hooks@1.0.10", "", { "dependencies": { "default-values": "^1.0.2" }, "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19" } }, "sha512-aEDZDiqkpPJX8WqLqcnPGjXzRpCFiZmbtdr5RVUOciNbbANhdNu+oIxJv3g7ezMcgsYhgWp2/XGxU+g/ClsBew=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
@@ -831,6 +836,8 @@
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
@@ -848,6 +855,8 @@
     "default-browser": ["default-browser@5.4.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg=="],
 
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "default-values": ["default-values@1.0.2", "", {}, "sha512-OaZEvojjexigvv1IT6N0rKUD5Af7fG11a0jg87jySv5xzjc2+IEW9oWNvqxWLHGhShRRZ0QopCGzGjJv/aY+mw=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },
   "dependencies": {
+    "@quidone/react-native-wheel-picker": "^1.6.4",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "8.5.1",
     "@react-native-google-signin/google-signin": "^16.1.2",


### PR DESCRIPTION
Installs @quidone/react-native-wheel-picker and replaces the SimplePicker
dropdowns for both period (month/year) and currency selection with wheel
pickers shown in a bottom-sheet modal. Tapping the compact filter bar
opens the modal with the wheel, selecting updates the value immediately.
The category pickers inside expanded chart panels remain as SimplePicker.

https://claude.ai/code/session_01Q5iXt2GpmRw1yCLbXDEN66