### PR TITLE
fix: eliminate parseFloat in aggregation queries, use Currency.add end-to-end

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -536,31 +536,31 @@ describe('OperationsDB Service', () => {
 
   describe('Aggregation Queries', () => {
     it('gets total expenses for account in date range', async () => {
-      queryFirst.mockResolvedValue({ total: '500.50' });
+      queryAll.mockResolvedValue([{ amount: '300.25' }, { amount: '200.25' }]);
 
       const result = await OperationsDB.getTotalExpenses('acc1', '2025-12-01', '2025-12-31');
 
-      expect(queryFirst).toHaveBeenCalledWith(
-        expect.stringContaining('SUM'),
+      expect(queryAll).toHaveBeenCalledWith(
+        expect.stringContaining("type = 'expense'"),
         ['acc1', '2025-12-01', '2025-12-31'],
       );
-      expect(result).toBe(500.50);
+      expect(result).toBe('500.5');
     });
 
-    it('returns 0 for no expenses', async () => {
-      queryFirst.mockResolvedValue({ total: null });
+    it('returns 0 string for no expenses', async () => {
+      queryAll.mockResolvedValue([]);
 
       const result = await OperationsDB.getTotalExpenses('acc1', '2025-12-01', '2025-12-31');
 
-      expect(result).toBe(0);
+      expect(result).toBe('0');
     });
 
     it('gets total income for account in date range', async () => {
-      queryFirst.mockResolvedValue({ total: '1200.00' });
+      queryAll.mockResolvedValue([{ amount: '1200.00' }]);
 
       const result = await OperationsDB.getTotalIncome('acc1', '2025-12-01', '2025-12-31');
 
-      expect(result).toBe(1200.00);
+      expect(result).toBe('1200');
     });
 
     it('gets spending by category', async () => {
@@ -1503,7 +1503,7 @@ describe('OperationsDB Service', () => {
     });
 
     it('getTotalExpenses throws error on failure', async () => {
-      queryFirst.mockRejectedValue(new Error('Query failed'));
+      queryAll.mockRejectedValue(new Error('Query failed'));
 
       await expect(
         OperationsDB.getTotalExpenses('acc1', '2025-12-01', '2025-12-31'),
@@ -1511,7 +1511,7 @@ describe('OperationsDB Service', () => {
     });
 
     it('getTotalIncome throws error on failure', async () => {
-      queryFirst.mockRejectedValue(new Error('Query failed'));
+      queryAll.mockRejectedValue(new Error('Query failed'));
 
       await expect(
         OperationsDB.getTotalIncome('acc1', '2025-12-01', '2025-12-31'),
@@ -2100,11 +2100,13 @@ describe('OperationsDB Service', () => {
   });
 
   describe('getMonthlySpendingByCategories', () => {
-    it('returns monthly totals for given categories', async () => {
+    it('returns monthly totals as Decimal-safe strings, aggregated in app code', async () => {
+      // DB returns individual rows with month + amount (no SQL-level GROUP BY/SUM)
       const mockResults = [
-        { month: 1, total: 150.5 },
-        { month: 3, total: 200.0 },
-        { month: 6, total: 75.25 },
+        { month: 1, amount: '100.25' },
+        { month: 1, amount: '50.25' },
+        { month: 3, amount: '200.0' },
+        { month: 6, amount: '75.25' },
       ];
       queryAll.mockResolvedValue(mockResults);
 
@@ -2112,9 +2114,9 @@ describe('OperationsDB Service', () => {
 
       expect(queryAll).toHaveBeenCalled();
       expect(result).toEqual([
-        { month: 1, total: 150.5 },
-        { month: 3, total: 200.0 },
-        { month: 6, total: 75.25 },
+        { month: 1, total: '150.5' },
+        { month: 3, total: '200' },
+        { month: 6, total: '75.25' },
       ]);
     });
 
@@ -2146,7 +2148,7 @@ describe('OperationsDB Service', () => {
     });
 
     it('handles multiple category IDs', async () => {
-      queryAll.mockResolvedValue([{ month: 5, total: 100 }]);
+      queryAll.mockResolvedValue([{ month: 5, amount: '100' }]);
 
       await OperationsDB.getMonthlySpendingByCategories('USD', 2024, ['cat1', 'cat2', 'cat3']);
 
@@ -2158,11 +2160,11 @@ describe('OperationsDB Service', () => {
       expect(params).toContain('cat3');
     });
 
-    it('groups by month correctly', async () => {
+    it('groups by month correctly using app-side accumulation', async () => {
       const mockResults = [
-        { month: 1, total: 100 },
-        { month: 2, total: 200 },
-        { month: 12, total: 300 },
+        { month: 1, amount: '100' },
+        { month: 2, amount: '200' },
+        { month: 12, amount: '300' },
       ];
       queryAll.mockResolvedValue(mockResults);
 
@@ -2203,16 +2205,21 @@ describe('OperationsDB Service', () => {
       ).rejects.toThrow('Database error');
     });
 
-    it('parses total as float correctly', async () => {
+    it('accumulates per-month totals using Currency.add for Decimal-safe arithmetic', async () => {
       queryAll.mockResolvedValue([
-        { month: 1, total: '123.45' },
-        { month: 2, total: null },
+        { month: 1, amount: '100' },
+        { month: 1, amount: '50.5' },
+        { month: 2, amount: '200' },
       ]);
 
       const result = await OperationsDB.getMonthlySpendingByCategories('USD', 2024, ['cat1']);
 
-      expect(result[0].total).toBe(123.45);
-      expect(result[1].total).toBe(0); // null becomes 0
+      // Two rows for month 1 are accumulated; month 2 stays separate
+      expect(result).toHaveLength(2);
+      expect(result[0].month).toBe(1);
+      expect(result[1].month).toBe(2);
+      // Verify Currency.add was called for accumulation (precision comes from real Decimal.js impl)
+      expect(Currency.add).toHaveBeenCalled();
     });
 
     it('uses correct SQL query structure', async () => {
@@ -2224,7 +2231,6 @@ describe('OperationsDB Service', () => {
       expect(sql).toContain("o.type = 'expense'");
       expect(sql).toContain('a.currency = ?');
       expect(sql).toContain('o.category_id IN');
-      expect(sql).toContain('GROUP BY');
       expect(sql).toContain('ORDER BY month ASC');
     });
   });

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -514,7 +514,7 @@ const BalanceHistoryCard = ({
                   // Daily avg = total expenses / days in month (negated: spending reduces balance)
                   const prevTotalExpenses = balanceHistoryData.prevMonthTotalExpenses;
                   if (prevTotalExpenses != null && prevMonthDaysCount > 0) {
-                    prevMonthDailyAvg = -prevTotalExpenses / prevMonthDaysCount;
+                    prevMonthDailyAvg = -parseFloat(prevTotalExpenses) / prevMonthDaysCount;
                   }
                 }
 
@@ -596,7 +596,7 @@ BalanceHistoryCard.propTypes = {
     actualForChart: PropTypes.array,
     burndown: PropTypes.array,
     prevMonth: PropTypes.array,
-    prevMonthTotalExpenses: PropTypes.number,
+    prevMonthTotalExpenses: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     prevMonthDaysCount: PropTypes.number,
   }).isRequired,
   selectedYear: PropTypes.number.isRequired,

--- a/app/hooks/useCategoryMonthlySpending.js
+++ b/app/hooks/useCategoryMonthlySpending.js
@@ -1,5 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { getLast12MonthsSpendingByCategories } from '../services/OperationsDB';
+import * as Currency from '../services/currency';
 import { getAllDescendants } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 
@@ -59,11 +60,13 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
       });
 
       // Build array of 12 months (fill 0 for missing months)
+      // totals arrive as Decimal-safe strings from the DB layer; convert to float here
+      // since chart components need numeric values for bar height arithmetic.
       const fullYearData = last12Months.map(monthInfo => ({
         yearMonth: monthInfo.yearMonth,
         year: monthInfo.year,
         month: monthInfo.month,
-        total: spendingMap.get(monthInfo.yearMonth) || 0,
+        total: parseFloat(spendingMap.get(monthInfo.yearMonth) || '0') || 0,
       }));
 
       setMonthlyData(fullYearData);
@@ -75,9 +78,13 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
     }
   }, [selectedCurrency, selectedCategoryId, last12Months]);
 
-  // Calculate total yearly spending
+  // Calculate total yearly spending using Decimal-safe addition before the final float conversion
   const totalYearlySpending = useMemo(() => {
-    return monthlyData.reduce((sum, item) => sum + item.total, 0);
+    const total = monthlyData.reduce(
+      (sum, item) => Currency.add(sum, String(item.total || '0')),
+      '0',
+    );
+    return parseFloat(total) || 0;
   }, [monthlyData]);
 
   // Listen for operation changes and reload data

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -329,7 +329,7 @@ const GraphsScreen = () => {
   // Use account-specific expenses from balance history for the prediction.
   // totalExpenses from useExpenseData covers all accounts in the currency (by design),
   // but the forecast line on the balance history chart must reflect only the selected account.
-  const accountTotalExpenses = balanceHistoryData.currentMonthTotalExpenses ?? 0;
+  const accountTotalExpenses = parseFloat(balanceHistoryData.currentMonthTotalExpenses ?? 0) || 0;
 
   // Calculate spending prediction
   const spendingPrediction = useMemo(() => {

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -783,17 +783,17 @@ export const deleteOperation = async (id) => {
  * @param {string} accountId
  * @param {string} startDate
  * @param {string} endDate
- * @returns {Promise<number>}
+ * @returns {Promise<string>} Decimal-safe string representation of total
  */
 export const getTotalExpenses = async (accountId, startDate, endDate) => {
   try {
-    const result = await queryFirst(
-      `SELECT SUM(CAST(amount AS REAL)) as total
-       FROM operations
+    const results = await queryAll(
+      `SELECT amount FROM operations
        WHERE account_id = ? AND type = 'expense' AND date >= ? AND date <= ?`,
       [accountId, startDate, endDate],
     );
-    return result && result.total ? parseFloat(result.total) : 0;
+    if (!results || results.length === 0) return '0';
+    return results.reduce((sum, row) => Currency.add(sum, String(row.amount || '0')), '0');
   } catch (error) {
     console.error('Failed to get total expenses:', error);
     throw error;
@@ -805,17 +805,17 @@ export const getTotalExpenses = async (accountId, startDate, endDate) => {
  * @param {string} accountId
  * @param {string} startDate
  * @param {string} endDate
- * @returns {Promise<number>}
+ * @returns {Promise<string>} Decimal-safe string representation of total
  */
 export const getTotalIncome = async (accountId, startDate, endDate) => {
   try {
-    const result = await queryFirst(
-      `SELECT SUM(CAST(amount AS REAL)) as total
-       FROM operations
+    const results = await queryAll(
+      `SELECT amount FROM operations
        WHERE account_id = ? AND type = 'income' AND date >= ? AND date <= ?`,
       [accountId, startDate, endDate],
     );
-    return result && result.total ? parseFloat(result.total) : 0;
+    if (!results || results.length === 0) return '0';
+    return results.reduce((sum, row) => Currency.add(sum, String(row.amount || '0')), '0');
   } catch (error) {
     console.error('Failed to get total income:', error);
     throw error;
@@ -1587,7 +1587,7 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
  * @param {string} currency - Currency code (e.g., 'USD', 'AMD')
  * @param {number} year - Year to query (e.g., 2024)
  * @param {string[]} categoryIds - Array of category IDs to include
- * @returns {Promise<Array<{month: number, total: number}>>} Monthly totals (month is 1-12)
+ * @returns {Promise<Array<{month: number, total: string}>>} Monthly totals (month is 1-12), total as Decimal-safe string
  */
 export const getMonthlySpendingByCategories = async (currency, year, categoryIds) => {
   try {
@@ -1602,7 +1602,7 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
     const results = await queryAll(
       `SELECT
          CAST(strftime('%m', o.date) AS INTEGER) as month,
-         SUM(CAST(o.amount AS REAL)) as total
+         o.amount
        FROM operations o
        JOIN accounts a ON o.account_id = a.id
        WHERE o.type = 'expense'
@@ -1610,15 +1610,19 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
          AND o.date >= ?
          AND o.date <= ?
          AND o.category_id IN (${placeholders})
-       GROUP BY strftime('%m', o.date)
        ORDER BY month ASC`,
       [currency, startDate, endDate, ...categoryIds],
     );
 
-    return (results || []).map(row => ({
-      month: row.month,
-      total: parseFloat(row.total) || 0,
-    }));
+    const monthTotals = new Map();
+    for (const row of results || []) {
+      const prev = monthTotals.get(row.month) || '0';
+      monthTotals.set(row.month, Currency.add(prev, String(row.amount || '0')));
+    }
+
+    return Array.from(monthTotals.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([month, total]) => ({ month, total }));
   } catch (error) {
     console.error('Failed to get monthly spending by categories:', error);
     throw error;
@@ -1629,7 +1633,7 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
  * Get spending by categories for the last 12 months (rolling)
  * @param {string} currency - Currency code
  * @param {Array<string>} categoryIds - Category IDs to include
- * @returns {Promise<Array<{yearMonth: string, total: number}>>} Array of {yearMonth: 'YYYY-MM', total}
+ * @returns {Promise<Array<{yearMonth: string, total: string}>>} Array of {yearMonth: 'YYYY-MM', total as Decimal-safe string}
  */
 export const getLast12MonthsSpendingByCategories = async (currency, categoryIds) => {
   try {
@@ -1648,7 +1652,7 @@ export const getLast12MonthsSpendingByCategories = async (currency, categoryIds)
     const results = await queryAll(
       `SELECT
          strftime('%Y-%m', o.date) as year_month,
-         SUM(CAST(o.amount AS REAL)) as total
+         o.amount
        FROM operations o
        JOIN accounts a ON o.account_id = a.id
        WHERE o.type = 'expense'
@@ -1656,15 +1660,19 @@ export const getLast12MonthsSpendingByCategories = async (currency, categoryIds)
          AND o.date >= ?
          AND o.date <= ?
          AND o.category_id IN (${placeholders})
-       GROUP BY strftime('%Y-%m', o.date)
        ORDER BY year_month ASC`,
       [currency, startDateStr, endDateStr, ...categoryIds],
     );
 
-    return (results || []).map(row => ({
-      yearMonth: row.year_month,
-      total: parseFloat(row.total) || 0,
-    }));
+    const monthTotals = new Map();
+    for (const row of results || []) {
+      const prev = monthTotals.get(row.year_month) || '0';
+      monthTotals.set(row.year_month, Currency.add(prev, String(row.amount || '0')));
+    }
+
+    return Array.from(monthTotals.entries())
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([yearMonth, total]) => ({ yearMonth, total }));
   } catch (error) {
     console.error('Failed to get last 12 months spending by categories:', error);
     throw error;


### PR DESCRIPTION
getTotalExpenses, getTotalIncome, getMonthlySpendingByCategories, and
getLast12MonthsSpendingByCategories all used parseFloat() on SQL SUM(CAST(amount AS REAL))
aggregates, compounding float precision loss with an additional JS float conversion.

Each function now fetches raw amount strings and accumulates them via Currency.add()
(Decimal.js) at the application layer, returning Decimal-safe strings instead of numbers.
The SQL-level CAST/SUM is removed — aggregation happens in app code where precision is
preserved until the chart display layer needs a float.

Display layer callers (useBalanceHistory, useCategoryMonthlySpending, GraphsScreen,
BalanceHistoryCard) convert to float only at the last step where chart arithmetic
requires it, making the precision trade-off explicit.

Fixes #584

https://claude.ai/code/session_01Egom9UFkVcfgxwyTZCkjJm