### PR TITLE
fix: "up to date" layout in Check for updates panel

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1869,6 +1869,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 44,
   },
+  upToDateContent: {
+    flex: 1,
+    paddingVertical: SPACING.xl,
+  },
+  upToDateHeader: {
+    alignItems: 'center',
+    paddingBottom: SPACING.lg,
+    paddingHorizontal: HORIZONTAL_PADDING * 2,
+  },
   updateActionColumn: {
     alignItems: 'center',
     flex: 1,
@@ -1928,15 +1937,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 22,
     textAlign: 'center',
-  },
-  upToDateContent: {
-    flex: 1,
-    paddingVertical: SPACING.xl,
-  },
-  upToDateHeader: {
-    alignItems: 'center',
-    paddingHorizontal: HORIZONTAL_PADDING * 2,
-    paddingBottom: SPACING.lg,
   },
   versionLabel: {
     fontSize: 13,

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1403,11 +1403,13 @@ export default function SettingsModal({ visible, onClose }) {
                         </>
                       )}
                       {updateResult.type === 'up_to_date' && (
-                        <View style={styles.importConfirmContent}>
-                          <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
-                          <Text style={[styles.updateVersionText, { color: colors.text }]}>
-                            {t('up_to_date') || 'You already have the latest version installed.'}
-                          </Text>
+                        <View style={styles.upToDateContent}>
+                          <View style={styles.upToDateHeader}>
+                            <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
+                            <Text style={[styles.updateVersionText, { color: colors.text }]}>
+                              {t('up_to_date') || 'You already have the latest version installed.'}
+                            </Text>
+                          </View>
                           {downloadedApks.length > 0 && (
                             <View style={styles.downloadedApksSection}>
                               <Divider />
@@ -1926,6 +1928,15 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 22,
     textAlign: 'center',
+  },
+  upToDateContent: {
+    flex: 1,
+    paddingVertical: SPACING.xl,
+  },
+  upToDateHeader: {
+    alignItems: 'center',
+    paddingHorizontal: HORIZONTAL_PADDING * 2,
+    paddingBottom: SPACING.lg,
   },
   versionLabel: {
     fontSize: 13,


### PR DESCRIPTION
The importConfirmContent wrapper had alignItems: center which caused the
downloaded APKs FlatList to shrink to content width, and justifyContent: center
which produced awkward empty space when APKs were shown. Replaced with a
dedicated upToDateContent layout that keeps the icon/text centered in their own
sub-view while letting the APKs section stretch full-width.

https://claude.ai/code/session_01U4axW1vrHyrF8f9TwodnU8