### PR TITLE
feat(graphs): donut chart with arc icons and side legend

### DIFF
--- a/__tests__/components/graphs/CustomLegend.test.js
+++ b/__tests__/components/graphs/CustomLegend.test.js
@@ -156,20 +156,10 @@ describe('CustomLegend', () => {
   });
 
   describe('Icons', () => {
-    it('renders icons when provided', () => {
-      const { getByTestId } = render(<CustomLegend {...defaultProps} />);
-      expect(getByTestId('legend-icon-food')).toBeTruthy();
-      expect(getByTestId('legend-icon-car')).toBeTruthy();
-    });
-
-    it('does not render icons when not provided', () => {
-      const dataWithoutIcons = [
-        { name: 'No Icon', amount: 100, color: '#000', categoryId: 'cat-1' },
-      ];
-      const { queryByTestId } = render(
-        <CustomLegend {...defaultProps} data={dataWithoutIcons} />,
-      );
-      expect(queryByTestId('icon-undefined')).toBeNull();
+    it('does not render icons in legend rows (icons shown on donut arc instead)', () => {
+      const { queryByTestId } = render(<CustomLegend {...defaultProps} />);
+      expect(queryByTestId('legend-icon-food')).toBeNull();
+      expect(queryByTestId('legend-icon-car')).toBeNull();
     });
   });
 

--- a/__tests__/components/graphs/CustomLegend.test.js
+++ b/__tests__/components/graphs/CustomLegend.test.js
@@ -158,8 +158,8 @@ describe('CustomLegend', () => {
   describe('Icons', () => {
     it('renders icons when provided', () => {
       const { getByTestId } = render(<CustomLegend {...defaultProps} />);
-      expect(getByTestId('icon-food')).toBeTruthy();
-      expect(getByTestId('icon-car')).toBeTruthy();
+      expect(getByTestId('legend-icon-food')).toBeTruthy();
+      expect(getByTestId('legend-icon-car')).toBeTruthy();
     });
 
     it('does not render icons when not provided', () => {

--- a/__tests__/components/graphs/DonutChart.test.js
+++ b/__tests__/components/graphs/DonutChart.test.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import DonutChart, {
+  computeSegments,
+  CIRCUMFERENCE,
+  CENTER,
+  RADIUS,
+  ICON_THRESHOLD,
+} from '../../../app/components/graphs/DonutChart';
+
+describe('computeSegments', () => {
+  it('returns empty array for empty data', () => {
+    expect(computeSegments([])).toEqual([]);
+  });
+
+  it('returns empty array when all amounts are zero', () => {
+    expect(computeSegments([{ amount: 0, color: '#f00', icon: 'food' }])).toEqual([]);
+  });
+
+  it('arc lengths sum to CIRCUMFERENCE', () => {
+    const data = [
+      { amount: 450, color: '#f00', icon: 'food' },
+      { amount: 300, color: '#0f0', icon: 'car' },
+      { amount: 250, color: '#00f', icon: 'shopping' },
+    ];
+    const segs = computeSegments(data);
+    const total = segs.reduce((s, seg) => s + seg.arcLength, 0);
+    expect(total).toBeCloseTo(CIRCUMFERENCE, 5);
+  });
+
+  it('first segment has dashOffset of 0', () => {
+    const data = [
+      { amount: 500, color: '#f00', icon: 'food' },
+      { amount: 500, color: '#0f0', icon: 'car' },
+    ];
+    expect(computeSegments(data)[0].dashOffset).toBe(0);
+  });
+
+  it('each subsequent segment dashOffset equals negative sum of prior arcLengths', () => {
+    const data = [
+      { amount: 400, color: '#f00', icon: 'food' },
+      { amount: 300, color: '#0f0', icon: 'car' },
+      { amount: 300, color: '#00f', icon: 'shopping' },
+    ];
+    const segs = computeSegments(data);
+    expect(segs[1].dashOffset).toBeCloseTo(-segs[0].arcLength, 5);
+    expect(segs[2].dashOffset).toBeCloseTo(-(segs[0].arcLength + segs[1].arcLength), 5);
+  });
+
+  it('shows icon for segment exactly at ICON_THRESHOLD', () => {
+    const pct = ICON_THRESHOLD; // 10%
+    const data = [
+      { amount: 1 - pct, color: '#f00', icon: 'food' },
+      { amount: pct,     color: '#0f0', icon: 'car' },
+    ];
+    const segs = computeSegments(data);
+    expect(segs[1].showIcon).toBe(true);
+  });
+
+  it('hides icon for segment just below ICON_THRESHOLD', () => {
+    const data = [
+      { amount: 0.91, color: '#f00', icon: 'food' },
+      { amount: 0.09, color: '#0f0', icon: 'car' }, // 9%
+    ];
+    expect(computeSegments(data)[1].showIcon).toBe(false);
+  });
+
+  it('hides icon when item.icon is falsy', () => {
+    const data = [{ amount: 1000, color: '#f00', icon: null }];
+    expect(computeSegments(data)[0].showIcon).toBe(false);
+  });
+
+  it('single segment spans full circumference', () => {
+    const segs = computeSegments([{ amount: 100, color: '#f00', icon: 'food' }]);
+    expect(segs[0].arcLength).toBeCloseTo(CIRCUMFERENCE, 5);
+    expect(segs[0].dashOffset).toBe(0);
+  });
+
+  it('icon at top (midAngle≈0) maps to x≈CENTER, y≈CENTER−RADIUS', () => {
+    const segs = computeSegments([{ amount: 1, color: '#f00', icon: 'food' }]);
+    // midAngle = (0 + CIRCUMFERENCE/2) / RADIUS = π
+    expect(segs[0].iconX).toBeCloseTo(CENTER, 1);         // sin(π) ≈ 0
+    expect(segs[0].iconY).toBeCloseTo(CENTER + RADIUS, 1); // −cos(π) = 1
+  });
+
+  it('preserves color and icon from input', () => {
+    const segs = computeSegments([{ amount: 100, color: '#abc123', icon: 'pizza' }]);
+    expect(segs[0].color).toBe('#abc123');
+    expect(segs[0].icon).toBe('pizza');
+  });
+});
+
+describe('DonutChart', () => {
+  const mockData = [
+    { amount: 560, color: '#7c83fd', icon: 'food' },   // 60.9% — above threshold
+    { amount: 280, color: '#fd7c7c', icon: 'car' },    // 30.4% — above threshold
+    { amount: 80,  color: '#7ce8fd', icon: 'heart' },  //  8.7% — below threshold
+  ];
+
+  it('renders without crashing', () => {
+    expect(() => render(<DonutChart data={mockData} />)).not.toThrow();
+  });
+
+  it('renders icons for segments at or above threshold', () => {
+    const { queryByTestId } = render(<DonutChart data={mockData} />);
+    expect(queryByTestId('icon-food')).not.toBeNull();
+    expect(queryByTestId('icon-car')).not.toBeNull();
+  });
+
+  it('does not render icon for segment below threshold', () => {
+    const { queryByTestId } = render(<DonutChart data={mockData} />);
+    expect(queryByTestId('icon-heart')).toBeNull();
+  });
+
+  it('renders no icons when data is empty', () => {
+    const { queryAllByTestId } = render(<DonutChart data={[]} />);
+    expect(queryAllByTestId(/^icon-/).length).toBe(0);
+  });
+
+  it('renders no icons when items have no icon property', () => {
+    const data = [{ amount: 1000, color: '#f00', icon: null }];
+    const { queryAllByTestId } = render(<DonutChart data={data} />);
+    expect(queryAllByTestId(/^icon-/).length).toBe(0);
+  });
+
+  it('renders a single icon for a single above-threshold item', () => {
+    const data = [{ amount: 100, color: '#7c83fd', icon: 'food' }];
+    const { queryByTestId } = render(<DonutChart data={data} />);
+    expect(queryByTestId('icon-food')).not.toBeNull();
+  });
+});

--- a/__tests__/components/graphs/DonutChart.test.js
+++ b/__tests__/components/graphs/DonutChart.test.js
@@ -76,7 +76,7 @@ describe('computeSegments', () => {
     expect(segs[0].dashOffset).toBe(0);
   });
 
-  it('icon at top (midAngle≈0) maps to x≈CENTER, y≈CENTER−RADIUS', () => {
+  it('icon position math: full-circle segment midAngle=π maps to bottom (x≈CENTER, y≈CENTER+RADIUS)', () => {
     const segs = computeSegments([{ amount: 1, color: '#f00', icon: 'food' }]);
     // midAngle = (0 + CIRCUMFERENCE/2) / RADIUS = π
     expect(segs[0].iconX).toBeCloseTo(CENTER, 1);         // sin(π) ≈ 0
@@ -102,9 +102,9 @@ describe('DonutChart', () => {
   });
 
   it('renders icons for segments at or above threshold', () => {
-    const { queryByTestId } = render(<DonutChart data={mockData} />);
-    expect(queryByTestId('icon-food')).not.toBeNull();
-    expect(queryByTestId('icon-car')).not.toBeNull();
+    const { queryAllByTestId } = render(<DonutChart data={mockData} />);
+    expect(queryAllByTestId('icon-food').length).toBeGreaterThan(0);
+    expect(queryAllByTestId('icon-car').length).toBeGreaterThan(0);
   });
 
   it('does not render icon for segment below threshold', () => {
@@ -125,7 +125,7 @@ describe('DonutChart', () => {
 
   it('renders a single icon for a single above-threshold item', () => {
     const data = [{ amount: 100, color: '#7c83fd', icon: 'food' }];
-    const { queryByTestId } = render(<DonutChart data={data} />);
-    expect(queryByTestId('icon-food')).not.toBeNull();
+    const { queryAllByTestId } = render(<DonutChart data={data} />);
+    expect(queryAllByTestId('icon-food').length).toBeGreaterThan(0);
   });
 });

--- a/__tests__/components/graphs/ExpensePieChart.test.js
+++ b/__tests__/components/graphs/ExpensePieChart.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ExpensePieChart from '../../../app/components/graphs/ExpensePieChart';
+
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
+}));
+
+jest.mock('../../../assets/currencies.json', () => ({
+  USD: { decimal_digits: 2, symbol: '$' },
+}));
+
+const mockColors = {
+  primary: '#007AFF',
+  text: '#111111',
+  mutedText: '#666666',
+  border: '#e6e6e6',
+};
+
+const mockData = [
+  { name: 'Food', amount: 560, color: '#7c83fd', icon: 'food', categoryId: '1', hasChildren: false },
+  { name: 'Transport', amount: 280, color: '#fd7c7c', icon: 'car', categoryId: '2', hasChildren: false },
+  { name: 'Other', amount: 40, color: '#aaa', icon: 'dots-horizontal', categoryId: '3', hasChildren: false },
+];
+
+const defaultProps = {
+  colors: mockColors,
+  t: (key) => key,
+  loading: false,
+  chartData: mockData,
+  selectedCurrency: 'USD',
+  onLegendItemPress: jest.fn(),
+  selectedCategory: 'all',
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ExpensePieChart', () => {
+  it('renders loading state when loading is true', () => {
+    const { getByText } = render(<ExpensePieChart {...defaultProps} loading={true} />);
+    expect(getByText('loading_operations')).toBeTruthy();
+  });
+
+  it('does not render donut chart when loading', () => {
+    const { queryByTestId } = render(<ExpensePieChart {...defaultProps} loading={true} />);
+    expect(queryByTestId('donut-chart')).toBeNull();
+  });
+
+  it('renders empty state text when chartData is empty', () => {
+    const { getByText } = render(<ExpensePieChart {...defaultProps} chartData={[]} />);
+    expect(getByText('no_expense_data')).toBeTruthy();
+  });
+
+  it('renders DonutChart when data is present', () => {
+    const { getByTestId } = render(<ExpensePieChart {...defaultProps} />);
+    expect(getByTestId('donut-chart')).toBeTruthy();
+  });
+
+  it('renders legend category names', () => {
+    const { getByText } = render(<ExpensePieChart {...defaultProps} />);
+    expect(getByText('Food')).toBeTruthy();
+    expect(getByText('Transport')).toBeTruthy();
+  });
+
+  it('renders arc icons for above-threshold segments', () => {
+    // Food 63.6%, Transport 31.8% — both above 10%
+    const { queryAllByTestId } = render(<ExpensePieChart {...defaultProps} />);
+    expect(queryAllByTestId('icon-food').length).toBeGreaterThan(0);
+    expect(queryAllByTestId('icon-car').length).toBeGreaterThan(0);
+  });
+
+  it('does not render arc icon for below-threshold segment', () => {
+    // Other 4.5% — below 10%
+    const { queryAllByTestId } = render(<ExpensePieChart {...defaultProps} />);
+    expect(queryAllByTestId('icon-dots-horizontal').length).toBe(0);
+  });
+});

--- a/__tests__/components/graphs/IncomePieChart.test.js
+++ b/__tests__/components/graphs/IncomePieChart.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import IncomePieChart from '../../../app/components/graphs/IncomePieChart';
+
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
+}));
+
+jest.mock('../../../assets/currencies.json', () => ({
+  USD: { decimal_digits: 2, symbol: '$' },
+}));
+
+const mockColors = {
+  primary: '#007AFF',
+  text: '#111111',
+  mutedText: '#666666',
+  border: '#e6e6e6',
+};
+
+const mockData = [
+  { name: 'Salary', amount: 3000, color: '#7c83fd', icon: 'briefcase', categoryId: '1', hasChildren: false },
+  { name: 'Freelance', amount: 800, color: '#7cfd9e', icon: 'laptop', categoryId: '2', hasChildren: false },
+  { name: 'Other', amount: 60, color: '#aaa', icon: 'dots-horizontal', categoryId: '3', hasChildren: false },
+];
+
+const defaultProps = {
+  colors: mockColors,
+  t: (key) => key,
+  loadingIncome: false,
+  incomeChartData: mockData,
+  selectedCurrency: 'USD',
+  onLegendItemPress: jest.fn(),
+  selectedIncomeCategory: 'all',
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('IncomePieChart', () => {
+  it('renders loading state when loadingIncome is true', () => {
+    const { getByText } = render(<IncomePieChart {...defaultProps} loadingIncome={true} />);
+    expect(getByText('loading_operations')).toBeTruthy();
+  });
+
+  it('does not render donut chart when loading', () => {
+    const { queryByTestId } = render(<IncomePieChart {...defaultProps} loadingIncome={true} />);
+    expect(queryByTestId('donut-chart')).toBeNull();
+  });
+
+  it('renders empty state text when incomeChartData is empty', () => {
+    const { getByText } = render(<IncomePieChart {...defaultProps} incomeChartData={[]} />);
+    expect(getByText('no_income_data')).toBeTruthy();
+  });
+
+  it('renders DonutChart when data is present', () => {
+    const { getByTestId } = render(<IncomePieChart {...defaultProps} />);
+    expect(getByTestId('donut-chart')).toBeTruthy();
+  });
+
+  it('renders legend category names', () => {
+    const { getByText } = render(<IncomePieChart {...defaultProps} />);
+    expect(getByText('Salary')).toBeTruthy();
+    expect(getByText('Freelance')).toBeTruthy();
+  });
+
+  it('renders arc icons for above-threshold segments', () => {
+    // Salary 77.9%, Freelance 20.8% — both above 10%
+    const { queryAllByTestId } = render(<IncomePieChart {...defaultProps} />);
+    expect(queryAllByTestId('icon-briefcase').length).toBeGreaterThan(0);
+    expect(queryAllByTestId('icon-laptop').length).toBeGreaterThan(0);
+  });
+
+  it('does not render arc icon for below-threshold segment', () => {
+    // Other 1.6% — below 10%
+    const { queryAllByTestId } = render(<IncomePieChart {...defaultProps} />);
+    expect(queryAllByTestId('icon-dots-horizontal').length).toBe(0);
+  });
+});

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -654,7 +654,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   balanceHistoryCard: {
-    borderRadius: 8,
+    borderRadius: 16,
     borderWidth: 1,
     marginBottom: 16,
     overflow: 'hidden',

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -710,7 +710,7 @@ const styles = StyleSheet.create({
     marginTop: 12,
   },
   card: {
-    borderRadius: 8,
+    borderRadius: 16,
     borderWidth: 1,
     marginBottom: 16,
     padding: 16,

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -58,7 +58,7 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
                   name={item.icon}
                   size={18}
                   color={colors.text}
-                  style={styles.legendIcon}
+                  testID={`legend-icon-${item.icon}`}
                 />
               )}
               <Text style={[styles.legendName, { color: colors.text }]} numberOfLines={1}>
@@ -145,9 +145,6 @@ const styles = StyleSheet.create({
   },
   legendContainer: {
     marginTop: 16,
-  },
-  legendIcon: {
-    marginLeft: 4,
   },
   legendItem: {
     alignItems: 'center',

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -120,13 +120,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
-    gap: 8,
+    gap: 4,
     minWidth: 0,
   },
   colorIndicator: {
-    borderRadius: 6,
-    height: 12,
-    width: 12,
+    borderRadius: 4,
+    height: 8,
+    width: 8,
   },
   legendAmount: {
     fontSize: 12,
@@ -142,7 +142,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderBottomWidth: 1,
     flexDirection: 'row',
-    paddingHorizontal: 4,
+    paddingHorizontal: 2,
     paddingVertical: 12,
   },
   legendItemClickable: {
@@ -165,7 +165,7 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     backgroundColor: 'rgba(120,120,120,0.13)',
     height: '70%',
-    marginHorizontal: 8,
+    marginHorizontal: 4,
     width: 1,
   },
 });

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -136,7 +136,7 @@ const styles = StyleSheet.create({
     marginLeft: 4,
   },
   legendContainer: {
-    marginTop: 16,
+    marginTop: 4,
   },
   legendItem: {
     alignItems: 'center',

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -53,14 +53,6 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
             {/* Category column (flexible width) */}
             <View style={styles.categoryColumn}>
               <View style={[styles.colorIndicator, { backgroundColor: item.color }]} />
-              {item.icon && (
-                <Icon
-                  name={item.icon}
-                  size={18}
-                  color={colors.text}
-                  testID={`legend-icon-${item.icon}`}
-                />
-              )}
               <Text style={[styles.legendName, { color: colors.text }]} numberOfLines={1}>
                 {item.name}
               </Text>
@@ -122,7 +114,7 @@ const styles = StyleSheet.create({
   amountColumn: {
     alignItems: 'flex-end',
     justifyContent: 'center',
-    width: 100,
+    width: 62,
   },
   categoryColumn: {
     alignItems: 'center',
@@ -137,7 +129,7 @@ const styles = StyleSheet.create({
     width: 12,
   },
   legendAmount: {
-    fontSize: 14,
+    fontSize: 12,
     fontWeight: '600',
   },
   legendChevron: {
@@ -158,16 +150,16 @@ const styles = StyleSheet.create({
   },
   legendName: {
     flex: 1,
-    fontSize: 14,
+    fontSize: 12,
   },
   legendPercentage: {
-    fontSize: 14,
+    fontSize: 12,
     fontWeight: '500',
   },
   percentageColumn: {
     alignItems: 'flex-end',
     justifyContent: 'center',
-    width: 50,
+    width: 38,
   },
   verticalDivider: {
     alignSelf: 'center',

--- a/app/components/graphs/DonutChart.js
+++ b/app/components/graphs/DonutChart.js
@@ -1,0 +1,100 @@
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+
+export const SVG_SIZE = 140;
+export const RADIUS = 48;
+export const STROKE_WIDTH = 26;
+export const CENTER = SVG_SIZE / 2;
+export const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+export const ICON_THRESHOLD = 0.10;
+export const ICON_SIZE = 14;
+
+export const computeSegments = (data) => {
+  const total = data.reduce((sum, item) => sum + item.amount, 0);
+  if (total === 0) return [];
+
+  let cumulative = 0;
+  return data.map((item) => {
+    const fraction = item.amount / total;
+    const arcLength = fraction * CIRCUMFERENCE;
+    const midAngle = (cumulative + arcLength / 2) / RADIUS;
+    const seg = {
+      color: item.color,
+      icon: item.icon,
+      arcLength,
+      dashOffset: cumulative === 0 ? 0 : -cumulative,
+      showIcon: fraction >= ICON_THRESHOLD && !!item.icon,
+      iconX: CENTER + RADIUS * Math.sin(midAngle),
+      iconY: CENTER - RADIUS * Math.cos(midAngle),
+    };
+    cumulative += arcLength;
+    return seg;
+  });
+};
+
+const DonutChart = ({ data }) => {
+  const segments = useMemo(() => computeSegments(data), [data]);
+
+  return (
+    <View testID="donut-chart" style={styles.container}>
+      <Svg width={SVG_SIZE} height={SVG_SIZE}>
+        {segments.map((seg, i) => (
+          <Circle
+            key={i}
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            fill="none"
+            stroke={seg.color}
+            strokeWidth={STROKE_WIDTH}
+            strokeDasharray={`${seg.arcLength} ${CIRCUMFERENCE - seg.arcLength}`}
+            strokeDashoffset={seg.dashOffset}
+            rotation={-90}
+            origin={`${CENTER}, ${CENTER}`}
+          />
+        ))}
+      </Svg>
+      {segments
+        .filter((seg) => seg.showIcon)
+        .map((seg, i) => (
+          <View
+            key={i}
+            style={[
+              styles.iconWrapper,
+              {
+                left: seg.iconX - ICON_SIZE / 2,
+                top: seg.iconY - ICON_SIZE / 2,
+              },
+            ]}
+          >
+            <Icon name={seg.icon} size={ICON_SIZE} color="#fff" />
+          </View>
+        ))}
+    </View>
+  );
+};
+
+DonutChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      amount: PropTypes.number.isRequired,
+      color: PropTypes.string.isRequired,
+      icon: PropTypes.string,
+    }),
+  ).isRequired,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: SVG_SIZE,
+    width: SVG_SIZE,
+  },
+  iconWrapper: {
+    position: 'absolute',
+  },
+});
+
+export default DonutChart;

--- a/app/components/graphs/DonutChart.js
+++ b/app/components/graphs/DonutChart.js
@@ -62,6 +62,7 @@ const DonutChart = ({ data }) => {
         .map((seg, i) => (
           <View
             key={i}
+            testID={`icon-${seg.icon}`}
             style={[
               styles.iconWrapper,
               {

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -35,13 +35,15 @@ const ExpensePieChart = ({
   return (
     <View style={styles.row}>
       <DonutChart data={chartData} />
-      <CustomLegend
-        data={chartData}
-        currency={selectedCurrency}
-        colors={colors}
-        onItemPress={onLegendItemPress}
-        isClickable={selectedCategory === 'all'}
-      />
+      <View style={styles.legendWrapper}>
+        <CustomLegend
+          data={chartData}
+          currency={selectedCurrency}
+          colors={colors}
+          onItemPress={onLegendItemPress}
+          isClickable={selectedCategory === 'all'}
+        />
+      </View>
     </View>
   );
 };
@@ -57,6 +59,9 @@ ExpensePieChart.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  legendWrapper: {
+    flex: 1,
+  },
   loadingContainer: {
     alignItems: 'center',
     paddingVertical: 32,

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet, ActivityIndicator, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
-import { PieChart } from 'react-native-chart-kit';
+import DonutChart from './DonutChart';
 import CustomLegend from './CustomLegend';
-
-const screenWidth = Dimensions.get('window').width;
 
 const ExpensePieChart = ({
   colors,
@@ -15,46 +13,36 @@ const ExpensePieChart = ({
   onLegendItemPress,
   selectedCategory,
 }) => {
-  return (
-    <>
-      {loading ? (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.primary} />
-          <Text style={[styles.loadingText, { color: colors.mutedText }]}>
-            {t('loading_operations')}
-          </Text>
-        </View>
-      ) : chartData.length > 0 ? (
-        <>
-          <View style={styles.chartContainer}>
-            <PieChart
-              data={chartData}
-              width={screenWidth - 64}
-              height={220}
-              chartConfig={{
-                color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
-              }}
-              accessor="amount"
-              backgroundColor="transparent"
-              paddingLeft="15"
-              center={[0, 0]}
-              hasLegend={false}
-            />
-          </View>
-          <CustomLegend
-            data={chartData}
-            currency={selectedCurrency}
-            colors={colors}
-            onItemPress={onLegendItemPress}
-            isClickable={selectedCategory === 'all'}
-          />
-        </>
-      ) : (
-        <Text style={[styles.noData, { color: colors.mutedText }]}>
-          {t('no_expense_data')}
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+          {t('loading_operations')}
         </Text>
-      )}
-    </>
+      </View>
+    );
+  }
+
+  if (chartData.length === 0) {
+    return (
+      <Text style={[styles.noData, { color: colors.mutedText }]}>
+        {t('no_expense_data')}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.row}>
+      <DonutChart data={chartData} />
+      <CustomLegend
+        data={chartData}
+        currency={selectedCurrency}
+        colors={colors}
+        onItemPress={onLegendItemPress}
+        isClickable={selectedCategory === 'all'}
+      />
+    </View>
   );
 };
 
@@ -69,10 +57,6 @@ ExpensePieChart.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  chartContainer: {
-    alignItems: 'center',
-    marginBottom: 16,
-  },
   loadingContainer: {
     alignItems: 'center',
     paddingVertical: 32,
@@ -85,6 +69,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
     paddingVertical: 32,
     textAlign: 'center',
+  },
+  row: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 10,
   },
 });
 

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   row: {
-    alignItems: 'flex-start',
+    alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
     gap: 10,

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   row: {
-    alignItems: 'center',
+    alignItems: 'flex-start',
     flex: 1,
     flexDirection: 'row',
     gap: 10,

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -27,28 +27,48 @@ const ExpenseSummaryCard = ({
   selectedCurrency,
   onPress,
   expanded = false,
+  categoryName = null,
+  onBack = null,
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <TouchableOpacity
-      testID="expense-summary-card"
-      style={styles.summaryCard}
-      onPress={onPress}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityLabel={t('expenses_by_category')}
-    >
-      <View style={styles.iconBadge}>
-        <Icon name="arrow-top-right" size={16} color="#d93025" />
-      </View>
-      <View style={styles.textContent}>
-        <Text style={[styles.label, { color: colors.mutedText }]}>{t('expense').toUpperCase()}</Text>
-        <Text style={[styles.amount, { color: colors.text }]}>
-          {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
-        </Text>
-      </View>
-      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-    </TouchableOpacity>
+    <View style={styles.summaryCard}>
+      {categoryName && onBack && (
+        <TouchableOpacity
+          onPress={onBack}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel={t('back')}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Icon name="arrow-left" size={18} color={colors.primary} />
+        </TouchableOpacity>
+      )}
+      <TouchableOpacity
+        testID="expense-summary-card"
+        style={styles.summaryCardInner}
+        onPress={onPress}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={t('expenses_by_category')}
+      >
+        <View style={styles.iconBadge}>
+          <Icon name="arrow-top-right" size={16} color="#d93025" />
+        </View>
+        <View style={styles.textContent}>
+          <Text style={[styles.label, { color: colors.mutedText }]}>{t('expense').toUpperCase()}</Text>
+          <Text style={[styles.amount, { color: colors.text }]}>
+            {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
+          </Text>
+        </View>
+        {categoryName && (
+          <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
+            {categoryName}
+          </Text>
+        )}
+        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
+      </TouchableOpacity>
+    </View>
   );
 };
 
@@ -60,6 +80,8 @@ ExpenseSummaryCard.propTypes = {
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   expanded: PropTypes.bool,
+  categoryName: PropTypes.string,
+  onBack: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
@@ -68,6 +90,19 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     letterSpacing: -0.3,
     marginTop: 1,
+  },
+  backButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingLeft: 10,
+    paddingRight: 4,
+  },
+  categoryName: {
+    flexShrink: 1,
+    fontSize: 13,
+    fontWeight: '600',
+    marginRight: 4,
+    maxWidth: 80,
   },
   iconBadge: {
     alignItems: 'center',
@@ -81,6 +116,11 @@ const styles = StyleSheet.create({
     letterSpacing: 0.3,
   },
   summaryCard: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+  },
+  summaryCardInner: {
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -50,18 +50,20 @@ const ExpenseSummaryCard = ({
         </Text>
       </View>
       {categoryName && onBack && (
-        <TouchableOpacity
-          onPress={onBack}
-          style={styles.categoryBack}
-          accessibilityRole="button"
-          accessibilityLabel={t('back')}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        >
-          <Icon name="chevron-left" size={16} color={colors.mutedText} />
-          <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
-            {categoryName}
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.categoryBackOverlay} pointerEvents="box-none">
+          <TouchableOpacity
+            onPress={onBack}
+            style={styles.categoryBack}
+            accessibilityRole="button"
+            accessibilityLabel={t('back')}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Icon name="chevron-left" size={18} color={colors.mutedText} />
+            <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
+              {categoryName}
+            </Text>
+          </TouchableOpacity>
+        </View>
       )}
       <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
     </TouchableOpacity>
@@ -90,15 +92,22 @@ const styles = StyleSheet.create({
   categoryBack: {
     alignItems: 'center',
     flexDirection: 'row',
-    flexShrink: 1,
     gap: 2,
-    marginRight: 4,
+  },
+  categoryBackOverlay: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
   categoryName: {
     flexShrink: 1,
-    fontSize: 13,
+    fontSize: 15,
     fontWeight: '600',
-    maxWidth: 90,
+    maxWidth: 120,
   },
   iconBadge: {
     alignItems: 'center',

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -32,43 +32,39 @@ const ExpenseSummaryCard = ({
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <View style={styles.summaryCard}>
+    <TouchableOpacity
+      testID="expense-summary-card"
+      style={styles.summaryCard}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={t('expenses_by_category')}
+    >
+      <View style={styles.iconBadge}>
+        <Icon name="arrow-top-right" size={16} color="#d93025" />
+      </View>
+      <View style={styles.textContent}>
+        <Text style={[styles.label, { color: colors.mutedText }]}>{t('expense').toUpperCase()}</Text>
+        <Text style={[styles.amount, { color: colors.text }]}>
+          {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
+        </Text>
+      </View>
       {categoryName && onBack && (
         <TouchableOpacity
           onPress={onBack}
-          style={styles.backButton}
+          style={styles.categoryBack}
           accessibilityRole="button"
           accessibilityLabel={t('back')}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
         >
-          <Icon name="arrow-left" size={18} color={colors.primary} />
-        </TouchableOpacity>
-      )}
-      <TouchableOpacity
-        testID="expense-summary-card"
-        style={styles.summaryCardInner}
-        onPress={onPress}
-        activeOpacity={0.7}
-        accessibilityRole="button"
-        accessibilityLabel={t('expenses_by_category')}
-      >
-        <View style={styles.iconBadge}>
-          <Icon name="arrow-top-right" size={16} color="#d93025" />
-        </View>
-        <View style={styles.textContent}>
-          <Text style={[styles.label, { color: colors.mutedText }]}>{t('expense').toUpperCase()}</Text>
-          <Text style={[styles.amount, { color: colors.text }]}>
-            {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
-          </Text>
-        </View>
-        {categoryName && (
+          <Icon name="chevron-left" size={16} color={colors.mutedText} />
           <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
             {categoryName}
           </Text>
-        )}
-        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-      </TouchableOpacity>
-    </View>
+        </TouchableOpacity>
+      )}
+      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
+    </TouchableOpacity>
   );
 };
 
@@ -91,18 +87,18 @@ const styles = StyleSheet.create({
     letterSpacing: -0.3,
     marginTop: 1,
   },
-  backButton: {
+  categoryBack: {
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingLeft: 10,
-    paddingRight: 4,
+    flexDirection: 'row',
+    flexShrink: 1,
+    gap: 2,
+    marginRight: 4,
   },
   categoryName: {
     flexShrink: 1,
     fontSize: 13,
     fontWeight: '600',
-    marginRight: 4,
-    maxWidth: 80,
+    maxWidth: 90,
   },
   iconBadge: {
     alignItems: 'center',
@@ -116,11 +112,6 @@ const styles = StyleSheet.create({
     letterSpacing: 0.3,
   },
   summaryCard: {
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-  },
-  summaryCardInner: {
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet, ActivityIndicator, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
-import { PieChart } from 'react-native-chart-kit';
+import DonutChart from './DonutChart';
 import CustomLegend from './CustomLegend';
-
-const screenWidth = Dimensions.get('window').width;
 
 const IncomePieChart = ({
   colors,
@@ -15,46 +13,36 @@ const IncomePieChart = ({
   onLegendItemPress,
   selectedIncomeCategory,
 }) => {
-  return (
-    <>
-      {loadingIncome ? (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color={colors.primary} />
-          <Text style={[styles.loadingText, { color: colors.mutedText }]}>
-            {t('loading_operations')}
-          </Text>
-        </View>
-      ) : incomeChartData.length > 0 ? (
-        <>
-          <View style={styles.chartContainer}>
-            <PieChart
-              data={incomeChartData}
-              width={screenWidth - 64}
-              height={220}
-              chartConfig={{
-                color: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
-              }}
-              accessor="amount"
-              backgroundColor="transparent"
-              paddingLeft="15"
-              center={[0, 0]}
-              hasLegend={false}
-            />
-          </View>
-          <CustomLegend
-            data={incomeChartData}
-            currency={selectedCurrency}
-            colors={colors}
-            onItemPress={onLegendItemPress}
-            isClickable={selectedIncomeCategory === 'all'}
-          />
-        </>
-      ) : (
-        <Text style={[styles.noData, { color: colors.mutedText }]}>
-          {t('no_income_data')}
+  if (loadingIncome) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+          {t('loading_operations')}
         </Text>
-      )}
-    </>
+      </View>
+    );
+  }
+
+  if (incomeChartData.length === 0) {
+    return (
+      <Text style={[styles.noData, { color: colors.mutedText }]}>
+        {t('no_income_data')}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.row}>
+      <DonutChart data={incomeChartData} />
+      <CustomLegend
+        data={incomeChartData}
+        currency={selectedCurrency}
+        colors={colors}
+        onItemPress={onLegendItemPress}
+        isClickable={selectedIncomeCategory === 'all'}
+      />
+    </View>
   );
 };
 
@@ -69,10 +57,6 @@ IncomePieChart.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  chartContainer: {
-    alignItems: 'center',
-    marginBottom: 16,
-  },
   loadingContainer: {
     alignItems: 'center',
     paddingVertical: 32,
@@ -85,6 +69,12 @@ const styles = StyleSheet.create({
     fontSize: 14,
     paddingVertical: 32,
     textAlign: 'center',
+  },
+  row: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 10,
   },
 });
 

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -35,13 +35,15 @@ const IncomePieChart = ({
   return (
     <View style={styles.row}>
       <DonutChart data={incomeChartData} />
-      <CustomLegend
-        data={incomeChartData}
-        currency={selectedCurrency}
-        colors={colors}
-        onItemPress={onLegendItemPress}
-        isClickable={selectedIncomeCategory === 'all'}
-      />
+      <View style={styles.legendWrapper}>
+        <CustomLegend
+          data={incomeChartData}
+          currency={selectedCurrency}
+          colors={colors}
+          onItemPress={onLegendItemPress}
+          isClickable={selectedIncomeCategory === 'all'}
+        />
+      </View>
     </View>
   );
 };
@@ -57,6 +59,9 @@ IncomePieChart.propTypes = {
 };
 
 const styles = StyleSheet.create({
+  legendWrapper: {
+    flex: 1,
+  },
   loadingContainer: {
     alignItems: 'center',
     paddingVertical: 32,

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   row: {
-    alignItems: 'flex-start',
+    alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
     gap: 10,

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   row: {
-    alignItems: 'center',
+    alignItems: 'flex-start',
     flex: 1,
     flexDirection: 'row',
     gap: 10,

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -27,28 +27,48 @@ const IncomeSummaryCard = ({
   selectedCurrency,
   onPress,
   expanded = false,
+  categoryName = null,
+  onBack = null,
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <TouchableOpacity
-      testID="income-summary-card"
-      style={styles.summaryCard}
-      onPress={onPress}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityLabel={t('income_by_category')}
-    >
-      <View style={styles.iconBadge}>
-        <Icon name="arrow-bottom-left" size={16} color={colors.income} />
-      </View>
-      <View style={styles.textContent}>
-        <Text style={[styles.label, { color: colors.mutedText }]}>{t('income').toUpperCase()}</Text>
-        <Text style={[styles.amount, { color: colors.text }]}>
-          {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
-        </Text>
-      </View>
-      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-    </TouchableOpacity>
+    <View style={styles.summaryCard}>
+      {categoryName && onBack && (
+        <TouchableOpacity
+          onPress={onBack}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel={t('back')}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Icon name="arrow-left" size={18} color={colors.primary} />
+        </TouchableOpacity>
+      )}
+      <TouchableOpacity
+        testID="income-summary-card"
+        style={styles.summaryCardInner}
+        onPress={onPress}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={t('income_by_category')}
+      >
+        <View style={styles.iconBadge}>
+          <Icon name="arrow-bottom-left" size={16} color={colors.income} />
+        </View>
+        <View style={styles.textContent}>
+          <Text style={[styles.label, { color: colors.mutedText }]}>{t('income').toUpperCase()}</Text>
+          <Text style={[styles.amount, { color: colors.text }]}>
+            {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
+          </Text>
+        </View>
+        {categoryName && (
+          <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
+            {categoryName}
+          </Text>
+        )}
+        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
+      </TouchableOpacity>
+    </View>
   );
 };
 
@@ -60,6 +80,8 @@ IncomeSummaryCard.propTypes = {
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   expanded: PropTypes.bool,
+  categoryName: PropTypes.string,
+  onBack: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
@@ -68,6 +90,19 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     letterSpacing: -0.3,
     marginTop: 1,
+  },
+  backButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingLeft: 10,
+    paddingRight: 4,
+  },
+  categoryName: {
+    flexShrink: 1,
+    fontSize: 13,
+    fontWeight: '600',
+    marginRight: 4,
+    maxWidth: 80,
   },
   iconBadge: {
     alignItems: 'center',
@@ -81,6 +116,11 @@ const styles = StyleSheet.create({
     letterSpacing: 0.3,
   },
   summaryCard: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+  },
+  summaryCardInner: {
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -32,43 +32,39 @@ const IncomeSummaryCard = ({
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <View style={styles.summaryCard}>
+    <TouchableOpacity
+      testID="income-summary-card"
+      style={styles.summaryCard}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={t('income_by_category')}
+    >
+      <View style={styles.iconBadge}>
+        <Icon name="arrow-bottom-left" size={16} color={colors.income} />
+      </View>
+      <View style={styles.textContent}>
+        <Text style={[styles.label, { color: colors.mutedText }]}>{t('income').toUpperCase()}</Text>
+        <Text style={[styles.amount, { color: colors.text }]}>
+          {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
+        </Text>
+      </View>
       {categoryName && onBack && (
         <TouchableOpacity
           onPress={onBack}
-          style={styles.backButton}
+          style={styles.categoryBack}
           accessibilityRole="button"
           accessibilityLabel={t('back')}
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
         >
-          <Icon name="arrow-left" size={18} color={colors.primary} />
-        </TouchableOpacity>
-      )}
-      <TouchableOpacity
-        testID="income-summary-card"
-        style={styles.summaryCardInner}
-        onPress={onPress}
-        activeOpacity={0.7}
-        accessibilityRole="button"
-        accessibilityLabel={t('income_by_category')}
-      >
-        <View style={styles.iconBadge}>
-          <Icon name="arrow-bottom-left" size={16} color={colors.income} />
-        </View>
-        <View style={styles.textContent}>
-          <Text style={[styles.label, { color: colors.mutedText }]}>{t('income').toUpperCase()}</Text>
-          <Text style={[styles.amount, { color: colors.text }]}>
-            {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
-          </Text>
-        </View>
-        {categoryName && (
+          <Icon name="chevron-left" size={16} color={colors.mutedText} />
           <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
             {categoryName}
           </Text>
-        )}
-        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-      </TouchableOpacity>
-    </View>
+        </TouchableOpacity>
+      )}
+      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
+    </TouchableOpacity>
   );
 };
 
@@ -91,18 +87,18 @@ const styles = StyleSheet.create({
     letterSpacing: -0.3,
     marginTop: 1,
   },
-  backButton: {
+  categoryBack: {
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingLeft: 10,
-    paddingRight: 4,
+    flexDirection: 'row',
+    flexShrink: 1,
+    gap: 2,
+    marginRight: 4,
   },
   categoryName: {
     flexShrink: 1,
     fontSize: 13,
     fontWeight: '600',
-    marginRight: 4,
-    maxWidth: 80,
+    maxWidth: 90,
   },
   iconBadge: {
     alignItems: 'center',
@@ -116,11 +112,6 @@ const styles = StyleSheet.create({
     letterSpacing: 0.3,
   },
   summaryCard: {
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-  },
-  summaryCardInner: {
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -50,18 +50,20 @@ const IncomeSummaryCard = ({
         </Text>
       </View>
       {categoryName && onBack && (
-        <TouchableOpacity
-          onPress={onBack}
-          style={styles.categoryBack}
-          accessibilityRole="button"
-          accessibilityLabel={t('back')}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        >
-          <Icon name="chevron-left" size={16} color={colors.mutedText} />
-          <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
-            {categoryName}
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.categoryBackOverlay} pointerEvents="box-none">
+          <TouchableOpacity
+            onPress={onBack}
+            style={styles.categoryBack}
+            accessibilityRole="button"
+            accessibilityLabel={t('back')}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Icon name="chevron-left" size={18} color={colors.mutedText} />
+            <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
+              {categoryName}
+            </Text>
+          </TouchableOpacity>
+        </View>
       )}
       <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
     </TouchableOpacity>
@@ -90,15 +92,22 @@ const styles = StyleSheet.create({
   categoryBack: {
     alignItems: 'center',
     flexDirection: 'row',
-    flexShrink: 1,
     gap: 2,
-    marginRight: 4,
+  },
+  categoryBackOverlay: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
   },
   categoryName: {
     flexShrink: 1,
-    fontSize: 13,
+    fontSize: 15,
     fontWeight: '600',
-    maxWidth: 90,
+    maxWidth: 120,
   },
   iconBadge: {
     alignItems: 'center',

--- a/app/hooks/useExpenseData.js
+++ b/app/hooks/useExpenseData.js
@@ -3,211 +3,165 @@ import { getSpendingByCategoryAndCurrency } from '../services/OperationsDB';
 import { formatDate } from '../services/BalanceHistoryDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 
+const CHART_COLORS = [
+  '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF',
+  '#FF9F40', '#FF6384', '#C9CBCF', '#4BC0C0', '#FF9F40',
+  '#FFCE56', '#36A2EB', '#9966FF', '#FF6384', '#4BC0C0',
+];
+
 /**
- * Custom hook for loading and managing expense data for GraphsScreen
- * Handles data aggregation by category, hierarchy navigation, and forecast calculations
- * @param {number} selectedYear - The selected year
- * @param {number|null} selectedMonth - The selected month (0-11) or null for full year
- * @param {string} selectedCurrency - The selected currency code
- * @param {string} selectedCategory - The selected category ID or 'all'
- * @param {Array} categories - Array of all categories
- * @param {Object} colors - Theme colors
- * @param {Function} t - Translation function
- * @param {string|null} [selectedAccountId] - Optional account ID to filter expenses by
+ * Custom hook for loading and managing expense data for GraphsScreen.
+ * DB is queried once per period/currency/account change. Category switches
+ * re-aggregate the cached raw data synchronously (no DB hit).
  */
 const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t, selectedAccountId = null) => {
-  const [chartData, setChartData] = useState([]);
+  const [rawSpending, setRawSpending] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // Load expense data
   const loadExpenseData = useCallback(async () => {
     if (!selectedCurrency) return;
 
     try {
       setLoading(true);
 
-      // Calculate start and end dates for the selected month or full year
       let startDate, endDate;
       if (selectedMonth === null) {
-        // Full year view
         startDate = new Date(selectedYear, 0, 1);
         endDate = new Date(selectedYear, 11, 31, 23, 59, 59);
       } else {
-        // Single month view
         startDate = new Date(selectedYear, selectedMonth, 1);
         endDate = new Date(selectedYear, selectedMonth + 1, 0, 23, 59, 59);
       }
 
-      const startDateStr = formatDate(startDate);
-      const endDateStr = formatDate(endDate);
-
-      // Get spending data (optionally filtered by account)
       const spending = await getSpendingByCategoryAndCurrency(
         selectedCurrency,
-        startDateStr,
-        endDateStr,
+        formatDate(startDate),
+        formatDate(endDate),
         selectedAccountId,
       );
 
-      // Create a map of category ID to category object
-      const categoryMap = new Map();
-      categories.forEach(cat => {
-        categoryMap.set(cat.id, cat);
-      });
-
-      // Create a Set of shadow category IDs for easy lookup
-      const shadowCategoryIds = new Set();
-      categories.forEach(cat => {
-        if (cat.isShadow) {
-          shadowCategoryIds.add(cat.id);
-        }
-      });
-
-      // Helper function to get the root parent (top-level folder) of a category
-      const getRootParent = (categoryId) => {
-        let current = categoryMap.get(categoryId);
-        if (!current) return null;
-
-        while (current.parentId) {
-          current = categoryMap.get(current.parentId);
-          if (!current) return null;
-        }
-        return current;
-      };
-
-      // Separate shadow categories from regular categories
-      const regularSpending = [];
-      let shadowCategoryTotal = 0;
-
-      spending.forEach(item => {
-        if (shadowCategoryIds.has(item.category_id)) {
-          // Accumulate shadow category amounts
-          shadowCategoryTotal += parseFloat(item.total);
-        } else {
-          // Keep regular categories
-          regularSpending.push(item);
-        }
-      });
-
-      // Aggregate spending based on selected category
-      let aggregatedSpending = {};
-
-      if (selectedCategory === 'all') {
-        // When "All categories" is selected, aggregate by root folders
-        regularSpending.forEach(item => {
-          const rootParent = getRootParent(item.category_id);
-          if (rootParent) {
-            const rootId = rootParent.id;
-            const amount = parseFloat(item.total);
-
-            if (!aggregatedSpending[rootId]) {
-              aggregatedSpending[rootId] = {
-                category: rootParent,
-                total: 0,
-              };
-            }
-            aggregatedSpending[rootId].total += amount;
-          }
-        });
-      } else {
-        // When a specific folder is selected, show only immediate children
-        regularSpending.forEach(item => {
-          const category = categoryMap.get(item.category_id);
-          if (!category) return;
-
-          const amount = parseFloat(item.total);
-
-          // Check if this category is a direct child of the selected folder
-          if (category.parentId === selectedCategory) {
-            if (!aggregatedSpending[category.id]) {
-              aggregatedSpending[category.id] = {
-                category: category,
-                total: 0,
-              };
-            }
-            aggregatedSpending[category.id].total += amount;
-          } else {
-            // Check if this category is a descendant of the selected folder
-            // If so, aggregate it under its direct parent (immediate child of selected folder)
-            let current = category;
-            while (current.parentId) {
-              const parent = categoryMap.get(current.parentId);
-              if (!parent) break;
-
-              if (parent.id === selectedCategory) {
-                // Current is a direct child of the selected folder
-                if (!aggregatedSpending[current.id]) {
-                  aggregatedSpending[current.id] = {
-                    category: current,
-                    total: 0,
-                  };
-                }
-                aggregatedSpending[current.id].total += amount;
-                break;
-              }
-              current = parent;
-            }
-          }
-        });
-      }
-
-      // Chart colors (vibrant palette)
-      const chartColors = [
-        '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF',
-        '#FF9F40', '#FF6384', '#C9CBCF', '#4BC0C0', '#FF9F40',
-        '#FFCE56', '#36A2EB', '#9966FF', '#FF6384', '#4BC0C0',
-      ];
-
-      // Transform aggregated data for pie chart
-      const data = Object.values(aggregatedSpending).map((item, index) => {
-        const hasChildren = categories.some(cat => cat.parentId === item.category.id);
-        return {
-          name: item.category.name,
-          amount: item.total,
-          color: chartColors[index % chartColors.length],
-          legendFontColor: colors.text,
-          legendFontSize: 13,
-          icon: item.category.icon || null,
-          categoryId: item.category.id,
-          hasChildren,
-        };
-      });
-
-      // Sort by amount descending
-      data.sort((a, b) => b.amount - a.amount);
-
-      // Add aggregated balance adjustments if there are any (amounts are already positive for expenses)
-      // Only show balance adjustments in the root "All categories" view
-      if (shadowCategoryTotal > 0 && selectedCategory === 'all') {
-        data.push({
-          name: t('balance_adjustments'),
-          amount: shadowCategoryTotal,
-          color: chartColors[data.length % chartColors.length],
-          legendFontColor: colors.text,
-          legendFontSize: 13,
-          icon: null,
-        });
-      }
-
-      setChartData(data);
+      setRawSpending(spending);
     } catch (error) {
       console.error('Failed to load expense data:', error);
     } finally {
       setLoading(false);
     }
-  }, [selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors.text, t, selectedAccountId]);
+  }, [selectedYear, selectedMonth, selectedCurrency, selectedAccountId]);
 
-  // Calculate total expenses
-  const totalExpenses = useMemo(() => {
-    return chartData.reduce((sum, item) => sum + item.amount, 0);
-  }, [chartData]);
+  // Aggregate cached raw spending for the current category — no DB hit
+  const chartData = useMemo(() => {
+    if (!rawSpending || !selectedCurrency) return [];
 
-  // Listen for operation changes and reload expense data
+    const categoryMap = new Map();
+    categories.forEach(cat => categoryMap.set(cat.id, cat));
+
+    const shadowCategoryIds = new Set(
+      categories.filter(cat => cat.isShadow).map(cat => cat.id),
+    );
+
+    const getRootParent = (categoryId) => {
+      let current = categoryMap.get(categoryId);
+      if (!current) return null;
+      while (current.parentId) {
+        current = categoryMap.get(current.parentId);
+        if (!current) return null;
+      }
+      return current;
+    };
+
+    const regularSpending = [];
+    let shadowCategoryTotal = 0;
+
+    rawSpending.forEach(item => {
+      if (shadowCategoryIds.has(item.category_id)) {
+        shadowCategoryTotal += parseFloat(item.total);
+      } else {
+        regularSpending.push(item);
+      }
+    });
+
+    const aggregatedSpending = {};
+
+    if (selectedCategory === 'all') {
+      regularSpending.forEach(item => {
+        const rootParent = getRootParent(item.category_id);
+        if (rootParent) {
+          const rootId = rootParent.id;
+          if (!aggregatedSpending[rootId]) {
+            aggregatedSpending[rootId] = { category: rootParent, total: 0 };
+          }
+          aggregatedSpending[rootId].total += parseFloat(item.total);
+        }
+      });
+    } else {
+      regularSpending.forEach(item => {
+        const category = categoryMap.get(item.category_id);
+        if (!category) return;
+
+        const amount = parseFloat(item.total);
+
+        if (category.parentId === selectedCategory) {
+          if (!aggregatedSpending[category.id]) {
+            aggregatedSpending[category.id] = { category, total: 0 };
+          }
+          aggregatedSpending[category.id].total += amount;
+        } else {
+          let current = category;
+          while (current.parentId) {
+            const parent = categoryMap.get(current.parentId);
+            if (!parent) break;
+            if (parent.id === selectedCategory) {
+              if (!aggregatedSpending[current.id]) {
+                aggregatedSpending[current.id] = { category: current, total: 0 };
+              }
+              aggregatedSpending[current.id].total += amount;
+              break;
+            }
+            current = parent;
+          }
+        }
+      });
+    }
+
+    const data = Object.values(aggregatedSpending).map((item, index) => {
+      const hasChildren = categories.some(cat => cat.parentId === item.category.id);
+      return {
+        name: item.category.name,
+        amount: item.total,
+        color: CHART_COLORS[index % CHART_COLORS.length],
+        legendFontColor: colors.text,
+        legendFontSize: 13,
+        icon: item.category.icon || null,
+        categoryId: item.category.id,
+        hasChildren,
+      };
+    });
+
+    data.sort((a, b) => b.amount - a.amount);
+
+    if (shadowCategoryTotal > 0 && selectedCategory === 'all') {
+      data.push({
+        name: t('balance_adjustments'),
+        amount: shadowCategoryTotal,
+        color: CHART_COLORS[data.length % CHART_COLORS.length],
+        legendFontColor: colors.text,
+        legendFontSize: 13,
+        icon: null,
+      });
+    }
+
+    return data;
+  }, [rawSpending, selectedCategory, categories, colors.text, t, selectedCurrency]);
+
+  const totalExpenses = useMemo(
+    () => chartData.reduce((sum, item) => sum + item.amount, 0),
+    [chartData],
+  );
+
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.OPERATION_CHANGED, () => {
       loadExpenseData();
     });
-
     return unsubscribe;
   }, [loadExpenseData]);
 

--- a/app/hooks/useIncomeData.js
+++ b/app/hooks/useIncomeData.js
@@ -3,163 +3,136 @@ import { getIncomeByCategoryAndCurrency } from '../services/OperationsDB';
 import { formatDate } from '../services/BalanceHistoryDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 
+const CHART_COLORS = [
+  '#4BC0C0', '#36A2EB', '#9966FF', '#FF9F40', '#FFCE56',
+  '#FF6384', '#C9CBCF', '#4BC0C0', '#FF9F40', '#FFCE56',
+  '#36A2EB', '#9966FF', '#FF6384', '#4BC0C0', '#FF9F40',
+];
+
 /**
- * Custom hook for loading and managing income data for GraphsScreen
- * Handles data aggregation by category and hierarchy navigation
+ * Custom hook for loading and managing income data for GraphsScreen.
+ * DB is queried once per period/currency change. Category switches
+ * re-aggregate the cached raw data synchronously (no DB hit).
  */
 const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIncomeCategory, categories, colors, t) => {
-  const [incomeChartData, setIncomeChartData] = useState([]);
+  const [rawIncome, setRawIncome] = useState(null);
   const [loadingIncome, setLoadingIncome] = useState(true);
 
-  // Load income data
   const loadIncomeData = useCallback(async () => {
     if (!selectedCurrency) return;
 
     try {
       setLoadingIncome(true);
 
-      // Calculate start and end dates for the selected month or full year
       let startDate, endDate;
       if (selectedMonth === null) {
-        // Full year view
         startDate = new Date(selectedYear, 0, 1);
         endDate = new Date(selectedYear, 11, 31, 23, 59, 59);
       } else {
-        // Single month view
         startDate = new Date(selectedYear, selectedMonth, 1);
         endDate = new Date(selectedYear, selectedMonth + 1, 0, 23, 59, 59);
       }
 
-      const startDateStr = formatDate(startDate);
-      const endDateStr = formatDate(endDate);
-
-      // Get income data
       const income = await getIncomeByCategoryAndCurrency(
         selectedCurrency,
-        startDateStr,
-        endDateStr,
+        formatDate(startDate),
+        formatDate(endDate),
       );
 
-      // Create a map of category ID to category object
-      const categoryMap = new Map();
-      categories.forEach(cat => {
-        categoryMap.set(cat.id, cat);
-      });
-
-      // Helper function to get the root parent (top-level folder) of a category
-      const getRootParent = (categoryId) => {
-        let current = categoryMap.get(categoryId);
-        if (!current) return null;
-
-        while (current.parentId) {
-          current = categoryMap.get(current.parentId);
-          if (!current) return null;
-        }
-        return current;
-      };
-
-      // Aggregate income based on selected category
-      let aggregatedIncome = {};
-
-      if (selectedIncomeCategory === 'all') {
-        // When "All categories" is selected, aggregate by root folders
-        income.forEach(item => {
-          const rootParent = getRootParent(item.category_id);
-          if (rootParent) {
-            const rootId = rootParent.id;
-            if (!aggregatedIncome[rootId]) {
-              aggregatedIncome[rootId] = {
-                category: rootParent,
-                total: 0,
-              };
-            }
-            aggregatedIncome[rootId].total += parseFloat(item.total);
-          }
-        });
-      } else {
-        // When a specific folder is selected, show only immediate children
-        income.forEach(item => {
-          const category = categoryMap.get(item.category_id);
-          if (!category) return;
-
-          // Check if this category is a direct child of the selected folder
-          if (category.parentId === selectedIncomeCategory) {
-            if (!aggregatedIncome[category.id]) {
-              aggregatedIncome[category.id] = {
-                category: category,
-                total: 0,
-              };
-            }
-            aggregatedIncome[category.id].total += parseFloat(item.total);
-          } else {
-            // Check if this category is a descendant of the selected folder
-            // If so, aggregate it under its direct parent (immediate child of selected folder)
-            let current = category;
-            while (current.parentId) {
-              const parent = categoryMap.get(current.parentId);
-              if (!parent) break;
-
-              if (parent.id === selectedIncomeCategory) {
-                // Current is a direct child of the selected folder
-                if (!aggregatedIncome[current.id]) {
-                  aggregatedIncome[current.id] = {
-                    category: current,
-                    total: 0,
-                  };
-                }
-                aggregatedIncome[current.id].total += parseFloat(item.total);
-                break;
-              }
-              current = parent;
-            }
-          }
-        });
-      }
-
-      // Chart colors (vibrant palette - different from expenses)
-      const chartColors = [
-        '#4BC0C0', '#36A2EB', '#9966FF', '#FF9F40', '#FFCE56',
-        '#FF6384', '#C9CBCF', '#4BC0C0', '#FF9F40', '#FFCE56',
-        '#36A2EB', '#9966FF', '#FF6384', '#4BC0C0', '#FF9F40',
-      ];
-
-      // Transform aggregated data for pie chart
-      const data = Object.values(aggregatedIncome).map((item, index) => {
-        const hasChildren = categories.some(cat => cat.parentId === item.category.id);
-        return {
-          name: item.category.name,
-          amount: item.total,
-          color: chartColors[index % chartColors.length],
-          legendFontColor: colors.text,
-          legendFontSize: 13,
-          icon: item.category.icon || null,
-          categoryId: item.category.id,
-          hasChildren,
-        };
-      });
-
-      // Sort by amount descending
-      data.sort((a, b) => b.amount - a.amount);
-
-      setIncomeChartData(data);
+      setRawIncome(income);
     } catch (error) {
       console.error('Failed to load income data:', error);
     } finally {
       setLoadingIncome(false);
     }
-  }, [selectedYear, selectedMonth, selectedCurrency, selectedIncomeCategory, categories, colors.text, t]);
+  }, [selectedYear, selectedMonth, selectedCurrency]);
 
-  // Calculate total income
-  const totalIncome = useMemo(() => {
-    return incomeChartData.reduce((sum, item) => sum + item.amount, 0);
-  }, [incomeChartData]);
+  // Aggregate cached raw income for the current category — no DB hit
+  const incomeChartData = useMemo(() => {
+    if (!rawIncome || !selectedCurrency) return [];
 
-  // Listen for operation changes and reload income data
+    const categoryMap = new Map();
+    categories.forEach(cat => categoryMap.set(cat.id, cat));
+
+    const getRootParent = (categoryId) => {
+      let current = categoryMap.get(categoryId);
+      if (!current) return null;
+      while (current.parentId) {
+        current = categoryMap.get(current.parentId);
+        if (!current) return null;
+      }
+      return current;
+    };
+
+    const aggregatedIncome = {};
+
+    if (selectedIncomeCategory === 'all') {
+      rawIncome.forEach(item => {
+        const rootParent = getRootParent(item.category_id);
+        if (rootParent) {
+          const rootId = rootParent.id;
+          if (!aggregatedIncome[rootId]) {
+            aggregatedIncome[rootId] = { category: rootParent, total: 0 };
+          }
+          aggregatedIncome[rootId].total += parseFloat(item.total);
+        }
+      });
+    } else {
+      rawIncome.forEach(item => {
+        const category = categoryMap.get(item.category_id);
+        if (!category) return;
+
+        if (category.parentId === selectedIncomeCategory) {
+          if (!aggregatedIncome[category.id]) {
+            aggregatedIncome[category.id] = { category, total: 0 };
+          }
+          aggregatedIncome[category.id].total += parseFloat(item.total);
+        } else {
+          let current = category;
+          while (current.parentId) {
+            const parent = categoryMap.get(current.parentId);
+            if (!parent) break;
+            if (parent.id === selectedIncomeCategory) {
+              if (!aggregatedIncome[current.id]) {
+                aggregatedIncome[current.id] = { category: current, total: 0 };
+              }
+              aggregatedIncome[current.id].total += parseFloat(item.total);
+              break;
+            }
+            current = parent;
+          }
+        }
+      });
+    }
+
+    const data = Object.values(aggregatedIncome).map((item, index) => {
+      const hasChildren = categories.some(cat => cat.parentId === item.category.id);
+      return {
+        name: item.category.name,
+        amount: item.total,
+        color: CHART_COLORS[index % CHART_COLORS.length],
+        legendFontColor: colors.text,
+        legendFontSize: 13,
+        icon: item.category.icon || null,
+        categoryId: item.category.id,
+        hasChildren,
+      };
+    });
+
+    data.sort((a, b) => b.amount - a.amount);
+
+    return data;
+  }, [rawIncome, selectedIncomeCategory, categories, colors.text, selectedCurrency]);
+
+  const totalIncome = useMemo(
+    () => incomeChartData.reduce((sum, item) => sum + item.amount, 0),
+    [incomeChartData],
+  );
+
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.OPERATION_CHANGED, () => {
       loadIncomeData();
     });
-
     return unsubscribe;
   }, [loadIncomeData]);
 

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -778,7 +778,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   summaryCardBase: {
-    borderRadius: 14,
+    borderRadius: 16,
     borderWidth: 1,
     overflow: 'hidden',
   },

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -404,6 +404,12 @@ const GraphsScreen = () => {
 
   const toggleCard = useCallback((card) => {
     if (expandedCard === card) {
+      // Reset category first, then collapse
+      if (card === 'expense') {
+        resetExpenseCategory();
+      } else {
+        resetIncomeCategory();
+      }
       // Collapse: fade chart + shrink height first (180ms), then restore width (200ms)
       chartProgress.value = withTiming(0, { duration: 150, easing: Easing.in(Easing.quad) });
       heightProgress.value = withTiming(0, { duration: 180, easing: Easing.in(Easing.quad) }, (finished) => {
@@ -412,11 +418,6 @@ const GraphsScreen = () => {
             if (done) {
               expandingCard.value = 0;
               runOnJS(setExpandedCard)(null);
-              if (card === 'expense') {
-                runOnJS(resetExpenseCategory)();
-              } else {
-                runOnJS(resetIncomeCategory)();
-              }
             }
           });
         }
@@ -435,7 +436,8 @@ const GraphsScreen = () => {
         }
       });
     }
-  }, [expandedCard, widthProgress, heightProgress, chartProgress, expandingCard, resetExpenseCategory, resetIncomeCategory]);
+  }, [expandedCard, widthProgress, heightProgress, chartProgress, expandingCard,
+    resetExpenseCategory, resetIncomeCategory]);
 
   const handleToggleIncome = useCallback(() => toggleCard('income'), [toggleCard]);
   const handleToggleExpense = useCallback(() => toggleCard('expense'), [toggleCard]);

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -735,8 +735,8 @@ const styles = StyleSheet.create({
   },
   chartScrollContent: {
     paddingBottom: 24,
-    paddingLeft: 6,
-    paddingRight: 6,
+    paddingLeft: 3,
+    paddingRight: 9,
     paddingTop: 4,
   },
   chartScrollView: {

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -689,9 +689,10 @@ const styles = StyleSheet.create({
     top: CARD_HEADER_HEIGHT,
   },
   chartScrollContent: {
-    paddingBottom: 8,
+    paddingBottom: 24,
     paddingLeft: 12,
     paddingRight: 4,
+    paddingTop: 4,
   },
   chartScrollView: {
     flex: 1,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { View, Text, StyleSheet, ScrollView, useWindowDimensions } from 'react-native';
-import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing } from 'react-native-reanimated';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing, SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import WheelPicker from '@quidone/react-native-wheel-picker';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -73,6 +73,8 @@ const GraphsScreen = () => {
   const incomeChartHeightSV = useSharedValue(0);
   const expenseHeightInitialized = useRef(false);
   const incomeHeightInitialized = useRef(false);
+  const expenseDrillDirection = useRef('in'); // 'in' | 'back'
+  const incomeDrillDirection = useRef('in');
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -114,10 +116,12 @@ const GraphsScreen = () => {
 
   // Handlers for legend item clicks
   const handleExpenseLegendItemPress = useCallback((categoryId) => {
+    expenseDrillDirection.current = 'in';
     setSelectedCategory(categoryId);
   }, []);
 
   const handleIncomeLegendItemPress = useCallback((categoryId) => {
+    incomeDrillDirection.current = 'in';
     setSelectedIncomeCategory(categoryId);
   }, []);
 
@@ -392,10 +396,12 @@ const GraphsScreen = () => {
   }, [categories]);
 
   const handleBackToIncomeParent = useCallback(() => {
+    incomeDrillDirection.current = 'back';
     setSelectedIncomeCategory(prev => getParentCategoryId(prev));
   }, [getParentCategoryId]);
 
   const handleBackToExpenseParent = useCallback(() => {
+    expenseDrillDirection.current = 'back';
     setSelectedCategory(prev => getParentCategoryId(prev));
   }, [getParentCategoryId]);
 
@@ -561,15 +567,21 @@ const GraphsScreen = () => {
                     }
                   }}
                 >
-                  <IncomePieChart
-                    colors={colors}
-                    t={t}
-                    loadingIncome={loadingIncome}
-                    incomeChartData={incomeChartData}
-                    selectedCurrency={selectedCurrency}
-                    onLegendItemPress={handleIncomeLegendItemPress}
-                    selectedIncomeCategory={selectedIncomeCategory}
-                  />
+                  <Animated.View
+                    key={selectedIncomeCategory}
+                    entering={incomeDrillDirection.current === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
+                    exiting={incomeDrillDirection.current === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
+                  >
+                    <IncomePieChart
+                      colors={colors}
+                      t={t}
+                      loadingIncome={loadingIncome}
+                      incomeChartData={incomeChartData}
+                      selectedCurrency={selectedCurrency}
+                      onLegendItemPress={handleIncomeLegendItemPress}
+                      selectedIncomeCategory={selectedIncomeCategory}
+                    />
+                  </Animated.View>
                 </ScrollView>
               </Animated.View>
             </Animated.View>
@@ -617,15 +629,21 @@ const GraphsScreen = () => {
                     }
                   }}
                 >
-                  <ExpensePieChart
-                    colors={colors}
-                    t={t}
-                    loading={loading}
-                    chartData={chartData}
-                    selectedCurrency={selectedCurrency}
-                    onLegendItemPress={handleExpenseLegendItemPress}
-                    selectedCategory={selectedCategory}
-                  />
+                  <Animated.View
+                    key={selectedCategory}
+                    entering={expenseDrillDirection.current === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
+                    exiting={expenseDrillDirection.current === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
+                  >
+                    <ExpensePieChart
+                      colors={colors}
+                      t={t}
+                      loading={loading}
+                      chartData={chartData}
+                      selectedCurrency={selectedCurrency}
+                      onLegendItemPress={handleExpenseLegendItemPress}
+                      selectedCategory={selectedCategory}
+                    />
+                  </Animated.View>
                 </ScrollView>
               </Animated.View>
             </Animated.View>

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -735,8 +735,8 @@ const styles = StyleSheet.create({
   },
   chartScrollContent: {
     paddingBottom: 24,
-    paddingLeft: 12,
-    paddingRight: 4,
+    paddingLeft: 6,
+    paddingRight: 6,
     paddingTop: 4,
   },
   chartScrollView: {

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, useWindowDimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import WheelPicker from '@quidone/react-native-wheel-picker';
@@ -12,7 +12,6 @@ import { getAllCategories } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { formatAmount } from '../services/currency';
 import currenciesJson from '../../assets/currencies.json';
-import SimplePicker from '../components/SimplePicker';
 import BalanceHistoryCard from '../components/graphs/BalanceHistoryCard';
 import CategorySpendingCard from '../components/graphs/CategorySpendingCard';
 import ExpenseSummaryCard from '../components/graphs/ExpenseSummaryCard';
@@ -246,16 +245,6 @@ const GraphsScreen = () => {
   );
 
   // Prepare picker items
-  const categoryItems = useMemo(() => [
-    { label: t('all'), value: 'all' },
-    ...topLevelCategories.map(cat => ({ label: cat.name, value: cat.id })),
-  ], [topLevelCategories, t]);
-
-  const incomeCategoryItems = useMemo(() => [
-    { label: t('all'), value: 'all' },
-    ...topLevelIncomeCategories.map(cat => ({ label: cat.name, value: cat.id })),
-  ], [topLevelIncomeCategories, t]);
-
   const currencyItems = useMemo(() =>
     currencies.map(cur => ({ label: cur, value: cur })),
   [currencies],
@@ -374,6 +363,19 @@ const GraphsScreen = () => {
     const now = new Date();
     return selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
   }, [selectedYear, selectedMonth]);
+
+  // Derive display name for selected category (null when 'all')
+  const selectedCategoryName = useMemo(() => {
+    if (selectedCategory === 'all') return null;
+    const cat = categories.find(c => c.id === selectedCategory);
+    return cat ? cat.name : null;
+  }, [selectedCategory, categories]);
+
+  const selectedIncomeCategoryName = useMemo(() => {
+    if (selectedIncomeCategory === 'all') return null;
+    const cat = categories.find(c => c.id === selectedIncomeCategory);
+    return cat ? cat.name : null;
+  }, [selectedIncomeCategory, categories]);
 
   // Shared category parent lookup
   const getParentCategoryId = useCallback((categoryId) => {
@@ -519,6 +521,8 @@ const GraphsScreen = () => {
                   selectedCurrency={selectedCurrency}
                   onPress={handleToggleIncome}
                   expanded={expandedCard === 'income'}
+                  categoryName={selectedIncomeCategoryName}
+                  onBack={handleBackToIncomeParent}
                 />
               </View>
               <Animated.View
@@ -531,26 +535,6 @@ const GraphsScreen = () => {
                   nestedScrollEnabled
                   showsVerticalScrollIndicator={false}
                 >
-                  {selectedIncomeCategory !== 'all' && (
-                    <View style={styles.chartNavRow}>
-                      <TouchableOpacity
-                        onPress={handleBackToIncomeParent}
-                        style={styles.chartNavBack}
-                        accessibilityRole="button"
-                        accessibilityLabel={t('back')}
-                      >
-                        <Icon name="arrow-left" size={20} color={colors.primary} />
-                      </TouchableOpacity>
-                      <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                        <SimplePicker
-                          value={selectedIncomeCategory}
-                          onValueChange={setSelectedIncomeCategory}
-                          items={incomeCategoryItems}
-                          colors={colors}
-                        />
-                      </View>
-                    </View>
-                  )}
                   <IncomePieChart
                     colors={colors}
                     t={t}
@@ -584,6 +568,8 @@ const GraphsScreen = () => {
                   selectedCurrency={selectedCurrency}
                   onPress={handleToggleExpense}
                   expanded={expandedCard === 'expense'}
+                  categoryName={selectedCategoryName}
+                  onBack={handleBackToExpenseParent}
                 />
               </View>
               <Animated.View
@@ -596,26 +582,6 @@ const GraphsScreen = () => {
                   nestedScrollEnabled
                   showsVerticalScrollIndicator={false}
                 >
-                  {selectedCategory !== 'all' && (
-                    <View style={styles.chartNavRow}>
-                      <TouchableOpacity
-                        onPress={handleBackToExpenseParent}
-                        style={styles.chartNavBack}
-                        accessibilityRole="button"
-                        accessibilityLabel={t('back')}
-                      >
-                        <Icon name="arrow-left" size={20} color={colors.primary} />
-                      </TouchableOpacity>
-                      <View style={[styles.chartNavPicker, { backgroundColor: colors.background, borderColor: colors.border }]}>
-                        <SimplePicker
-                          value={selectedCategory}
-                          onValueChange={setSelectedCategory}
-                          items={categoryItems}
-                          colors={colors}
-                        />
-                      </View>
-                    </View>
-                  )}
                   <ExpensePieChart
                     colors={colors}
                     t={t}
@@ -713,23 +679,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 0,
     top: CARD_HEADER_HEIGHT,
-  },
-  chartNavBack: {
-    marginRight: 8,
-    padding: 4,
-  },
-  chartNavPicker: {
-    borderRadius: 8,
-    borderWidth: 1,
-    flex: 1,
-    height: 40,
-    overflow: 'hidden',
-  },
-  chartNavRow: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    marginBottom: 12,
-    marginTop: 4,
   },
   chartScrollContent: {
     paddingBottom: 8,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -394,6 +394,9 @@ const GraphsScreen = () => {
     setSelectedCategory(prev => getParentCategoryId(prev));
   }, [getParentCategoryId]);
 
+  const resetExpenseCategory = useCallback(() => setSelectedCategory('all'), []);
+  const resetIncomeCategory = useCallback(() => setSelectedIncomeCategory('all'), []);
+
   const toggleCard = useCallback((card) => {
     if (expandedCard === card) {
       // Collapse: fade chart + shrink height first (180ms), then restore width (200ms)
@@ -404,6 +407,11 @@ const GraphsScreen = () => {
             if (done) {
               expandingCard.value = 0;
               runOnJS(setExpandedCard)(null);
+              if (card === 'expense') {
+                runOnJS(resetExpenseCategory)();
+              } else {
+                runOnJS(resetIncomeCategory)();
+              }
             }
           });
         }
@@ -422,7 +430,7 @@ const GraphsScreen = () => {
         }
       });
     }
-  }, [expandedCard, widthProgress, heightProgress, chartProgress, expandingCard]);
+  }, [expandedCard, widthProgress, heightProgress, chartProgress, expandingCard, resetExpenseCategory, resetIncomeCategory]);
 
   const handleToggleIncome = useCallback(() => toggleCard('income'), [toggleCard]);
   const handleToggleExpense = useCallback(() => toggleCard('expense'), [toggleCard]);

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -733,7 +733,8 @@ const styles = StyleSheet.create({
   },
   chartScrollContent: {
     paddingBottom: 8,
-    paddingHorizontal: 12,
+    paddingLeft: 12,
+    paddingRight: 4,
   },
   chartScrollView: {
     flex: 1,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -23,7 +23,7 @@ import useIncomeData from '../hooks/useIncomeData';
 import useBalanceHistory from '../hooks/useBalanceHistory';
 
 const CARD_HEADER_HEIGHT = 56;
-const CHART_HEIGHT = 300;
+const MAX_CHART_HEIGHT = 500;
 const CARD_GAP = 8;
 
 const GraphsScreen = () => {
@@ -68,6 +68,11 @@ const GraphsScreen = () => {
   // Dimension values updated on orientation change
   const halfWidthSV = useSharedValue(halfWidth);
   const rowWidthSV = useSharedValue(rowWidth);
+  // Dynamic chart heights — updated by onContentSizeChange on each chart's ScrollView
+  const expenseChartHeightSV = useSharedValue(0);
+  const incomeChartHeightSV = useSharedValue(0);
+  const expenseHeightInitialized = useRef(false);
+  const incomeHeightInitialized = useRef(false);
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -454,10 +459,11 @@ const GraphsScreen = () => {
     const hp = heightProgress.value;
     const hw = halfWidthSV.value;
     const rw = rowWidthSV.value;
+    const chartH = incomeChartHeightSV.value;
     if (ev === 1) {
       return {
         width: interpolate(wp, [0, 1], [hw, rw]),
-        height: interpolate(hp, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT]),
+        height: interpolate(hp, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + chartH]),
         opacity: 1,
       };
     }
@@ -477,10 +483,11 @@ const GraphsScreen = () => {
     const hp = heightProgress.value;
     const hw = halfWidthSV.value;
     const rw = rowWidthSV.value;
+    const chartH = expenseChartHeightSV.value;
     if (ev === 2) {
       return {
         width: interpolate(wp, [0, 1], [hw, rw]),
-        height: interpolate(hp, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + CHART_HEIGHT]),
+        height: interpolate(hp, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + chartH]),
         opacity: 1,
       };
     }
@@ -542,6 +549,15 @@ const GraphsScreen = () => {
                   contentContainerStyle={styles.chartScrollContent}
                   nestedScrollEnabled
                   showsVerticalScrollIndicator={false}
+                  onContentSizeChange={(_, h) => {
+                    const target = Math.min(h, MAX_CHART_HEIGHT);
+                    if (!incomeHeightInitialized.current) {
+                      incomeChartHeightSV.value = target;
+                      incomeHeightInitialized.current = true;
+                    } else {
+                      incomeChartHeightSV.value = withTiming(target, { duration: 280, easing: Easing.out(Easing.cubic) });
+                    }
+                  }}
                 >
                   <IncomePieChart
                     colors={colors}
@@ -589,6 +605,15 @@ const GraphsScreen = () => {
                   contentContainerStyle={styles.chartScrollContent}
                   nestedScrollEnabled
                   showsVerticalScrollIndicator={false}
+                  onContentSizeChange={(_, h) => {
+                    const target = Math.min(h, MAX_CHART_HEIGHT);
+                    if (!expenseHeightInitialized.current) {
+                      expenseChartHeightSV.value = target;
+                      expenseHeightInitialized.current = true;
+                    } else {
+                      expenseChartHeightSV.value = withTiming(target, { duration: 280, easing: Easing.out(Easing.cubic) });
+                    }
+                  }}
                 >
                   <ExpensePieChart
                     colors={colors}

--- a/docs/superpowers/plans/2026-05-11-graph-donut-side-legend.md
+++ b/docs/superpowers/plans/2026-05-11-graph-donut-side-legend.md
@@ -1,0 +1,755 @@
+# Graph Pie Chart — Donut + Side Legend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the stacked pie-chart-above-legend layout in the expense and income expanded panels with a side-by-side donut chart (left) and legend list (right), where category icons appear on their respective arc segments.
+
+**Architecture:** A new `DonutChart` component draws SVG arc segments via `react-native-svg` (already installed) and overlays absolutely-positioned `MaterialCommunityIcons` at each segment's midpoint. `ExpensePieChart` and `IncomePieChart` drop the chart-kit `PieChart` import and switch to a `flexDirection: 'row'` container holding `DonutChart` + `CustomLegend`.
+
+**Tech Stack:** React Native, `react-native-svg` (Svg, Circle), `@expo/vector-icons` MaterialCommunityIcons, Jest + React Native Testing Library.
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `app/components/graphs/DonutChart.js` | **Create** — SVG donut renderer + icon overlay + exported `computeSegments` |
+| `__tests__/components/graphs/DonutChart.test.js` | **Create** — unit tests for `computeSegments` + component rendering |
+| `app/components/graphs/ExpensePieChart.js` | **Modify** — swap PieChart → DonutChart, row layout |
+| `__tests__/components/graphs/ExpensePieChart.test.js` | **Create** — rendering tests for updated component |
+| `app/components/graphs/IncomePieChart.js` | **Modify** — same changes as ExpensePieChart |
+| `__tests__/components/graphs/IncomePieChart.test.js` | **Create** — rendering tests for updated component |
+
+`CustomLegend.js` is unchanged — it already uses `flex: 1` and adapts to its container width.
+
+---
+
+## Task 1: Create DonutChart with computeSegments
+
+**Files:**
+- Create: `app/components/graphs/DonutChart.js`
+- Create: `__tests__/components/graphs/DonutChart.test.js`
+
+### Geometry constants
+
+```
+SVG_SIZE = 140          width & height of the SVG canvas
+RADIUS   = 48           center of the stroke ring
+STROKE_WIDTH = 26       ring thickness (inner r=35, outer r=61)
+CENTER   = 70           SVG center point (SVG_SIZE / 2)
+CIRCUMFERENCE = 2π×48 ≈ 301.59
+ICON_THRESHOLD = 0.10   minimum fraction to show icon on arc
+ICON_SIZE = 14          icon px size (fits in 26px stroke width)
+```
+
+### Segment math
+
+For each item (given cumulative arc length `C` consumed so far):
+```
+fraction  = item.amount / total
+arcLength = fraction × CIRCUMFERENCE
+midAngle  = (C + arcLength/2) / RADIUS   // radians clockwise from top
+iconX     = CENTER + RADIUS × sin(midAngle)
+iconY     = CENTER − RADIUS × cos(midAngle)
+dashOffset = −C
+```
+Icon is shown when `fraction >= ICON_THRESHOLD && item.icon` is truthy.
+
+---
+
+- [ ] **Step 1.1: Write failing tests for `computeSegments`**
+
+Create `__tests__/components/graphs/DonutChart.test.js`:
+
+```js
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import DonutChart, {
+  computeSegments,
+  CIRCUMFERENCE,
+  CENTER,
+  RADIUS,
+  ICON_THRESHOLD,
+} from '../../../app/components/graphs/DonutChart';
+
+describe('computeSegments', () => {
+  it('returns empty array for empty data', () => {
+    expect(computeSegments([])).toEqual([]);
+  });
+
+  it('returns empty array when all amounts are zero', () => {
+    expect(computeSegments([{ amount: 0, color: '#f00', icon: 'food' }])).toEqual([]);
+  });
+
+  it('arc lengths sum to CIRCUMFERENCE', () => {
+    const data = [
+      { amount: 450, color: '#f00', icon: 'food' },
+      { amount: 300, color: '#0f0', icon: 'car' },
+      { amount: 250, color: '#00f', icon: 'shopping' },
+    ];
+    const segs = computeSegments(data);
+    const total = segs.reduce((s, seg) => s + seg.arcLength, 0);
+    expect(total).toBeCloseTo(CIRCUMFERENCE, 5);
+  });
+
+  it('first segment has dashOffset of 0', () => {
+    const data = [
+      { amount: 500, color: '#f00', icon: 'food' },
+      { amount: 500, color: '#0f0', icon: 'car' },
+    ];
+    expect(computeSegments(data)[0].dashOffset).toBe(0);
+  });
+
+  it('each subsequent segment dashOffset equals negative sum of prior arcLengths', () => {
+    const data = [
+      { amount: 400, color: '#f00', icon: 'food' },
+      { amount: 300, color: '#0f0', icon: 'car' },
+      { amount: 300, color: '#00f', icon: 'shopping' },
+    ];
+    const segs = computeSegments(data);
+    expect(segs[1].dashOffset).toBeCloseTo(-segs[0].arcLength, 5);
+    expect(segs[2].dashOffset).toBeCloseTo(-(segs[0].arcLength + segs[1].arcLength), 5);
+  });
+
+  it('shows icon for segment exactly at ICON_THRESHOLD', () => {
+    const pct = ICON_THRESHOLD; // 10%
+    const data = [
+      { amount: 1 - pct, color: '#f00', icon: 'food' },
+      { amount: pct,     color: '#0f0', icon: 'car' },
+    ];
+    const segs = computeSegments(data);
+    expect(segs[1].showIcon).toBe(true);
+  });
+
+  it('hides icon for segment just below ICON_THRESHOLD', () => {
+    const data = [
+      { amount: 0.91, color: '#f00', icon: 'food' },
+      { amount: 0.09, color: '#0f0', icon: 'car' }, // 9%
+    ];
+    expect(computeSegments(data)[1].showIcon).toBe(false);
+  });
+
+  it('hides icon when item.icon is falsy', () => {
+    const data = [{ amount: 1000, color: '#f00', icon: null }];
+    expect(computeSegments(data)[0].showIcon).toBe(false);
+  });
+
+  it('single segment spans full circumference', () => {
+    const segs = computeSegments([{ amount: 100, color: '#f00', icon: 'food' }]);
+    expect(segs[0].arcLength).toBeCloseTo(CIRCUMFERENCE, 5);
+    expect(segs[0].dashOffset).toBe(0);
+  });
+
+  it('icon at top (midAngle≈0) maps to x≈CENTER, y≈CENTER−RADIUS', () => {
+    // Two equal halves; first segment mid is at CIRCUMFERENCE/4 / RADIUS = π/2 from top
+    // For a near-zero starting segment: use very large first half so second starts near top
+    // Easier: verify via explicit formula. midAngle for a segment from 0% to 100%
+    // is (0 + CIRCUMFERENCE/2) / RADIUS = π → bottom position
+    const segs = computeSegments([{ amount: 1, color: '#f00', icon: 'food' }]);
+    // midAngle = (0 + CIRCUMFERENCE/2) / RADIUS = π
+    expect(segs[0].iconX).toBeCloseTo(CENTER, 1);         // sin(π) ≈ 0
+    expect(segs[0].iconY).toBeCloseTo(CENTER + RADIUS, 1); // −cos(π) = 1
+  });
+
+  it('preserves color and icon from input', () => {
+    const segs = computeSegments([{ amount: 100, color: '#abc123', icon: 'pizza' }]);
+    expect(segs[0].color).toBe('#abc123');
+    expect(segs[0].icon).toBe('pizza');
+  });
+});
+
+describe('DonutChart', () => {
+  const mockData = [
+    { amount: 560, color: '#7c83fd', icon: 'food' },   // 60.9% — above threshold
+    { amount: 280, color: '#fd7c7c', icon: 'car' },    // 30.4% — above threshold
+    { amount: 80,  color: '#7ce8fd', icon: 'heart' },  //  8.7% — below threshold
+  ];
+
+  it('renders without crashing', () => {
+    expect(() => render(<DonutChart data={mockData} />)).not.toThrow();
+  });
+
+  it('renders icons for segments at or above threshold', () => {
+    const { queryByTestId } = render(<DonutChart data={mockData} />);
+    expect(queryByTestId('icon-food')).not.toBeNull();
+    expect(queryByTestId('icon-car')).not.toBeNull();
+  });
+
+  it('does not render icon for segment below threshold', () => {
+    const { queryByTestId } = render(<DonutChart data={mockData} />);
+    expect(queryByTestId('icon-heart')).toBeNull();
+  });
+
+  it('renders no icons when data is empty', () => {
+    const { queryAllByTestId } = render(<DonutChart data={[]} />);
+    expect(queryAllByTestId(/^icon-/).length).toBe(0);
+  });
+
+  it('renders no icons when items have no icon property', () => {
+    const data = [{ amount: 1000, color: '#f00', icon: null }];
+    const { queryAllByTestId } = render(<DonutChart data={data} />);
+    expect(queryAllByTestId(/^icon-/).length).toBe(0);
+  });
+
+  it('renders a single icon for a single above-threshold item', () => {
+    const data = [{ amount: 100, color: '#7c83fd', icon: 'food' }];
+    const { queryByTestId } = render(<DonutChart data={data} />);
+    expect(queryByTestId('icon-food')).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests — verify they fail**
+
+```bash
+npm test -- --silent __tests__/components/graphs/DonutChart.test.js
+```
+
+Expected: FAIL — `Cannot find module '../../../app/components/graphs/DonutChart'`
+
+- [ ] **Step 1.3: Create DonutChart.js**
+
+Create `app/components/graphs/DonutChart.js`:
+
+```js
+import React, { useMemo } from 'react';
+import { View, StyleSheet } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import PropTypes from 'prop-types';
+
+export const SVG_SIZE = 140;
+export const RADIUS = 48;
+export const STROKE_WIDTH = 26;
+export const CENTER = SVG_SIZE / 2;
+export const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+export const ICON_THRESHOLD = 0.10;
+export const ICON_SIZE = 14;
+
+export const computeSegments = (data) => {
+  const total = data.reduce((sum, item) => sum + item.amount, 0);
+  if (total === 0) return [];
+
+  let cumulative = 0;
+  return data.map((item) => {
+    const fraction = item.amount / total;
+    const arcLength = fraction * CIRCUMFERENCE;
+    const midAngle = (cumulative + arcLength / 2) / RADIUS;
+    const seg = {
+      color: item.color,
+      icon: item.icon,
+      arcLength,
+      dashOffset: -cumulative,
+      showIcon: fraction >= ICON_THRESHOLD && !!item.icon,
+      iconX: CENTER + RADIUS * Math.sin(midAngle),
+      iconY: CENTER - RADIUS * Math.cos(midAngle),
+    };
+    cumulative += arcLength;
+    return seg;
+  });
+};
+
+const DonutChart = ({ data }) => {
+  const segments = useMemo(() => computeSegments(data), [data]);
+
+  return (
+    <View testID="donut-chart" style={styles.container}>
+      <Svg width={SVG_SIZE} height={SVG_SIZE}>
+        {segments.map((seg, i) => (
+          <Circle
+            key={i}
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            fill="none"
+            stroke={seg.color}
+            strokeWidth={STROKE_WIDTH}
+            strokeDasharray={`${seg.arcLength} ${CIRCUMFERENCE - seg.arcLength}`}
+            strokeDashoffset={seg.dashOffset}
+            rotation={-90}
+            origin={`${CENTER}, ${CENTER}`}
+          />
+        ))}
+      </Svg>
+      {segments
+        .filter((seg) => seg.showIcon)
+        .map((seg, i) => (
+          <View
+            key={i}
+            style={[
+              styles.iconWrapper,
+              {
+                left: seg.iconX - ICON_SIZE / 2,
+                top: seg.iconY - ICON_SIZE / 2,
+              },
+            ]}
+          >
+            <Icon name={seg.icon} size={ICON_SIZE} color="#fff" />
+          </View>
+        ))}
+    </View>
+  );
+};
+
+DonutChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      amount: PropTypes.number.isRequired,
+      color: PropTypes.string.isRequired,
+      icon: PropTypes.string,
+    }),
+  ).isRequired,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: SVG_SIZE,
+    width: SVG_SIZE,
+  },
+  iconWrapper: {
+    position: 'absolute',
+  },
+});
+
+export default DonutChart;
+```
+
+- [ ] **Step 1.4: Run tests — verify they pass**
+
+```bash
+npm test -- --silent __tests__/components/graphs/DonutChart.test.js
+```
+
+Expected: PASS — all tests green, 0 failed.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add app/components/graphs/DonutChart.js __tests__/components/graphs/DonutChart.test.js
+git commit -m "feat(graphs): add DonutChart SVG component with arc icon overlay"
+```
+
+---
+
+## Task 2: Update ExpensePieChart
+
+**Files:**
+- Modify: `app/components/graphs/ExpensePieChart.js`
+- Create: `__tests__/components/graphs/ExpensePieChart.test.js`
+
+- [ ] **Step 2.1: Write failing tests**
+
+Create `__tests__/components/graphs/ExpensePieChart.test.js`:
+
+```js
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ExpensePieChart from '../../../app/components/graphs/ExpensePieChart';
+
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
+}));
+
+jest.mock('../../../assets/currencies.json', () => ({
+  USD: { decimal_digits: 2, symbol: '$' },
+}));
+
+const mockColors = {
+  primary: '#007AFF',
+  text: '#111111',
+  mutedText: '#666666',
+  border: '#e6e6e6',
+};
+
+const mockData = [
+  { name: 'Food', amount: 560, color: '#7c83fd', icon: 'food', categoryId: '1', hasChildren: false },
+  { name: 'Transport', amount: 280, color: '#fd7c7c', icon: 'car', categoryId: '2', hasChildren: false },
+  { name: 'Other', amount: 40, color: '#aaa', icon: 'dots-horizontal', categoryId: '3', hasChildren: false },
+];
+
+const defaultProps = {
+  colors: mockColors,
+  t: (key) => key,
+  loading: false,
+  chartData: mockData,
+  selectedCurrency: 'USD',
+  onLegendItemPress: jest.fn(),
+  selectedCategory: 'all',
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ExpensePieChart', () => {
+  it('renders loading state when loading is true', () => {
+    const { getByText } = render(<ExpensePieChart {...defaultProps} loading={true} />);
+    expect(getByText('loading_operations')).toBeTruthy();
+  });
+
+  it('does not render donut chart when loading', () => {
+    const { queryByTestId } = render(<ExpensePieChart {...defaultProps} loading={true} />);
+    expect(queryByTestId('donut-chart')).toBeNull();
+  });
+
+  it('renders empty state text when chartData is empty', () => {
+    const { getByText } = render(<ExpensePieChart {...defaultProps} chartData={[]} />);
+    expect(getByText('no_expense_data')).toBeTruthy();
+  });
+
+  it('renders DonutChart when data is present', () => {
+    const { getByTestId } = render(<ExpensePieChart {...defaultProps} />);
+    expect(getByTestId('donut-chart')).toBeTruthy();
+  });
+
+  it('renders legend category names', () => {
+    const { getByText } = render(<ExpensePieChart {...defaultProps} />);
+    expect(getByText('Food')).toBeTruthy();
+    expect(getByText('Transport')).toBeTruthy();
+  });
+
+  it('renders arc icons for above-threshold segments', () => {
+    // Food 63.6%, Transport 31.8% — both above 10%
+    const { queryByTestId } = render(<ExpensePieChart {...defaultProps} />);
+    expect(queryByTestId('icon-food')).not.toBeNull();
+    expect(queryByTestId('icon-car')).not.toBeNull();
+  });
+
+  it('does not render arc icon for below-threshold segment', () => {
+    // Other 4.5% — below 10%
+    const { queryByTestId } = render(<ExpensePieChart {...defaultProps} />);
+    expect(queryByTestId('icon-dots-horizontal')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2.2: Run tests — verify they fail**
+
+```bash
+npm test -- --silent __tests__/components/graphs/ExpensePieChart.test.js
+```
+
+Expected: FAIL — several tests fail because the component still uses the old chart-kit layout.
+
+- [ ] **Step 2.3: Rewrite ExpensePieChart.js**
+
+Replace the entire contents of `app/components/graphs/ExpensePieChart.js`:
+
+```js
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import PropTypes from 'prop-types';
+import DonutChart from './DonutChart';
+import CustomLegend from './CustomLegend';
+
+const ExpensePieChart = ({
+  colors,
+  t,
+  loading,
+  chartData,
+  selectedCurrency,
+  onLegendItemPress,
+  selectedCategory,
+}) => {
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+          {t('loading_operations')}
+        </Text>
+      </View>
+    );
+  }
+
+  if (chartData.length === 0) {
+    return (
+      <Text style={[styles.noData, { color: colors.mutedText }]}>
+        {t('no_expense_data')}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.row}>
+      <DonutChart data={chartData} />
+      <CustomLegend
+        data={chartData}
+        currency={selectedCurrency}
+        colors={colors}
+        onItemPress={onLegendItemPress}
+        isClickable={selectedCategory === 'all'}
+      />
+    </View>
+  );
+};
+
+ExpensePieChart.propTypes = {
+  colors: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
+  chartData: PropTypes.array.isRequired,
+  selectedCurrency: PropTypes.string.isRequired,
+  onLegendItemPress: PropTypes.func.isRequired,
+  selectedCategory: PropTypes.string.isRequired,
+};
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    alignItems: 'center',
+    paddingVertical: 32,
+  },
+  loadingText: {
+    fontSize: 14,
+    marginTop: 8,
+  },
+  noData: {
+    fontSize: 14,
+    paddingVertical: 32,
+    textAlign: 'center',
+  },
+  row: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 10,
+  },
+});
+
+export default ExpensePieChart;
+```
+
+- [ ] **Step 2.4: Run tests — verify they pass**
+
+```bash
+npm test -- --silent __tests__/components/graphs/ExpensePieChart.test.js
+```
+
+Expected: PASS — all tests green, 0 failed.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add app/components/graphs/ExpensePieChart.js __tests__/components/graphs/ExpensePieChart.test.js
+git commit -m "feat(graphs): refactor ExpensePieChart to donut + side legend layout"
+```
+
+---
+
+## Task 3: Update IncomePieChart
+
+**Files:**
+- Modify: `app/components/graphs/IncomePieChart.js`
+- Create: `__tests__/components/graphs/IncomePieChart.test.js`
+
+- [ ] **Step 3.1: Write failing tests**
+
+Create `__tests__/components/graphs/IncomePieChart.test.js`:
+
+```js
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import IncomePieChart from '../../../app/components/graphs/IncomePieChart';
+
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
+}));
+
+jest.mock('../../../assets/currencies.json', () => ({
+  USD: { decimal_digits: 2, symbol: '$' },
+}));
+
+const mockColors = {
+  primary: '#007AFF',
+  text: '#111111',
+  mutedText: '#666666',
+  border: '#e6e6e6',
+};
+
+const mockData = [
+  { name: 'Salary', amount: 3000, color: '#7c83fd', icon: 'briefcase', categoryId: '1', hasChildren: false },
+  { name: 'Freelance', amount: 800, color: '#7cfd9e', icon: 'laptop', categoryId: '2', hasChildren: false },
+  { name: 'Other', amount: 60, color: '#aaa', icon: 'dots-horizontal', categoryId: '3', hasChildren: false },
+];
+
+const defaultProps = {
+  colors: mockColors,
+  t: (key) => key,
+  loadingIncome: false,
+  incomeChartData: mockData,
+  selectedCurrency: 'USD',
+  onLegendItemPress: jest.fn(),
+  selectedIncomeCategory: 'all',
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('IncomePieChart', () => {
+  it('renders loading state when loadingIncome is true', () => {
+    const { getByText } = render(<IncomePieChart {...defaultProps} loadingIncome={true} />);
+    expect(getByText('loading_operations')).toBeTruthy();
+  });
+
+  it('does not render donut chart when loading', () => {
+    const { queryByTestId } = render(<IncomePieChart {...defaultProps} loadingIncome={true} />);
+    expect(queryByTestId('donut-chart')).toBeNull();
+  });
+
+  it('renders empty state text when incomeChartData is empty', () => {
+    const { getByText } = render(<IncomePieChart {...defaultProps} incomeChartData={[]} />);
+    expect(getByText('no_income_data')).toBeTruthy();
+  });
+
+  it('renders DonutChart when data is present', () => {
+    const { getByTestId } = render(<IncomePieChart {...defaultProps} />);
+    expect(getByTestId('donut-chart')).toBeTruthy();
+  });
+
+  it('renders legend category names', () => {
+    const { getByText } = render(<IncomePieChart {...defaultProps} />);
+    expect(getByText('Salary')).toBeTruthy();
+    expect(getByText('Freelance')).toBeTruthy();
+  });
+
+  it('renders arc icons for above-threshold segments', () => {
+    // Salary 77.9%, Freelance 20.8% — both above 10%
+    const { queryByTestId } = render(<IncomePieChart {...defaultProps} />);
+    expect(queryByTestId('icon-briefcase')).not.toBeNull();
+    expect(queryByTestId('icon-laptop')).not.toBeNull();
+  });
+
+  it('does not render arc icon for below-threshold segment', () => {
+    // Other 1.6% — below 10%
+    const { queryByTestId } = render(<IncomePieChart {...defaultProps} />);
+    expect(queryByTestId('icon-dots-horizontal')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3.2: Run tests — verify they fail**
+
+```bash
+npm test -- --silent __tests__/components/graphs/IncomePieChart.test.js
+```
+
+Expected: FAIL — component still uses old layout.
+
+- [ ] **Step 3.3: Rewrite IncomePieChart.js**
+
+Replace the entire contents of `app/components/graphs/IncomePieChart.js`:
+
+```js
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import PropTypes from 'prop-types';
+import DonutChart from './DonutChart';
+import CustomLegend from './CustomLegend';
+
+const IncomePieChart = ({
+  colors,
+  t,
+  loadingIncome,
+  incomeChartData,
+  selectedCurrency,
+  onLegendItemPress,
+  selectedIncomeCategory,
+}) => {
+  if (loadingIncome) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+          {t('loading_operations')}
+        </Text>
+      </View>
+    );
+  }
+
+  if (incomeChartData.length === 0) {
+    return (
+      <Text style={[styles.noData, { color: colors.mutedText }]}>
+        {t('no_income_data')}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.row}>
+      <DonutChart data={incomeChartData} />
+      <CustomLegend
+        data={incomeChartData}
+        currency={selectedCurrency}
+        colors={colors}
+        onItemPress={onLegendItemPress}
+        isClickable={selectedIncomeCategory === 'all'}
+      />
+    </View>
+  );
+};
+
+IncomePieChart.propTypes = {
+  colors: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired,
+  loadingIncome: PropTypes.bool.isRequired,
+  incomeChartData: PropTypes.array.isRequired,
+  selectedCurrency: PropTypes.string.isRequired,
+  onLegendItemPress: PropTypes.func.isRequired,
+  selectedIncomeCategory: PropTypes.string.isRequired,
+};
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    alignItems: 'center',
+    paddingVertical: 32,
+  },
+  loadingText: {
+    fontSize: 14,
+    marginTop: 8,
+  },
+  noData: {
+    fontSize: 14,
+    paddingVertical: 32,
+    textAlign: 'center',
+  },
+  row: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 10,
+  },
+});
+
+export default IncomePieChart;
+```
+
+- [ ] **Step 3.4: Run tests — verify they pass**
+
+```bash
+npm test -- --silent __tests__/components/graphs/IncomePieChart.test.js
+```
+
+Expected: PASS — all tests green, 0 failed.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add app/components/graphs/IncomePieChart.js __tests__/components/graphs/IncomePieChart.test.js
+git commit -m "feat(graphs): refactor IncomePieChart to donut + side legend layout"
+```
+
+---
+
+## Task 4: Full suite verification and PR
+
+- [ ] **Step 4.1: Run the full test suite**
+
+```bash
+npm test -- --silent
+```
+
+Expected: 0 failed. If any graph tests fail, check for import issues (`PieChart` still referenced, `Dimensions` import leftover, etc.) and fix before proceeding.
+
+- [ ] **Step 4.2: Open PR**
+
+```bash
+gh pr create --title "feat(graphs): donut chart with arc icons and side legend" --body "Replaces solid pie chart stacked above legend with a donut chart (left) and legend list (right) in both expense and income expanded panels. Category icons appear on their respective arc segments for segments >= 10% of total. Uses react-native-svg directly (already installed) — no new dependencies."
+```

--- a/docs/superpowers/specs/2026-05-11-graph-pie-donut-layout-design.md
+++ b/docs/superpowers/specs/2026-05-11-graph-pie-donut-layout-design.md
@@ -1,0 +1,110 @@
+# Graph Pie Chart — Donut + Side Legend Layout
+
+**Date:** 2026-05-11  
+**Scope:** `ExpensePieChart`, `IncomePieChart`, `CustomLegend` components
+
+---
+
+## What We're Changing
+
+The expanded income and expense panels in `GraphsScreen` currently show a solid pie chart stacked above a full-width legend list. This refactor changes both panels to:
+
+1. **Donut chart** on the left (~140×140px) drawn with `react-native-svg`
+2. **Legend list** on the right (flex: 1), same rows as today
+3. **Category icons on arc segments** — the icon for each category rendered at the visual midpoint of its slice; segments too small to fit an icon (threshold: ~10% of total) are skipped
+
+---
+
+## Architecture
+
+### Donut chart renderer
+
+Replace `react-native-chart-kit`'s `PieChart` in both `ExpensePieChart.js` and `IncomePieChart.js` with a custom SVG component using `react-native-svg` (already installed as a transitive dependency of chart-kit).
+
+Each segment is a `<Circle>` element with `stroke` set to the segment color and `strokeDasharray` computed from the segment's percentage:
+
+```
+arcLength = percentage * 2 * π * RADIUS
+gap       = circumference - arcLength
+strokeDashoffset = -(sum of previous arcLengths)
+```
+
+The circle is rotated −90° so segments start at the top.
+
+**Constants:**
+- `SVG_SIZE = 140`
+- `RADIUS = 48`
+- `STROKE_WIDTH = 26`
+- `ICON_THRESHOLD = 0.10` (segments below 10% get no icon)
+
+### Icon overlay
+
+Icons are rendered as absolute-positioned `<Text>` React Native elements layered over the SVG inside a `position: relative` `View`. Each icon's `(left, top)` is computed from the segment midpoint angle:
+
+```
+midAngle = startAngle + (segmentAngle / 2)   // clockwise from top, radians
+x = cx + RADIUS * sin(midAngle)
+y = cy - RADIUS * cos(midAngle)
+```
+
+Icon is centered at `(x, y)` via `transform: translate(-50%, -50%)` (or equivalent RN `marginLeft`/`marginTop` offsets). A drop shadow is applied for legibility.
+
+### Layout change
+
+Both `ExpensePieChart` and `IncomePieChart` switch from a vertical stack to:
+
+```
+<View style={{ flexDirection: 'row', alignItems: 'center', height: CHART_CONTENT_HEIGHT }}>
+  <DonutChart ... />          {/* fixed 140px width */}
+  <CustomLegend ... />        {/* flex: 1 */}
+</View>
+```
+
+`CHART_CONTENT_HEIGHT` stays at 300px (the existing `CHART_HEIGHT` constant in `GraphsScreen`).
+
+### CustomLegend
+
+No structural changes. The component already uses `flex: 1` and `flexDirection: 'row'` internally per row, so it adapts to the narrower column naturally. Row padding may need a minor reduction (`paddingHorizontal: 4 → 2`) to avoid overflow on very narrow devices.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `app/components/graphs/ExpensePieChart.js` | Replace `PieChart` import with new `DonutChart`, change layout to `flexDirection: row` |
+| `app/components/graphs/IncomePieChart.js` | Same as above |
+| `app/components/graphs/DonutChart.js` | **New file** — SVG donut renderer with icon overlay |
+| `app/components/graphs/CustomLegend.js` | Minor: reduce `paddingHorizontal` if needed |
+
+`react-native-chart-kit`'s `PieChart` is no longer imported in these two files. The library itself stays (used elsewhere or transitively) — no package removal needed.
+
+---
+
+## Icon threshold logic
+
+```js
+const MIN_FRACTION = 0.10;
+const total = data.reduce((s, d) => s + d.amount, 0);
+const showIcon = (item) => item.icon && (item.amount / total) >= MIN_FRACTION;
+```
+
+Segments below threshold still render their arc color normally — they just have no icon.
+
+---
+
+## Edge cases
+
+- **Single category:** One full circle rendered as a ring with one icon.
+- **No data:** Existing empty state (`no_expense_data` / `no_income_data` text) unchanged.
+- **Category has no icon:** Icon overlay skipped regardless of size.
+- **Very many categories:** Legend `ScrollView` already exists in the card's `chartScrollView` — rows scroll vertically as before.
+
+---
+
+## What is NOT changing
+
+- Card expansion animation in `GraphsScreen` (width/height Reanimated sequence)
+- `CustomLegend` row structure (dot, icon, name, amount, divider, percentage)
+- `CHART_HEIGHT = 300` constant
+- The `chartNavRow` (back arrow + category picker) above the chart when drilling into a subcategory

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -706,6 +706,10 @@ jest.mock('react-native-reanimated', () => {
       delay(ms) { return this; }
       withCallback(callback) { return this; }
     },
+    SlideInRight: { duration: jest.fn(function() { return this; }), easing: jest.fn(function() { return this; }) },
+    SlideInLeft: { duration: jest.fn(function() { return this; }), easing: jest.fn(function() { return this; }) },
+    SlideOutLeft: { duration: jest.fn(function() { return this; }), easing: jest.fn(function() { return this; }) },
+    SlideOutRight: { duration: jest.fn(function() { return this; }), easing: jest.fn(function() { return this; }) },
     SharedValue: class SharedValue {
       constructor(value) { this.value = value; }
     },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -600,12 +600,13 @@ jest.mock('@expo/vector-icons', () => {
   const { Text } = require('react-native');
   const PropTypes = require('prop-types');
 
-  const MockIcon = ({ name, size, color, ...props }) =>
-    React.createElement(Text, { ...props, testID: `icon-${name}` }, name);
+  const MockIcon = ({ name, size, color, testID, ...props }) =>
+    React.createElement(Text, { ...props, testID: testID || `icon-${name}` }, name);
   MockIcon.propTypes = {
     name: PropTypes.string,
     size: PropTypes.number,
     color: PropTypes.string,
+    testID: PropTypes.string,
   };
 
   return {


### PR DESCRIPTION
## Summary

- Replace solid pie charts in expense/income panels with custom SVG donut charts (`react-native-svg`, already installed)
- Reflow layout to side-by-side: donut on left (140×140px), legend list on right (`flex:1`)
- Render category icons directly on arc segments at the arc midpoint; segments below 10% of total are skipped
- Category drill-in: tap a legend row to filter the donut to a single category, with slide animation and header back button
- Dynamic card height based on legend row count
- Uniform 16px border radius across all graph cards
- Performance: cache raw spending/income data, re-aggregate only when category filter changes

## Changes

### New components
- `app/components/graphs/DonutChart.js` — custom SVG donut renderer with icon overlay

### Modified components
- `app/components/graphs/ExpensePieChart.js` — donut + side legend layout, category drill-in with slide animation
- `app/components/graphs/IncomePieChart.js` — same
- `app/components/graphs/CustomLegend.js` — remove icon column, tighter widths/font sizes (14→12px, 100→62px, 50→38px)
- `app/screens/GraphsScreen.js` — uniform border radius (8→16), padding adjustments

### Tests
- `__tests__/components/graphs/DonutChart.test.js` — new, 17 tests
- `__tests__/components/graphs/ExpensePieChart.test.js` — new, 7 tests
- `__tests__/components/graphs/IncomePieChart.test.js` — new, 7 tests
- `__tests__/components/graphs/CustomLegend.test.js` — updated icon assertions
