### PR TITLE
fix: show editable exchange rate fields for foreign currency ops in OperationModal

### DIFF
--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -1205,28 +1205,44 @@ describe('useOperationForm', () => {
       });
     });
 
-    it('should fetch foreignExchangeRate when isForeignCurrencyOp is true', async () => {
-      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '1.09', source: 'live' });
-
+    it('should preserve stored exchangeRate and not clear it for foreign currency ops', async () => {
+      // The critical regression: auto-calculate used to clear values.exchangeRate for any
+      // non-transfer op. For foreign currency ops it must be preserved.
       const props = { ...defaultProps, operation: foreignCurrencyExpense, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
 
       await waitFor(() => {
-        expect(result.current.foreignExchangeRate).toBe('1.09');
-        expect(result.current.foreignRateSource).toBe('live');
+        expect(result.current.values.exchangeRate).toBe('1.08');
+        expect(result.current.values.destinationAmount).toBe('263.52');
       });
     });
 
-    it('should fall back to offline rate when live fetch fails', async () => {
-      Currency.fetchLiveExchangeRate.mockRejectedValue(new Error('network'));
-      Currency.getExchangeRate.mockReturnValue('1.07');
+    it('should auto-populate exchangeRate via rateSource when no stored rate exists', async () => {
+      // For new foreign currency ops (no stored rate), auto-populate fetches and sets
+      // values.exchangeRate, and updates rateSource accordingly.
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '1.09', source: 'live' });
 
-      const props = { ...defaultProps, operation: foreignCurrencyExpense, isNew: false };
+      const noRateOp = { ...foreignCurrencyExpense, exchangeRate: null, destinationAmount: null };
+      const props = { ...defaultProps, operation: noRateOp, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
 
       await waitFor(() => {
-        expect(result.current.foreignExchangeRate).toBe('1.07');
-        expect(result.current.foreignRateSource).toBe('offline');
+        expect(result.current.values.exchangeRate).toBe('1.09');
+        expect(result.current.rateSource).toBe('live');
+      });
+    });
+
+    it('should fall back to offline rate when live fetch fails for foreign op', async () => {
+      Currency.fetchLiveExchangeRate.mockRejectedValue(new Error('network'));
+      Currency.getExchangeRate.mockReturnValue('1.07');
+
+      const noRateOp = { ...foreignCurrencyExpense, exchangeRate: null, destinationAmount: null };
+      const props = { ...defaultProps, operation: noRateOp, isNew: false };
+      const { result } = renderHook(() => useOperationForm(props));
+
+      await waitFor(() => {
+        expect(result.current.values.exchangeRate).toBe('1.07');
+        expect(result.current.rateSource).toBe('offline');
       });
     });
 
@@ -1279,24 +1295,24 @@ describe('useOperationForm', () => {
       );
     });
 
-    it('should reset foreignExchangeRate and foreignRateSource when modal closes', async () => {
-      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '1.09', source: 'live' });
+    it('should recalculate destinationAmount when amount changes for foreign currency op', async () => {
+      // When the user edits the amount, the destinationAmount should update automatically.
+      Currency.convertAmount.mockReturnValue('291.60');
 
-      const { result, rerender } = renderHook(
-        (props) => useOperationForm(props),
-        { initialProps: { ...defaultProps, operation: foreignCurrencyExpense, isNew: false } },
-      );
+      const props = { ...defaultProps, operation: foreignCurrencyExpense, isNew: false };
+      const { result } = renderHook(() => useOperationForm(props));
 
       await waitFor(() => {
-        expect(result.current.foreignExchangeRate).toBe('1.09');
+        expect(result.current.values.exchangeRate).toBe('1.08');
       });
 
-      // Close modal
-      rerender({ ...defaultProps, operation: foreignCurrencyExpense, isNew: false, visible: false });
+      await act(async () => {
+        result.current.setValues(v => ({ ...v, amount: '270' }));
+        result.current.setLastEditedField('amount');
+      });
 
       await waitFor(() => {
-        expect(result.current.foreignExchangeRate).toBe('');
-        expect(result.current.foreignRateSource).toBeNull();
+        expect(result.current.values.destinationAmount).toBe('291.60');
       });
     });
   });

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -88,6 +88,7 @@ const OperationFormFields = memo(({
   onOperationCurrencyChange,
   foreignRateSource,
   foreignExchangeRate,
+  foreignCurrencyEditable = false,
 }) => {
   const { hideBalances } = useDisplaySettings();
 
@@ -529,7 +530,7 @@ const OperationFormFields = memo(({
           onCurrencyPress={compact && values.type !== 'transfer' && onOperationCurrencyChange ? () => setShowCurrencyPicker(true) : undefined}
         />
       </View>
-      {isForeignCurrencyOp && sourceAccount && (
+      {isForeignCurrencyOp && sourceAccount && !foreignCurrencyEditable && (
         <View style={styles.ratePreviewRow}>
           <Text style={[styles.ratePreviewText, { color: colors.mutedText }]}>
             {foreignRateSource === 'loading'
@@ -539,6 +540,20 @@ const OperationFormFields = memo(({
                 : t('rate_unavailable')}
           </Text>
         </View>
+      )}
+      {isForeignCurrencyOp && sourceAccount && foreignCurrencyEditable && onExchangeRateChange && onDestinationAmountChange && (
+        <MultiCurrencyFields
+          colors={colors}
+          t={t}
+          sourceAccount={{ currency: values.operationCurrency }}
+          destinationAccount={{ currency: sourceAccount.currency }}
+          exchangeRate={values.exchangeRate || ''}
+          destinationAmount={values.destinationAmount || ''}
+          isShadowOperation={disabled}
+          onExchangeRateChange={onExchangeRateChange}
+          onDestinationAmountChange={onDestinationAmountChange}
+          rateSource={rateSource || 'offline'}
+        />
       )}
       {isMultiCurrencyTransfer && sourceAccount && destinationAccount && onExchangeRateChange && onDestinationAmountChange && (
         <MultiCurrencyFields
@@ -615,6 +630,7 @@ OperationFormFields.propTypes = {
   onOperationCurrencyChange: PropTypes.func,
   foreignRateSource: PropTypes.oneOf(['loading', 'live', 'offline']),
   foreignExchangeRate: PropTypes.string,
+  foreignCurrencyEditable: PropTypes.bool,
 };
 
 const styles = StyleSheet.create({

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -48,9 +48,7 @@ const useOperationForm = ({
   const [lastEditedField, setLastEditedField] = useState(null);
   const [rateSource, setRateSource] = useState('offline');
 
-  // Foreign currency expense/income state
-  const [foreignExchangeRate, setForeignExchangeRate] = useState('');
-  const [foreignRateSource, setForeignRateSource] = useState(null);
+  // rateSource is shared for both multicurrency transfers and foreign currency ops
 
   // Track if form has been initialized to prevent re-initialization from overwriting user changes.
   // Set to true right after first initialization; reset to false when the modal closes.
@@ -104,16 +102,24 @@ const useOperationForm = ({
     return values.operationCurrency !== sourceAccount.currency;
   }, [values.type, values.operationCurrency, sourceAccount]);
 
-  // Auto-populate exchange rate when accounts change (async with live rate)
+  // Auto-populate exchange rate when a multicurrency pair is detected and no rate is set yet.
+  // Handles both multicurrency transfers and foreign currency expense/income ops.
   useEffect(() => {
-    if (!isMultiCurrencyTransfer || !sourceAccount || !destinationAccount || values.exchangeRate) {
+    const forTransfer = isMultiCurrencyTransfer && sourceAccount && destinationAccount;
+    const forForeignOp = isForeignCurrencyOp && sourceAccount && values.operationCurrency;
+
+    if ((!forTransfer && !forForeignOp) || values.exchangeRate) {
       return;
     }
+
+    const fromCurrency = forForeignOp ? values.operationCurrency : sourceAccount.currency;
+    const toCurrency = forForeignOp ? sourceAccount.currency : destinationAccount?.currency;
+    if (!fromCurrency || !toCurrency) return;
 
     let cancelled = false;
     setRateSource('loading');
 
-    Currency.fetchLiveExchangeRate(sourceAccount.currency, destinationAccount.currency)
+    Currency.fetchLiveExchangeRate(fromCurrency, toCurrency)
       .then(({ rate, source }) => {
         if (cancelled) return;
         if (rate) {
@@ -124,8 +130,7 @@ const useOperationForm = ({
       })
       .catch(() => {
         if (cancelled) return;
-        // Fallback to offline
-        const rate = Currency.getExchangeRate(sourceAccount.currency, destinationAccount.currency);
+        const rate = Currency.getExchangeRate(fromCurrency, toCurrency);
         if (rate) {
           setValues(v => ({ ...v, exchangeRate: rate }));
           setLastEditedField('exchangeRate');
@@ -134,12 +139,13 @@ const useOperationForm = ({
       });
 
     return () => { cancelled = true; };
-  }, [isMultiCurrencyTransfer, sourceAccount, destinationAccount, values.exchangeRate]);
+  }, [isMultiCurrencyTransfer, isForeignCurrencyOp, sourceAccount, destinationAccount, values.exchangeRate, values.operationCurrency]);
 
-  // Auto-calculate based on which field was last edited
+  // Auto-calculate exchange rate / destination amount based on which field was last edited.
+  // Handles both multicurrency transfers and foreign currency expense/income ops.
   useEffect(() => {
-    if (!isMultiCurrencyTransfer) {
-      // Clear exchange rate fields for same-currency transfers
+    if (!isMultiCurrencyTransfer && !isForeignCurrencyOp) {
+      // Clear exchange rate fields only for plain same-currency ops
       if (values.exchangeRate || values.destinationAmount) {
         setValues(v => ({ ...v, exchangeRate: '', destinationAmount: '' }));
         setLastEditedField(null);
@@ -147,9 +153,12 @@ const useOperationForm = ({
       return;
     }
 
-    if (!sourceAccount || !destinationAccount) return;
+    // Determine currency pair
+    const fromCurrency = isForeignCurrencyOp ? values.operationCurrency : sourceAccount?.currency;
+    const toCurrency = isForeignCurrencyOp ? sourceAccount?.currency : destinationAccount?.currency;
+    if (!fromCurrency || !toCurrency) return;
 
-    // If user edited destination amount, calculate the rate
+    // If user edited destination amount, back-calculate the rate
     if (lastEditedField === 'destinationAmount') {
       if (values.amount && values.destinationAmount) {
         const sourceAmount = parseFloat(values.amount);
@@ -170,8 +179,8 @@ const useOperationForm = ({
       if (values.amount && values.exchangeRate) {
         const converted = Currency.convertAmount(
           values.amount,
-          sourceAccount.currency,
-          destinationAccount.currency,
+          fromCurrency,
+          toCurrency,
           values.exchangeRate,
         );
         if (converted && converted !== values.destinationAmount) {
@@ -179,51 +188,7 @@ const useOperationForm = ({
         }
       }
     }
-  }, [isMultiCurrencyTransfer, values.amount, values.exchangeRate, values.destinationAmount, sourceAccount, destinationAccount, lastEditedField]);
-
-  // Auto-fetch exchange rate for foreign currency expense/income ops
-  useEffect(() => {
-    if (!isForeignCurrencyOp || !values.operationCurrency || !values.accountId) {
-      setForeignRateSource(null);
-      setForeignExchangeRate('');
-      return;
-    }
-
-    const account = accountsRef.current.find(a => a.id === values.accountId);
-    if (!account) return;
-
-    let cancelled = false;
-    setForeignRateSource('loading');
-
-    Currency.fetchLiveExchangeRate(values.operationCurrency, account.currency)
-      .then(({ rate, source }) => {
-        if (cancelled) return;
-        if (rate) {
-          setForeignExchangeRate(rate);
-          setForeignRateSource(source === 'live' ? 'live' : 'offline');
-        } else {
-          const offlineRate = Currency.getExchangeRate(values.operationCurrency, account.currency);
-          if (offlineRate) {
-            setForeignExchangeRate(String(offlineRate));
-            setForeignRateSource('offline');
-          } else {
-            setForeignRateSource(null);
-          }
-        }
-      })
-      .catch(() => {
-        if (cancelled) return;
-        const offlineRate = Currency.getExchangeRate(values.operationCurrency, account.currency);
-        if (offlineRate) {
-          setForeignExchangeRate(String(offlineRate));
-          setForeignRateSource('offline');
-        } else {
-          setForeignRateSource(null);
-        }
-      });
-
-    return () => { cancelled = true; };
-  }, [isForeignCurrencyOp, values.operationCurrency, values.accountId]);
+  }, [isMultiCurrencyTransfer, isForeignCurrencyOp, values.amount, values.exchangeRate, values.destinationAmount, values.operationCurrency, sourceAccount, destinationAccount, lastEditedField]);
 
   // Clear category when switching between expense and income to avoid mismatched categories
   useEffect(() => {
@@ -248,8 +213,6 @@ const useOperationForm = ({
     if (!visible) {
       // Reset the guard when modal closes so next open will initialize properly
       formModifiedRef.current = false;
-      setForeignExchangeRate('');
-      setForeignRateSource(null);
       return;
     }
 
@@ -561,8 +524,6 @@ const useOperationForm = ({
     isForeignCurrencyOp,
     rateSource,
     setRateSource,
-    foreignExchangeRate,
-    foreignRateSource,
 
     // Handlers
     handleSave,

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -84,8 +84,6 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     isForeignCurrencyOp,
     rateSource,
     setRateSource,
-    foreignExchangeRate,
-    foreignRateSource,
     handleSave,
     handleClose,
     handleDelete,
@@ -414,8 +412,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
           onDestinationAmountChange={handleDestinationAmountChange}
           rateSource={rateSource}
           onOperationCurrencyChange={handleOperationCurrencyChange}
-          foreignExchangeRate={foreignExchangeRate}
-          foreignRateSource={foreignRateSource}
+          foreignCurrencyEditable={true}
         />
 
         {/* Category / To Account + Date row */}


### PR DESCRIPTION
## Summary

Supersedes #612. When editing a foreign currency expense/income in OperationModal, the Exchange Rate and Destination Amount fields were not visible — only a read-only text preview was shown. This PR shows the same editable MultiCurrencyFields inputs that appear for multicurrency transfers.

Root causes fixed:
- The auto-calculate effect cleared values.exchangeRate and values.destinationAmount for any non-transfer op, wiping the stored rate when editing a foreign currency expense
- OperationFormFields only showed a read-only preview row for foreign currency ops; there was no path to show editable fields

Changes:

useOperationForm.js
- Removed separate foreignExchangeRate/foreignRateSource states; foreign currency op rate handling is now folded into the shared auto-populate and auto-calculate effects (consistent with how multicurrency transfers work)
- Auto-populate effect now fetches a live rate and sets values.exchangeRate for foreign currency ops when no rate is stored yet
- Auto-calculate effect now skips clearing values.exchangeRate/values.destinationAmount for foreign currency ops, and recalculates destination amount when the user edits amount or rate

OperationFormFields.js
- Added foreignCurrencyEditable prop (default false)
- When true: renders MultiCurrencyFields with virtual account objects {currency: operationCurrency} to {currency: sourceAccount.currency} using values.exchangeRate and values.destinationAmount
- When false: keeps the existing read-only preview row (QuickAddForm behaviour is unchanged)

OperationModal.js
- Passes foreignCurrencyEditable={true} to OperationFormFields

## Test plan

- [ ] Edit a foreign currency expense (e.g. EUR amount on an AMD account) — Exchange Rate and Destination Amount fields should be visible and pre-filled with stored values
- [ ] Edit the exchange rate — Destination Amount should recalculate automatically
- [ ] Edit the destination amount — Exchange Rate should back-calculate automatically
- [ ] Edit the amount — Destination Amount should recalculate automatically
- [ ] Save — sourceCurrency / destinationCurrency / exchangeRate / destinationAmount preserved in DB
- [ ] QuickAdd foreign currency expense still shows read-only preview row (no regression)
- [ ] Multicurrency transfer edit still works (no regression)
- [ ] All 3121 Jest tests pass (npm test)

https://claude.ai/code/session_017YuSgjMZZrdkM1KDJMNSwm

---
_Generated by [Claude Code](https://claude.ai/code/session_017YuSgjMZZrdkM1KDJMNSwm)_