### PR TITLE
feat(graphs): refine expense/income card category drill-down UX

### DIFF
--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -32,13 +32,9 @@ const ExpenseSummaryCard = ({
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <TouchableOpacity
+    <View
       testID="expense-summary-card"
       style={styles.summaryCard}
-      onPress={onPress}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityLabel={t('expenses_by_category')}
     >
       <View style={styles.iconBadge}>
         <Icon name="arrow-top-right" size={16} color="#d93025" />
@@ -53,20 +49,28 @@ const ExpenseSummaryCard = ({
         <View style={styles.categoryBackOverlay} pointerEvents="box-none">
           <TouchableOpacity
             onPress={onBack}
-            style={styles.categoryBack}
+            style={[styles.filterChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+            activeOpacity={0.7}
             accessibilityRole="button"
             accessibilityLabel={t('back')}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
-            <Icon name="chevron-left" size={18} color={colors.mutedText} />
-            <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
+            <Text style={[styles.filterChipText, { color: colors.text }]} numberOfLines={1}>
               {categoryName}
             </Text>
+            <Icon name="close-circle" size={14} color={colors.mutedText} />
           </TouchableOpacity>
         </View>
       )}
-      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-    </TouchableOpacity>
+      <TouchableOpacity
+        onPress={onPress}
+        style={styles.collapseButton}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={t('expenses_by_category')}
+      >
+        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
+      </TouchableOpacity>
+    </View>
   );
 };
 
@@ -89,11 +93,6 @@ const styles = StyleSheet.create({
     letterSpacing: -0.3,
     marginTop: 1,
   },
-  categoryBack: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 2,
-  },
   categoryBackOverlay: {
     alignItems: 'center',
     bottom: 0,
@@ -103,11 +102,26 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
   },
-  categoryName: {
+  collapseButton: {
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    justifyContent: 'center',
+    width: '15%',
+  },
+  filterChip: {
+    alignItems: 'center',
+    borderRadius: 20,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 4,
+    maxWidth: '75%',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  filterChipText: {
     flexShrink: 1,
-    fontSize: 15,
+    fontSize: 13,
     fontWeight: '600',
-    maxWidth: 120,
   },
   iconBadge: {
     alignItems: 'center',

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -32,13 +32,9 @@ const IncomeSummaryCard = ({
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <TouchableOpacity
+    <View
       testID="income-summary-card"
       style={styles.summaryCard}
-      onPress={onPress}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityLabel={t('income_by_category')}
     >
       <View style={styles.iconBadge}>
         <Icon name="arrow-bottom-left" size={16} color={colors.income} />
@@ -53,20 +49,28 @@ const IncomeSummaryCard = ({
         <View style={styles.categoryBackOverlay} pointerEvents="box-none">
           <TouchableOpacity
             onPress={onBack}
-            style={styles.categoryBack}
+            style={[styles.filterChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+            activeOpacity={0.7}
             accessibilityRole="button"
             accessibilityLabel={t('back')}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
-            <Icon name="chevron-left" size={18} color={colors.mutedText} />
-            <Text style={[styles.categoryName, { color: colors.text }]} numberOfLines={1}>
+            <Text style={[styles.filterChipText, { color: colors.text }]} numberOfLines={1}>
               {categoryName}
             </Text>
+            <Icon name="close-circle" size={14} color={colors.mutedText} />
           </TouchableOpacity>
         </View>
       )}
-      <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-    </TouchableOpacity>
+      <TouchableOpacity
+        onPress={onPress}
+        style={styles.collapseButton}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={t('income_by_category')}
+      >
+        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
+      </TouchableOpacity>
+    </View>
   );
 };
 
@@ -89,11 +93,6 @@ const styles = StyleSheet.create({
     letterSpacing: -0.3,
     marginTop: 1,
   },
-  categoryBack: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 2,
-  },
   categoryBackOverlay: {
     alignItems: 'center',
     bottom: 0,
@@ -103,11 +102,26 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
   },
-  categoryName: {
+  collapseButton: {
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    justifyContent: 'center',
+    width: '15%',
+  },
+  filterChip: {
+    alignItems: 'center',
+    borderRadius: 20,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 4,
+    maxWidth: '75%',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  filterChipText: {
     flexShrink: 1,
-    fontSize: 15,
+    fontSize: 13,
     fontWeight: '600',
-    maxWidth: 120,
   },
   iconBadge: {
     alignItems: 'center',

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
 import { View, Text, StyleSheet, ScrollView, useWindowDimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing, SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
@@ -73,8 +73,10 @@ const GraphsScreen = () => {
   const incomeChartHeightSV = useSharedValue(0);
   const expenseHeightInitialized = useRef(false);
   const incomeHeightInitialized = useRef(false);
-  const expenseDrillDirection = useRef('in'); // 'in' | 'back'
-  const incomeDrillDirection = useRef('in');
+  // dir + target bundled so a single setState triggers a render that refreshes
+  // the exiting prop on the old component BEFORE the key changes in the next render
+  const [expenseDrillReq, setExpenseDrillReq] = useState({ dir: 'in', target: null });
+  const [incomeDrillReq, setIncomeDrillReq] = useState({ dir: 'in', target: null });
 
   // Derive selectedYear and selectedMonth from combined selectedPeriod
   // This must be defined before the hooks that use these values
@@ -114,15 +116,29 @@ const GraphsScreen = () => {
     handleDeleteBalance,
   } = useBalanceHistory(selectedAccount, selectedYear, selectedMonth);
 
+  // Phase 2: apply the pending category change after the old component has
+  // re-rendered with the correct exiting prop (useLayoutEffect fires before paint)
+  useLayoutEffect(() => {
+    if (expenseDrillReq.target !== null) {
+      setSelectedCategory(expenseDrillReq.target);
+      setExpenseDrillReq(prev => ({ ...prev, target: null }));
+    }
+  }, [expenseDrillReq]);
+
+  useLayoutEffect(() => {
+    if (incomeDrillReq.target !== null) {
+      setSelectedIncomeCategory(incomeDrillReq.target);
+      setIncomeDrillReq(prev => ({ ...prev, target: null }));
+    }
+  }, [incomeDrillReq]);
+
   // Handlers for legend item clicks
   const handleExpenseLegendItemPress = useCallback((categoryId) => {
-    expenseDrillDirection.current = 'in';
-    setSelectedCategory(categoryId);
+    setExpenseDrillReq({ dir: 'in', target: categoryId });
   }, []);
 
   const handleIncomeLegendItemPress = useCallback((categoryId) => {
-    incomeDrillDirection.current = 'in';
-    setSelectedIncomeCategory(categoryId);
+    setIncomeDrillReq({ dir: 'in', target: categoryId });
   }, []);
 
   const handleShowCalendar = useCallback(async () => {
@@ -396,17 +412,15 @@ const GraphsScreen = () => {
   }, [categories]);
 
   const handleBackToIncomeParent = useCallback(() => {
-    incomeDrillDirection.current = 'back';
-    setSelectedIncomeCategory(prev => getParentCategoryId(prev));
-  }, [getParentCategoryId]);
+    setIncomeDrillReq({ dir: 'back', target: getParentCategoryId(selectedIncomeCategory) });
+  }, [getParentCategoryId, selectedIncomeCategory]);
 
   const handleBackToExpenseParent = useCallback(() => {
-    expenseDrillDirection.current = 'back';
-    setSelectedCategory(prev => getParentCategoryId(prev));
-  }, [getParentCategoryId]);
+    setExpenseDrillReq({ dir: 'back', target: getParentCategoryId(selectedCategory) });
+  }, [getParentCategoryId, selectedCategory]);
 
-  const resetExpenseCategory = useCallback(() => setSelectedCategory('all'), []);
-  const resetIncomeCategory = useCallback(() => setSelectedIncomeCategory('all'), []);
+  const resetExpenseCategory = useCallback(() => setExpenseDrillReq({ dir: 'none', target: 'all' }), []);
+  const resetIncomeCategory = useCallback(() => setIncomeDrillReq({ dir: 'none', target: 'all' }), []);
 
   const toggleCard = useCallback((card) => {
     if (expandedCard === card) {
@@ -569,8 +583,8 @@ const GraphsScreen = () => {
                 >
                   <Animated.View
                     key={selectedIncomeCategory}
-                    entering={incomeDrillDirection.current === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
-                    exiting={incomeDrillDirection.current === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
+                    entering={incomeDrillReq.dir === 'none' ? undefined : incomeDrillReq.dir === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
+                    exiting={incomeDrillReq.dir === 'none' ? undefined : incomeDrillReq.dir === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
                   >
                     <IncomePieChart
                       colors={colors}
@@ -631,8 +645,8 @@ const GraphsScreen = () => {
                 >
                   <Animated.View
                     key={selectedCategory}
-                    entering={expenseDrillDirection.current === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
-                    exiting={expenseDrillDirection.current === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
+                    entering={expenseDrillReq.dir === 'none' ? undefined : expenseDrillReq.dir === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
+                    exiting={expenseDrillReq.dir === 'none' ? undefined : expenseDrillReq.dir === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
                   >
                     <ExpensePieChart
                       colors={colors}


### PR DESCRIPTION
## Summary

- Collapse button is now only the rightmost 15% of the card header (tapping the label/amount area no longer collapses)
- Active category shown as a grayscale filter chip centered in the header; tap to reset to all categories
- Fix stale exiting-animation bug: drill direction is state-driven with a two-phase useLayoutEffect update so Reanimated always reads the correct exiting prop before the keyed view unmounts
- Drill-in animates old panel left / new panel in from right; going back reverses direction
- Collapsing while a category is active skips the slide animation (instant swap)

## Test plan

- [ ] Tap expense/income card to expand — chevron area (rightmost ~15%) collapses, rest of header does nothing
- [ ] Tap a legend item to drill into a category — filter chip appears centered in header, old panel slides left, new slides in from right
- [ ] Tap the filter chip to go back — new panel slides in from left, category panel exits right
- [ ] Drill in, then collapse — no slide animation on chart content, card collapses cleanly
- [ ] Drill in -> back -> drill in again — animation directions are correct on all transitions (tests the stale-prop fix)
