### PR TITLE
feat: redesign update dialog with compact downloaded APKs display

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1209,33 +1209,68 @@ export default function SettingsModal({ visible, onClose }) {
                               {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
                             </Text>
                           )}
-                          <View style={styles.updateActions}>
-                            {updateResult.releaseNotes && (
-                              <Text style={[styles.updateHintText, { color: colors.mutedText }]}>
-                                {t('update_install_hint') || 'If installation is blocked, allow "Install unknown apps" for your browser or file manager in Android settings.'}
-                              </Text>
+                          <Divider style={styles.updateDivider} />
+                          <View style={styles.updateBottomRow}>
+                            {downloadedApks.length > 0 && (
+                              <View style={styles.downloadedApksCompact}>
+                                <Text style={[styles.downloadedApksTitleCompact, { color: colors.mutedText }]}>
+                                  {t('downloaded_apks') || 'Downloaded APKs'}
+                                </Text>
+                                <FlatList
+                                  horizontal
+                                  data={downloadedApks}
+                                  keyExtractor={(item) => item.uri}
+                                  renderItem={({ item }) => (
+                                    <TouchableOpacity
+                                      onPress={() => handleInstallApk(item.uri)}
+                                      style={styles.apkChipCompact}
+                                      accessibilityRole="button"
+                                      accessibilityLabel={`Install version ${item.version || item.filename}`}
+                                    >
+                                      <Ionicons name="archive-outline" size={22} color={colors.primary} />
+                                      <Text style={[styles.apkChipVersion, { color: colors.text }]}>
+                                        {item.version ? `v${item.version}` : item.filename.replace(/\.apk$/i, '')}
+                                      </Text>
+                                      <Text style={[styles.apkChipDate, { color: colors.mutedText }]}>
+                                        {formatApkDate(item.modificationTime)}
+                                      </Text>
+                                    </TouchableOpacity>
+                                  )}
+                                  showsHorizontalScrollIndicator={false}
+                                  contentContainerStyle={styles.apkListContent}
+                                />
+                              </View>
                             )}
-                            <TouchableRipple
-                              onPress={async () => {
-                                await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
-                                closeSubPanel();
-                                onClose();
-                                startDownload(updateResult.downloadUrl, {
-                                  onError: () => {
-                                    showDialog(
-                                      t('error') || 'Error',
-                                      t('update_download_failed') || 'Could not download the update. Please try again.',
-                                      [{ text: t('ok') || 'OK' }],
-                                    );
-                                  },
-                                });
-                              }}
-                              style={[styles.importConfirmButton, { backgroundColor: colors.primary }]}
-                            >
-                              <Text style={styles.importConfirmButtonText}>
-                                {t('update_now') || 'Update now'}
+                            <View style={styles.updateActionColumn}>
+                              <Text style={[styles.updateButtonVersion, { color: colors.text }]}>
+                                v{updateResult.latestVersion}
                               </Text>
-                            </TouchableRipple>
+                              <Text style={[styles.updateButtonCurrentVersion, { color: colors.mutedText }]}>
+                                {(t('update_from_version') || 'installed: v{currentVersion}')
+                                  .replace('{currentVersion}', updateResult.currentVersion)}
+                              </Text>
+                              <TouchableRipple
+                                onPress={async () => {
+                                  await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
+                                  closeSubPanel();
+                                  onClose();
+                                  startDownload(updateResult.downloadUrl, {
+                                    onError: () => {
+                                      showDialog(
+                                        t('error') || 'Error',
+                                        t('update_download_failed') || 'Could not download the update. Please try again.',
+                                        [{ text: t('ok') || 'OK' }],
+                                      );
+                                    },
+                                  });
+                                }}
+                                style={[styles.updateButtonCompact, { backgroundColor: colors.primary }]}
+                              >
+                                <Text style={styles.importConfirmButtonText}>
+                                  {t('update_now') || 'Update now'}
+                                </Text>
+                              </TouchableRipple>
+                            </View>
                           </View>
                         </>
                       )}
@@ -1259,7 +1294,7 @@ export default function SettingsModal({ visible, onClose }) {
                       )}
                     </Animated.View>
                   )}
-                  {downloadedApks.length > 0 && (
+                  {downloadedApks.length > 0 && updateResult?.type !== 'available' && (
                     <View style={styles.downloadedApksSection}>
                       <Divider />
                       <Text style={[styles.downloadedApksTitle, { color: colors.mutedText }]}>
@@ -1313,6 +1348,13 @@ const styles = StyleSheet.create({
     gap: SPACING.xs,
     minWidth: 72,
     paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+  },
+  apkChipCompact: {
+    alignItems: 'center',
+    gap: SPACING.xs,
+    minWidth: 44,
+    paddingHorizontal: SPACING.xs,
     paddingVertical: SPACING.sm,
   },
   apkChipDate: {
@@ -1422,6 +1464,10 @@ const styles = StyleSheet.create({
   divider: {
     marginVertical: SPACING.xs,
   },
+  downloadedApksCompact: {
+    flex: 1,
+    overflow: 'hidden',
+  },
   downloadedApksSection: {
     paddingBottom: SPACING.md,
   },
@@ -1432,6 +1478,13 @@ const styles = StyleSheet.create({
     paddingBottom: SPACING.sm,
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingTop: SPACING.md,
+    textTransform: 'uppercase',
+  },
+  downloadedApksTitleCompact: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    paddingBottom: SPACING.sm,
     textTransform: 'uppercase',
   },
   filterChip: {
@@ -1476,12 +1529,6 @@ const styles = StyleSheet.create({
   },
   headerTitle: {
     fontWeight: '600',
-  },
-  importConfirmButton: {
-    borderRadius: BORDER_RADIUS.md,
-    marginTop: SPACING.xl,
-    paddingHorizontal: SPACING.xl,
-    paddingVertical: SPACING.md,
   },
   importConfirmButtonDestructive: {
     backgroundColor: '#c44',
@@ -1685,14 +1732,38 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 44,
   },
-  updateActions: {
-    paddingTop: SPACING.md,
+  updateActionColumn: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'flex-end',
   },
   updateAvailableHeader: {
     alignItems: 'center',
     flexDirection: 'row',
     gap: SPACING.md,
     paddingBottom: SPACING.sm,
+  },
+  updateBottomRow: {
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingTop: SPACING.sm,
+  },
+  updateButtonCompact: {
+    alignSelf: 'stretch',
+    borderRadius: BORDER_RADIUS.md,
+    marginTop: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    paddingVertical: SPACING.sm,
+  },
+  updateButtonCurrentVersion: {
+    fontSize: 11,
+    marginTop: 2,
+    textAlign: 'center',
+  },
+  updateButtonVersion: {
+    fontSize: 15,
+    fontWeight: '600',
+    textAlign: 'center',
   },
   updateCheckingContainer: {
     alignItems: 'center',
@@ -1712,12 +1783,6 @@ const styles = StyleSheet.create({
   },
   updateDivider: {
     marginTop: SPACING.sm,
-  },
-  updateHintText: {
-    fontSize: 13,
-    lineHeight: 19,
-    marginTop: SPACING.md,
-    textAlign: 'center',
   },
   updateNewVersion: {
     fontSize: 20,

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1280,6 +1280,37 @@ export default function SettingsModal({ visible, onClose }) {
                           <Text style={[styles.updateVersionText, { color: colors.text }]}>
                             {t('up_to_date') || 'You already have the latest version installed.'}
                           </Text>
+                          {downloadedApks.length > 0 && (
+                            <View style={styles.downloadedApksSection}>
+                              <Divider />
+                              <Text style={[styles.downloadedApksTitle, { color: colors.mutedText }]}>
+                                {t('downloaded_apks') || 'Downloaded'}
+                              </Text>
+                              <FlatList
+                                horizontal
+                                data={downloadedApks}
+                                keyExtractor={(item) => item.uri}
+                                renderItem={({ item }) => (
+                                  <TouchableOpacity
+                                    onPress={() => handleInstallApk(item.uri)}
+                                    style={styles.apkChip}
+                                    accessibilityRole="button"
+                                    accessibilityLabel={`Install version ${item.version || item.filename}`}
+                                  >
+                                    <Ionicons name="archive-outline" size={28} color={colors.primary} />
+                                    <Text style={[styles.apkChipVersion, { color: colors.text }]}>
+                                      {item.version ? `v${item.version}` : item.filename.replace(/\.apk$/i, '')}
+                                    </Text>
+                                    <Text style={[styles.apkChipDate, { color: colors.mutedText }]}>
+                                      {formatApkDate(item.modificationTime)}
+                                    </Text>
+                                  </TouchableOpacity>
+                                )}
+                                showsHorizontalScrollIndicator={false}
+                                contentContainerStyle={styles.apkListContent}
+                              />
+                            </View>
+                          )}
                         </View>
                       )}
                       {updateResult.type === 'error' && (
@@ -1293,37 +1324,6 @@ export default function SettingsModal({ visible, onClose }) {
                         </View>
                       )}
                     </Animated.View>
-                  )}
-                  {downloadedApks.length > 0 && updateResult?.type !== 'available' && (
-                    <View style={styles.downloadedApksSection}>
-                      <Divider />
-                      <Text style={[styles.downloadedApksTitle, { color: colors.mutedText }]}>
-                        {t('downloaded_apks') || 'Downloaded'}
-                      </Text>
-                      <FlatList
-                        horizontal
-                        data={downloadedApks}
-                        keyExtractor={(item) => item.uri}
-                        renderItem={({ item }) => (
-                          <TouchableOpacity
-                            onPress={() => handleInstallApk(item.uri)}
-                            style={styles.apkChip}
-                            accessibilityRole="button"
-                            accessibilityLabel={`Install version ${item.version || item.filename}`}
-                          >
-                            <Ionicons name="archive-outline" size={28} color={colors.primary} />
-                            <Text style={[styles.apkChipVersion, { color: colors.text }]}>
-                              {item.version ? `v${item.version}` : item.filename.replace(/\.apk$/i, '')}
-                            </Text>
-                            <Text style={[styles.apkChipDate, { color: colors.mutedText }]}>
-                              {formatApkDate(item.modificationTime)}
-                            </Text>
-                          </TouchableOpacity>
-                        )}
-                        showsHorizontalScrollIndicator={false}
-                        contentContainerStyle={styles.apkListContent}
-                      />
-                    </View>
                   )}
                 </View>
               )}

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -148,9 +148,9 @@ export const checkForAppUpdate = async ({
         break; // reached current or older — stop
       }
 
-      newerReleases.push({ version: releaseVersion, notes: release.body || null });
-
       const apkAsset = extractApkAsset(release.assets);
+      newerReleases.push({ version: releaseVersion, notes: release.body || null, hasApk: !!apkAsset });
+
       if (apkAsset && !bestRelease) {
         bestRelease = {
           version: releaseVersion,
@@ -183,7 +183,7 @@ export const checkForAppUpdate = async ({
     }
 
     const releaseNotes = newerReleases
-      .filter((r) => r.notes)
+      .filter((r) => r.notes && r.hasApk)
       .map((r) => ({ version: r.version, notes: r.notes }));
 
     return {

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "Heruntergeladene APKs",
   "later": "Later",
   "local_backups": "Lokale Backups",
   "local_backups_empty": "Noch keine lokalen Backups",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "Downloaded APKs",
   "later": "Later",
   "local_backups": "Local Backups",
   "local_backups_empty": "No local backups yet",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "APKs descargados",
   "later": "Later",
   "local_backups": "Copias de seguridad locales",
   "local_backups_empty": "Aún no hay copias de seguridad locales",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "APKs téléchargés",
   "later": "Later",
   "local_backups": "Sauvegardes locales",
   "local_backups_empty": "Aucune sauvegarde locale pour l'instant",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -357,6 +357,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "Ներբեռնված APK-ներ",
   "later": "Later",
   "local_backups": "Տեղական կրկնօրինակներ",
   "local_backups_empty": "Տեղական կրկնօրինակ չկա",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -112,6 +112,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "APK scaricati",
   "later": "Later",
   "local_backups": "Backup locali",
   "local_backups_empty": "Nessun backup locale ancora",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "ダウンロード済みAPK",
   "later": "Later",
   "local_backups": "Local Backups",
   "local_backups_empty": "No local backups yet",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "다운로드된 APK",
   "later": "Later",
   "local_backups": "Local Backups",
   "local_backups_empty": "No local backups yet",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "APKs baixados",
   "later": "Later",
   "local_backups": "Local Backups",
   "local_backups_empty": "No local backups yet",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -369,6 +369,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "Загруженные APK",
   "later": "Later",
   "local_backups": "Локальные резервные копии",
   "local_backups_empty": "Нет локальных резервных копий",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -371,6 +371,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "downloaded_apks": "已下载 APK",
   "later": "Later",
   "local_backups": "本地备份",
   "local_backups_empty": "暂无本地备份",


### PR DESCRIPTION
## Summary
Refactored the app update notification UI in the Settings modal to display downloaded APKs in a more compact, horizontal layout integrated directly into the update dialog, rather than as a separate section below.

## Key Changes

- **Redesigned update dialog layout**: Restructured the update actions section to use a horizontal bottom row layout with the update button and downloaded APKs displayed side-by-side
- **Compact APK display**: Moved downloaded APKs from a separate full-width section into a horizontal scrollable list within the update dialog, reducing visual clutter
- **Conditional rendering**: Updated the full-width downloaded APKs section to only display when no update is available (`updateResult?.type !== 'available'`)
- **Updated styling**: 
  - Added new compact styles: `apkChipCompact`, `downloadedApksCompact`, `downloadedApksTitleCompact`, `updateActionColumn`, `updateBottomRow`, `updateButtonCompact`, `updateButtonVersion`, `updateButtonCurrentVersion`
  - Removed obsolete styles: `importConfirmButton`, `updateActions`, `updateHintText`
  - Added `updateDivider` to separate the update info from the action row
- **Enhanced update service**: Modified `AppUpdateService.js` to track which releases have APK assets (`hasApk` flag) and filter release notes to only show those with available APKs
- **Internationalization**: Added `downloaded_apks` translation key across all language files

## Implementation Details

- The update dialog now displays the latest version number and current installed version in the action column
- Downloaded APKs are shown as horizontal chips with version/filename and modification date
- The layout uses flexbox to ensure proper spacing and alignment between the APK list and update button
- Release notes filtering now ensures only releases with actual APK assets are included in the update information

https://claude.ai/code/session_01YT6ygJM9M2qLGmVSA6zDUu