### PR TITLE
fix(#588): make split operation atomic and use precise arithmetic

### DIFF
--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -37,6 +37,7 @@ jest.mock('../../app/services/currency', () => ({
   getExchangeRate: jest.fn(),
   convertAmount: jest.fn(),
   formatAmount: jest.fn((amount) => String(amount)),
+  subtract: jest.fn((a, b) => String(parseFloat(a) - parseFloat(b))),
   fetchLiveExchangeRate: jest.fn().mockResolvedValue({ rate: null, source: 'none' }),
 }));
 
@@ -70,6 +71,7 @@ describe('useOperationForm', () => {
   ];
 
   const mockAddOperation = jest.fn();
+  const mockSplitOperation = jest.fn();
   const mockUpdateOperation = jest.fn();
   const mockValidateOperation = jest.fn();
   const mockShowDialog = jest.fn();
@@ -84,6 +86,7 @@ describe('useOperationForm', () => {
     categories: mockCategories,
     t: mockT,
     addOperation: mockAddOperation,
+    splitOperation: mockSplitOperation,
     updateOperation: mockUpdateOperation,
     validateOperation: mockValidateOperation,
     showDialog: mockShowDialog,
@@ -968,7 +971,7 @@ describe('useOperationForm', () => {
       });
 
       expect(splitResult.success).toBe(false);
-      expect(mockAddOperation).not.toHaveBeenCalled();
+      expect(mockSplitOperation).not.toHaveBeenCalled();
     });
 
     it('should reject invalid split amount (zero)', async () => {
@@ -985,7 +988,7 @@ describe('useOperationForm', () => {
       });
 
       expect(splitResult.success).toBe(false);
-      expect(mockAddOperation).not.toHaveBeenCalled();
+      expect(mockSplitOperation).not.toHaveBeenCalled();
     });
 
     it('should reject invalid split amount (negative)', async () => {
@@ -1002,7 +1005,7 @@ describe('useOperationForm', () => {
       });
 
       expect(splitResult.success).toBe(false);
-      expect(mockAddOperation).not.toHaveBeenCalled();
+      expect(mockSplitOperation).not.toHaveBeenCalled();
     });
 
     it('should reject split amount equal to original', async () => {
@@ -1019,7 +1022,7 @@ describe('useOperationForm', () => {
       });
 
       expect(splitResult.success).toBe(false);
-      expect(mockAddOperation).not.toHaveBeenCalled();
+      expect(mockSplitOperation).not.toHaveBeenCalled();
     });
 
     it('should reject split amount greater than original', async () => {
@@ -1036,12 +1039,11 @@ describe('useOperationForm', () => {
       });
 
       expect(splitResult.success).toBe(false);
-      expect(mockAddOperation).not.toHaveBeenCalled();
+      expect(mockSplitOperation).not.toHaveBeenCalled();
     });
 
     it('should create new operation with split amount', async () => {
-      mockAddOperation.mockResolvedValue();
-      mockUpdateOperation.mockResolvedValue();
+      mockSplitOperation.mockResolvedValue();
 
       const props = { ...defaultProps, operation: existingOperation, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
@@ -1056,10 +1058,12 @@ describe('useOperationForm', () => {
       });
 
       expect(splitResult.success).toBe(true);
-      expect(mockAddOperation).toHaveBeenCalledWith(
+      expect(mockSplitOperation).toHaveBeenCalledWith(
+        'op-1',
+        expect.objectContaining({ amount: '70' }),
         expect.objectContaining({
           type: 'expense',
-          amount: '30',
+          amount: '30.00',
           accountId: 'acc-1',
           categoryId: 'cat-2',
           date: '2024-01-15',
@@ -1068,8 +1072,7 @@ describe('useOperationForm', () => {
     });
 
     it('should update original operation with reduced amount', async () => {
-      mockAddOperation.mockResolvedValue();
-      mockUpdateOperation.mockResolvedValue();
+      mockSplitOperation.mockResolvedValue();
 
       const props = { ...defaultProps, operation: existingOperation, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
@@ -1082,17 +1085,15 @@ describe('useOperationForm', () => {
         await result.current.handleSplit('30.00', 'cat-2');
       });
 
-      expect(mockUpdateOperation).toHaveBeenCalledWith(
+      expect(mockSplitOperation).toHaveBeenCalledWith(
         'op-1',
-        expect.objectContaining({
-          amount: '70',
-        }),
+        expect.objectContaining({ amount: '70' }),
+        expect.anything(),
       );
     });
 
     it('should update local state with new amount after split', async () => {
-      mockAddOperation.mockResolvedValue();
-      mockUpdateOperation.mockResolvedValue();
+      mockSplitOperation.mockResolvedValue();
 
       const props = { ...defaultProps, operation: existingOperation, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
@@ -1111,8 +1112,7 @@ describe('useOperationForm', () => {
     });
 
     it('should return new amount in success result', async () => {
-      mockAddOperation.mockResolvedValue();
-      mockUpdateOperation.mockResolvedValue();
+      mockSplitOperation.mockResolvedValue();
 
       const props = { ...defaultProps, operation: existingOperation, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
@@ -1131,8 +1131,7 @@ describe('useOperationForm', () => {
     });
 
     it('should preserve description in new split operation', async () => {
-      mockAddOperation.mockResolvedValue();
-      mockUpdateOperation.mockResolvedValue();
+      mockSplitOperation.mockResolvedValue();
 
       const props = { ...defaultProps, operation: existingOperation, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
@@ -1145,15 +1144,17 @@ describe('useOperationForm', () => {
         await result.current.handleSplit('30.00', 'cat-2');
       });
 
-      expect(mockAddOperation).toHaveBeenCalledWith(
+      expect(mockSplitOperation).toHaveBeenCalledWith(
+        'op-1',
+        expect.anything(),
         expect.objectContaining({
           description: 'Test expense',
         }),
       );
     });
 
-    it('should handle addOperation failure', async () => {
-      mockAddOperation.mockRejectedValue(new Error('Database error'));
+    it('should handle splitOperation failure atomically', async () => {
+      mockSplitOperation.mockRejectedValue(new Error('Database error'));
 
       const props = { ...defaultProps, operation: existingOperation, isNew: false };
       const { result } = renderHook(() => useOperationForm(props));
@@ -1168,7 +1169,7 @@ describe('useOperationForm', () => {
       });
 
       expect(splitResult.success).toBe(false);
-      // Original amount should not be changed
+      // Local state must not change when the atomic DB operation fails
       expect(result.current.values.amount).toBe('100.00');
     });
   });

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -341,6 +341,29 @@ export const OperationsActionsProvider = ({ children }) => {
     }
   }, [reloadAccounts, showDialog, loadInitialOperations, activeFilters, _setSaveError]);
 
+  const splitOperation = useCallback(async (id, updates, newOperationData) => {
+    try {
+      await OperationsDB.splitOperation(id, updates, newOperationData);
+
+      await loadInitialOperations(activeFilters, false);
+
+      _setSaveError(null);
+
+      await reloadAccounts();
+
+      appEvents.emit(EVENTS.OPERATION_CHANGED);
+    } catch (error) {
+      console.error('Failed to split operation:', error);
+      _setSaveError(error.message);
+      showDialog(
+        'Error',
+        'Failed to split operation. Please try again.',
+        [{ text: 'OK' }],
+      );
+      throw error;
+    }
+  }, [reloadAccounts, showDialog, loadInitialOperations, activeFilters, _setSaveError]);
+
   const updateOperation = useCallback(async (id, updates) => {
     try {
       // Update operation in DB (handles balance updates automatically)
@@ -549,6 +572,7 @@ export const OperationsActionsProvider = ({ children }) => {
 
   const value = useMemo(() => ({
     addOperation,
+    splitOperation,
     updateOperation,
     deleteOperation,
     validateOperation,
@@ -569,6 +593,7 @@ export const OperationsActionsProvider = ({ children }) => {
     clearAllSearch: _clearAllSearch,
   }), [
     addOperation,
+    splitOperation,
     updateOperation,
     deleteOperation,
     validateOperation,

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -25,6 +25,7 @@ const useOperationForm = ({
   categories,
   t,
   addOperation,
+  splitOperation,
   updateOperation,
   validateOperation,
   showDialog,
@@ -485,7 +486,7 @@ const useOperationForm = ({
     });
   }, [categories, values.type]);
 
-  // Split operation: create new operation with split amount and reduce original
+  // Split operation: atomically reduce original and insert sibling in one transaction
   const handleSplit = useCallback(async (splitAmount, newCategoryId) => {
     if (!operation || isNew) {
       return { success: false, error: 'Cannot split new operations' };
@@ -494,7 +495,7 @@ const useOperationForm = ({
     const numSplitAmount = parseFloat(splitAmount);
     const numOriginalAmount = parseFloat(values.amount);
 
-    // Validate split amount
+    // Validate split amount (parseFloat is acceptable here: validation only, not arithmetic)
     if (isNaN(numSplitAmount) || numSplitAmount <= 0) {
       return { success: false, error: t('valid_amount_required') };
     }
@@ -504,35 +505,25 @@ const useOperationForm = ({
     }
 
     try {
-      // Calculate new amount for original operation
-      const newAmount = String(numOriginalAmount - numSplitAmount);
+      // Use Currency.subtract for precision-safe arithmetic
+      const newAmount = Currency.subtract(values.amount, splitAmount);
 
-      // formModifiedRef is already true (set during initialization) so the
-      // initialization effect won't re-run when reloadAccounts triggers a re-render.
-      // Set it explicitly here as a safety measure in case split is called very early.
       formModifiedRef.current = true;
 
-      // 1. FIRST update original operation in database (reduces amount)
-      // This must happen before addOperation, because addOperation calls
-      // loadInitialOperations() which would reload the old amount otherwise
-      await updateOperation(operation.id, {
-        ...values,
-        amount: newAmount,
-      });
-
-      // 2. THEN create new operation with split amount
-      // When addOperation reloads operations, the original will already have reduced amount
+      const updates = { ...values, amount: newAmount };
       const newOperation = {
         type: values.type,
-        amount: String(numSplitAmount),
+        amount: splitAmount,
         accountId: values.accountId,
         categoryId: newCategoryId,
         date: values.date,
         description: values.description || null,
       };
-      await addOperation(newOperation);
 
-      // 3. Update local form state AFTER both DB operations succeed
+      // Single atomic call: both DB writes succeed or neither does
+      await splitOperation(operation.id, updates, newOperation);
+
+      // Update local form state only after the atomic DB operation succeeds
       setValues(v => ({ ...v, amount: newAmount }));
 
       return { success: true, newAmount };
@@ -540,7 +531,7 @@ const useOperationForm = ({
       console.error('[useOperationForm] Failed to split operation:', error);
       return { success: false, error: t('error') };
     }
-  }, [operation, isNew, values, addOperation, updateOperation, t, setValues]);
+  }, [operation, isNew, values, splitOperation, t, setValues]);
 
   return {
     // State

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -62,7 +62,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { showDialog } = useDialog();
-  const { addOperation, updateOperation, validateOperation } = useOperationsActions();
+  const { addOperation, splitOperation, updateOperation, validateOperation } = useOperationsActions();
   const { visibleAccounts: accounts } = useAccountsData();
   const { categories } = useCategories();
 
@@ -100,6 +100,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     categories,
     t,
     addOperation,
+    splitOperation,
     updateOperation,
     validateOperation,
     showDialog,

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -579,6 +579,139 @@ export const updateOperation = async (id, updates) => {
 };
 
 /**
+ * Atomically reduce the original operation's amount and insert a new sibling
+ * operation for the split portion. Both the UPDATE and INSERT run inside a
+ * single executeTransaction so a partial failure cannot corrupt the database.
+ *
+ * @param {number} id - ID of the operation to reduce
+ * @param {Object} updates - Fields to apply to the original (camelCase, same shape as updateOperation)
+ * @param {Object} newOperationData - Data for the new split sibling (camelCase, same shape as createOperation)
+ * @returns {Promise<Object>} The newly created split operation
+ */
+export const splitOperation = async (id, updates, newOperationData) => {
+  try {
+    const now = new Date().toISOString();
+
+    const extractId = (value) => {
+      if (value === null || value === undefined || value === '') return null;
+      if (typeof value === 'object' && value.id !== undefined) return value.id;
+      return value;
+    };
+
+    let createdOperation;
+
+    await executeTransaction(async (db) => {
+      // Step 1: fetch old operation for balance reversal
+      const oldOperation = await db.getFirstAsync(
+        'SELECT * FROM operations WHERE id = ?',
+        [id],
+      );
+
+      if (!oldOperation) {
+        throw new Error(`Operation ${id} not found`);
+      }
+
+      // Step 2: apply updates to original operation
+      const fields = [];
+      const vals = [];
+
+      if (updates.type !== undefined) { fields.push('type = ?'); vals.push(updates.type); }
+      if (updates.amount !== undefined) { fields.push('amount = ?'); vals.push(updates.amount); }
+      if (updates.accountId !== undefined) { fields.push('account_id = ?'); vals.push(extractId(updates.accountId)); }
+      if (updates.categoryId !== undefined) { fields.push('category_id = ?'); vals.push(extractId(updates.categoryId)); }
+      if (updates.toAccountId !== undefined) { fields.push('to_account_id = ?'); vals.push(extractId(updates.toAccountId)); }
+      if (updates.date !== undefined) { fields.push('date = ?'); vals.push(updates.date); }
+      if (updates.description !== undefined) { fields.push('description = ?'); vals.push(updates.description || null); }
+      if (updates.exchangeRate !== undefined) { fields.push('exchange_rate = ?'); vals.push(updates.exchangeRate || null); }
+      if (updates.destinationAmount !== undefined) { fields.push('destination_amount = ?'); vals.push(updates.destinationAmount || null); }
+      if (updates.sourceCurrency !== undefined) { fields.push('source_currency = ?'); vals.push(updates.sourceCurrency || null); }
+      if (updates.destinationCurrency !== undefined) { fields.push('destination_currency = ?'); vals.push(updates.destinationCurrency || null); }
+
+      if (fields.length > 0) {
+        vals.push(id);
+        await db.runAsync(`UPDATE operations SET ${fields.join(', ')} WHERE id = ?`, vals);
+      }
+
+      const updatedOperation = await db.getFirstAsync(
+        'SELECT * FROM operations WHERE id = ?',
+        [id],
+      );
+
+      // Step 3: insert new (split) operation
+      const newRow = {
+        type: newOperationData.type,
+        amount: newOperationData.amount,
+        account_id: extractId(newOperationData.accountId),
+        category_id: extractId(newOperationData.categoryId),
+        to_account_id: extractId(newOperationData.toAccountId) || null,
+        date: newOperationData.date,
+        created_at: now,
+        description: newOperationData.description || null,
+        exchange_rate: newOperationData.exchangeRate || null,
+        destination_amount: newOperationData.destinationAmount || null,
+        source_currency: newOperationData.sourceCurrency || null,
+        destination_currency: newOperationData.destinationCurrency || null,
+      };
+
+      const result = await db.runAsync(
+        'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [
+          newRow.type, newRow.amount, newRow.account_id, newRow.category_id,
+          newRow.to_account_id, newRow.date, newRow.created_at, newRow.description,
+          newRow.exchange_rate, newRow.destination_amount, newRow.source_currency, newRow.destination_currency,
+        ],
+      );
+
+      createdOperation = { ...newRow, id: result.lastInsertRowId };
+
+      // Step 4: compute net balance changes across all three operations
+      // Net effect on any account: reverse(old) + apply(updated) + apply(new)
+      const balanceChanges = new Map();
+
+      const applyChanges = (changes, sign) => {
+        for (const [accountId, delta] of changes.entries()) {
+          balanceChanges.set(accountId, (balanceChanges.get(accountId) || 0) + sign * delta);
+        }
+      };
+
+      applyChanges(calculateBalanceChanges(oldOperation), -1);
+      applyChanges(calculateBalanceChanges(updatedOperation), +1);
+      applyChanges(calculateBalanceChanges(createdOperation), +1);
+
+      // Step 5: update account balances and balance history
+      const updateTime = new Date().toISOString();
+      for (const [accountId, delta] of balanceChanges.entries()) {
+        if (delta === 0) continue;
+
+        const account = await db.getFirstAsync(
+          'SELECT balance FROM accounts WHERE id = ?',
+          [accountId],
+        );
+
+        if (!account) {
+          console.warn(`Account ${accountId} not found, skipping balance update`);
+          continue;
+        }
+
+        const newBalance = Currency.add(account.balance, delta);
+
+        await db.runAsync(
+          'UPDATE accounts SET balance = ?, updated_at = ? WHERE id = ?',
+          [newBalance, updateTime, accountId],
+        );
+
+        await updateTodayBalance(accountId, newBalance, db);
+      }
+    });
+
+    return createdOperation;
+  } catch (error) {
+    console.error('Failed to split operation:', error);
+    throw error;
+  }
+};
+
+/**
  * Delete an operation
  * @param {number} id
  * @returns {Promise<void>}


### PR DESCRIPTION
The previous implementation called updateOperation() then addOperation()
in two separate transactions. If the second call failed, the original
operation's amount was permanently reduced with no sibling created —
leaving the database in a corrupted state.

Also, the reduced amount was computed via JS float subtraction
(numOriginalAmount - numSplitAmount), which introduces IEEE-754
precision errors for high-decimal or large amounts.

Changes:
- Add OperationsDB.splitOperation(): wraps the UPDATE and INSERT in a
  single executeTransaction so both succeed or neither does. Balance
  adjustments are also computed atomically in the same transaction.
- Add splitOperation wrapper in OperationsActionsContext that reloads
  operations/accounts and emits OPERATION_CHANGED after the atomic call.
- Replace the two-step sequence in useOperationForm.handleSplit with a
  single splitOperation() call. Use Currency.subtract() instead of
  float subtraction for the reduced-amount calculation.
- Wire splitOperation through OperationModal into useOperationForm.
- Update useOperationForm tests: swap mockUpdateOperation/mockAddOperation
  expectations for mockSplitOperation; add Currency.subtract mock.

Closes #588