### PR TITLE
feat(ui): move version display from header to update button in Settings

### DIFF
--- a/__tests__/components/Header.test.js
+++ b/__tests__/components/Header.test.js
@@ -3,11 +3,8 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import Header from '../../app/components/Header';
-import { appEvents } from '../../app/services/eventEmitter';
-import { getDatabaseVersion } from '../../app/services/db';
-import { IMPORT_PROGRESS_EVENT } from '../../app/services/BackupRestore';
 
 // Mock contexts
 const mockSetTheme = jest.fn();
@@ -35,24 +32,6 @@ jest.mock('../../app/contexts/LocalizationContext', () => ({
   useLocalization: () => ({
     t: (key) => key,
   }),
-}));
-
-// Mock db service
-jest.mock('../../app/services/db', () => ({
-  getDatabaseVersion: jest.fn(),
-}));
-
-// Mock eventEmitter
-jest.mock('../../app/services/eventEmitter', () => ({
-  appEvents: {
-    on: jest.fn(),
-    off: jest.fn(),
-  },
-}));
-
-// Mock BackupRestore
-jest.mock('../../app/services/BackupRestore', () => ({
-  IMPORT_PROGRESS_EVENT: 'import_progress',
 }));
 
 // Mock expo vector icons
@@ -96,7 +75,6 @@ describe('Header', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    getDatabaseVersion.mockResolvedValue(5);
     mockIsDownloading = false;
     mockDownloadProgress = null;
   });
@@ -112,12 +90,10 @@ describe('Header', () => {
       expect(getByText('Penny')).toBeTruthy();
     });
 
-    it('renders version information', async () => {
-      const { getByText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      await waitFor(() => {
-        expect(getByText(/v.*\| DB v5/)).toBeTruthy();
-      });
+    it('does not render version text in header', () => {
+      const { queryByText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
+      expect(queryByText(/v\d+\.\d+/)).toBeNull();
+      expect(queryByText(/DB v/)).toBeNull();
     });
 
     it('renders settings icon', () => {
@@ -171,123 +147,6 @@ describe('Header', () => {
       const themeButton = getByLabelText('Switch to dark theme');
       expect(themeButton.props.accessibilityRole).toBe('button');
       expect(themeButton.props.accessibilityHint).toBe('Toggles between light and dark theme');
-    });
-  });
-
-  describe('Database version', () => {
-    it('fetches database version on mount', async () => {
-      render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      await waitFor(() => {
-        expect(getDatabaseVersion).toHaveBeenCalled();
-      });
-    });
-
-    it('displays database version when loaded', async () => {
-      getDatabaseVersion.mockResolvedValue(10);
-
-      const { getByText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      await waitFor(() => {
-        expect(getByText(/DB v10/)).toBeTruthy();
-      });
-    });
-
-    it('displays ? when database version fails to load', async () => {
-      getDatabaseVersion.mockRejectedValue(new Error('DB error'));
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      const { getByText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      // Version should show ? since loading failed
-      await waitFor(() => {
-        expect(getByText(/DB v\?/)).toBeTruthy();
-      });
-
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch database version:', expect.any(Error));
-      consoleSpy.mockRestore();
-    });
-  });
-
-  describe('Import progress event listener', () => {
-    it('subscribes to import progress events on mount', () => {
-      render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      expect(appEvents.on).toHaveBeenCalledWith(
-        IMPORT_PROGRESS_EVENT,
-        expect.any(Function),
-      );
-    });
-
-    it('unsubscribes from import progress events on unmount', () => {
-      const { unmount } = render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      unmount();
-
-      expect(appEvents.off).toHaveBeenCalledWith(
-        IMPORT_PROGRESS_EVENT,
-        expect.any(Function),
-      );
-    });
-
-    it('refreshes DB version when import completes', async () => {
-      let eventHandler;
-      appEvents.on.mockImplementation((event, handler) => {
-        eventHandler = handler;
-      });
-
-      const consoleSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
-
-      render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      // Initial fetch
-      expect(getDatabaseVersion).toHaveBeenCalledTimes(1);
-
-      // Simulate import completion event
-      eventHandler({ stepId: 'complete', status: 'completed' });
-
-      await waitFor(() => {
-        expect(getDatabaseVersion).toHaveBeenCalledTimes(2);
-      });
-
-      expect(consoleSpy).toHaveBeenCalledWith('Import completed, refreshing DB version...');
-      consoleSpy.mockRestore();
-    });
-
-    it('does not refresh DB version for non-complete events', async () => {
-      let eventHandler;
-      appEvents.on.mockImplementation((event, handler) => {
-        eventHandler = handler;
-      });
-
-      render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      // Initial fetch
-      expect(getDatabaseVersion).toHaveBeenCalledTimes(1);
-
-      // Simulate non-complete event
-      eventHandler({ stepId: 'accounts', status: 'in_progress' });
-
-      // Should not have been called again
-      expect(getDatabaseVersion).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not refresh DB version for complete step with non-completed status', async () => {
-      let eventHandler;
-      appEvents.on.mockImplementation((event, handler) => {
-        eventHandler = handler;
-      });
-
-      render(<Header onOpenSettings={mockOnOpenSettings} />);
-
-      // Initial fetch
-      expect(getDatabaseVersion).toHaveBeenCalledTimes(1);
-
-      // Simulate complete step but not completed status
-      eventHandler({ stepId: 'complete', status: 'in_progress' });
-
-      // Should not have been called again
-      expect(getDatabaseVersion).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -355,4 +214,3 @@ describe('Header', () => {
     });
   });
 });
-

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -1,5 +1,5 @@
 import { View, Text, TouchableOpacity, StyleSheet, Image, Animated } from 'react-native';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import SearchBar from './search/SearchBar';
 import PropTypes from 'prop-types';
@@ -7,9 +7,6 @@ import { useThemeConfig } from '../contexts/ThemeConfigContext';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import { useLocalization } from '../contexts/LocalizationContext';
-import { getDatabaseVersion } from '../services/db';
-import { appEvents } from '../services/eventEmitter';
-import { IMPORT_PROGRESS_EVENT } from '../services/BackupRestore';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
 import { useSearch } from '../contexts/SearchContext';
 import FilterBadge from './search/FilterBadge';
@@ -28,7 +25,6 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
   const { openSearch, searchMode, closeSearch, reopenSearch, toggleFilters } = useSearch();
   console.debug('[Header] openSearch exists:', !!openSearch);
   console.debug('[Header] searchMode:', searchMode);
-  const [dbVersion, setDbVersion] = useState(null);
   const downloadArrowAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -67,33 +63,6 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
     };
     updateSearchFilters(clearValues[groupKey]);
   }, [updateSearchFilters]);
-
-  const fetchDbVersion = useCallback(async () => {
-    try {
-      const version = await getDatabaseVersion();
-      setDbVersion(version);
-    } catch (error) {
-      console.error('Failed to fetch database version:', error);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchDbVersion();
-
-    // Listen for import completion to refresh DB version
-    const handleImportProgress = (event) => {
-      if (event.stepId === 'complete' && event.status === 'completed') {
-        console.debug('Import completed, refreshing DB version...');
-        fetchDbVersion();
-      }
-    };
-
-    appEvents.on(IMPORT_PROGRESS_EVENT, handleImportProgress);
-
-    return () => {
-      appEvents.off(IMPORT_PROGRESS_EVENT, handleImportProgress);
-    };
-  }, [fetchDbVersion]);
 
   const toggleTheme = () => {
     const newTheme = colorScheme === 'dark' ? 'light' : 'dark';
@@ -136,12 +105,7 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
               style={styles.icon}
               accessibilityLabel="Penny app icon"
             />
-            <View>
-              <Text style={[styles.title, { color: colors.text }]}>Penny</Text>
-              <Text style={[styles.version, { color: colors.mutedText }]}>
-                v{APP_VERSION} | DB v{dbVersion || '?'}
-              </Text>
-            </View>
+            <Text style={[styles.title, { color: colors.text }]}>Penny</Text>
           </View>
           <View style={styles.buttonContainer}>
             {rightContent || (
@@ -295,9 +259,5 @@ const styles = StyleSheet.create({
   titleContainer: {
     alignItems: 'center',
     flexDirection: 'row',
-  },
-  version: {
-    fontSize: 10,
-    marginTop: 2,
   },
 });

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -811,7 +811,12 @@ export default function SettingsModal({ visible, onClose }) {
                     {t('check_updates') || 'Check for updates'}
                   </Text>
                 </View>
-                <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                <View style={styles.updateRowRight}>
+                  <Text style={[styles.versionLabel, { color: colors.mutedText }]}>
+                    {`v${require('../../package.json').version}`}
+                  </Text>
+                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                </View>
               </View>
             </TouchableRipple>
 
@@ -1306,18 +1311,6 @@ export default function SettingsModal({ visible, onClose }) {
                     <Animated.View style={[styles.updateResultContainer, { opacity: updateContentAnim }]}>
                       {updateResult.type === 'available' && (
                         <>
-                          <View style={styles.updateAvailableHeader}>
-                            <Ionicons name="download-outline" size={36} color={colors.primary} />
-                            <View style={styles.updateVersionInfo}>
-                              <Text style={[styles.updateNewVersion, { color: colors.text }]}>
-                                v{updateResult.latestVersion}
-                              </Text>
-                              <Text style={[styles.updateCurrentVersion, { color: colors.mutedText }]}>
-                                {(t('update_from_version') || 'installed: v{currentVersion}')
-                                  .replace('{currentVersion}', updateResult.currentVersion)}
-                              </Text>
-                            </View>
-                          </View>
                           {updateResult.releaseNotes ? (
                             <>
                               <Divider style={styles.updateDivider} />
@@ -1802,6 +1795,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 2,
   },
+  updateRowRight: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 4,
+  },
+  versionLabel: {
+    fontSize: 13,
+  },
   sheetsErrorText: {
     color: '#c44',
     fontSize: 14,
@@ -1879,12 +1880,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'flex-end',
   },
-  updateAvailableHeader: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: SPACING.md,
-    paddingBottom: SPACING.sm,
-  },
   updateBottomRow: {
     flexDirection: 'row',
     gap: SPACING.sm,
@@ -1919,16 +1914,8 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     textAlign: 'center',
   },
-  updateCurrentVersion: {
-    fontSize: 13,
-    marginTop: 2,
-  },
   updateDivider: {
     marginTop: SPACING.sm,
-  },
-  updateNewVersion: {
-    fontSize: 20,
-    fontWeight: '600',
   },
   updatePanelWrapper: {
     flex: 1,
@@ -1937,9 +1924,6 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.lg,
-  },
-  updateVersionInfo: {
-    flex: 1,
   },
   updateVersionText: {
     fontSize: 15,

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1795,14 +1795,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 2,
   },
-  updateRowRight: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 4,
-  },
-  versionLabel: {
-    fontSize: 13,
-  },
   sheetsErrorText: {
     color: '#c44',
     fontSize: 14,
@@ -1925,10 +1917,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.lg,
   },
+  updateRowRight: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 4,
+  },
   updateVersionText: {
     fontSize: 15,
     lineHeight: 22,
     textAlign: 'center',
+  },
+  versionLabel: {
+    fontSize: 13,
   },
 });
 


### PR DESCRIPTION
Remove the `v{APP_VERSION} | DB v{dbVersion}` subtitle from the header
top-left to avoid duplicating version info when the update dialog is
visible. The current app version is now shown as a muted label on the
right side of the "Check for updates" row in Settings, keeping it
co-located with the update button and freeing header space for release
notes in the update flow.

https://claude.ai/code/session_01TwoPbjpUDiYEo7w6caFyg7