### PR TITLE
fix: use account-specific expenses for balance history spending prediction

### DIFF
--- a/app/hooks/useBalanceHistory.js
+++ b/app/hooks/useBalanceHistory.js
@@ -65,6 +65,9 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
       const prevHistory = await getBalanceHistory(selectedAccount, prevStartDateStr, prevEndDateStr);
       const prevMonthTotalExpenses = await getTotalExpenses(selectedAccount, prevStartDateStr, prevEndDateStr);
 
+      // Get current month's total expenses for the selected account (used for spending prediction)
+      const currentMonthTotalExpenses = await getTotalExpenses(selectedAccount, startDateStr, endDateStr);
+
       // Transform history data for chart
       const dataPoints = history.map(item => ({
         date: item.date,
@@ -196,6 +199,7 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
         prevMonth: prevMonthData,
         prevMonthTotalExpenses,
         prevMonthDaysCount: prevMonthDays,
+        currentMonthTotalExpenses,
         labels: allDays,
       });
     } catch (error) {

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -326,9 +326,14 @@ const GraphsScreen = () => {
     return items;
   }, [availableYears, availableMonths, t, monthKeys]);
 
+  // Use account-specific expenses from balance history for the prediction.
+  // totalExpenses from useExpenseData covers all accounts in the currency (by design),
+  // but the forecast line on the balance history chart must reflect only the selected account.
+  const accountTotalExpenses = balanceHistoryData.currentMonthTotalExpenses ?? 0;
+
   // Calculate spending prediction
   const spendingPrediction = useMemo(() => {
-    if (totalExpenses === 0) {
+    if (accountTotalExpenses === 0) {
       return null; // No spending data yet
     }
 
@@ -364,7 +369,7 @@ const GraphsScreen = () => {
     }
 
     // Calculate daily average
-    const dailyAverage = totalExpenses / daysElapsed;
+    const dailyAverage = accountTotalExpenses / daysElapsed;
 
     // Predict total spending by month end
     const predictedTotal = dailyAverage * daysInMonth;
@@ -373,15 +378,15 @@ const GraphsScreen = () => {
     const percentElapsed = (daysElapsed / daysInMonth) * 100;
 
     return {
-      currentSpending: totalExpenses,
+      currentSpending: accountTotalExpenses,
       predictedTotal,
-      predictedRemaining: predictedTotal - totalExpenses,
+      predictedRemaining: predictedTotal - accountTotalExpenses,
       dailyAverage,
       daysElapsed,
       daysInMonth,
       percentElapsed,
     };
-  }, [totalExpenses, selectedYear, selectedMonth]);
+  }, [accountTotalExpenses, selectedYear, selectedMonth]);
 
   // Calculate if the selected period is the current month
   const isCurrentMonth = useMemo(() => {


### PR DESCRIPTION
The forecast line on the balance history graph uses dailyAverage derived
from totalExpenses. After #618 removed account filtering from useExpenseData,
totalExpenses reflected all accounts for the selected currency, inflating the
prediction when multiple accounts share a currency.

Fix: fetch current-month total expenses per selected account inside
useBalanceHistory (mirrors the existing prevMonthTotalExpenses fetch) and
use that value in GraphsScreen's spendingPrediction memo instead of the
currency-wide totalExpenses from useExpenseData.

https://claude.ai/code/session_01A7RbR4HPo9Ejp71cWoYZSe