### PR TITLE
fix: cyrillic text search and improve search UX

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1109,10 +1109,11 @@ describe('OperationsDB Service', () => {
       await OperationsDB.getFilteredOperationsByDateRange('2025-12-01', '2025-12-31', filters);
 
       const sqlCall = queryAll.mock.calls[0][0];
-      expect(sqlCall).toContain('LOWER(o.description) LIKE ?');
-      expect(sqlCall).toContain('LOWER(a.name) LIKE ?');
-      expect(sqlCall).toContain('LOWER(to_a.name) LIKE ?');
-      expect(sqlCall).toContain('LOWER(c.name) LIKE ?');
+      expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
+      expect(sqlCall).toContain('UNICODE_LOWER(a.name) LIKE ?');
+      expect(sqlCall).toContain('UNICODE_LOWER(to_a.name) LIKE ?');
+      expect(sqlCall).toContain('UNICODE_LOWER(c.name) LIKE ?');
+      expect(sqlCall).toContain('UNICODE_LOWER(pc.name) LIKE ?');
     });
 
     it('trims search text before searching', async () => {
@@ -1125,21 +1126,20 @@ describe('OperationsDB Service', () => {
       expect(params).toContain('%coffee%');
     });
 
-    it('includes both lowercase and original-case search terms for Unicode support', async () => {
+    it('passes only the lowercased search term — UNICODE_LOWER handles all scripts', async () => {
       queryAll.mockResolvedValue([]);
 
       const filters = { searchText: 'GROCERY' };
       await OperationsDB.getFilteredOperationsByDateRange('2025-12-01', '2025-12-31', filters);
 
       const params = queryAll.mock.calls[0][1];
-      // Lowercase term for ASCII case-insensitive matching
       expect(params).toContain('%grocery%');
-      // Original-case term so SQLite LIKE matches non-ASCII text (e.g. Cyrillic) verbatim,
-      // since SQLite's LOWER() only handles ASCII characters.
-      expect(params).toContain('%GROCERY%');
+      // Only the lowercase variant is needed — UNICODE_LOWER() on the DB side
+      // converts stored values via JS toLowerCase(), which handles all Unicode.
+      expect(params).not.toContain('%GROCERY%');
     });
 
-    it('matches non-ASCII category names with original-case term', async () => {
+    it('matches non-ASCII (Cyrillic) category names via UNICODE_LOWER', async () => {
       queryAll.mockResolvedValue([]);
 
       const filters = { searchText: 'Газ' };
@@ -1147,11 +1147,11 @@ describe('OperationsDB Service', () => {
 
       const sqlCall = queryAll.mock.calls[0][0];
       const params = queryAll.mock.calls[0][1];
-      // Must include original-case match for Cyrillic (SQLite LOWER doesn't handle non-ASCII)
-      expect(sqlCall).toContain('c.name LIKE ?');
-      expect(params).toContain('%Газ%');
-      // Lowercase variant is also included for completeness
+      // UNICODE_LOWER on the DB side means we only need the lowercase JS-normalised term.
+      expect(sqlCall).toContain('UNICODE_LOWER(c.name) LIKE ?');
+      expect(sqlCall).toContain('UNICODE_LOWER(pc.name) LIKE ?');
       expect(params).toContain('%газ%');
+      expect(params).not.toContain('%Газ%');
     });
 
     it('combines all filters correctly', async () => {
@@ -1173,7 +1173,7 @@ describe('OperationsDB Service', () => {
       expect(sqlCall).toContain('o.category_id IN');
       expect(sqlCall).toContain('CAST(o.amount AS REAL) >=');
       expect(sqlCall).toContain('CAST(o.amount AS REAL) <=');
-      expect(sqlCall).toContain('LOWER(o.description) LIKE');
+      expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE');
     });
 
     it('handles null result from query', async () => {
@@ -1360,7 +1360,7 @@ describe('OperationsDB Service', () => {
         await OperationsDB.getNextNewestFilteredOperation('2025-12-05', filters);
 
         const sqlCall = queryFirst.mock.calls[0][0];
-        expect(sqlCall).toContain('LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
       });
 
       it('throws error on query failure', async () => {
@@ -1446,7 +1446,7 @@ describe('OperationsDB Service', () => {
         await OperationsDB.getFilteredOperationsByWeekToDate('2025-12-05', filters);
 
         const sqlCall = queryAll.mock.calls[0][0];
-        expect(sqlCall).toContain('LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
       });
 
       it('returns empty array when no operations match', async () => {
@@ -1752,7 +1752,7 @@ describe('OperationsDB Service', () => {
       await OperationsDB.getNextOldestFilteredOperation('2025-12-05', filters);
 
       const sqlCall = queryFirst.mock.calls[0][0];
-      expect(sqlCall).toContain('LOWER(o.description) LIKE ?');
+      expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
     });
 
     it('applies category filters to getNextOldestFilteredOperation', async () => {
@@ -1870,10 +1870,11 @@ describe('OperationsDB Service', () => {
         await OperationsDB.getFilteredOperationsByWeekFromDate('2025-12-05', filters);
 
         const sqlCall = queryAll.mock.calls[0][0];
-        expect(sqlCall).toContain('LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
         expect(sqlCall).toContain('o.amount LIKE ?');
-        expect(sqlCall).toContain('LOWER(a.name) LIKE ?');
-        expect(sqlCall).toContain('LOWER(c.name) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(a.name) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(c.name) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(pc.name) LIKE ?');
       });
 
       it('filters by amount range (min and max)', async () => {
@@ -1923,7 +1924,7 @@ describe('OperationsDB Service', () => {
         const sqlCall = queryAll.mock.calls[0][0];
         expect(sqlCall).toContain('o.type IN (?)');
         expect(sqlCall).toContain('o.account_id IN (?)');
-        expect(sqlCall).toContain('LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
         expect(sqlCall).toContain('CAST(o.amount AS REAL) >= ?');
         expect(sqlCall).toContain('CAST(o.amount AS REAL) <= ?');
       });
@@ -2012,7 +2013,7 @@ describe('OperationsDB Service', () => {
         const sqlCall = queryFirst.mock.calls[0][0];
         expect(sqlCall).toContain('o.type IN (?)');
         expect(sqlCall).toContain('o.account_id IN (?)');
-        expect(sqlCall).toContain('LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
       });
     });
 

--- a/__tests__/services/db.test.js
+++ b/__tests__/services/db.test.js
@@ -29,6 +29,7 @@ describe('Database Service', () => {
       getAllAsync: jest.fn(() => Promise.resolve([])),
       closeAsync: jest.fn(() => Promise.resolve()),
       withTransactionAsync: jest.fn((callback) => callback()),
+      createFunctionAsync: jest.fn(() => Promise.resolve()),
     };
 
     SQLite.openDatabaseAsync.mockResolvedValue(mockDb);

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -269,17 +269,34 @@ export const OperationsActionsProvider = ({ children }) => {
     loadInitialOperations();
   }, [loadInitialOperations]);
 
-  // Reload operations from DB whenever search/filter state changes via the new search API.
-  // The mount effect above handles the initial load; skip the first run here.
-  // The legacy updateFilters/clearFilters path also calls loadInitialOperations directly;
-  // a duplicate call from this effect is harmless because loadRequestIdRef discards stale results.
+  // Reload operations from DB when structural filters change (account, type, category, date,
+  // amount). Text search is intentionally excluded: it is handled entirely by the in-memory
+  // filteredOperations computation, so typing does not replace the lazy-loaded history.
   const isFirstSearchEffectRef = useRef(true);
+  const prevStructuralRef = useRef(null);
   useEffect(() => {
     if (isFirstSearchEffectRef.current) {
       isFirstSearchEffectRef.current = false;
+      prevStructuralRef.current = activeFilters;
       return;
     }
-    loadInitialOperations(activeFilters, false);
+
+    const prev = prevStructuralRef.current;
+    prevStructuralRef.current = activeFilters;
+
+    // Compare structural fields by reference — React never mutates arrays in place,
+    // so reference equality is sufficient to detect changes.
+    const structuralChanged = !prev
+      || prev.types !== activeFilters.types
+      || prev.accountIds !== activeFilters.accountIds
+      || prev.categoryIds !== activeFilters.categoryIds
+      || prev.dateRange !== activeFilters.dateRange
+      || prev.amountRange !== activeFilters.amountRange;
+
+    if (structuralChanged) {
+      loadInitialOperations(activeFilters, false);
+    }
+
     setJsonPreference(PREF_KEYS.OPERATIONS_FILTERS, activeFilters).catch(err => {
       console.error('Failed to persist filters:', err);
     });

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -193,6 +193,7 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
       LEFT JOIN accounts a ON o.account_id = a.id
       LEFT JOIN accounts to_a ON o.to_account_id = to_a.id
       LEFT JOIN categories c ON o.category_id = c.id
+      LEFT JOIN categories pc ON c.parent_id = pc.id
       WHERE o.date >= ? AND o.date <= ?
     `;
 
@@ -246,15 +247,15 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ? OR o.description LIKE ?
+        UNICODE_LOWER(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
-        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
-        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
+        OR UNICODE_LOWER(a.name) LIKE ?
+        OR UNICODE_LOWER(to_a.name) LIKE ?
+        OR UNICODE_LOWER(c.name) LIKE ?
+        OR UNICODE_LOWER(pc.name) LIKE ?
       )`;
-      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
+      params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
@@ -1139,6 +1140,7 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
       LEFT JOIN accounts a ON o.account_id = a.id
       LEFT JOIN accounts to_a ON o.to_account_id = to_a.id
       LEFT JOIN categories c ON o.category_id = c.id
+      LEFT JOIN categories pc ON c.parent_id = pc.id
       WHERE o.date >= ? AND o.date <= ?
     `;
 
@@ -1192,15 +1194,15 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ? OR o.description LIKE ?
+        UNICODE_LOWER(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
-        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
-        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
+        OR UNICODE_LOWER(a.name) LIKE ?
+        OR UNICODE_LOWER(to_a.name) LIKE ?
+        OR UNICODE_LOWER(c.name) LIKE ?
+        OR UNICODE_LOWER(pc.name) LIKE ?
       )`;
-      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
+      params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
@@ -1233,6 +1235,7 @@ export const getNextOldestFilteredOperation = async (beforeDate, filters = {}) =
       LEFT JOIN accounts a ON o.account_id = a.id
       LEFT JOIN accounts to_a ON o.to_account_id = to_a.id
       LEFT JOIN categories c ON o.category_id = c.id
+      LEFT JOIN categories pc ON c.parent_id = pc.id
       WHERE o.date < ?
     `;
 
@@ -1286,15 +1289,15 @@ export const getNextOldestFilteredOperation = async (beforeDate, filters = {}) =
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ? OR o.description LIKE ?
+        UNICODE_LOWER(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
-        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
-        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
+        OR UNICODE_LOWER(a.name) LIKE ?
+        OR UNICODE_LOWER(to_a.name) LIKE ?
+        OR UNICODE_LOWER(c.name) LIKE ?
+        OR UNICODE_LOWER(pc.name) LIKE ?
       )`;
-      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
+      params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC LIMIT 1';
@@ -1396,6 +1399,7 @@ export const getNextNewestFilteredOperation = async (afterDate, filters = {}) =>
       LEFT JOIN accounts a ON o.account_id = a.id
       LEFT JOIN accounts to_a ON o.to_account_id = to_a.id
       LEFT JOIN categories c ON o.category_id = c.id
+      LEFT JOIN categories pc ON c.parent_id = pc.id
       WHERE o.date > ?
     `;
 
@@ -1449,15 +1453,15 @@ export const getNextNewestFilteredOperation = async (afterDate, filters = {}) =>
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ? OR o.description LIKE ?
+        UNICODE_LOWER(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
-        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
-        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
+        OR UNICODE_LOWER(a.name) LIKE ?
+        OR UNICODE_LOWER(to_a.name) LIKE ?
+        OR UNICODE_LOWER(c.name) LIKE ?
+        OR UNICODE_LOWER(pc.name) LIKE ?
       )`;
-      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
+      params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
 
     sql += ' ORDER BY o.date ASC, o.created_at ASC LIMIT 1';
@@ -1502,6 +1506,7 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
       LEFT JOIN accounts a ON o.account_id = a.id
       LEFT JOIN accounts to_a ON o.to_account_id = to_a.id
       LEFT JOIN categories c ON o.category_id = c.id
+      LEFT JOIN categories pc ON c.parent_id = pc.id
       WHERE o.date >= ? AND o.date <= ?
     `;
 
@@ -1555,15 +1560,15 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const searchOrig = `%${filters.searchText.trim()}%`;
       sql += ` AND (
-        LOWER(o.description) LIKE ? OR o.description LIKE ?
+        UNICODE_LOWER(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR LOWER(a.name) LIKE ? OR a.name LIKE ?
-        OR LOWER(to_a.name) LIKE ? OR to_a.name LIKE ?
-        OR LOWER(c.name) LIKE ? OR c.name LIKE ?
+        OR UNICODE_LOWER(a.name) LIKE ?
+        OR UNICODE_LOWER(to_a.name) LIKE ?
+        OR UNICODE_LOWER(c.name) LIKE ?
+        OR UNICODE_LOWER(pc.name) LIKE ?
       )`;
-      params.push(searchLower, searchOrig, searchOrig, searchLower, searchOrig, searchLower, searchOrig, searchLower, searchOrig);
+      params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
 
     sql += ' ORDER BY o.date DESC, o.created_at DESC';

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -36,6 +36,14 @@ export const getDatabase = async () => {
         throw new Error('Database instance is null after opening');
       }
 
+      // Register Unicode-aware LOWER function — SQLite's built-in LOWER() only handles ASCII,
+      // so Cyrillic (and other non-ASCII) characters are left unchanged. This custom function
+      // delegates to JS String.prototype.toLowerCase() which handles all Unicode correctly.
+      await dbInstance.createFunctionAsync('UNICODE_LOWER', { deterministic: true }, (value) => {
+        if (value == null) return null;
+        return String(value).toLowerCase();
+      });
+
       drizzleInstance = drizzle(dbInstance, { schema });
       console.log('Drizzle instance created');
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -27,6 +27,7 @@ jest.mock('expo-sqlite', () => ({
     getAllAsync: jest.fn(() => Promise.resolve([])),
     closeAsync: jest.fn(() => Promise.resolve()),
     withTransactionAsync: jest.fn((callback) => callback()),
+    createFunctionAsync: jest.fn(() => Promise.resolve()),
   })),
   openDatabaseSync: jest.fn(() => ({
     execSync: jest.fn(),


### PR DESCRIPTION
Three bugs fixed:

1. Register UNICODE_LOWER custom SQLite function (db.js)
   SQLite's built-in LOWER() is ASCII-only — Cyrillic characters are
   left unchanged, causing case-insensitive search to silently fail.
   A JS-backed UNICODE_LOWER function is registered at DB open time;
   JS String.prototype.toLowerCase() correctly handles all Unicode.

2. Search parent category names in DB text filter (OperationsDB.js)
   All five filtered-query functions now join the parent category
   (LEFT JOIN categories pc ON c.parent_id = pc.id) and include
   UNICODE_LOWER(pc.name) LIKE ? in the text-search condition.
   This means typing a parent category name finds operations whose
   leaf category is a child of that parent, matching what the
   in-memory filter already did via getCategoryPath.

3. Skip DB reload when only search text changes (OperationsActionsContext.js)
   Previously, every keystroke in the search bar triggered
   loadInitialOperations, which replaced the full lazy-loaded
   operations array with a fresh 7-day DB window. Operations
   outside that window were silently discarded. Text search is now
   handled entirely by the in-memory filteredOperations computation
   (which already uses JS toLowerCase correctly). A DB reload is only
   triggered when structural filters change (account, type, category,
   date, amount). Scrolling to load more weeks still uses the full
   filter including search text.

https://claude.ai/code/session_01AaP2qEuSpjHaGgiR87tNHw