### PR TITLE
fix: expense graph now aggregates all accounts for selected currency

### DIFF
--- a/__tests__/hooks/useExpenseData.test.js
+++ b/__tests__/hooks/useExpenseData.test.js
@@ -91,7 +91,6 @@ describe('useExpenseData', () => {
         mockCurrency,
         '2024-01-01',
         '2024-01-31',
-        null,
       );
       expect(result.current.chartData.length).toBeGreaterThan(0);
     });
@@ -119,7 +118,6 @@ describe('useExpenseData', () => {
         mockCurrency,
         '2024-01-01',
         '2024-12-31',
-        null,
       );
     });
 
@@ -416,6 +414,56 @@ describe('useExpenseData', () => {
         expect(result.current.loading).toBe(false);
         expect(result.current.totalExpenses).toBeCloseTo(191.34, 2);
       });
+    });
+
+    it('should query all accounts for the currency without an account ID filter', async () => {
+      OperationsDB.getSpendingByCategoryAndCurrency.mockResolvedValue([]);
+
+      const { result } = renderHook(() =>
+        useExpenseData(mockYear, mockMonth, mockCurrency, 'all', mockCategories, mockColors, mockT),
+      );
+
+      await act(async () => {
+        await result.current.loadExpenseData();
+      });
+
+      expect(OperationsDB.getSpendingByCategoryAndCurrency).toHaveBeenCalledWith(
+        mockCurrency,
+        expect.any(String),
+        expect.any(String),
+      );
+      expect(OperationsDB.getSpendingByCategoryAndCurrency).toHaveBeenCalledTimes(1);
+      const callArgs = OperationsDB.getSpendingByCategoryAndCurrency.mock.calls[0];
+      expect(callArgs).toHaveLength(3);
+    });
+
+    it('should include expenses from multiple accounts in the same currency', async () => {
+      // Simulates the DB returning rows that span multiple accounts for the currency
+      const mockSpending = [
+        { category_id: 'cat-2', total: '400' }, // from account A
+        { category_id: 'cat-2', total: '600' }, // from account B, same category
+        { category_id: 'cat-3', total: '200' },
+      ];
+
+      OperationsDB.getSpendingByCategoryAndCurrency.mockResolvedValue(mockSpending);
+
+      const { result } = renderHook(() =>
+        useExpenseData(mockYear, mockMonth, mockCurrency, 'all', mockCategories, mockColors, mockT),
+      );
+
+      await act(async () => {
+        await result.current.loadExpenseData();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      const foodItem = result.current.chartData.find(item => item.name === 'Food');
+      expect(foodItem).toBeDefined();
+      expect(foodItem.amount).toBe(1000); // 400 + 600 aggregated across accounts
+
+      expect(result.current.totalExpenses).toBe(1200);
     });
   });
 });

--- a/__tests__/hooks/useIncomeData.test.js
+++ b/__tests__/hooks/useIncomeData.test.js
@@ -424,5 +424,55 @@ describe('useIncomeData', () => {
         expect(result.current.totalIncome).toBe(7000);
       });
     });
+
+    it('should query all accounts for the currency without an account ID filter', async () => {
+      OperationsDB.getIncomeByCategoryAndCurrency.mockResolvedValue([]);
+
+      const { result } = renderHook(() =>
+        useIncomeData(mockYear, mockMonth, mockCurrency, 'all', mockCategories, mockColors, mockT),
+      );
+
+      await act(async () => {
+        await result.current.loadIncomeData();
+      });
+
+      expect(OperationsDB.getIncomeByCategoryAndCurrency).toHaveBeenCalledWith(
+        mockCurrency,
+        expect.any(String),
+        expect.any(String),
+      );
+      expect(OperationsDB.getIncomeByCategoryAndCurrency).toHaveBeenCalledTimes(1);
+      const callArgs = OperationsDB.getIncomeByCategoryAndCurrency.mock.calls[0];
+      expect(callArgs).toHaveLength(3);
+    });
+
+    it('should include income from multiple accounts in the same currency', async () => {
+      // Simulates the DB returning rows that span multiple accounts for the currency
+      const mockIncome = [
+        { category_id: 'cat-2', total: '3000' }, // from account A
+        { category_id: 'cat-2', total: '2000' }, // from account B, same category
+        { category_id: 'cat-3', total: '1500' },
+      ];
+
+      OperationsDB.getIncomeByCategoryAndCurrency.mockResolvedValue(mockIncome);
+
+      const { result } = renderHook(() =>
+        useIncomeData(mockYear, mockMonth, mockCurrency, 'all', mockCategories, mockColors, mockT),
+      );
+
+      await act(async () => {
+        await result.current.loadIncomeData();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loadingIncome).toBe(false);
+      });
+
+      const salaryItem = result.current.incomeChartData.find(item => item.name === 'Salary');
+      expect(salaryItem).toBeDefined();
+      expect(salaryItem.amount).toBe(5000); // 3000 + 2000 aggregated across accounts
+
+      expect(result.current.totalIncome).toBe(6500);
+    });
   });
 });

--- a/app/hooks/useExpenseData.js
+++ b/app/hooks/useExpenseData.js
@@ -14,7 +14,7 @@ const CHART_COLORS = [
  * DB is queried once per period/currency/account change. Category switches
  * re-aggregate the cached raw data synchronously (no DB hit).
  */
-const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t, selectedAccountId = null) => {
+const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t) => {
   const [rawSpending, setRawSpending] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -37,7 +37,6 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
         selectedCurrency,
         formatDate(startDate),
         formatDate(endDate),
-        selectedAccountId,
       );
 
       setRawSpending(spending);
@@ -46,7 +45,7 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
     } finally {
       setLoading(false);
     }
-  }, [selectedYear, selectedMonth, selectedCurrency, selectedAccountId]);
+  }, [selectedYear, selectedMonth, selectedCurrency]);
 
   // Aggregate cached raw spending for the current category — no DB hit
   const chartData = useMemo(() => {

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -93,7 +93,7 @@ const GraphsScreen = () => {
     loading,
     loadExpenseData,
     totalExpenses,
-  } = useExpenseData(selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t, selectedAccount);
+  } = useExpenseData(selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t);
 
   const {
     incomeChartData,


### PR DESCRIPTION
The expense pie chart was incorrectly filtering by the account selected
in the balance history picker. Income and expense graphs should show
data for all accounts in the selected currency, matching how income
data was already queried.

https://claude.ai/code/session_01LjLTWEXPFD7fEndmDBLde1