### PR TITLE
fix: currency picker to show as popover anchored to button

### DIFF
--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { View, Text, Modal, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
@@ -51,6 +51,8 @@ const GraphsScreen = () => {
 
   const [showPeriodPicker, setShowPeriodPicker] = useState(false);
   const [showCurrencyPicker, setShowCurrencyPicker] = useState(false);
+  const currencyPickerRef = useRef(null);
+  const [currencyPickerLayout, setCurrencyPickerLayout] = useState({ x: 0, y: 0, width: 0, height: 0 });
 
   // Account selection state
   const [selectedAccount, setSelectedAccount] = useState(null);
@@ -427,6 +429,17 @@ const GraphsScreen = () => {
   const handleToggleIncome = useCallback(() => toggleCard('income'), [toggleCard]);
   const handleToggleExpense = useCallback(() => toggleCard('expense'), [toggleCard]);
 
+  const handleOpenCurrencyPicker = useCallback(() => {
+    if (currencyPickerRef.current) {
+      currencyPickerRef.current.measureInWindow((x, y, width, height) => {
+        setCurrencyPickerLayout({ x, y, width, height });
+        setShowCurrencyPicker(true);
+      });
+    } else {
+      setShowCurrencyPicker(true);
+    }
+  }, []);
+
   // Reset expansion and update dimension shared values on orientation change
   useEffect(() => {
     halfWidthSV.value = halfWidth;
@@ -505,8 +518,9 @@ const GraphsScreen = () => {
           <View style={styles.filtersRow}>
             {/* Currency Picker */}
             <TouchableOpacity
+              ref={currencyPickerRef}
               style={[styles.pickerWrapper, { backgroundColor: colors.surface, borderColor: colors.border }]}
-              onPress={() => setShowCurrencyPicker(true)}
+              onPress={handleOpenCurrencyPicker}
               activeOpacity={0.7}
             >
               <View style={styles.periodPickerButton}>
@@ -706,34 +720,36 @@ const GraphsScreen = () => {
       <Modal
         visible={showCurrencyPicker}
         transparent
-        animationType="slide"
+        animationType="fade"
         onRequestClose={() => setShowCurrencyPicker(false)}
       >
         <TouchableOpacity
-          style={styles.pickerModalOverlay}
+          style={styles.pickerPopoverOverlay}
           activeOpacity={1}
           onPress={() => setShowCurrencyPicker(false)}
-        >
-          <TouchableOpacity activeOpacity={1} style={[styles.pickerModalSheet, { backgroundColor: colors.surface }]}>
-            <View style={[styles.pickerModalHeader, { borderBottomColor: colors.border }]}>
-              <Text style={[styles.pickerModalTitle, { color: colors.text }]}>{t('select_currency')}</Text>
-              <TouchableOpacity onPress={() => setShowCurrencyPicker(false)}>
-                <Text style={[styles.pickerModalDone, { color: colors.primary }]}>{t('done')}</Text>
-              </TouchableOpacity>
-            </View>
-            <WheelPicker
-              data={currencyItems}
-              value={selectedCurrency}
-              onValueChanged={({ item }) => setSelectedCurrency(item.value)}
-              itemHeight={48}
-              visibleItemCount={5}
-              itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
-              overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
-              enableScrollByTapOnItem
-              keyExtractor={(item, index) => `currency-${index}`}
-            />
-          </TouchableOpacity>
-        </TouchableOpacity>
+        />
+        <View style={[
+          styles.currencyPopover,
+          {
+            top: currencyPickerLayout.y + currencyPickerLayout.height + 4,
+            left: currencyPickerLayout.x,
+            width: Math.max(currencyPickerLayout.width, 160),
+            backgroundColor: colors.surface,
+            borderColor: colors.border,
+          },
+        ]}>
+          <WheelPicker
+            data={currencyItems}
+            value={selectedCurrency}
+            onValueChanged={({ item }) => setSelectedCurrency(item.value)}
+            itemHeight={48}
+            visibleItemCount={5}
+            itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
+            overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
+            enableScrollByTapOnItem
+            keyExtractor={(item, index) => `currency-${index}`}
+          />
+        </View>
       </Modal>
 
       <Modal
@@ -862,6 +878,20 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.4)',
     flex: 1,
     justifyContent: 'flex-end',
+  },
+  pickerPopoverOverlay: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  currencyPopover: {
+    borderRadius: 12,
+    borderWidth: 1,
+    elevation: 8,
+    overflow: 'hidden',
+    position: 'absolute',
   },
   pickerModalSheet: {
     borderTopLeftRadius: 16,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -831,6 +831,13 @@ const styles = StyleSheet.create({
     padding: TOP_CONTENT_SPACING,
     paddingTop: TOP_CONTENT_SPACING + 4,
   },
+  currencyPopover: {
+    borderRadius: 12,
+    borderWidth: 1,
+    elevation: 8,
+    overflow: 'hidden',
+    position: 'absolute',
+  },
   currencySymbol: {
     fontSize: 15,
     fontWeight: '600',
@@ -879,20 +886,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'flex-end',
   },
-  pickerPopoverOverlay: {
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
-  currencyPopover: {
-    borderRadius: 12,
-    borderWidth: 1,
-    elevation: 8,
-    overflow: 'hidden',
-    position: 'absolute',
-  },
   pickerModalSheet: {
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
@@ -901,6 +894,13 @@ const styles = StyleSheet.create({
   pickerModalTitle: {
     fontSize: 16,
     fontWeight: '600',
+  },
+  pickerPopoverOverlay: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
   pickerWrapper: {
     borderRadius: 12,

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Fertig",
   "remaining": "remaining"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Done",
   "remaining": "remaining"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Listo",
   "remaining": "remaining"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Terminé",
   "remaining": "remaining"
 }

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -373,6 +373,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Պատրաստ",
   "remaining": "remaining"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -138,7 +138,7 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Fatto",
   "remaining": "remaining",
   "import": "Import",
   "import_from_file": "From Google Drive",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "完了",
   "remaining": "remaining"
 }

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "완료",
   "remaining": "remaining"
 }

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Pronto",
   "remaining": "remaining"
 }

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -385,6 +385,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "Готово",
   "remaining": "remaining"
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -387,6 +387,6 @@
   "pending_out": "Pending out",
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
-  "done": "done",
+  "done": "完成",
   "remaining": "remaining"
 }


### PR DESCRIPTION
Instead of sliding up from the bottom, the wheel picker now appears
directly below the currency picker button using measureInWindow to
anchor the popover to the button's on-screen position.

https://claude.ai/code/session_01XmRQhT7VD9T7h1dmHDHneG