### PR TITLE
fix(graphs): guard WheelPicker against empty data to prevent launch crash

### DIFF
--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -689,34 +689,38 @@ const GraphsScreen = () => {
       </ScrollView>
 
       {/* Floating currency wheel FAB */}
-      <View style={[styles.fabWheel, styles.fabWheelLeft, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}>
-        <WheelPicker
-          data={currencyItems}
-          value={selectedCurrency}
-          onValueChanged={({ item }) => setSelectedCurrency(item.value)}
-          itemHeight={28}
-          visibleItemCount={3}
-          itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
-          overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
-          enableScrollByTapOnItem
-          keyExtractor={(item, index) => `currency-${index}`}
-        />
-      </View>
+      {currencyItems.length > 0 && (
+        <View style={[styles.fabWheel, styles.fabWheelLeft, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}>
+          <WheelPicker
+            data={currencyItems}
+            value={selectedCurrency}
+            onValueChanged={({ item }) => item && setSelectedCurrency(item.value)}
+            itemHeight={28}
+            visibleItemCount={3}
+            itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
+            overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
+            enableScrollByTapOnItem
+            keyExtractor={(item, index) => `currency-${index}`}
+          />
+        </View>
+      )}
 
       {/* Floating period wheel FAB */}
-      <View style={[styles.fabWheel, styles.fabWheelRight, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}>
-        <WheelPicker
-          data={periodItems}
-          value={selectedPeriod}
-          onValueChanged={({ item }) => setSelectedPeriod(item.value)}
-          itemHeight={28}
-          visibleItemCount={3}
-          itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
-          overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
-          enableScrollByTapOnItem
-          keyExtractor={(item, index) => `period-${index}`}
-        />
-      </View>
+      {periodItems.length > 0 && (
+        <View style={[styles.fabWheel, styles.fabWheelRight, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}>
+          <WheelPicker
+            data={periodItems}
+            value={selectedPeriod}
+            onValueChanged={({ item }) => item && setSelectedPeriod(item.value)}
+            itemHeight={28}
+            visibleItemCount={3}
+            itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
+            overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
+            enableScrollByTapOnItem
+            keyExtractor={(item, index) => `period-${index}`}
+          />
+        </View>
+      )}
 
     </View>
   );


### PR DESCRIPTION
## Summary

- WheelPicker for currency and period selection crashes the release APK on launch
- Root cause: `onValueChanged` fires with `{ item: undefined }` when `data` is empty
- Accounts context hasn't loaded yet on first render, so `currencyItems` is `[]`

## Problem

`TypeError: Cannot read property 'value' of undefined` thrown in `onValueChanged` on the expo-updates-error-recovery thread, killing the app immediately after launch.

Confirmed via `adb logcat` on a physical device running the release APK.

## Solution

- Conditionally render both WheelPicker FABs only when their data arrays are non-empty
- Add `item &&` null guard in both `onValueChanged` callbacks as secondary defense

## Test plan

- [ ] Fresh install: app launches without crash
- [ ] Currency wheel appears once accounts are loaded
- [ ] Period wheel appears once available months are loaded
- [ ] Switching currency and period still works correctly
