### PR TITLE
fix: cyrillic text search and improve search UX

### DIFF
--- a/__tests__/contexts/OperationsActionsContext-structural-reload.test.js
+++ b/__tests__/contexts/OperationsActionsContext-structural-reload.test.js
@@ -1,0 +1,375 @@
+// Unmock the split contexts to use real implementations
+jest.unmock('../../app/contexts/OperationsDataContext');
+jest.unmock('../../app/contexts/OperationsActionsContext');
+jest.unmock('../../app/contexts/AccountsDataContext');
+jest.unmock('../../app/contexts/AccountsActionsContext');
+
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useOperationsData } from '../../app/contexts/OperationsDataContext';
+import { useOperationsActions } from '../../app/contexts/OperationsActionsContext';
+import { OperationsProvider } from '../../app/contexts/OperationsContext';
+import * as OperationsDB from '../../app/services/OperationsDB';
+
+jest.mock('../../app/services/OperationsDB');
+jest.mock('../../app/services/PreferencesDB', () => ({
+  setJsonPreference: jest.fn(() => Promise.resolve()),
+  getJsonPreference: jest.fn(() => Promise.resolve(null)),
+  setPreference: jest.fn(() => Promise.resolve()),
+  getPreference: jest.fn(() => Promise.resolve(null)),
+  PREF_KEYS: {
+    OPERATIONS_FILTERS: 'operations_active_filters',
+    LANGUAGE: 'language',
+    THEME: 'theme',
+    GOOGLE_SHEETS_ID: 'google_sheets_id',
+    DAILY_BACKUP_ENABLED: 'daily_backup_enabled',
+    LAST_BACKUP_DATE: 'last_backup_date',
+    HIDE_BALANCES: 'hide_balances',
+  },
+}));
+
+jest.mock('../../app/services/eventEmitter', () => ({
+  appEvents: {
+    on: jest.fn(() => jest.fn()),
+    emit: jest.fn(),
+  },
+  EVENTS: {
+    RELOAD_ALL: 'reload:all',
+    OPERATION_CHANGED: 'operation:changed',
+  },
+}));
+
+const mockAccounts = [
+  { id: 'acc-1', name: 'Cash', balance: '100', currency: 'USD' },
+];
+
+jest.mock('../../app/contexts/AccountsDataContext', () => ({
+  AccountsDataProvider: ({ children }) => children,
+  useAccountsData: () => ({ accounts: mockAccounts, loading: false }),
+}));
+
+const mockReloadAccounts = jest.fn();
+jest.mock('../../app/contexts/AccountsActionsContext', () => ({
+  AccountsActionsProvider: ({ children }) => children,
+  useAccountsActions: () => ({ reloadAccounts: mockReloadAccounts }),
+}));
+
+const mockCategories = [
+  { id: 'cat-1', name: 'Food', type: 'expense', parentId: null },
+  { id: 'cat-2', name: 'Transport', type: 'expense', parentId: null },
+];
+
+jest.mock('../../app/contexts/CategoriesContext', () => ({
+  CategoriesProvider: ({ children }) => children,
+  useCategories: () => ({
+    categories: mockCategories,
+    getCategoryPath: (id) => {
+      const cats = mockCategories;
+      const path = [];
+      let current = cats.find(c => c.id === id);
+      while (current) {
+        path.unshift(current);
+        current = cats.find(c => c.id === current.parentId);
+      }
+      return path;
+    },
+    loading: false,
+  }),
+}));
+
+jest.mock('../../app/contexts/LocalizationContext', () => ({
+  LocalizationProvider: ({ children }) => children,
+  useLocalization: () => ({ t: (key) => key, currentLanguage: 'en' }),
+}));
+
+jest.mock('../../app/contexts/DialogContext', () => ({
+  useDialog: () => ({ showDialog: jest.fn(), hideDialog: jest.fn() }),
+}));
+
+describe('OperationsActionsContext - structural filter reload detection', () => {
+  let mockSetJsonPreference;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    OperationsDB.getOperationsByWeekOffset.mockResolvedValue([]);
+    OperationsDB.getFilteredOperationsByWeekOffset.mockResolvedValue([]);
+    const PreferencesDB = require('../../app/services/PreferencesDB');
+    mockSetJsonPreference = PreferencesDB.setJsonPreference;
+  });
+
+  const wrapper = ({ children }) => (
+    <OperationsProvider>{children}</OperationsProvider>
+  );
+
+  const setupHook = () =>
+    renderHook(
+      () => ({
+        data: useOperationsData(),
+        actions: useOperationsActions(),
+      }),
+      { wrapper },
+    );
+
+  describe('text-only changes do not trigger DB reload', () => {
+    it('does not call getOperationsByWeekOffset again when only searchText changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.setSearchText('coffee');
+      });
+
+      // Allow any pending async work to settle
+      await waitFor(() => {
+        expect(result.current.data.searchState.text).toBe('coffee');
+      });
+
+      // No additional DB call beyond the initial mount
+      expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      expect(OperationsDB.getFilteredOperationsByWeekOffset).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger DB reload when searchText changes multiple times', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => { result.current.actions.setSearchText('c'); });
+      act(() => { result.current.actions.setSearchText('co'); });
+      act(() => { result.current.actions.setSearchText('cof'); });
+      act(() => { result.current.actions.setSearchText('coffee'); });
+
+      await waitFor(() => {
+        expect(result.current.data.searchState.text).toBe('coffee');
+      });
+
+      expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      expect(OperationsDB.getFilteredOperationsByWeekOffset).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger reload when searchText changes from non-empty to empty', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => { result.current.actions.setSearchText('coffee'); });
+      act(() => { result.current.actions.setSearchText(''); });
+
+      await waitFor(() => {
+        expect(result.current.data.searchState.text).toBe('');
+      });
+
+      expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('structural filter changes trigger DB reload', () => {
+    it('triggers reload when types filter changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.updateSearchFilters({ types: ['expense'] });
+      });
+
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('triggers reload when accountIds filter changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.updateSearchFilters({ accountIds: ['acc-1'] });
+      });
+
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('triggers reload when categoryIds filter changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.updateSearchFilters({ categoryIds: ['cat-1'] });
+      });
+
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('triggers reload when dateRange filter changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.updateSearchFilters({
+          dateRange: { startDate: '2026-01-01', endDate: '2026-12-31' },
+        });
+      });
+
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('triggers reload when amountRange filter changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.updateSearchFilters({
+          amountRange: { min: 10, max: 500 },
+        });
+      });
+
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('passes the updated filters to the filtered DB query', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.updateSearchFilters({ types: ['income'] });
+      });
+
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      const [offset, filters] = OperationsDB.getFilteredOperationsByWeekOffset.mock.calls[0];
+      expect(offset).toBe(0);
+      expect(filters.types).toEqual(['income']);
+    });
+  });
+
+  describe('text + structural change combination', () => {
+    it('combined update with structural change triggers exactly one reload', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      // Set text first (no reload)
+      act(() => { result.current.actions.setSearchText('grocery'); });
+
+      await waitFor(() => {
+        expect(result.current.data.searchState.text).toBe('grocery');
+      });
+      expect(OperationsDB.getFilteredOperationsByWeekOffset).not.toHaveBeenCalled();
+
+      // Then set structural (one reload)
+      act(() => {
+        result.current.actions.updateSearchFilters({ types: ['expense'] });
+      });
+
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('setJsonPreference is called for every filter change', () => {
+    it('does NOT call setJsonPreference on initial mount', async () => {
+      setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockSetJsonPreference).not.toHaveBeenCalled();
+    });
+
+    it('calls setJsonPreference when searchText changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => { result.current.actions.setSearchText('coffee'); });
+
+      await waitFor(() => {
+        expect(mockSetJsonPreference).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockSetJsonPreference).toHaveBeenCalledWith(
+        'operations_active_filters',
+        expect.objectContaining({ searchText: 'coffee' }),
+      );
+    });
+
+    it('calls setJsonPreference when structural filter changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => {
+        result.current.actions.updateSearchFilters({ types: ['expense'] });
+      });
+
+      await waitFor(() => {
+        expect(mockSetJsonPreference).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockSetJsonPreference).toHaveBeenCalledWith(
+        'operations_active_filters',
+        expect.objectContaining({ types: ['expense'] }),
+      );
+    });
+
+    it('calls setJsonPreference once per filter change even for text-only changes', async () => {
+      const { result } = setupHook();
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+      });
+
+      act(() => { result.current.actions.setSearchText('a'); });
+      act(() => { result.current.actions.setSearchText('ab'); });
+      act(() => { result.current.actions.setSearchText('abc'); });
+
+      await waitFor(() => {
+        expect(result.current.data.searchState.text).toBe('abc');
+        // Each setSearchText can merge (React may batch), so we check at least 1 call
+        expect(mockSetJsonPreference).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/__tests__/contexts/OperationsDataContext-search.test.js
+++ b/__tests__/contexts/OperationsDataContext-search.test.js
@@ -36,6 +36,9 @@ const mockCategories = [
   { id: 'cat-2', name: 'Salary', nameKey: 'category.salary', type: 'income', parentId: null },
   { id: 'cat-3', name: 'Transport', nameKey: 'category.transport', type: 'expense', parentId: null },
   { id: 'cat-4', name: 'Restaurants', nameKey: null, type: 'expense', parentId: 'cat-1' },
+  // Cyrillic categories for Unicode search tests
+  { id: 'cat-5', name: 'Транспорт', nameKey: null, type: 'expense', parentId: 'cat-6' },
+  { id: 'cat-6', name: 'Путешествия', nameKey: null, type: 'expense', parentId: null },
 ];
 
 const mockOperations = [
@@ -809,6 +812,142 @@ describe('OperationsDataContext - Search API', () => {
 
         await waitFor(() => {
           expect(result.current.data.operations).toHaveLength(0);
+        });
+      });
+    });
+
+    describe('Cyrillic text search filtering', () => {
+      const cyrillicOperations = [
+        {
+          id: 'op-cyr-1',
+          type: 'expense',
+          accountId: 'acc-1',
+          categoryId: 'cat-3',
+          amount: '250',
+          description: 'Самолет Москва-Лондон',
+          date: '2026-04-18',
+        },
+        {
+          id: 'op-cyr-2',
+          type: 'expense',
+          accountId: 'acc-1',
+          categoryId: 'cat-5', // Транспорт (child of Путешествия)
+          amount: '30',
+          description: 'Автобус',
+          date: '2026-04-19',
+        },
+        {
+          id: 'op-cyr-3',
+          type: 'expense',
+          accountId: 'acc-2',
+          categoryId: 'cat-6', // Путешествия (parent category)
+          amount: '500',
+          description: 'Отель',
+          date: '2026-04-20',
+        },
+      ];
+
+      const setupWithCyrillicOperations = () => {
+        OperationsDB.getOperationsByWeekOffset.mockResolvedValue(cyrillicOperations);
+
+        const { result } = renderHook(
+          () => ({
+            data: useOperationsData(),
+            actions: useOperationsActions(),
+          }),
+          { wrapper },
+        );
+
+        return result;
+      };
+
+      it('matches Cyrillic description case-insensitively (uppercase search finds lowercase data)', async () => {
+        const result = setupWithCyrillicOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(3);
+        });
+
+        act(() => {
+          result.current.actions.setSearchText('САМОЛЕТ');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(1);
+          expect(result.current.data.operations[0].id).toBe('op-cyr-1');
+        });
+      });
+
+      it('matches Cyrillic description case-insensitively (lowercase search finds mixed-case data)', async () => {
+        const result = setupWithCyrillicOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(3);
+        });
+
+        act(() => {
+          result.current.actions.setSearchText('самолет');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(1);
+          expect(result.current.data.operations[0].id).toBe('op-cyr-1');
+        });
+      });
+
+      it('matches Cyrillic category name case-insensitively', async () => {
+        const result = setupWithCyrillicOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(3);
+        });
+
+        // Search for category name "Транспорт" using uppercase
+        act(() => {
+          result.current.actions.setSearchText('ТРАНСПОРТ');
+        });
+
+        await waitFor(() => {
+          const filtered = result.current.data.operations;
+          // op-cyr-2 has category Транспорт (cat-5)
+          expect(filtered.some(op => op.id === 'op-cyr-2')).toBe(true);
+        });
+      });
+
+      it('matches Cyrillic parent category name via hierarchy traversal', async () => {
+        const result = setupWithCyrillicOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(3);
+        });
+
+        // "путешествия" is the parent of "Транспорт"; searching for it should find op-cyr-2
+        act(() => {
+          result.current.actions.setSearchText('путешествия');
+        });
+
+        await waitFor(() => {
+          const filtered = result.current.data.operations;
+          // op-cyr-2 has cat-5 (Транспорт, child of Путешествия)
+          // op-cyr-3 has cat-6 (Путешествия directly)
+          expect(filtered.map(op => op.id).sort()).toEqual(['op-cyr-2', 'op-cyr-3']);
+        });
+      });
+
+      it('matches partial Cyrillic text in description', async () => {
+        const result = setupWithCyrillicOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(3);
+        });
+
+        act(() => {
+          result.current.actions.setSearchText('моск');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(1);
+          expect(result.current.data.operations[0].id).toBe('op-cyr-1');
         });
       });
     });

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1154,6 +1154,27 @@ describe('OperationsDB Service', () => {
       expect(params).not.toContain('%Газ%');
     });
 
+    it('includes parent category JOIN for hierarchy-aware text search', async () => {
+      queryAll.mockResolvedValue([]);
+
+      const filters = { searchText: 'transport' };
+      await OperationsDB.getFilteredOperationsByDateRange('2025-12-01', '2025-12-31', filters);
+
+      const sqlCall = queryAll.mock.calls[0][0];
+      expect(sqlCall).toContain('LEFT JOIN categories c ON o.category_id = c.id');
+      expect(sqlCall).toContain('LEFT JOIN categories pc ON c.parent_id = pc.id');
+    });
+
+    it('parent JOIN is present even without search text (to support future use)', async () => {
+      queryAll.mockResolvedValue([]);
+
+      const filters = { types: ['expense'] };
+      await OperationsDB.getFilteredOperationsByDateRange('2025-12-01', '2025-12-31', filters);
+
+      const sqlCall = queryAll.mock.calls[0][0];
+      expect(sqlCall).toContain('LEFT JOIN categories pc ON c.parent_id = pc.id');
+    });
+
     it('combines all filters correctly', async () => {
       queryAll.mockResolvedValue([]);
 
@@ -1957,6 +1978,28 @@ describe('OperationsDB Service', () => {
 
         const sqlCall = queryAll.mock.calls[0][0];
         expect(sqlCall).toContain('SELECT DISTINCT o.*');
+      });
+
+      it('includes parent category JOIN for hierarchy-aware text search', async () => {
+        queryAll.mockResolvedValue([]);
+
+        const filters = { searchText: 'путешествия' };
+        await OperationsDB.getFilteredOperationsByWeekFromDate('2025-12-05', filters);
+
+        const sqlCall = queryAll.mock.calls[0][0];
+        expect(sqlCall).toContain('LEFT JOIN categories c ON o.category_id = c.id');
+        expect(sqlCall).toContain('LEFT JOIN categories pc ON c.parent_id = pc.id');
+      });
+
+      it('Cyrillic parent category name search passes lowercase term to UNICODE_LOWER', async () => {
+        queryAll.mockResolvedValue([]);
+
+        const filters = { searchText: 'Транспорт' };
+        await OperationsDB.getFilteredOperationsByWeekFromDate('2025-12-05', filters);
+
+        const params = queryAll.mock.calls[0][1];
+        expect(params).toContain('%транспорт%');
+        expect(params).not.toContain('%Транспорт%');
       });
 
       it('orders results by date DESC and created_at DESC', async () => {

--- a/__tests__/services/db.test.js
+++ b/__tests__/services/db.test.js
@@ -224,4 +224,80 @@ describe('Database Service', () => {
       expect(mockDb.closeAsync).toHaveBeenCalled();
     });
   });
+
+  describe('UNICODE_LOWER custom function', () => {
+    it('registers UNICODE_LOWER during database initialization', async () => {
+      await getDatabase();
+
+      expect(mockDb.createFunctionAsync).toHaveBeenCalledWith(
+        'UNICODE_LOWER',
+        { deterministic: true },
+        expect.any(Function),
+      );
+    });
+
+    it('registers UNICODE_LOWER with deterministic: true option', async () => {
+      await getDatabase();
+
+      const [, options] = mockDb.createFunctionAsync.mock.calls[0];
+      expect(options).toEqual({ deterministic: true });
+    });
+
+    it('registers UNICODE_LOWER before first runAsync call', async () => {
+      await getDatabase();
+
+      const createFunctionOrder = mockDb.createFunctionAsync.mock.invocationCallOrder[0];
+      const firstRunAsyncOrder = mockDb.runAsync.mock.invocationCallOrder[0];
+      expect(createFunctionOrder).toBeLessThan(firstRunAsyncOrder);
+    });
+
+    it('UNICODE_LOWER callback returns null for null input', async () => {
+      await getDatabase();
+
+      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      expect(callback(null)).toBeNull();
+    });
+
+    it('UNICODE_LOWER callback returns null for undefined input', async () => {
+      await getDatabase();
+
+      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      expect(callback(undefined)).toBeNull();
+    });
+
+    it('UNICODE_LOWER callback lowercases ASCII text', async () => {
+      await getDatabase();
+
+      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      expect(callback('COFFEE')).toBe('coffee');
+      expect(callback('Grocery')).toBe('grocery');
+      expect(callback('TEST123')).toBe('test123');
+    });
+
+    it('UNICODE_LOWER callback correctly lowercases Cyrillic text', async () => {
+      await getDatabase();
+
+      // SQLite's built-in LOWER() leaves Cyrillic unchanged; this custom function must handle it
+      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      expect(callback('Транспорт')).toBe('транспорт');
+      expect(callback('САМОЛЕТ')).toBe('самолет');
+      expect(callback('Путешествия')).toBe('путешествия');
+    });
+
+    it('UNICODE_LOWER callback lowercases mixed-script and accented text', async () => {
+      await getDatabase();
+
+      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      expect(callback('Café')).toBe('café');
+      expect(callback('München')).toBe('münchen');
+    });
+
+    it('UNICODE_LOWER callback preserves numeric strings', async () => {
+      await getDatabase();
+
+      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      expect(callback('12345')).toBe('12345');
+      expect(callback('3.14')).toBe('3.14');
+    });
+  });
 });


### PR DESCRIPTION
Three bugs fixed:

1. Register UNICODE_LOWER custom SQLite function (db.js)
   SQLite's built-in LOWER() is ASCII-only — Cyrillic characters are
   left unchanged, causing case-insensitive search to silently fail.
   A JS-backed UNICODE_LOWER function is registered at DB open time;
   JS String.prototype.toLowerCase() correctly handles all Unicode.

2. Search parent category names in DB text filter (OperationsDB.js)
   All five filtered-query functions now join the parent category
   (LEFT JOIN categories pc ON c.parent_id = pc.id) and include
   UNICODE_LOWER(pc.name) LIKE ? in the text-search condition.
   This means typing a parent category name finds operations whose
   leaf category is a child of that parent, matching what the
   in-memory filter already did via getCategoryPath.

3. Skip DB reload when only search text changes (OperationsActionsContext.js)
   Previously, every keystroke in the search bar triggered
   loadInitialOperations, which replaced the full lazy-loaded
   operations array with a fresh 7-day DB window. Operations
   outside that window were silently discarded. Text search is now
   handled entirely by the in-memory filteredOperations computation
   (which already uses JS toLowerCase correctly). A DB reload is only
   triggered when structural filters change (account, type, category,
   date, amount). Scrolling to load more weeks still uses the full
   filter including search text.

https://claude.ai/code/session_01AaP2qEuSpjHaGgiR87tNHw