### PR TITLE
fix: replace createFunctionAsync with createCustomFunctionAsync (expo-sqlite 16.x API)

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -5,7 +5,7 @@
 
 import * as OperationsDB from '../../app/services/OperationsDB';
 import * as Currency from '../../app/services/currency';
-import { executeQuery, queryAll, queryFirst, executeTransaction } from '../../app/services/db';
+import { executeQuery, queryAll, queryFirst, executeTransaction, isUnicodeLowerAvailable } from '../../app/services/db';
 
 // Mock dependencies
 jest.mock('../../app/services/db');
@@ -41,6 +41,9 @@ describe('OperationsDB Service', () => {
     Currency.add.mockImplementation((a, b) => String(parseFloat(a) + parseFloat(b)));
     Currency.subtract.mockImplementation((a, b) => String(parseFloat(a) - parseFloat(b)));
     Currency.isZero.mockImplementation((a) => parseFloat(a) === 0);
+
+    // UNICODE_LOWER is available in tests so search SQL uses UNICODE_LOWER(...)
+    isUnicodeLowerAvailable.mockReturnValue(true);
   });
 
   describe('Query Operations', () => {

--- a/__tests__/services/db.test.js
+++ b/__tests__/services/db.test.js
@@ -29,6 +29,7 @@ describe('Database Service', () => {
       getAllAsync: jest.fn(() => Promise.resolve([])),
       closeAsync: jest.fn(() => Promise.resolve()),
       withTransactionAsync: jest.fn((callback) => callback()),
+      createCustomFunctionAsync: jest.fn(() => Promise.resolve()),
       createFunctionAsync: jest.fn(() => Promise.resolve()),
     };
 
@@ -229,24 +230,25 @@ describe('Database Service', () => {
     it('registers UNICODE_LOWER during database initialization', async () => {
       await getDatabase();
 
-      expect(mockDb.createFunctionAsync).toHaveBeenCalledWith(
+      // expo-sqlite 16.x API: createCustomFunctionAsync(name, callback, options)
+      expect(mockDb.createCustomFunctionAsync).toHaveBeenCalledWith(
         'UNICODE_LOWER',
-        { deterministic: true },
         expect.any(Function),
+        { deterministic: true },
       );
     });
 
     it('registers UNICODE_LOWER with deterministic: true option', async () => {
       await getDatabase();
 
-      const [, options] = mockDb.createFunctionAsync.mock.calls[0];
+      const [,, options] = mockDb.createCustomFunctionAsync.mock.calls[0];
       expect(options).toEqual({ deterministic: true });
     });
 
     it('registers UNICODE_LOWER before first runAsync call', async () => {
       await getDatabase();
 
-      const createFunctionOrder = mockDb.createFunctionAsync.mock.invocationCallOrder[0];
+      const createFunctionOrder = mockDb.createCustomFunctionAsync.mock.invocationCallOrder[0];
       const firstRunAsyncOrder = mockDb.runAsync.mock.invocationCallOrder[0];
       expect(createFunctionOrder).toBeLessThan(firstRunAsyncOrder);
     });
@@ -254,21 +256,21 @@ describe('Database Service', () => {
     it('UNICODE_LOWER callback returns null for null input', async () => {
       await getDatabase();
 
-      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback(null)).toBeNull();
     });
 
     it('UNICODE_LOWER callback returns null for undefined input', async () => {
       await getDatabase();
 
-      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback(undefined)).toBeNull();
     });
 
     it('UNICODE_LOWER callback lowercases ASCII text', async () => {
       await getDatabase();
 
-      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback('COFFEE')).toBe('coffee');
       expect(callback('Grocery')).toBe('grocery');
       expect(callback('TEST123')).toBe('test123');
@@ -278,7 +280,7 @@ describe('Database Service', () => {
       await getDatabase();
 
       // SQLite's built-in LOWER() leaves Cyrillic unchanged; this custom function must handle it
-      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback('Транспорт')).toBe('транспорт');
       expect(callback('САМОЛЕТ')).toBe('самолет');
       expect(callback('Путешествия')).toBe('путешествия');
@@ -287,7 +289,7 @@ describe('Database Service', () => {
     it('UNICODE_LOWER callback lowercases mixed-script and accented text', async () => {
       await getDatabase();
 
-      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback('Café')).toBe('café');
       expect(callback('München')).toBe('münchen');
     });
@@ -295,7 +297,7 @@ describe('Database Service', () => {
     it('UNICODE_LOWER callback preserves numeric strings', async () => {
       await getDatabase();
 
-      const callback = mockDb.createFunctionAsync.mock.calls[0][2];
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback('12345')).toBe('12345');
       expect(callback('3.14')).toBe('3.14');
     });

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1,4 +1,8 @@
-import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
+import { executeQuery, queryAll, queryFirst, executeTransaction, isUnicodeLowerAvailable } from './db';
+
+// Returns 'UNICODE_LOWER' when the custom function was registered successfully,
+// otherwise falls back to SQLite's built-in LOWER() (ASCII-only but safe).
+const lowerFn = () => (isUnicodeLowerAvailable() ? 'UNICODE_LOWER' : 'LOWER');
 import * as Currency from './currency';
 import { formatDate, updateTodayBalance } from './BalanceHistoryDB';
 import * as AccountsDB from './AccountsDB';
@@ -247,13 +251,14 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const lower = lowerFn();
       sql += ` AND (
-        UNICODE_LOWER(o.description) LIKE ?
+        ${lower}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR UNICODE_LOWER(a.name) LIKE ?
-        OR UNICODE_LOWER(to_a.name) LIKE ?
-        OR UNICODE_LOWER(c.name) LIKE ?
-        OR UNICODE_LOWER(pc.name) LIKE ?
+        OR ${lower}(a.name) LIKE ?
+        OR ${lower}(to_a.name) LIKE ?
+        OR ${lower}(c.name) LIKE ?
+        OR ${lower}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1194,13 +1199,14 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const lower = lowerFn();
       sql += ` AND (
-        UNICODE_LOWER(o.description) LIKE ?
+        ${lower}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR UNICODE_LOWER(a.name) LIKE ?
-        OR UNICODE_LOWER(to_a.name) LIKE ?
-        OR UNICODE_LOWER(c.name) LIKE ?
-        OR UNICODE_LOWER(pc.name) LIKE ?
+        OR ${lower}(a.name) LIKE ?
+        OR ${lower}(to_a.name) LIKE ?
+        OR ${lower}(c.name) LIKE ?
+        OR ${lower}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1289,13 +1295,14 @@ export const getNextOldestFilteredOperation = async (beforeDate, filters = {}) =
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const lower = lowerFn();
       sql += ` AND (
-        UNICODE_LOWER(o.description) LIKE ?
+        ${lower}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR UNICODE_LOWER(a.name) LIKE ?
-        OR UNICODE_LOWER(to_a.name) LIKE ?
-        OR UNICODE_LOWER(c.name) LIKE ?
-        OR UNICODE_LOWER(pc.name) LIKE ?
+        OR ${lower}(a.name) LIKE ?
+        OR ${lower}(to_a.name) LIKE ?
+        OR ${lower}(c.name) LIKE ?
+        OR ${lower}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1453,13 +1460,14 @@ export const getNextNewestFilteredOperation = async (afterDate, filters = {}) =>
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const lower = lowerFn();
       sql += ` AND (
-        UNICODE_LOWER(o.description) LIKE ?
+        ${lower}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR UNICODE_LOWER(a.name) LIKE ?
-        OR UNICODE_LOWER(to_a.name) LIKE ?
-        OR UNICODE_LOWER(c.name) LIKE ?
-        OR UNICODE_LOWER(pc.name) LIKE ?
+        OR ${lower}(a.name) LIKE ?
+        OR ${lower}(to_a.name) LIKE ?
+        OR ${lower}(c.name) LIKE ?
+        OR ${lower}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1560,13 +1568,14 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
       const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const lower = lowerFn();
       sql += ` AND (
-        UNICODE_LOWER(o.description) LIKE ?
+        ${lower}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR UNICODE_LOWER(a.name) LIKE ?
-        OR UNICODE_LOWER(to_a.name) LIKE ?
-        OR UNICODE_LOWER(c.name) LIKE ?
-        OR UNICODE_LOWER(pc.name) LIKE ?
+        OR ${lower}(a.name) LIKE ?
+        OR ${lower}(to_a.name) LIKE ?
+        OR ${lower}(c.name) LIKE ?
+        OR ${lower}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -9,6 +9,9 @@ const DB_NAME = 'penny.db';
 let dbInstance = null;
 let drizzleInstance = null;
 let initPromise = null;
+let unicodeLowerAvailable = false;
+
+export const isUnicodeLowerAvailable = () => unicodeLowerAvailable;
 
 /**
  * Get or create the database instance
@@ -39,10 +42,24 @@ export const getDatabase = async () => {
       // Register Unicode-aware LOWER function — SQLite's built-in LOWER() only handles ASCII,
       // so Cyrillic (and other non-ASCII) characters are left unchanged. This custom function
       // delegates to JS String.prototype.toLowerCase() which handles all Unicode correctly.
-      await dbInstance.createFunctionAsync('UNICODE_LOWER', { deterministic: true }, (value) => {
+      // expo-sqlite 16.x uses createCustomFunctionAsync(name, callback, options).
+      const unicodeLowerCallback = (value) => {
         if (value == null) return null;
         return String(value).toLowerCase();
-      });
+      };
+      try {
+        if (typeof dbInstance.createCustomFunctionAsync === 'function') {
+          await dbInstance.createCustomFunctionAsync('UNICODE_LOWER', unicodeLowerCallback, { deterministic: true });
+          unicodeLowerAvailable = true;
+        } else if (typeof dbInstance.createFunctionAsync === 'function') {
+          await dbInstance.createFunctionAsync('UNICODE_LOWER', unicodeLowerCallback, { deterministic: true });
+          unicodeLowerAvailable = true;
+        } else {
+          console.warn('UNICODE_LOWER: no custom function API found, Cyrillic search will use LOWER()');
+        }
+      } catch (fnError) {
+        console.warn('UNICODE_LOWER registration failed, Cyrillic search will use LOWER():', fnError.message);
+      }
 
       drizzleInstance = drizzle(dbInstance, { schema });
       console.log('Drizzle instance created');
@@ -55,6 +72,7 @@ export const getDatabase = async () => {
       dbInstance = null;
       drizzleInstance = null;
       initPromise = null;
+      unicodeLowerAvailable = false;
       throw error;
     }
   })();
@@ -335,6 +353,7 @@ export const closeDatabase = async () => {
     } finally {
       dbInstance = null;
       drizzleInstance = null;
+      unicodeLowerAvailable = false;
     }
   }
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -27,6 +27,7 @@ jest.mock('expo-sqlite', () => ({
     getAllAsync: jest.fn(() => Promise.resolve([])),
     closeAsync: jest.fn(() => Promise.resolve()),
     withTransactionAsync: jest.fn((callback) => callback()),
+    createCustomFunctionAsync: jest.fn(() => Promise.resolve()),
     createFunctionAsync: jest.fn(() => Promise.resolve()),
   })),
   openDatabaseSync: jest.fn(() => ({


### PR DESCRIPTION
createFunctionAsync does not exist in expo-sqlite 16.x. Calling it caused
"undefined is not a function" during database initialization, making the
entire app fail to load accounts (and everything else).

Fix:
- Use createCustomFunctionAsync(name, callback, options) — the correct
  expo-sqlite 16.x signature — with createFunctionAsync as a runtime
  fallback for any environment that exposes the old name instead.
- Wrap registration in try/catch so a future API change cannot crash DB init.
- Export isUnicodeLowerAvailable() so search queries can fall back to
  SQLite's built-in LOWER() when the custom function is unavailable,
  preserving full app functionality at the cost of Cyrillic-insensitive
  search in that edge case.
- Update tests to match the corrected method name and argument order.

https://claude.ai/code/session_01VwCk12UZgpCm9SLWpt3iZj