### PR TITLE
fix: remove border styling from calculator buttons

### DIFF
--- a/app/components/Calculator.js
+++ b/app/components/Calculator.js
@@ -109,9 +109,8 @@ const CalcButton = memo(({ value, onPress, style, textStyle, icon, colors }) => 
 
   const buttonStyle = useMemo(() => [
     styles.button,
-    { borderColor: colors.border },
     style,
-  ], [colors.border, style]);
+  ], [style]);
 
   const finalTextStyle = useMemo(() => [
     styles.buttonText,
@@ -444,7 +443,7 @@ export default function Calculator({ value, onValueChange, colors, placeholder =
               style={[
                 styles.button,
                 sharedButtonStyle,
-                { backgroundColor: colors.selected, borderColor: colors.border },
+                { backgroundColor: colors.selected },
               ]}
               onPress={() => onAdd()}
               accessibilityRole="button"
@@ -485,7 +484,6 @@ const styles = StyleSheet.create({
   button: {
     alignItems: 'center',
     borderRadius: BORDER_RADIUS.sm,
-    borderWidth: 1,
     elevation: 2,
     flex: 1,
     height: HEIGHTS.calculator,


### PR DESCRIPTION
## Summary
Removed border-related styling from calculator buttons to simplify the component's visual design.

## Key Changes
- Removed `borderColor` prop dependency from `CalcButton` component's style memoization
- Removed `borderColor: colors.border` from the button style object in `CalcButton`
- Removed `borderColor: colors.border` from the selected button style in the main Calculator component
- Removed `borderWidth: 1` from the base button styles in StyleSheet

## Implementation Details
These changes eliminate the border styling that was previously applied to all calculator buttons. The `colors.border` prop is no longer used in button styling, and the memoization dependency array in `CalcButton` has been simplified to only depend on the `style` prop, reducing unnecessary re-renders.

https://claude.ai/code/session_01Ac4qJvVUhw8vdaVWmXVFEd