### PR TITLE
fix: eliminate float precision loss and transfer desync in financial ops

### DIFF
--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -1277,6 +1277,9 @@ describe('useOperationForm', () => {
 
     it('should include sourceCurrency and destinationCurrency when saving foreign currency expense', async () => {
       Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '1.09', source: 'live' });
+      // convertAmount is called synchronously in prepareOperationData to recompute
+      // destinationAmount from the form's foreign amount × rate (263.52 EUR × 0.925926 ≈ 244 USD)
+      Currency.convertAmount.mockReturnValue('244');
       mockUpdateOperation.mockResolvedValue();
 
       const props = { ...defaultProps, operation: foreignCurrencyExpense, isNew: false };

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -39,6 +39,8 @@ describe('OperationsDB Service', () => {
 
     // Currency mock defaults
     Currency.add.mockImplementation((a, b) => String(parseFloat(a) + parseFloat(b)));
+    Currency.subtract.mockImplementation((a, b) => String(parseFloat(a) - parseFloat(b)));
+    Currency.isZero.mockImplementation((a) => parseFloat(a) === 0);
   });
 
   describe('Query Operations', () => {
@@ -183,7 +185,7 @@ describe('OperationsDB Service', () => {
         'SELECT balance FROM accounts WHERE id = ?',
         ['acc1'],
       );
-      expect(Currency.add).toHaveBeenCalledWith('1000', -100);
+      expect(Currency.add).toHaveBeenCalledWith('1000', '-100');
       expect(mockDb.runAsync).toHaveBeenCalledWith(
         'UPDATE accounts SET balance = ?, updated_at = ? WHERE id = ?',
         expect.any(Array),
@@ -204,7 +206,7 @@ describe('OperationsDB Service', () => {
       await OperationsDB.createOperation(operation);
 
       // Should update account balance (income increases balance)
-      expect(Currency.add).toHaveBeenCalledWith('1000', 200);
+      expect(Currency.add).toHaveBeenCalledWith('1000', '200');
     });
 
     it('creates transfer operation and updates both account balances', async () => {
@@ -227,9 +229,9 @@ describe('OperationsDB Service', () => {
       expect(mockDb.getFirstAsync).toHaveBeenCalledTimes(2);
 
       // Source account should be reduced
-      expect(Currency.add).toHaveBeenCalledWith('1000', -300);
+      expect(Currency.add).toHaveBeenCalledWith('1000', '-300');
       // Destination account should be increased
-      expect(Currency.add).toHaveBeenCalledWith('500', 300);
+      expect(Currency.add).toHaveBeenCalledWith('500', '300');
 
       expect(mockDb.runAsync).toHaveBeenCalledTimes(5); // INSERT + 2 UPDATEs + 2 balance history inserts
     });
@@ -255,9 +257,9 @@ describe('OperationsDB Service', () => {
       await OperationsDB.createOperation(operation);
 
       // Source: -100 USD
-      expect(Currency.add).toHaveBeenCalledWith('1000', -100);
+      expect(Currency.add).toHaveBeenCalledWith('1000', '-100');
       // Destination: +370 AMD (using destination_amount)
-      expect(Currency.add).toHaveBeenCalledWith('50000', 370);
+      expect(Currency.add).toHaveBeenCalledWith('50000', '370');
     });
 
     it('skips balance update when account not found', async () => {
@@ -498,7 +500,7 @@ describe('OperationsDB Service', () => {
       );
 
       // Should reverse balance change (expense was -100, so reverse is +100)
-      expect(Currency.add).toHaveBeenCalledWith('900', 100);
+      expect(Currency.add).toHaveBeenCalledWith('900', '100');
     });
 
     it('reverses transfer balance changes on delete', async () => {
@@ -519,8 +521,8 @@ describe('OperationsDB Service', () => {
       await OperationsDB.deleteOperation(1);
 
       // Should reverse both account changes
-      expect(Currency.add).toHaveBeenCalledWith('700', 300);   // Restore source
-      expect(Currency.add).toHaveBeenCalledWith('800', -300);  // Reverse destination
+      expect(Currency.add).toHaveBeenCalledWith('700', '300');   // Restore source
+      expect(Currency.add).toHaveBeenCalledWith('800', '-300');  // Reverse destination
     });
 
     it('throws error when operation not found', async () => {
@@ -947,7 +949,7 @@ describe('OperationsDB Service', () => {
       await OperationsDB.createOperation(operation);
 
       // Currency module should handle precision
-      expect(Currency.add).toHaveBeenCalledWith('100.50', -0.01);
+      expect(Currency.add).toHaveBeenCalledWith('100.50', '-0.01');
     });
 
     it('handles operations without optional fields', async () => {

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -351,9 +351,31 @@ const useOperationForm = ({
     if (isMultiCurrencyTransfer && sourceAccount && destinationAccount) {
       data.sourceCurrency = sourceAccount.currency;
       data.destinationCurrency = destinationAccount.currency;
+      // Recompute synchronously so a save before the async useEffect resolves
+      // never stores a destinationAmount that is inconsistent with amount × rate.
+      if (data.amount && data.exchangeRate) {
+        const recomputed = Currency.convertAmount(
+          data.amount,
+          sourceAccount.currency,
+          destinationAccount.currency,
+          data.exchangeRate,
+        );
+        if (recomputed) data.destinationAmount = recomputed;
+      }
     } else if (isForeignCurrencyOp && sourceAccount && values.operationCurrency) {
       data.sourceCurrency = values.operationCurrency;
       data.destinationCurrency = sourceAccount.currency;
+      // Recompute destinationAmount (account currency) from foreign amount × rate
+      // before the swap so stale form state is never persisted.
+      if (data.amount && data.exchangeRate) {
+        const recomputed = Currency.convertAmount(
+          data.amount,
+          values.operationCurrency,
+          sourceAccount.currency,
+          data.exchangeRate,
+        );
+        if (recomputed) data.destinationAmount = recomputed;
+      }
       // Form model: amount = foreign currency, destinationAmount = account currency,
       //             exchangeRate = foreign→account rate
       // DB model:   amount = account currency, destinationAmount = foreign currency,

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -294,29 +294,29 @@ export const getOperationsByType = async (type) => {
  * Calculate balance changes for an operation
  * Handles multi-currency transfers by using destination_amount when available
  * @param {Object} operation
- * @returns {Map<string, number>}
+ * @returns {Map<string, string>} Map of accountId → string delta (Decimal-safe)
  */
 const calculateBalanceChanges = (operation) => {
   const balanceChanges = new Map();
-  const amount = parseFloat(operation.amount) || 0;
+  const amount = String(operation.amount || '0');
 
   if (operation.type === 'expense') {
-    balanceChanges.set(operation.account_id, -amount);
+    balanceChanges.set(operation.account_id, Currency.subtract('0', amount));
   } else if (operation.type === 'income') {
     balanceChanges.set(operation.account_id, amount);
   } else if (operation.type === 'transfer') {
     // Deduct from source account
-    balanceChanges.set(operation.account_id, -amount);
+    balanceChanges.set(operation.account_id, Currency.subtract('0', amount));
 
     if (operation.to_account_id) {
       // For multi-currency transfers, use destination_amount if available
       // Otherwise fall back to source amount (same currency transfer)
       const destinationAmount = operation.destination_amount
-        ? parseFloat(operation.destination_amount)
+        ? String(operation.destination_amount)
         : amount;
 
-      const toChange = balanceChanges.get(operation.to_account_id) || 0;
-      balanceChanges.set(operation.to_account_id, toChange + destinationAmount);
+      const toChange = balanceChanges.get(operation.to_account_id) || '0';
+      balanceChanges.set(operation.to_account_id, Currency.add(toChange, destinationAmount));
     }
   }
 
@@ -403,7 +403,7 @@ export const createOperation = async (operation) => {
       const updateTime = new Date().toISOString();
 
       for (const [accountId, delta] of balanceChanges.entries()) {
-        if (delta === 0) continue;
+        if (Currency.isZero(delta)) continue;
 
         // Get current balance
         const account = await db.getFirstAsync(
@@ -534,19 +534,19 @@ export const updateOperation = async (id, updates) => {
       // Reverse old operation
       const oldChanges = calculateBalanceChanges(oldOperation);
       for (const [accountId, delta] of oldChanges.entries()) {
-        balanceChanges.set(accountId, (balanceChanges.get(accountId) || 0) - delta);
+        balanceChanges.set(accountId, Currency.subtract(balanceChanges.get(accountId) || '0', delta));
       }
 
       // Apply new operation
       const newChanges = calculateBalanceChanges(newOperation);
       for (const [accountId, delta] of newChanges.entries()) {
-        balanceChanges.set(accountId, (balanceChanges.get(accountId) || 0) + delta);
+        balanceChanges.set(accountId, Currency.add(balanceChanges.get(accountId) || '0', delta));
       }
 
       // Update account balances within the same transaction
       const updateTime = new Date().toISOString();
       for (const [accountId, delta] of balanceChanges.entries()) {
-        if (delta === 0) continue;
+        if (Currency.isZero(delta)) continue;
 
         // Get current balance
         const account = await db.getFirstAsync(
@@ -668,20 +668,24 @@ export const splitOperation = async (id, updates, newOperationData) => {
       // Net effect on any account: reverse(old) + apply(updated) + apply(new)
       const balanceChanges = new Map();
 
-      const applyChanges = (changes, sign) => {
+      const applyChanges = (changes, negate) => {
         for (const [accountId, delta] of changes.entries()) {
-          balanceChanges.set(accountId, (balanceChanges.get(accountId) || 0) + sign * delta);
+          const existing = balanceChanges.get(accountId) || '0';
+          balanceChanges.set(
+            accountId,
+            negate ? Currency.subtract(existing, delta) : Currency.add(existing, delta),
+          );
         }
       };
 
-      applyChanges(calculateBalanceChanges(oldOperation), -1);
-      applyChanges(calculateBalanceChanges(updatedOperation), +1);
-      applyChanges(calculateBalanceChanges(createdOperation), +1);
+      applyChanges(calculateBalanceChanges(oldOperation), true);
+      applyChanges(calculateBalanceChanges(updatedOperation), false);
+      applyChanges(calculateBalanceChanges(createdOperation), false);
 
       // Step 5: update account balances and balance history
       const updateTime = new Date().toISOString();
       for (const [accountId, delta] of balanceChanges.entries()) {
-        if (delta === 0) continue;
+        if (Currency.isZero(delta)) continue;
 
         const account = await db.getFirstAsync(
           'SELECT balance FROM accounts WHERE id = ?',
@@ -736,13 +740,13 @@ export const deleteOperation = async (id) => {
       const balanceChanges = calculateBalanceChanges(operation);
       const reverseChanges = new Map();
       for (const [accountId, delta] of balanceChanges.entries()) {
-        reverseChanges.set(accountId, -delta);
+        reverseChanges.set(accountId, Currency.subtract('0', delta));
       }
 
       // Update account balances within the same transaction
       const updateTime = new Date().toISOString();
       for (const [accountId, delta] of reverseChanges.entries()) {
-        if (delta === 0) continue;
+        if (Currency.isZero(delta)) continue;
 
         // Get current balance
         const account = await db.getFirstAsync(


### PR DESCRIPTION
Issue #584: calculateBalanceChanges used parseFloat which converts stored
decimal strings to IEEE-754 floats before any arithmetic, causing precision
drift on accounts with many transactions or high-decimal currencies. All
balance deltas are now kept as Decimal-safe strings throughout using
Currency.subtract/add; callers updated to accumulate with string ops and
use Currency.isZero for zero-skip checks.

Issue #587: prepareOperationData relied on an async useEffect to compute
destinationAmount, so a save triggered before the effect resolved would
persist a stale (pre-edit) destination amount for multi-currency transfers
and foreign currency expense/income ops. destinationAmount is now
recomputed synchronously in prepareOperationData via Currency.convertAmount
before the DB-model swap, guaranteeing amount×rate consistency at save time.

https://claude.ai/code/session_01AsSCPLrVnVhN8VnUH9Kdxg