### PR TITLE
fix: show foreign currency amount as primary in operation modal

### DIFF
--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -1205,15 +1205,19 @@ describe('useOperationForm', () => {
       });
     });
 
-    it('should preserve stored exchangeRate and not clear it for foreign currency ops', async () => {
-      // The critical regression: auto-calculate used to clear values.exchangeRate for any
-      // non-transfer op. For foreign currency ops it must be preserved.
+    it('should load foreign currency op with foreign amount as primary and inverted rate', async () => {
+      // The form shows the foreign currency amount (what was spent) as the primary calculator
+      // value, and the account currency amount (what was deducted) as the destination field.
+      // The exchange rate is inverted so it points foreign→account (e.g. EUR→USD).
+      // DB has: amount=244(USD), destinationAmount=263.52(EUR), exchangeRate=1.08 (USD→EUR).
+      // Form shows: amount=263.52(EUR), destinationAmount=244(USD), exchangeRate=0.925926 (EUR→USD).
       const props = { ...defaultProps, operation: foreignCurrencyExpense, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
 
       await waitFor(() => {
-        expect(result.current.values.exchangeRate).toBe('1.08');
-        expect(result.current.values.destinationAmount).toBe('263.52');
+        expect(result.current.values.amount).toBe('263.52');          // foreign currency (EUR)
+        expect(result.current.values.destinationAmount).toBe('244'); // account currency (USD)
+        expect(result.current.values.exchangeRate).toBe('0.925926'); // inverted: EUR→USD
       });
     });
 
@@ -1291,6 +1295,8 @@ describe('useOperationForm', () => {
         expect.objectContaining({
           sourceCurrency: 'EUR',
           destinationCurrency: 'USD',
+          amount: '244',               // account currency (USD) swapped back for DB
+          destinationAmount: '263.52', // foreign currency (EUR) swapped back for DB
         }),
       );
     });
@@ -1303,7 +1309,8 @@ describe('useOperationForm', () => {
       const { result } = renderHook(() => useOperationForm(props));
 
       await waitFor(() => {
-        expect(result.current.values.exchangeRate).toBe('1.08');
+        // Rate is inverted on load: EUR→USD = 1/1.08 = 0.925926
+        expect(result.current.values.exchangeRate).toBe('0.925926');
       });
 
       await act(async () => {

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -228,17 +228,42 @@ const useOperationForm = ({
       // preventing re-initialization whenever the context emits a new reference.
       const currentAccounts = accountsRef.current;
       if (operation && !isNew) {
-        // Normalize values when editing an existing operation
+        // For foreign currency expense/income ops the DB stores:
+        //   amount = account currency (e.g. AMD 244)
+        //   destinationAmount = foreign currency (e.g. TRY 30)
+        //   exchangeRate = account→foreign rate (e.g. 0.122951 AMD→TRY)
+        // The form should show the intuitive ordering:
+        //   calculator = foreign currency (what was spent, e.g. 30 TRY)
+        //   destinationAmount field = account currency (what was deducted, e.g. 244 AMD)
+        //   exchangeRate = foreign→account rate (e.g. 8.13 TRY→AMD)
+        // So we swap amount↔destinationAmount and invert the rate on load.
+        const acct = currentAccounts.find(a => a.id === (operation.accountId || currentAccounts[0]?.id || ''));
+        const isForeignOp = operation.type !== 'transfer'
+          && operation.sourceCurrency
+          && acct
+          && operation.sourceCurrency !== acct.currency;
+
+        const storedRate = parseFloat(String(operation.exchangeRate || '0'));
+        const loadExchangeRate = isForeignOp && storedRate > 0
+          ? String((1 / storedRate).toFixed(6))
+          : String(operation.exchangeRate || '');
+        const loadAmount = isForeignOp
+          ? String(operation.destinationAmount || '')
+          : String(operation.amount || '');
+        const loadDestAmount = isForeignOp
+          ? String(operation.amount || '')
+          : String(operation.destinationAmount || '');
+
         setValues({
           type: operation.type || 'expense',
-          amount: String(operation.amount || ''),
+          amount: loadAmount,
           accountId: operation.accountId || currentAccounts[0]?.id || '',
           categoryId: operation.categoryId || '',
           description: operation.description || '',
           date: operation.date || formatDate(new Date()),
           toAccountId: operation.toAccountId || '',
-          exchangeRate: String(operation.exchangeRate || ''),
-          destinationAmount: String(operation.destinationAmount || ''),
+          exchangeRate: loadExchangeRate,
+          destinationAmount: loadDestAmount,
           operationCurrency: operation.type !== 'transfer' ? (operation.sourceCurrency || '') : '',
         });
       } else if (isNew) {
@@ -328,6 +353,19 @@ const useOperationForm = ({
     } else if (isForeignCurrencyOp && sourceAccount && values.operationCurrency) {
       data.sourceCurrency = values.operationCurrency;
       data.destinationCurrency = sourceAccount.currency;
+      // Form model: amount = foreign currency, destinationAmount = account currency,
+      //             exchangeRate = foreign→account rate
+      // DB model:   amount = account currency, destinationAmount = foreign currency,
+      //             exchangeRate = account→foreign rate
+      // Swap back and invert the rate before persisting.
+      const formForeignAmount = data.amount;
+      const formAccountAmount = data.destinationAmount;
+      data.amount = formAccountAmount;        // account currency — formatted below
+      data.destinationAmount = formForeignAmount;  // foreign currency
+      const displayRate = parseFloat(data.exchangeRate || '0');
+      if (displayRate > 0) {
+        data.exchangeRate = String((1 / displayRate).toFixed(6));
+      }
     }
 
     // Ensure amount is preserved when editing


### PR DESCRIPTION
For foreign currency expenses, the user enters an amount in the
foreign currency (e.g. 30 liras) and the account is debited in the
home currency (e.g. 244 AMD). The calculator should show the foreign
amount (what was spent) and the destination field should show the
account amount (what was deducted).

Previously the values were reversed: the calculator showed 244 AMD
and the destination field showed 30 liras.

The DB storage order is unchanged (amount = account currency,
destinationAmount = foreign currency). We swap and invert the exchange
rate on load so the form reflects the intuitive ordering, then swap
back when saving so persisted data stays consistent.

https://claude.ai/code/session_018PrRjZnuNF5fMPpfQr4ZRc