### PR TITLE
fix(search): resolve TDZ crash, lazy-load gap, and stale-state bugs

### DIFF
--- a/__tests__/components/search/ExpandableFilters.test.js
+++ b/__tests__/components/search/ExpandableFilters.test.js
@@ -95,6 +95,7 @@ describe('ExpandableFilters', () => {
     const { getByTestId } = render(<ExpandableFilters {...defaultProps} />);
     fireEvent.press(getByTestId('clear-all-button'));
     expect(defaultProps.onFilterChange).toHaveBeenCalledWith({
+      text: '',
       types: [],
       accountIds: [],
       categoryIds: [],

--- a/__tests__/integration/SearchIntegration.test.js
+++ b/__tests__/integration/SearchIntegration.test.js
@@ -193,6 +193,7 @@ describe('Search Integration', () => {
       );
       fireEvent.press(getByTestId('clear-all-button'));
       expect(mockUpdateSearchFilters).toHaveBeenCalledWith({
+        text: '',
         types: [],
         accountIds: [],
         categoryIds: [],

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -22,7 +22,7 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { isDownloading, downloadProgress } = useUpdateDownload();
-  const { openSearch, searchMode, closeSearch, reopenSearch, toggleFilters } = useSearch();
+  const { openSearch, searchMode, closeSearch, reopenSearch, toggleFilters, filtersExpanded } = useSearch();
   console.debug('[Header] openSearch exists:', !!openSearch);
   console.debug('[Header] searchMode:', searchMode);
   const downloadArrowAnim = useRef(new Animated.Value(0)).current;
@@ -55,6 +55,7 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
 
   const handleClearFilterGroup = useCallback((groupKey) => {
     const clearValues = {
+      text: { text: '' },
       types: { types: [] },
       dateRange: { dateRange: { startDate: null, endDate: null } },
       amountRange: { amountRange: { min: null, max: null } },
@@ -131,18 +132,21 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
                       onPress={() => {
                         console.debug('[Header] Search button pressed, mode:', searchMode);
                         if (searchMode === 'collapsed') {
-                          // Reopen with smart logic
-                          const hasTextOnly = (searchState?.text !== '') &&
-                            (searchState?.types?.length === 0) &&
-                            (searchState?.accountIds?.length === 0) &&
-                            (searchState?.categoryIds?.length === 0) &&
-                            (!searchState?.dateRange?.startDate) &&
-                            (!searchState?.amountRange?.min);
-                          const hasOtherFilters = !hasTextOnly && hasActiveSearch;
+                          // Reopen with smart logic: auto-expand the filter panel when
+                          // any non-text filter is active.
+                          const hasOtherFilters =
+                            (searchState?.types?.length > 0) ||
+                            (searchState?.accountIds?.length > 0) ||
+                            (searchState?.categoryIds?.length > 0) ||
+                            !!searchState?.dateRange?.startDate ||
+                            !!searchState?.dateRange?.endDate ||
+                            (searchState?.amountRange?.min !== null && searchState?.amountRange?.min !== undefined) ||
+                            (searchState?.amountRange?.max !== null && searchState?.amountRange?.max !== undefined);
 
                           reopenSearch(searchState?.text !== '', hasOtherFilters, (shouldExpand) => {
-                            console.debug('[Header] Should expand filters:', shouldExpand);
-                            // This callback will be handled by SearchOverlay in task 10
+                            if (shouldExpand !== filtersExpanded) {
+                              toggleFilters();
+                            }
                           });
                         } else {
                           openSearch();

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, TextInput, StyleSheet } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -23,9 +23,36 @@ const ExpandableFilters = ({
     filters.amountRange.max !== null ? String(filters.amountRange.max) : '',
   );
 
+  // Sync local amount inputs when filters change externally (Clear all, chip clear, etc.)
+  useEffect(() => {
+    const newMin = filters.amountRange.min !== null ? String(filters.amountRange.min) : '';
+    const parsedLocalMin = localMinAmount === '' ? null : parseFloat(localMinAmount.replace(',', '.'));
+    if ((filters.amountRange.min === null && localMinAmount !== '')
+      || (filters.amountRange.min !== null && parsedLocalMin !== filters.amountRange.min)) {
+      setLocalMinAmount(newMin);
+    }
+  }, [filters.amountRange.min]);
+
+  useEffect(() => {
+    const newMax = filters.amountRange.max !== null ? String(filters.amountRange.max) : '';
+    const parsedLocalMax = localMaxAmount === '' ? null : parseFloat(localMaxAmount.replace(',', '.'));
+    if ((filters.amountRange.max === null && localMaxAmount !== '')
+      || (filters.amountRange.max !== null && parsedLocalMax !== filters.amountRange.max)) {
+      setLocalMaxAmount(newMax);
+    }
+  }, [filters.amountRange.max]);
+
   if (!isExpanded) {
     return null;
   }
+
+  // Locale-tolerant parse: accept "1,5" as 1.5; reject NaN and negatives.
+  const parseAmount = (str) => {
+    if (str === '' || str === '-' || str === '.') return null;
+    const value = parseFloat(str.replace(',', '.'));
+    if (isNaN(value) || value < 0) return null;
+    return value;
+  };
 
   const toggleType = (type) => {
     const newTypes = filters.types.includes(type)
@@ -63,8 +90,10 @@ const ExpandableFilters = ({
 
   const formatDateDisplay = (dateStr) => {
     if (!dateStr) return '';
-    const date = new Date(dateStr);
-    return date.toLocaleDateString();
+    // Parse "YYYY-MM-DD" as local time to avoid timezone shift on display.
+    const [y, m, d] = dateStr.split('-').map(Number);
+    if (!y || !m || !d) return '';
+    return new Date(y, m - 1, d).toLocaleDateString();
   };
 
   return (
@@ -152,8 +181,7 @@ const ExpandableFilters = ({
               value={localMinAmount}
               onChangeText={setLocalMinAmount}
               onBlur={() => {
-                const value = localMinAmount === '' ? null : parseFloat(localMinAmount);
-                onFilterChange({ amountRange: { ...filters.amountRange, min: isNaN(value) ? null : value } });
+                onFilterChange({ amountRange: { ...filters.amountRange, min: parseAmount(localMinAmount) } });
               }}
               placeholder={t('min_amount')}
               placeholderTextColor={colors.mutedText}
@@ -165,8 +193,7 @@ const ExpandableFilters = ({
               value={localMaxAmount}
               onChangeText={setLocalMaxAmount}
               onBlur={() => {
-                const value = localMaxAmount === '' ? null : parseFloat(localMaxAmount);
-                onFilterChange({ amountRange: { ...filters.amountRange, max: isNaN(value) ? null : value } });
+                onFilterChange({ amountRange: { ...filters.amountRange, max: parseAmount(localMaxAmount) } });
               }}
               placeholder={t('max_amount')}
               placeholderTextColor={colors.mutedText}
@@ -206,6 +233,7 @@ const ExpandableFilters = ({
           testID="clear-all-button"
           style={styles.clearAllButton}
           onPress={() => onFilterChange({
+            text: '',
             types: [],
             accountIds: [],
             categoryIds: [],

--- a/app/components/search/FilterChipStrip.js
+++ b/app/components/search/FilterChipStrip.js
@@ -6,8 +6,14 @@ import { HORIZONTAL_PADDING } from '../../styles/layout';
 
 const formatDateLabel = (dateRange) => {
   const { startDate, endDate } = dateRange;
-  const fmt = (d) =>
-    new Date(d).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  // Parse "YYYY-MM-DD" as local time so the displayed day doesn't shift in
+  // timezones west of UTC (where new Date("YYYY-MM-DD") yields the previous day).
+  const fmt = (d) => {
+    if (!d) return '';
+    const [y, m, day] = d.split('-').map(Number);
+    if (!y || !m || !day) return '';
+    return new Date(y, m - 1, day).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  };
   if (startDate && endDate) return `${fmt(startDate)} – ${fmt(endDate)}`;
   if (startDate) return `${fmt(startDate)} –`;
   if (endDate) return `– ${fmt(endDate)}`;
@@ -24,6 +30,12 @@ const formatAmountLabel = (amountRange) => {
 
 const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
   const chips = [];
+
+  if (searchState.text && searchState.text.trim().length > 0) {
+    const trimmed = searchState.text.trim();
+    const display = trimmed.length > 24 ? `${trimmed.slice(0, 24)}…` : trimmed;
+    chips.push({ key: 'text', label: `"${display}"` });
+  }
 
   if (searchState.types.length > 0) {
     const label =
@@ -81,6 +93,7 @@ const FilterChipStrip = ({ searchState, onClearGroup, colors, t }) => {
 
 FilterChipStrip.propTypes = {
   searchState: PropTypes.shape({
+    text: PropTypes.string,
     types: PropTypes.array.isRequired,
     accountIds: PropTypes.array.isRequired,
     categoryIds: PropTypes.array.isRequired,

--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { View, TextInput, TouchableOpacity, StyleSheet, Text, Keyboard } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
@@ -14,16 +14,51 @@ const SearchBar = ({
   t,
 }) => {
   const [localText, setLocalText] = useState(searchText);
+  // Track the last value we sent to the parent so we can distinguish
+  // "the parent just received our debounced update" (no-op) from
+  // "the parent changed searchText externally" (e.g. clear-all).
+  const lastSentRef = useRef(searchText);
+  const localTextRef = useRef(localText);
+  localTextRef.current = localText;
+  const onChangeRef = useRef(onSearchTextChange);
+  onChangeRef.current = onSearchTextChange;
 
+  // Debounce local text into parent state.
+  // Skip the initial mount call — there's nothing new to send.
+  const isInitialMountRef = useRef(true);
   useEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false;
+      return undefined;
+    }
     const timer = setTimeout(() => {
+      lastSentRef.current = localText;
       onSearchTextChange(localText);
     }, 300);
     return () => clearTimeout(timer);
   }, [localText, onSearchTextChange]);
 
+  // Sync local text when searchText changes externally (e.g. clear-all from outside).
+  useEffect(() => {
+    if (searchText !== lastSentRef.current) {
+      lastSentRef.current = searchText;
+      setLocalText(searchText);
+    }
+  }, [searchText]);
+
+  // Flush any pending debounced change on unmount so closing the search bar
+  // mid-typing doesn't discard the last keystrokes.
+  useEffect(() => {
+    return () => {
+      if (lastSentRef.current !== localTextRef.current) {
+        onChangeRef.current(localTextRef.current);
+      }
+    };
+  }, []);
+
   const handleClear = useCallback(() => {
     setLocalText('');
+    lastSentRef.current = '';
     onSearchTextChange('');
   }, [onSearchTextChange]);
 
@@ -107,7 +142,6 @@ SearchBar.propTypes = {
   filterCount: PropTypes.number,
   colors: PropTypes.shape({
     background: PropTypes.string.isRequired,
-    inputBorder: PropTypes.string.isRequired,
     border: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
     mutedText: PropTypes.string.isRequired,

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   StyleSheet,
   Dimensions,
@@ -28,6 +28,14 @@ const SearchOverlay = ({ onClose, colors, t, visible, onHeightChange }) => {
       onHeightChange(event.nativeEvent.layout.height);
     }
   }, [onHeightChange]);
+
+  // Reset reported height when the overlay hides so parents don't keep a phantom
+  // spacer once search is closed.
+  useEffect(() => {
+    if (!visible && onHeightChange) {
+      onHeightChange(0);
+    }
+  }, [visible, onHeightChange]);
 
   if (!visible) {
     return null;

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -269,6 +269,22 @@ export const OperationsActionsProvider = ({ children }) => {
     loadInitialOperations();
   }, [loadInitialOperations]);
 
+  // Reload operations from DB whenever search/filter state changes via the new search API.
+  // The mount effect above handles the initial load; skip the first run here.
+  // The legacy updateFilters/clearFilters path also calls loadInitialOperations directly;
+  // a duplicate call from this effect is harmless because loadRequestIdRef discards stale results.
+  const isFirstSearchEffectRef = useRef(true);
+  useEffect(() => {
+    if (isFirstSearchEffectRef.current) {
+      isFirstSearchEffectRef.current = false;
+      return;
+    }
+    loadInitialOperations(activeFilters, false);
+    setJsonPreference(PREF_KEYS.OPERATIONS_FILTERS, activeFilters).catch(err => {
+      console.error('Failed to persist filters:', err);
+    });
+  }, [activeFilters, loadInitialOperations]);
+
   // Listen for reload events
   useEffect(() => {
     const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -135,8 +135,9 @@ export const OperationsDataProvider = ({ children }) => {
     let result = operations;
 
     // text search - match description, account name, category name, amount, type
-    if (searchState.text) {
-      const searchLower = searchState.text.toLowerCase();
+    const trimmedText = searchState.text ? searchState.text.trim() : '';
+    if (trimmedText) {
+      const searchLower = trimmedText.toLowerCase();
       result = result.filter(op => {
         // match description
         if (op.description && op.description.toLowerCase().includes(searchLower)) {
@@ -190,33 +191,18 @@ export const OperationsDataProvider = ({ children }) => {
       result = result.filter(op => searchState.categoryIds.includes(op.categoryId));
     }
 
-    // date range filter
+    // date range filter — string compare YYYY-MM-DD to avoid timezone issues from new Date(...)
     if (searchState.dateRange.startDate || searchState.dateRange.endDate) {
+      // Extract just the date portion (in case op.date includes a time component)
+      const dateOnly = (d) => (typeof d === 'string' ? d.slice(0, 10) : d);
+      let { startDate, endDate } = searchState.dateRange;
+      if (startDate && endDate && startDate > endDate) {
+        [startDate, endDate] = [endDate, startDate];
+      }
       result = result.filter(op => {
-        const opDate = new Date(op.date);
-
-        // handle case when both dates are present
-        if (searchState.dateRange.startDate && searchState.dateRange.endDate) {
-          let start = new Date(searchState.dateRange.startDate);
-          let end = new Date(searchState.dateRange.endDate);
-
-          // swap if start > end
-          if (start > end) {
-            [start, end] = [end, start];
-          }
-
-          // filter to include operations within range
-          if (opDate < start || opDate > end) return false;
-        } else if (searchState.dateRange.startDate) {
-          // only start date
-          const startDate = new Date(searchState.dateRange.startDate);
-          if (opDate < startDate) return false;
-        } else if (searchState.dateRange.endDate) {
-          // only end date
-          const endDate = new Date(searchState.dateRange.endDate);
-          if (opDate > endDate) return false;
-        }
-
+        const opDate = dateOnly(op.date);
+        if (startDate && opDate < startDate) return false;
+        if (endDate && opDate > endDate) return false;
         return true;
       });
     }

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -134,6 +134,44 @@ const OperationsScreen = () => {
     setRateSource,
   } = useMultiCurrencyTransfer(quickAddValues, accounts);
 
+  // Group operations by date into date-group objects for the list.
+  // Declared here (not after the unrelated effects below) because several hooks
+  // reference it in their dependency arrays; declaring later would put it in
+  // the Temporal Dead Zone when those arrays are evaluated during render.
+  const groupedOperations = useMemo(() => {
+    const sorted = [...operations].sort((a, b) => new Date(b.date) - new Date(a.date));
+    const groups = [];
+    let currentGroup = null;
+
+    sorted.forEach((operation) => {
+      if (!currentGroup || operation.date !== currentGroup.date) {
+        currentGroup = {
+          type: 'dateGroup',
+          id: `group-${operation.date}`,
+          date: operation.date,
+          spendingSums: {},
+          operations: [],
+        };
+        groups.push(currentGroup);
+      }
+
+      currentGroup.operations.push(operation);
+
+      if (operation.type === 'expense') {
+        const account = accounts.find(acc => acc.id === operation.accountId);
+        if (account) {
+          const currency = account.currency || 'USD';
+          const amount = parseFloat(operation.amount);
+          if (!isNaN(amount)) {
+            currentGroup.spendingSums[currency] = (currentGroup.spendingSums[currency] || 0) + amount;
+          }
+        }
+      }
+    });
+
+    return groups;
+  }, [operations, accounts]);
+
   // Scroll to date after operations are loaded
   useEffect(() => {
     if (scrollToDateString && !operationsLoading) {
@@ -547,42 +585,6 @@ const OperationsScreen = () => {
       setPendingSuggestions([]);
     }
   }, [operations, pendingSuggestionId]);
-
-  // Group operations by date into date-group objects for the list
-  const groupedOperations = useMemo(() => {
-    const sorted = [...operations].sort((a, b) => new Date(b.date) - new Date(a.date));
-    const groups = [];
-    let currentGroup = null;
-
-    sorted.forEach((operation) => {
-      if (!currentGroup || operation.date !== currentGroup.date) {
-        currentGroup = {
-          type: 'dateGroup',
-          id: `group-${operation.date}`,
-          date: operation.date,
-          spendingSums: {},
-          operations: [],
-        };
-        groups.push(currentGroup);
-      }
-
-      currentGroup.operations.push(operation);
-
-      // Accumulate spending sums for expenses
-      if (operation.type === 'expense') {
-        const account = accounts.find(acc => acc.id === operation.accountId);
-        if (account) {
-          const currency = account.currency || 'USD';
-          const amount = parseFloat(operation.amount);
-          if (!isNaN(amount)) {
-            currentGroup.spendingSums[currency] = (currentGroup.spendingSums[currency] || 0) + amount;
-          }
-        }
-      }
-    });
-
-    return groups;
-  }, [operations, accounts]);
 
   const TYPES = useMemo(() => [
     { key: 'expense', label: t('expense'), icon: 'minus-circle' },

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -4,6 +4,10 @@ import { formatDate, updateTodayBalance } from './BalanceHistoryDB';
 import * as AccountsDB from './AccountsDB';
 import getDefaultOperations from '../defaults/defaultOperations';
 
+// Operation types currently supported. Used as the upper bound for the
+// "all types selected → no type filter" optimization.
+const OPERATION_TYPES = ['expense', 'income', 'transfer'];
+
 /**
  * Map database field names to camelCase for application use
  * @param {Object} dbOperation - Operation object from database with snake_case fields
@@ -195,7 +199,7 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
     const params = [startDate, endDate];
 
     // Apply type filters
-    if (filters.types && filters.types.length > 0 && filters.types.length < 3) {
+    if (filters.types && filters.types.length > 0 && filters.types.length < OPERATION_TYPES.length) {
       const placeholders = filters.types.map(() => '?').join(',');
       sql += ` AND o.type IN (${placeholders})`;
       params.push(...filters.types);
@@ -1004,7 +1008,7 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
     const params = [startDateStr, endDateStr];
 
     // Apply type filters
-    if (filters.types && filters.types.length > 0 && filters.types.length < 3) {
+    if (filters.types && filters.types.length > 0 && filters.types.length < OPERATION_TYPES.length) {
       const placeholders = filters.types.map(() => '?').join(',');
       sql += ` AND o.type IN (${placeholders})`;
       params.push(...filters.types);
@@ -1098,7 +1102,7 @@ export const getNextOldestFilteredOperation = async (beforeDate, filters = {}) =
     const params = [beforeDate];
 
     // Apply type filters
-    if (filters.types && filters.types.length > 0 && filters.types.length < 3) {
+    if (filters.types && filters.types.length > 0 && filters.types.length < OPERATION_TYPES.length) {
       const placeholders = filters.types.map(() => '?').join(',');
       sql += ` AND o.type IN (${placeholders})`;
       params.push(...filters.types);
@@ -1261,7 +1265,7 @@ export const getNextNewestFilteredOperation = async (afterDate, filters = {}) =>
     const params = [afterDate];
 
     // Apply type filters
-    if (filters.types && filters.types.length > 0 && filters.types.length < 3) {
+    if (filters.types && filters.types.length > 0 && filters.types.length < OPERATION_TYPES.length) {
       const placeholders = filters.types.map(() => '?').join(',');
       sql += ` AND o.type IN (${placeholders})`;
       params.push(...filters.types);
@@ -1367,7 +1371,7 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
     const params = [startDateStr, endDateStr];
 
     // Apply type filters
-    if (filters.types && filters.types.length > 0 && filters.types.length < 3) {
+    if (filters.types && filters.types.length > 0 && filters.types.length < OPERATION_TYPES.length) {
       const placeholders = filters.types.map(() => '?').join(',');
       sql += ` AND o.type IN (${placeholders})`;
       params.push(...filters.types);


### PR DESCRIPTION
- Move OperationsScreen's groupedOperations useMemo above the hooks that
  list it as a dependency. Previously those dep arrays referenced a const
  in its Temporal Dead Zone; Babel's var-rewrite silently demoted the
  slot to undefined, leaving the effects unable to react to actual
  groupedOperations changes.
- Reload operations from SQLite whenever the new search API
  (setSearchText / updateSearchFilters / clearAllSearch) mutates
  searchState, and persist the resulting filters to PreferencesDB.
  Without this, typing in the search bar only filtered the
  already-loaded weeks; matches in older weeks were invisible until the
  user scrolled.
- SearchBar: sync local text from props on external clears, flush the
  debounced value on unmount so closing mid-typing doesn't drop the last
  keystrokes, and skip the redundant no-op call on mount. Drop the
  unused inputBorder propType.
- ExpandableFilters: sync local min/max amount inputs from filters when
  cleared externally; parse amounts locale-tolerantly ("1,5" -> 1.5),
  reject NaN/negative values; include text: '' in the Clear-all payload;
  format date display from YYYY-MM-DD as local time to prevent
  timezone-induced day shifts.
- FilterChipStrip: show a chip for the active text filter so users can
  see and clear it from the collapsed strip; parse dates as local time
  for display.
- Header: fix the hasTextOnly check used by the smart-reopen logic
  (missing endDate and amountRange.max), and wire the
  onShouldExpandFilters callback to actually toggle the filter panel
  instead of just logging.
- OperationsDataContext: trim search text before matching and use
  string-comparison on YYYY-MM-DD for the date-range filter so
  operations land in the correct range regardless of timezone.
- SearchOverlay: report height 0 when hidden so the spacer used to
  reserve room under the overlay collapses on close.
- OperationsDB: replace the magic types.length < 3 with a named
  OPERATION_TYPES constant for the all-types-selected shortcut.