### PR TITLE
fix: preserve multicurrency exchange rate when editing description in OperationModal

### DIFF
--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -808,6 +808,103 @@ describe('useOperationForm', () => {
       });
     });
 
+    it('should preserve multicurrency exchange rate when accounts prop gets a new reference', async () => {
+      // Regression: accounts getting a new array reference (from a context update) while the
+      // user is editing (e.g. typing description) used to re-trigger initialization and wipe
+      // the exchange rate that had been auto-populated or manually entered.
+      const multicurrencyOperation = {
+        id: 'op-mc',
+        type: 'transfer',
+        amount: '100',
+        accountId: 'acc-1',
+        toAccountId: 'acc-2',
+        exchangeRate: '1.2',
+        destinationAmount: '60',
+        date: '2024-01-15',
+      };
+
+      const { result, rerender } = renderHook(
+        (props) => useOperationForm(props),
+        { initialProps: { ...defaultProps, operation: multicurrencyOperation, isNew: false } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.values.exchangeRate).toBe('1.2');
+        expect(result.current.values.destinationAmount).toBe('60');
+      });
+
+      // Simulate the accounts context emitting a new array reference with the same data
+      const newAccountsRef = [...mockAccounts];
+      rerender({ ...defaultProps, operation: multicurrencyOperation, isNew: false, accounts: newAccountsRef });
+
+      // Exchange rate and destination amount must NOT reset
+      await waitFor(() => {
+        expect(result.current.values.exchangeRate).toBe('1.2');
+        expect(result.current.values.destinationAmount).toBe('60');
+      });
+    });
+
+    it('should preserve exchange rate set by auto-populate when accounts ref changes', async () => {
+      // Regression: when operation has no stored exchange rate, auto-populate fetches one.
+      // A subsequent accounts reference change must not wipe the auto-populated value.
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '0.85', source: 'live' });
+
+      const multicurrencyOperation = {
+        id: 'op-mc2',
+        type: 'transfer',
+        amount: '100',
+        accountId: 'acc-1',
+        toAccountId: 'acc-2',
+        exchangeRate: null, // no stored rate — auto-populate will fetch one
+        destinationAmount: null,
+        date: '2024-01-15',
+      };
+
+      const { result, rerender } = renderHook(
+        (props) => useOperationForm(props),
+        { initialProps: { ...defaultProps, operation: multicurrencyOperation, isNew: false } },
+      );
+
+      // Wait for auto-populate to set the fetched rate
+      await waitFor(() => {
+        expect(result.current.values.exchangeRate).toBe('0.85');
+      }, { timeout: 3000 });
+
+      // Simulate accounts context emitting a new array reference
+      const newAccountsRef = [...mockAccounts];
+      rerender({ ...defaultProps, operation: multicurrencyOperation, isNew: false, accounts: newAccountsRef });
+
+      // Auto-populated rate must survive the accounts reference change
+      await waitFor(() => {
+        expect(result.current.values.exchangeRate).toBe('0.85');
+      });
+    });
+
+    it('should treat stored exchangeRate of 0 as empty so auto-populate can provide a valid rate', async () => {
+      // 0 is not a valid exchange rate; if it somehow got persisted (e.g. DB default), we
+      // should treat it as "not set" so auto-populate can fetch a real rate.
+      const operationWithZeroRate = {
+        id: 'op-zero',
+        type: 'transfer',
+        amount: '100',
+        accountId: 'acc-1',
+        toAccountId: 'acc-2',
+        exchangeRate: 0,    // stored as numeric 0
+        destinationAmount: 0,
+        date: '2024-01-15',
+      };
+
+      const { result } = renderHook(() =>
+        useOperationForm({ ...defaultProps, operation: operationWithZeroRate, isNew: false }),
+      );
+
+      await waitFor(() => {
+        // String(0 || '') === '' — zero is treated as falsy so auto-populate can kick in
+        expect(result.current.values.exchangeRate).toBe('');
+        expect(result.current.values.destinationAmount).toBe('');
+      });
+    });
+
     it('should handle string amounts correctly', async () => {
       const { result } = renderHook(() => useOperationForm(defaultProps));
 

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -47,10 +47,16 @@ const useOperationForm = ({
   const [lastEditedField, setLastEditedField] = useState(null);
   const [rateSource, setRateSource] = useState('offline');
 
-  // Track if form has been modified to prevent re-initialization from overwriting changes
-  // This is needed because split operations trigger context updates (reloadAccounts)
-  // which would cause the initialization useEffect to re-run with stale operation data
+  // Track if form has been initialized to prevent re-initialization from overwriting user changes.
+  // Set to true right after first initialization; reset to false when the modal closes.
+  // This guards against accounts/operation prop getting a new reference from a context update
+  // while the user is actively editing (e.g. typing description while accounts reload).
   const formModifiedRef = useRef(false);
+
+  // Keep a stable ref to the latest accounts so the initialization effect can read the
+  // current list without depending on it — preventing a re-run when accounts changes.
+  const accountsRef = useRef(accounts);
+  accountsRef.current = accounts;
 
   // Check if operation belongs to a shadow category
   const isShadowOperation = useMemo(() => {
@@ -184,25 +190,28 @@ const useOperationForm = ({
   // Initialize form values when modal opens
   useEffect(() => {
     if (!visible) {
-      // Reset the modified flag when modal closes so next open will initialize properly
+      // Reset the guard when modal closes so next open will initialize properly
       formModifiedRef.current = false;
       return;
     }
 
-    // Skip re-initialization if form has been modified (e.g., after a split operation)
-    // This prevents context updates (reloadAccounts) from overwriting user changes
+    // Once initialized, skip any re-runs caused by prop reference changes (e.g. accounts
+    // getting a new array reference after a context update while the user is editing).
     if (formModifiedRef.current) {
       return;
     }
 
     let cancelled = false;
     async function setDefaultAccount() {
+      // Read accounts via ref so this effect does not depend on the accounts array —
+      // preventing re-initialization whenever the context emits a new reference.
+      const currentAccounts = accountsRef.current;
       if (operation && !isNew) {
         // Normalize values when editing an existing operation
         setValues({
           type: operation.type || 'expense',
           amount: String(operation.amount || ''),
-          accountId: operation.accountId || accounts[0]?.id || '',
+          accountId: operation.accountId || currentAccounts[0]?.id || '',
           categoryId: operation.categoryId || '',
           description: operation.description || '',
           date: operation.date || formatDate(new Date()),
@@ -212,14 +221,14 @@ const useOperationForm = ({
         });
       } else if (isNew) {
         let defaultAccountId = '';
-        if (accounts.length === 1) {
-          defaultAccountId = accounts[0].id;
-        } else if (accounts.length > 1) {
+        if (currentAccounts.length === 1) {
+          defaultAccountId = currentAccounts[0].id;
+        } else if (currentAccounts.length > 1) {
           const lastId = await getLastAccessedAccount();
-          if (lastId && accounts.some(acc => acc.id === lastId)) {
+          if (lastId && currentAccounts.some(acc => acc.id === lastId)) {
             defaultAccountId = lastId;
           } else {
-            defaultAccountId = accounts.slice().sort((a, b) => (a.id < b.id ? -1 : 1))[0].id;
+            defaultAccountId = currentAccounts.slice().sort((a, b) => (a.id < b.id ? -1 : 1))[0].id;
           }
         }
         if (!cancelled) {
@@ -236,11 +245,16 @@ const useOperationForm = ({
           });
         }
       }
-      if (!cancelled) setErrors({});
+      if (!cancelled) {
+        setErrors({});
+        // Mark as initialized so that any subsequent dep-change (new object reference for
+        // operation or accounts from a context update) does not wipe the user's edits.
+        formModifiedRef.current = true;
+      }
     }
     setDefaultAccount();
     return () => { cancelled = true; };
-  }, [operation, isNew, visible, accounts]);
+  }, [operation, isNew, visible]); // accounts intentionally omitted — accessed via accountsRef
 
   // Validate form fields
   const validateFields = useCallback((valuesToValidate = null) => {
@@ -430,9 +444,9 @@ const useOperationForm = ({
       // Calculate new amount for original operation
       const newAmount = String(numOriginalAmount - numSplitAmount);
 
-      // Mark form as modified BEFORE context operations run
-      // This prevents the initialization useEffect from re-running and
-      // overwriting our changes when reloadAccounts triggers a re-render
+      // formModifiedRef is already true (set during initialization) so the
+      // initialization effect won't re-run when reloadAccounts triggers a re-render.
+      // Set it explicitly here as a safety measure in case split is called very early.
       formModifiedRef.current = true;
 
       // 1. FIRST update original operation in database (reduces amount)


### PR DESCRIPTION
The initialization effect in useOperationForm depended on the `accounts` array.
React context can emit a new array reference (same data) on any state change, causing
the initialization effect to re-run while the user is editing.  Because
formModifiedRef was only set to true in the split-operation path, any
description/amount/etc. change could coincide with such a re-render, wiping the
exchange rate and destination amount fields back to their stored values (or to ''
if stored as null, triggering an unwanted auto-populate re-fetch).

Fix:
- Read accounts via a ref (accountsRef.current) inside the initialization effect so
  `accounts` is no longer a dependency — a new accounts array reference from a context
  update no longer triggers re-initialization.
- Set formModifiedRef.current = true immediately after initialization completes so that
  any subsequent dep-change (e.g. operation object getting a new reference) is also
  ignored, providing a complete guard for all user-editing scenarios.

Closes #609

https://claude.ai/code/session_017YuSgjMZZrdkM1KDJMNSwm