### PR TITLE
fix: category search missing non-ASCII names in lazy loading

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1123,15 +1123,33 @@ describe('OperationsDB Service', () => {
       expect(params).toContain('%coffee%');
     });
 
-    it('lowercases search text for case-insensitive matching', async () => {
+    it('includes both lowercase and original-case search terms for Unicode support', async () => {
       queryAll.mockResolvedValue([]);
 
       const filters = { searchText: 'GROCERY' };
       await OperationsDB.getFilteredOperationsByDateRange('2025-12-01', '2025-12-31', filters);
 
       const params = queryAll.mock.calls[0][1];
+      // Lowercase term for ASCII case-insensitive matching
       expect(params).toContain('%grocery%');
-      expect(params).not.toContain('%GROCERY%');
+      // Original-case term so SQLite LIKE matches non-ASCII text (e.g. Cyrillic) verbatim,
+      // since SQLite's LOWER() only handles ASCII characters.
+      expect(params).toContain('%GROCERY%');
+    });
+
+    it('matches non-ASCII category names with original-case term', async () => {
+      queryAll.mockResolvedValue([]);
+
+      const filters = { searchText: 'Газ' };
+      await OperationsDB.getFilteredOperationsByDateRange('2025-01-01', '2025-12-31', filters);
+
+      const sqlCall = queryAll.mock.calls[0][0];
+      const params = queryAll.mock.calls[0][1];
+      // Must include original-case match for Cyrillic (SQLite LOWER doesn't handle non-ASCII)
+      expect(sqlCall).toContain('c.name LIKE ?');
+      expect(params).toContain('%Газ%');
+      // Lowercase variant is also included for completeness
+      expect(params).toContain('%газ%');
     });
 
     it('combines all filters correctly', async () => {

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -241,15 +241,16 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
 
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
-      const searchTerm = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ?
+        LOWER(o.description) LIKE ? OR o.description LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ?
-        OR LOWER(to_a.name) LIKE ?
-        OR LOWER(c.name) LIKE ?
+        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
+        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
+        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
       )`;
-      params.push(searchTerm, searchTerm, searchTerm, searchTerm, searchTerm);
+      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
@@ -1049,15 +1050,16 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
 
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
-      const searchTerm = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ?
+        LOWER(o.description) LIKE ? OR o.description LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ?
-        OR LOWER(to_a.name) LIKE ?
-        OR LOWER(c.name) LIKE ?
+        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
+        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
+        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
       )`;
-      params.push(searchTerm, searchTerm, searchTerm, searchTerm, searchTerm);
+      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
@@ -1142,15 +1144,16 @@ export const getNextOldestFilteredOperation = async (beforeDate, filters = {}) =
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const searchTerm = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ?
+        LOWER(o.description) LIKE ? OR o.description LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ?
-        OR LOWER(to_a.name) LIKE ?
-        OR LOWER(c.name) LIKE ?
+        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
+        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
+        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
       )`;
-      params.push(searchTerm, searchTerm, searchTerm, searchTerm, searchTerm);
+      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC LIMIT 1';
@@ -1304,15 +1307,16 @@ export const getNextNewestFilteredOperation = async (afterDate, filters = {}) =>
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const searchTerm = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ?
+        LOWER(o.description) LIKE ? OR o.description LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ?
-        OR LOWER(to_a.name) LIKE ?
-        OR LOWER(c.name) LIKE ?
+        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
+        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
+        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
       )`;
-      params.push(searchTerm, searchTerm, searchTerm, searchTerm, searchTerm);
+      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
     }
 
     sql += ' ORDER BY o.date ASC, o.created_at ASC LIMIT 1';
@@ -1409,15 +1413,16 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const searchTerm = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ?
+        LOWER(o.description) LIKE ? OR o.description LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ?
-        OR LOWER(to_a.name) LIKE ?
-        OR LOWER(c.name) LIKE ?
+        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
+        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
+        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
       )`;
-      params.push(searchTerm, searchTerm, searchTerm, searchTerm, searchTerm);
+      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';


### PR DESCRIPTION
SQLite's LOWER() only handles ASCII, so LOWER(c.name) LIKE '%газ%'
never matched a Cyrillic category name like 'Газ'. When lazy-loading
older operations, getNextOldestFilteredOperation returned null and
stopped pagination, hiding all matching historical operations.

Fix: include both the JS-lowercased term (for ASCII case-insensitive
matching) and the original-case term (for Cyrillic/Unicode verbatim
matching) in all five filtered-query search conditions. Applies to
description, account name, destination account name, and category name.

https://claude.ai/code/session_01LfyJ76UKbnb1Mj4HgSYcWX