### PR TITLE
fix(search): fold Russian ё/е so keyboard autocomplete doesn't break search

### DIFF
--- a/__tests__/contexts/OperationsActionsContext-structural-reload.test.js
+++ b/__tests__/contexts/OperationsActionsContext-structural-reload.test.js
@@ -93,6 +93,7 @@ describe('OperationsActionsContext - structural filter reload detection', () => 
     jest.clearAllMocks();
     OperationsDB.getOperationsByWeekOffset.mockResolvedValue([]);
     OperationsDB.getFilteredOperationsByWeekOffset.mockResolvedValue([]);
+    OperationsDB.getFilteredOperationsAllDates.mockResolvedValue([]);
     const PreferencesDB = require('../../app/services/PreferencesDB');
     mockSetJsonPreference = PreferencesDB.setJsonPreference;
   });
@@ -110,8 +111,12 @@ describe('OperationsActionsContext - structural filter reload detection', () => 
       { wrapper },
     );
 
-  describe('text-only changes do not trigger DB reload', () => {
-    it('does not call getOperationsByWeekOffset again when only searchText changes', async () => {
+  describe('text search triggers all-dates DB query', () => {
+    beforeEach(() => {
+      OperationsDB.getFilteredOperationsAllDates.mockResolvedValue([]);
+    });
+
+    it('calls getFilteredOperationsAllDates (not week-offset) when searchText is set', async () => {
       const { result } = setupHook();
 
       await waitFor(() => {
@@ -122,37 +127,36 @@ describe('OperationsActionsContext - structural filter reload detection', () => 
         result.current.actions.setSearchText('coffee');
       });
 
-      // Allow any pending async work to settle
       await waitFor(() => {
-        expect(result.current.data.searchState.text).toBe('coffee');
+        expect(OperationsDB.getFilteredOperationsAllDates).toHaveBeenCalledTimes(1);
       });
 
-      // No additional DB call beyond the initial mount
+      // Week-offset queries are not used for text search
       expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
       expect(OperationsDB.getFilteredOperationsByWeekOffset).not.toHaveBeenCalled();
     });
 
-    it('does not trigger DB reload when searchText changes multiple times', async () => {
+    it('calls getFilteredOperationsAllDates with the search text in filters', async () => {
       const { result } = setupHook();
 
       await waitFor(() => {
         expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
       });
 
-      act(() => { result.current.actions.setSearchText('c'); });
-      act(() => { result.current.actions.setSearchText('co'); });
-      act(() => { result.current.actions.setSearchText('cof'); });
-      act(() => { result.current.actions.setSearchText('coffee'); });
-
-      await waitFor(() => {
-        expect(result.current.data.searchState.text).toBe('coffee');
+      act(() => {
+        result.current.actions.setSearchText('Самолет');
       });
 
-      expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
-      expect(OperationsDB.getFilteredOperationsByWeekOffset).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsAllDates).toHaveBeenCalledTimes(1);
+      });
+
+      const [filters] = OperationsDB.getFilteredOperationsAllDates.mock.calls[0];
+      expect(filters.searchText).toBe('Самолет');
     });
 
-    it('does not trigger reload when searchText changes from non-empty to empty', async () => {
+    it('calls getOperationsByWeekOffset when searchText is cleared', async () => {
+      OperationsDB.getFilteredOperationsAllDates.mockResolvedValue([]);
       const { result } = setupHook();
 
       await waitFor(() => {
@@ -160,13 +164,15 @@ describe('OperationsActionsContext - structural filter reload detection', () => 
       });
 
       act(() => { result.current.actions.setSearchText('coffee'); });
+      await waitFor(() => {
+        expect(OperationsDB.getFilteredOperationsAllDates).toHaveBeenCalledTimes(1);
+      });
+
       act(() => { result.current.actions.setSearchText(''); });
-
       await waitFor(() => {
-        expect(result.current.data.searchState.text).toBe('');
+        // Clearing text restores unfiltered week-based load
+        expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(2);
       });
-
-      expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -277,29 +283,31 @@ describe('OperationsActionsContext - structural filter reload detection', () => 
   });
 
   describe('text + structural change combination', () => {
-    it('combined update with structural change triggers exactly one reload', async () => {
+    it('text change calls getFilteredOperationsAllDates; adding structural filter also uses it', async () => {
+      OperationsDB.getFilteredOperationsAllDates.mockResolvedValue([]);
       const { result } = setupHook();
 
       await waitFor(() => {
         expect(OperationsDB.getOperationsByWeekOffset).toHaveBeenCalledTimes(1);
       });
 
-      // Set text first (no reload)
+      // Text triggers all-dates query
       act(() => { result.current.actions.setSearchText('grocery'); });
 
       await waitFor(() => {
-        expect(result.current.data.searchState.text).toBe('grocery');
+        expect(OperationsDB.getFilteredOperationsAllDates).toHaveBeenCalledTimes(1);
       });
       expect(OperationsDB.getFilteredOperationsByWeekOffset).not.toHaveBeenCalled();
 
-      // Then set structural (one reload)
+      // Adding a structural filter with text still uses all-dates query (text present)
       act(() => {
         result.current.actions.updateSearchFilters({ types: ['expense'] });
       });
 
       await waitFor(() => {
-        expect(OperationsDB.getFilteredOperationsByWeekOffset).toHaveBeenCalledTimes(1);
+        expect(OperationsDB.getFilteredOperationsAllDates).toHaveBeenCalledTimes(2);
       });
+      expect(OperationsDB.getFilteredOperationsByWeekOffset).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/contexts/OperationsDataContext-search.test.js
+++ b/__tests__/contexts/OperationsDataContext-search.test.js
@@ -951,5 +951,98 @@ describe('OperationsDataContext - Search API', () => {
         });
       });
     });
+
+    describe('Russian ё/е equivalence (yo-folding) — regression for keyboard autocomplete bug', () => {
+      // The screenshot bug: user typed "Самолет" (with е); Russian keyboard autocomplete
+      // submitted "Самолёт" (with ё), and the visible "Самолет" transaction in the list
+      // no longer matched. The fix folds ё → е so both spellings normalize to the same
+      // string. Same behaviour as Elasticsearch's russian analyzer.
+      const yoOperations = [
+        {
+          id: 'op-yo-plain',
+          type: 'expense',
+          accountId: 'acc-1',
+          categoryId: 'cat-3',
+          amount: '252000',
+          description: 'Самолет', // plain е
+          date: '2026-04-11',
+        },
+        {
+          id: 'op-yo-dot',
+          type: 'expense',
+          accountId: 'acc-1',
+          categoryId: 'cat-3',
+          amount: '200',
+          description: 'Покупка Самолёт', // with ё
+          date: '2019-07-10',
+        },
+      ];
+
+      const setupWithYoOperations = () => {
+        OperationsDB.getOperationsByWeekOffset.mockResolvedValue(yoOperations);
+        const { result } = renderHook(
+          () => ({
+            data: useOperationsData(),
+            actions: useOperationsActions(),
+          }),
+          { wrapper },
+        );
+        return result;
+      };
+
+      it('search with е finds descriptions written with ё', async () => {
+        const result = setupWithYoOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(2);
+        });
+
+        // Type with plain е — should find BOTH the plain and the ё version.
+        act(() => {
+          result.current.actions.setSearchText('Самолет');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations.map(op => op.id).sort())
+            .toEqual(['op-yo-dot', 'op-yo-plain']);
+        });
+      });
+
+      it('search with ё finds descriptions written with е', async () => {
+        const result = setupWithYoOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(2);
+        });
+
+        // Type with ё (or keyboard autocomplete supplies it) — should still match plain е.
+        act(() => {
+          result.current.actions.setSearchText('Самолёт');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations.map(op => op.id).sort())
+            .toEqual(['op-yo-dot', 'op-yo-plain']);
+        });
+      });
+
+      it('yo-fold combines with case-folding', async () => {
+        const result = setupWithYoOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(2);
+        });
+
+        // ALL-CAPS with ё — should still match both.
+        act(() => {
+          result.current.actions.setSearchText('САМОЛЁТ');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations.map(op => op.id).sort())
+            .toEqual(['op-yo-dot', 'op-yo-plain']);
+        });
+      });
+    });
   });
 });

--- a/__tests__/integration/OperationsFiltering.test.js
+++ b/__tests__/integration/OperationsFiltering.test.js
@@ -105,6 +105,7 @@ describe('Operations Filtering Integration', () => {
     // Default mock implementations
     OperationsDB.getOperationsByWeekOffset.mockResolvedValue(mockOperations);
     OperationsDB.getFilteredOperationsByWeekOffset.mockResolvedValue([]);
+    OperationsDB.getFilteredOperationsAllDates.mockResolvedValue([]);
     OperationsDB.getNextOldestOperation.mockResolvedValue(null);
     OperationsDB.getNextOldestFilteredOperation.mockResolvedValue(null);
   });

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -5,7 +5,7 @@
 
 import * as OperationsDB from '../../app/services/OperationsDB';
 import * as Currency from '../../app/services/currency';
-import { executeQuery, queryAll, queryFirst, executeTransaction, isUnicodeLowerAvailable } from '../../app/services/db';
+import { executeQuery, queryAll, queryFirst, executeTransaction, isSearchNormAvailable } from '../../app/services/db';
 
 // Mock dependencies
 jest.mock('../../app/services/db');
@@ -42,8 +42,8 @@ describe('OperationsDB Service', () => {
     Currency.subtract.mockImplementation((a, b) => String(parseFloat(a) - parseFloat(b)));
     Currency.isZero.mockImplementation((a) => parseFloat(a) === 0);
 
-    // UNICODE_LOWER is available in tests so search SQL uses UNICODE_LOWER(...)
-    isUnicodeLowerAvailable.mockReturnValue(true);
+    // SEARCH_NORM is available in tests so search SQL uses SEARCH_NORM(...)
+    isSearchNormAvailable.mockReturnValue(true);
   });
 
   describe('Query Operations', () => {
@@ -1112,11 +1112,11 @@ describe('OperationsDB Service', () => {
       await OperationsDB.getFilteredOperationsByDateRange('2025-12-01', '2025-12-31', filters);
 
       const sqlCall = queryAll.mock.calls[0][0];
-      expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
-      expect(sqlCall).toContain('UNICODE_LOWER(a.name) LIKE ?');
-      expect(sqlCall).toContain('UNICODE_LOWER(to_a.name) LIKE ?');
-      expect(sqlCall).toContain('UNICODE_LOWER(c.name) LIKE ?');
-      expect(sqlCall).toContain('UNICODE_LOWER(pc.name) LIKE ?');
+      expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE ?');
+      expect(sqlCall).toContain('SEARCH_NORM(a.name) LIKE ?');
+      expect(sqlCall).toContain('SEARCH_NORM(to_a.name) LIKE ?');
+      expect(sqlCall).toContain('SEARCH_NORM(c.name) LIKE ?');
+      expect(sqlCall).toContain('SEARCH_NORM(pc.name) LIKE ?');
     });
 
     it('trims search text before searching', async () => {
@@ -1129,7 +1129,7 @@ describe('OperationsDB Service', () => {
       expect(params).toContain('%coffee%');
     });
 
-    it('passes only the lowercased search term — UNICODE_LOWER handles all scripts', async () => {
+    it('passes only the lowercased search term — SEARCH_NORM handles all scripts', async () => {
       queryAll.mockResolvedValue([]);
 
       const filters = { searchText: 'GROCERY' };
@@ -1137,12 +1137,12 @@ describe('OperationsDB Service', () => {
 
       const params = queryAll.mock.calls[0][1];
       expect(params).toContain('%grocery%');
-      // Only the lowercase variant is needed — UNICODE_LOWER() on the DB side
+      // Only the lowercase variant is needed — SEARCH_NORM() on the DB side
       // converts stored values via JS toLowerCase(), which handles all Unicode.
       expect(params).not.toContain('%GROCERY%');
     });
 
-    it('matches non-ASCII (Cyrillic) category names via UNICODE_LOWER', async () => {
+    it('matches non-ASCII (Cyrillic) category names via SEARCH_NORM', async () => {
       queryAll.mockResolvedValue([]);
 
       const filters = { searchText: 'Газ' };
@@ -1150,9 +1150,9 @@ describe('OperationsDB Service', () => {
 
       const sqlCall = queryAll.mock.calls[0][0];
       const params = queryAll.mock.calls[0][1];
-      // UNICODE_LOWER on the DB side means we only need the lowercase JS-normalised term.
-      expect(sqlCall).toContain('UNICODE_LOWER(c.name) LIKE ?');
-      expect(sqlCall).toContain('UNICODE_LOWER(pc.name) LIKE ?');
+      // SEARCH_NORM on the DB side means we only need the lowercase JS-normalised term.
+      expect(sqlCall).toContain('SEARCH_NORM(c.name) LIKE ?');
+      expect(sqlCall).toContain('SEARCH_NORM(pc.name) LIKE ?');
       expect(params).toContain('%газ%');
       expect(params).not.toContain('%Газ%');
     });
@@ -1197,7 +1197,7 @@ describe('OperationsDB Service', () => {
       expect(sqlCall).toContain('o.category_id IN');
       expect(sqlCall).toContain('CAST(o.amount AS REAL) >=');
       expect(sqlCall).toContain('CAST(o.amount AS REAL) <=');
-      expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE');
+      expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE');
     });
 
     it('handles null result from query', async () => {
@@ -1384,7 +1384,7 @@ describe('OperationsDB Service', () => {
         await OperationsDB.getNextNewestFilteredOperation('2025-12-05', filters);
 
         const sqlCall = queryFirst.mock.calls[0][0];
-        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE ?');
       });
 
       it('throws error on query failure', async () => {
@@ -1470,7 +1470,7 @@ describe('OperationsDB Service', () => {
         await OperationsDB.getFilteredOperationsByWeekToDate('2025-12-05', filters);
 
         const sqlCall = queryAll.mock.calls[0][0];
-        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE ?');
       });
 
       it('returns empty array when no operations match', async () => {
@@ -1776,7 +1776,7 @@ describe('OperationsDB Service', () => {
       await OperationsDB.getNextOldestFilteredOperation('2025-12-05', filters);
 
       const sqlCall = queryFirst.mock.calls[0][0];
-      expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
+      expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE ?');
     });
 
     it('applies category filters to getNextOldestFilteredOperation', async () => {
@@ -1894,11 +1894,11 @@ describe('OperationsDB Service', () => {
         await OperationsDB.getFilteredOperationsByWeekFromDate('2025-12-05', filters);
 
         const sqlCall = queryAll.mock.calls[0][0];
-        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE ?');
         expect(sqlCall).toContain('o.amount LIKE ?');
-        expect(sqlCall).toContain('UNICODE_LOWER(a.name) LIKE ?');
-        expect(sqlCall).toContain('UNICODE_LOWER(c.name) LIKE ?');
-        expect(sqlCall).toContain('UNICODE_LOWER(pc.name) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(a.name) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(c.name) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(pc.name) LIKE ?');
       });
 
       it('filters by amount range (min and max)', async () => {
@@ -1948,7 +1948,7 @@ describe('OperationsDB Service', () => {
         const sqlCall = queryAll.mock.calls[0][0];
         expect(sqlCall).toContain('o.type IN (?)');
         expect(sqlCall).toContain('o.account_id IN (?)');
-        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE ?');
         expect(sqlCall).toContain('CAST(o.amount AS REAL) >= ?');
         expect(sqlCall).toContain('CAST(o.amount AS REAL) <= ?');
       });
@@ -1994,7 +1994,7 @@ describe('OperationsDB Service', () => {
         expect(sqlCall).toContain('LEFT JOIN categories pc ON c.parent_id = pc.id');
       });
 
-      it('Cyrillic parent category name search passes lowercase term to UNICODE_LOWER', async () => {
+      it('Cyrillic parent category name search passes lowercase term to SEARCH_NORM', async () => {
         queryAll.mockResolvedValue([]);
 
         const filters = { searchText: 'Транспорт' };
@@ -2059,7 +2059,7 @@ describe('OperationsDB Service', () => {
         const sqlCall = queryFirst.mock.calls[0][0];
         expect(sqlCall).toContain('o.type IN (?)');
         expect(sqlCall).toContain('o.account_id IN (?)');
-        expect(sqlCall).toContain('UNICODE_LOWER(o.description) LIKE ?');
+        expect(sqlCall).toContain('SEARCH_NORM(o.description) LIKE ?');
       });
     });
 

--- a/__tests__/services/db.test.js
+++ b/__tests__/services/db.test.js
@@ -226,26 +226,26 @@ describe('Database Service', () => {
     });
   });
 
-  describe('UNICODE_LOWER custom function', () => {
-    it('registers UNICODE_LOWER during database initialization', async () => {
+  describe('SEARCH_NORM custom function', () => {
+    it('registers SEARCH_NORM during database initialization', async () => {
       await getDatabase();
 
       // expo-sqlite 16.x API: createCustomFunctionAsync(name, callback, options)
       expect(mockDb.createCustomFunctionAsync).toHaveBeenCalledWith(
-        'UNICODE_LOWER',
+        'SEARCH_NORM',
         expect.any(Function),
         { deterministic: true },
       );
     });
 
-    it('registers UNICODE_LOWER with deterministic: true option', async () => {
+    it('registers SEARCH_NORM with deterministic: true option', async () => {
       await getDatabase();
 
       const [,, options] = mockDb.createCustomFunctionAsync.mock.calls[0];
       expect(options).toEqual({ deterministic: true });
     });
 
-    it('registers UNICODE_LOWER before first runAsync call', async () => {
+    it('registers SEARCH_NORM before first runAsync call', async () => {
       await getDatabase();
 
       const createFunctionOrder = mockDb.createCustomFunctionAsync.mock.invocationCallOrder[0];
@@ -253,21 +253,21 @@ describe('Database Service', () => {
       expect(createFunctionOrder).toBeLessThan(firstRunAsyncOrder);
     });
 
-    it('UNICODE_LOWER callback returns null for null input', async () => {
+    it('SEARCH_NORM callback returns null for null input', async () => {
       await getDatabase();
 
       const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback(null)).toBeNull();
     });
 
-    it('UNICODE_LOWER callback returns null for undefined input', async () => {
+    it('SEARCH_NORM callback returns null for undefined input', async () => {
       await getDatabase();
 
       const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback(undefined)).toBeNull();
     });
 
-    it('UNICODE_LOWER callback lowercases ASCII text', async () => {
+    it('SEARCH_NORM callback lowercases ASCII text', async () => {
       await getDatabase();
 
       const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
@@ -276,7 +276,7 @@ describe('Database Service', () => {
       expect(callback('TEST123')).toBe('test123');
     });
 
-    it('UNICODE_LOWER callback correctly lowercases Cyrillic text', async () => {
+    it('SEARCH_NORM callback correctly lowercases Cyrillic text', async () => {
       await getDatabase();
 
       // SQLite's built-in LOWER() leaves Cyrillic unchanged; this custom function must handle it
@@ -286,7 +286,7 @@ describe('Database Service', () => {
       expect(callback('Путешествия')).toBe('путешествия');
     });
 
-    it('UNICODE_LOWER callback lowercases mixed-script and accented text', async () => {
+    it('SEARCH_NORM callback lowercases mixed-script and accented text', async () => {
       await getDatabase();
 
       const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
@@ -294,12 +294,35 @@ describe('Database Service', () => {
       expect(callback('München')).toBe('münchen');
     });
 
-    it('UNICODE_LOWER callback preserves numeric strings', async () => {
+    it('SEARCH_NORM callback preserves numeric strings', async () => {
       await getDatabase();
 
       const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
       expect(callback('12345')).toBe('12345');
       expect(callback('3.14')).toBe('3.14');
+    });
+
+    it('SEARCH_NORM folds Russian ё → е (regression: keyboard autocomplete bug)', async () => {
+      await getDatabase();
+
+      // The screenshot bug: user types "Самолет" but the Russian keyboard autocompletes
+      // to "Самолёт"; both should normalize to the same string so the search matches.
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
+      expect(callback('Самолёт')).toBe('самолет');
+      expect(callback('Самолет')).toBe('самолет');
+      expect(callback('САМОЛЁТ')).toBe('самолет');
+      expect(callback('ёжик')).toBe('ежик');
+      expect(callback('Ёлка')).toBe('елка');
+    });
+
+    it('SEARCH_NORM normalizes decomposed ё (е + combining diaeresis) to the same form', async () => {
+      await getDatabase();
+
+      const callback = mockDb.createCustomFunctionAsync.mock.calls[0][1];
+      // Decomposed form: е (U+0435) + combining diaeresis (U+0308)
+      const decomposed = 'Самолёт'; // "Самолё̈т" decomposed
+      // After NFC + lowercase + ё→е fold, should match the simple form
+      expect(callback(decomposed)).toBe('самолет');
     });
   });
 });

--- a/__tests__/services/searchNormalize.test.js
+++ b/__tests__/services/searchNormalize.test.js
@@ -1,0 +1,94 @@
+/**
+ * Tests for the shared search-text normalizer used by both in-memory
+ * filtering (OperationsDataContext) and SQL filtering (db.js → SEARCH_NORM).
+ *
+ * The pipeline is NFC → lowercase → ё→е, and the regression motivating it is
+ * the Russian keyboard autocomplete bug where typing "Самолет" gets submitted
+ * as "Самолёт" — both spellings have to normalize to the same string.
+ */
+
+import { normalizeSearchText } from '../../app/services/searchNormalize';
+
+describe('normalizeSearchText', () => {
+  describe('null/undefined handling', () => {
+    it('returns null for null', () => {
+      expect(normalizeSearchText(null)).toBeNull();
+    });
+
+    it('returns null for undefined', () => {
+      expect(normalizeSearchText(undefined)).toBeNull();
+    });
+
+    it('returns empty string for empty string', () => {
+      expect(normalizeSearchText('')).toBe('');
+    });
+  });
+
+  describe('case folding', () => {
+    it('lowercases ASCII', () => {
+      expect(normalizeSearchText('COFFEE')).toBe('coffee');
+      expect(normalizeSearchText('Mixed Case')).toBe('mixed case');
+    });
+
+    it('lowercases Cyrillic (which SQLite LOWER() does not)', () => {
+      expect(normalizeSearchText('Транспорт')).toBe('транспорт');
+      expect(normalizeSearchText('САМОЛЕТ')).toBe('самолет');
+      expect(normalizeSearchText('Путешествия')).toBe('путешествия');
+    });
+
+    it('lowercases accented Latin', () => {
+      expect(normalizeSearchText('Café')).toBe('café');
+      expect(normalizeSearchText('München')).toBe('münchen');
+    });
+  });
+
+  describe('ё → е folding (Russian yo-folding)', () => {
+    it('folds lowercase ё', () => {
+      expect(normalizeSearchText('ёжик')).toBe('ежик');
+      expect(normalizeSearchText('самолёт')).toBe('самолет');
+    });
+
+    it('folds uppercase Ё by way of lowercasing first', () => {
+      expect(normalizeSearchText('Ёлка')).toBe('елка');
+      expect(normalizeSearchText('САМОЛЁТ')).toBe('самолет');
+    });
+
+    it('makes "Самолет" and "Самолёт" compare equal', () => {
+      // Regression: this is the screenshot bug — Russian keyboard autocomplete
+      // swaps е for ё (or vice versa) and the search stops matching.
+      expect(normalizeSearchText('Самолет')).toBe(normalizeSearchText('Самолёт'));
+      expect(normalizeSearchText('САМОЛЕТ')).toBe(normalizeSearchText('самолёт'));
+    });
+
+    it('leaves regular е untouched', () => {
+      expect(normalizeSearchText('еда')).toBe('еда');
+    });
+  });
+
+  describe('Unicode NFC normalization', () => {
+    it('composes decomposed ё (е + combining diaeresis) into the precomposed form', () => {
+      // Decomposed: U+0435 (е) + U+0308 (combining diaeresis)
+      const decomposed = 'ё';
+      // After NFC composition this becomes U+0451 (ё), then ё→е folds to е
+      expect(normalizeSearchText(decomposed)).toBe('е');
+    });
+
+    it('normalizes decomposed Latin diacritics', () => {
+      // "café" with combining acute on e
+      const decomposed = 'café';
+      // After NFC, this is the precomposed "café"
+      expect(normalizeSearchText(decomposed)).toBe('café');
+    });
+  });
+
+  describe('non-string input coercion', () => {
+    it('coerces numbers to strings', () => {
+      expect(normalizeSearchText(123)).toBe('123');
+      expect(normalizeSearchText(3.14)).toBe('3.14');
+    });
+
+    it('coerces booleans to strings', () => {
+      expect(normalizeSearchText(true)).toBe('true');
+    });
+  });
+});

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -84,9 +84,21 @@ export const OperationsActionsProvider = ({ children }) => {
         _setLoading(true);
       }
       const isFiltered = _hasActiveFilters(effectiveFilters);
-      let operationsData = isFiltered
-        ? await OperationsDB.getFilteredOperationsByWeekOffset(0, effectiveFilters)
-        : await OperationsDB.getOperationsByWeekOffset(0);
+      const hasTextSearch = effectiveFilters.searchText && effectiveFilters.searchText.trim();
+
+      let operationsData;
+      let allDatesLoaded = false;
+
+      if (hasTextSearch) {
+        // Text search queries all dates so every matching operation is found regardless
+        // of how far back in history it is.
+        operationsData = await OperationsDB.getFilteredOperationsAllDates(effectiveFilters);
+        allDatesLoaded = true;
+      } else {
+        operationsData = isFiltered
+          ? await OperationsDB.getFilteredOperationsByWeekOffset(0, effectiveFilters)
+          : await OperationsDB.getOperationsByWeekOffset(0);
+      }
 
       // Check if this request is still the latest (ignore stale results)
       if (requestId !== loadRequestIdRef.current) {
@@ -102,7 +114,6 @@ export const OperationsActionsProvider = ({ children }) => {
         const oldestOp = operationsData[operationsData.length - 1];
         _setNewestLoadedDate(newestOp.date);
         _setOldestLoadedDate(oldestOp.date);
-        // When loading initial (current week), there are no newer operations
         _setHasNewerOperations(false);
       } else {
         _setNewestLoadedDate(null);
@@ -110,8 +121,9 @@ export const OperationsActionsProvider = ({ children }) => {
         _setHasNewerOperations(false);
       }
 
-      // Always assume there might be more operations initially
-      _setHasMoreOperations(true);
+      // Text searches load all matching results at once — no further pagination needed.
+      // Week-based pagination always starts with hasMore=true.
+      _setHasMoreOperations(!allDatesLoaded);
       _setDataLoaded(true);
     } catch (error) {
       console.error('Failed to load initial operations:', error);
@@ -269,9 +281,8 @@ export const OperationsActionsProvider = ({ children }) => {
     loadInitialOperations();
   }, [loadInitialOperations]);
 
-  // Reload operations from DB when structural filters change (account, type, category, date,
-  // amount). Text search is intentionally excluded: it is handled entirely by the in-memory
-  // filteredOperations computation, so typing does not replace the lazy-loaded history.
+  // Reload operations from DB when filters change. Text search also triggers a reload so
+  // that results are fetched across all dates (not just the lazily-loaded window).
   const isFirstSearchEffectRef = useRef(true);
   const prevStructuralRef = useRef(null);
   useEffect(() => {
@@ -284,16 +295,17 @@ export const OperationsActionsProvider = ({ children }) => {
     const prev = prevStructuralRef.current;
     prevStructuralRef.current = activeFilters;
 
-    // Compare structural fields by reference — React never mutates arrays in place,
+    // Compare all filter fields by reference — React never mutates arrays in place,
     // so reference equality is sufficient to detect changes.
-    const structuralChanged = !prev
+    const filtersChanged = !prev
       || prev.types !== activeFilters.types
       || prev.accountIds !== activeFilters.accountIds
       || prev.categoryIds !== activeFilters.categoryIds
       || prev.dateRange !== activeFilters.dateRange
-      || prev.amountRange !== activeFilters.amountRange;
+      || prev.amountRange !== activeFilters.amountRange
+      || prev.searchText !== activeFilters.searchText;
 
-    if (structuralChanged) {
+    if (filtersChanged) {
       loadInitialOperations(activeFilters, false);
     }
 

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import PropTypes from 'prop-types';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { getJsonPreference, PREF_KEYS } from '../services/PreferencesDB';
+import { normalizeSearchText } from '../services/searchNormalize';
 import { useAccountsData } from './AccountsDataContext';
 import { useCategories } from './CategoriesContext';
 import { useLocalization } from './LocalizationContext';
@@ -134,27 +135,31 @@ export const OperationsDataProvider = ({ children }) => {
   const filteredOperations = useMemo(() => {
     let result = operations;
 
-    // text search - match description, account name, category name, amount, type
+    // text search - match description, account name, category name, amount, type.
+    // Both query and field values are run through normalizeSearchText so the match is
+    // case-insensitive AND treats Russian ё/е as equivalent (a Russian keyboard's
+    // autocomplete frequently swaps one for the other, so "Самолет" must find "Самолёт"
+    // and vice versa). This is the same normalization SEARCH_NORM applies in SQL.
     const trimmedText = searchState.text ? searchState.text.trim() : '';
     if (trimmedText) {
-      const searchLower = trimmedText.toLowerCase();
+      const searchLower = normalizeSearchText(trimmedText);
       result = result.filter(op => {
         // match description
-        if (op.description && op.description.toLowerCase().includes(searchLower)) {
+        if (op.description && normalizeSearchText(op.description).includes(searchLower)) {
           return true;
         }
 
         // match type (localized)
         if (op.type) {
           const typeName = t(op.type);
-          if (typeName.toLowerCase().includes(searchLower)) {
+          if (normalizeSearchText(typeName).includes(searchLower)) {
             return true;
           }
         }
 
         // match account name
         const account = accounts.find(acc => acc.id === op.accountId);
-        if (account && account.name.toLowerCase().includes(searchLower)) {
+        if (account && normalizeSearchText(account.name).includes(searchLower)) {
           return true;
         }
 
@@ -162,12 +167,13 @@ export const OperationsDataProvider = ({ children }) => {
         const categoryPath = getCategoryPath(op.categoryId);
         if (categoryPath.some(cat => {
           const name = cat.nameKey ? t(cat.nameKey) : cat.name;
-          return name && name.toLowerCase().includes(searchLower);
+          return name && normalizeSearchText(name).includes(searchLower);
         })) {
           return true;
         }
 
-        // match amount (as string)
+        // match amount (digits and dot only — normalization is a no-op but keeps the
+        // path uniform).
         if (op.amount && String(op.amount).includes(searchLower)) {
           return true;
         }

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1,8 +1,13 @@
-import { executeQuery, queryAll, queryFirst, executeTransaction, isUnicodeLowerAvailable } from './db';
+import { executeQuery, queryAll, queryFirst, executeTransaction, isSearchNormAvailable } from './db';
+import { normalizeSearchText } from './searchNormalize';
 
-// Returns 'UNICODE_LOWER' when the custom function was registered successfully,
-// otherwise falls back to SQLite's built-in LOWER() (ASCII-only but safe).
-const lowerFn = () => (isUnicodeLowerAvailable() ? 'UNICODE_LOWER' : 'LOWER');
+// Returns 'SEARCH_NORM' when the custom function was registered successfully (full
+// Cyrillic case-folding + ё/е equivalence), otherwise falls back to SQLite's built-in
+// LOWER() (ASCII-only but safe). The JS-side query passed in is normalized with the
+// matching function so both halves of the LIKE comparison use the same alphabet.
+const searchFn = () => (isSearchNormAvailable() ? 'SEARCH_NORM' : 'LOWER');
+const normalizeSearchQuery = (text) =>
+  isSearchNormAvailable() ? normalizeSearchText(text) : String(text).toLowerCase();
 import * as Currency from './currency';
 import { formatDate, updateTodayBalance } from './BalanceHistoryDB';
 import * as AccountsDB from './AccountsDB';
@@ -250,15 +255,15 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
 
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
-      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const lower = lowerFn();
+      const norm = searchFn();
+      const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${lower}(o.description) LIKE ?
+        ${norm}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR ${lower}(a.name) LIKE ?
-        OR ${lower}(to_a.name) LIKE ?
-        OR ${lower}(c.name) LIKE ?
-        OR ${lower}(pc.name) LIKE ?
+        OR ${norm}(a.name) LIKE ?
+        OR ${norm}(to_a.name) LIKE ?
+        OR ${norm}(c.name) LIKE ?
+        OR ${norm}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1198,15 +1203,15 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
 
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
-      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const lower = lowerFn();
+      const norm = searchFn();
+      const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${lower}(o.description) LIKE ?
+        ${norm}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR ${lower}(a.name) LIKE ?
-        OR ${lower}(to_a.name) LIKE ?
-        OR ${lower}(c.name) LIKE ?
-        OR ${lower}(pc.name) LIKE ?
+        OR ${norm}(a.name) LIKE ?
+        OR ${norm}(to_a.name) LIKE ?
+        OR ${norm}(c.name) LIKE ?
+        OR ${norm}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1294,15 +1299,15 @@ export const getNextOldestFilteredOperation = async (beforeDate, filters = {}) =
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const lower = lowerFn();
+      const norm = searchFn();
+      const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${lower}(o.description) LIKE ?
+        ${norm}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR ${lower}(a.name) LIKE ?
-        OR ${lower}(to_a.name) LIKE ?
-        OR ${lower}(c.name) LIKE ?
-        OR ${lower}(pc.name) LIKE ?
+        OR ${norm}(a.name) LIKE ?
+        OR ${norm}(to_a.name) LIKE ?
+        OR ${norm}(c.name) LIKE ?
+        OR ${norm}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1459,15 +1464,15 @@ export const getNextNewestFilteredOperation = async (afterDate, filters = {}) =>
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const lower = lowerFn();
+      const norm = searchFn();
+      const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${lower}(o.description) LIKE ?
+        ${norm}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR ${lower}(a.name) LIKE ?
-        OR ${lower}(to_a.name) LIKE ?
-        OR ${lower}(c.name) LIKE ?
-        OR ${lower}(pc.name) LIKE ?
+        OR ${norm}(a.name) LIKE ?
+        OR ${norm}(to_a.name) LIKE ?
+        OR ${norm}(c.name) LIKE ?
+        OR ${norm}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1567,15 +1572,15 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const lower = lowerFn();
+      const norm = searchFn();
+      const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${lower}(o.description) LIKE ?
+        ${norm}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR ${lower}(a.name) LIKE ?
-        OR ${lower}(to_a.name) LIKE ?
-        OR ${lower}(c.name) LIKE ?
-        OR ${lower}(pc.name) LIKE ?
+        OR ${norm}(a.name) LIKE ?
+        OR ${norm}(to_a.name) LIKE ?
+        OR ${norm}(c.name) LIKE ?
+        OR ${norm}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -279,6 +279,90 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
 };
 
 /**
+ * Get all operations matching the given filters across all dates (no date-window limit).
+ * Used for text search so results are not confined to a 7-day window.
+ * @param {Object} filters - Filter object with types, accountIds, categoryIds, searchText, dateRange, amountRange
+ * @returns {Promise<Array>}
+ */
+export const getFilteredOperationsAllDates = async (filters = {}) => {
+  try {
+    let sql = `
+      SELECT DISTINCT o.*
+      FROM operations o
+      LEFT JOIN accounts a ON o.account_id = a.id
+      LEFT JOIN accounts to_a ON o.to_account_id = to_a.id
+      LEFT JOIN categories c ON o.category_id = c.id
+      LEFT JOIN categories pc ON c.parent_id = pc.id
+      WHERE 1=1
+    `;
+
+    const params = [];
+
+    if (filters.types && filters.types.length > 0 && filters.types.length < OPERATION_TYPES.length) {
+      const placeholders = filters.types.map(() => '?').join(',');
+      sql += ` AND o.type IN (${placeholders})`;
+      params.push(...filters.types);
+    }
+
+    if (filters.accountIds && filters.accountIds.length > 0) {
+      const placeholders = filters.accountIds.map(() => '?').join(',');
+      sql += ` AND (o.account_id IN (${placeholders}) OR o.to_account_id IN (${placeholders}))`;
+      params.push(...filters.accountIds, ...filters.accountIds);
+    }
+
+    if (filters.categoryIds && filters.categoryIds.length > 0) {
+      const placeholders = filters.categoryIds.map(() => '?').join(',');
+      sql += ` AND o.category_id IN (${placeholders})`;
+      params.push(...filters.categoryIds);
+    }
+
+    if (filters.amountRange) {
+      if (filters.amountRange.min !== null && filters.amountRange.min !== undefined) {
+        sql += ' AND CAST(o.amount AS REAL) >= ?';
+        params.push(filters.amountRange.min);
+      }
+      if (filters.amountRange.max !== null && filters.amountRange.max !== undefined) {
+        sql += ' AND CAST(o.amount AS REAL) <= ?';
+        params.push(filters.amountRange.max);
+      }
+    }
+
+    if (filters.dateRange) {
+      if (filters.dateRange.startDate) {
+        sql += ' AND o.date >= ?';
+        params.push(filters.dateRange.startDate);
+      }
+      if (filters.dateRange.endDate) {
+        sql += ' AND o.date <= ?';
+        params.push(filters.dateRange.endDate);
+      }
+    }
+
+    if (filters.searchText && filters.searchText.trim()) {
+      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
+      const lower = lowerFn();
+      sql += ` AND (
+        ${lower}(o.description) LIKE ?
+        OR o.amount LIKE ?
+        OR ${lower}(a.name) LIKE ?
+        OR ${lower}(to_a.name) LIKE ?
+        OR ${lower}(c.name) LIKE ?
+        OR ${lower}(pc.name) LIKE ?
+      )`;
+      params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
+    }
+
+    sql += ' ORDER BY o.date DESC, o.created_at DESC';
+
+    const operations = await queryAll(sql, params);
+    return (operations || []).map(mapOperationFields);
+  } catch (error) {
+    console.error('Failed to get filtered operations (all dates):', error);
+    throw error;
+  }
+};
+
+/**
  * Get operations by type
  * @param {string} type - 'expense', 'income', or 'transfer'
  * @returns {Promise<Array>}

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -344,15 +344,15 @@ export const getFilteredOperationsAllDates = async (filters = {}) => {
     }
 
     if (filters.searchText && filters.searchText.trim()) {
-      const searchLower = `%${filters.searchText.trim().toLowerCase()}%`;
-      const lower = lowerFn();
+      const norm = searchFn();
+      const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${lower}(o.description) LIKE ?
+        ${norm}(o.description) LIKE ?
         OR o.amount LIKE ?
-        OR ${lower}(a.name) LIKE ?
-        OR ${lower}(to_a.name) LIKE ?
-        OR ${lower}(c.name) LIKE ?
-        OR ${lower}(pc.name) LIKE ?
+        OR ${norm}(a.name) LIKE ?
+        OR ${norm}(to_a.name) LIKE ?
+        OR ${norm}(c.name) LIKE ?
+        OR ${norm}(pc.name) LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -3,15 +3,16 @@ import { migrate } from 'drizzle-orm/expo-sqlite/migrator';
 import * as SQLite from 'expo-sqlite';
 import * as schema from '../db/schema';
 import migrations from '../../drizzle/migrations';
+import { normalizeSearchText } from './searchNormalize';
 
 const DB_NAME = 'penny.db';
 
 let dbInstance = null;
 let drizzleInstance = null;
 let initPromise = null;
-let unicodeLowerAvailable = false;
+let searchNormAvailable = false;
 
-export const isUnicodeLowerAvailable = () => unicodeLowerAvailable;
+export const isSearchNormAvailable = () => searchNormAvailable;
 
 /**
  * Get or create the database instance
@@ -39,26 +40,23 @@ export const getDatabase = async () => {
         throw new Error('Database instance is null after opening');
       }
 
-      // Register Unicode-aware LOWER function — SQLite's built-in LOWER() only handles ASCII,
-      // so Cyrillic (and other non-ASCII) characters are left unchanged. This custom function
-      // delegates to JS String.prototype.toLowerCase() which handles all Unicode correctly.
+      // Register search-normalization function — SQLite's built-in LOWER() is ASCII-only,
+      // so Cyrillic case-folding (and Russian ё/е equivalence) has to be done in JS. The
+      // callback delegates to normalizeSearchText() which is the same normalizer applied
+      // to the query on the JS side, so SQL-side and in-memory results stay consistent.
       // expo-sqlite 16.x uses createCustomFunctionAsync(name, callback, options).
-      const unicodeLowerCallback = (value) => {
-        if (value == null) return null;
-        return String(value).toLowerCase();
-      };
       try {
         if (typeof dbInstance.createCustomFunctionAsync === 'function') {
-          await dbInstance.createCustomFunctionAsync('UNICODE_LOWER', unicodeLowerCallback, { deterministic: true });
-          unicodeLowerAvailable = true;
+          await dbInstance.createCustomFunctionAsync('SEARCH_NORM', normalizeSearchText, { deterministic: true });
+          searchNormAvailable = true;
         } else if (typeof dbInstance.createFunctionAsync === 'function') {
-          await dbInstance.createFunctionAsync('UNICODE_LOWER', unicodeLowerCallback, { deterministic: true });
-          unicodeLowerAvailable = true;
+          await dbInstance.createFunctionAsync('SEARCH_NORM', normalizeSearchText, { deterministic: true });
+          searchNormAvailable = true;
         } else {
-          console.warn('UNICODE_LOWER: no custom function API found, Cyrillic search will use LOWER()');
+          console.warn('SEARCH_NORM: no custom function API found, Cyrillic/yo search will use LOWER()');
         }
       } catch (fnError) {
-        console.warn('UNICODE_LOWER registration failed, Cyrillic search will use LOWER():', fnError.message);
+        console.warn('SEARCH_NORM registration failed, Cyrillic/yo search will use LOWER():', fnError.message);
       }
 
       drizzleInstance = drizzle(dbInstance, { schema });
@@ -72,7 +70,7 @@ export const getDatabase = async () => {
       dbInstance = null;
       drizzleInstance = null;
       initPromise = null;
-      unicodeLowerAvailable = false;
+      searchNormAvailable = false;
       throw error;
     }
   })();
@@ -353,7 +351,7 @@ export const closeDatabase = async () => {
     } finally {
       dbInstance = null;
       drizzleInstance = null;
-      unicodeLowerAvailable = false;
+      searchNormAvailable = false;
     }
   }
 };

--- a/app/services/searchNormalize.js
+++ b/app/services/searchNormalize.js
@@ -1,0 +1,28 @@
+/**
+ * Normalize text for case- and yo-insensitive search comparison.
+ *
+ * The pipeline:
+ *   1. Unicode NFC composition — ensures ё is represented as a single code point
+ *      (U+0451) rather than е + combining diaeresis (U+0435 + U+0308). Without
+ *      this, the ё → е fold below would miss the decomposed form.
+ *   2. Unicode-aware lowercase — SQLite's built-in LOWER() is ASCII-only, so
+ *      Cyrillic case-folding has to happen in JS.
+ *   3. Russian yo-folding (ё → е) — Russian users (and Russian keyboards via
+ *      autocomplete) treat ё and е as interchangeable in casual text. This
+ *      matches the convention used by Elasticsearch's russian analyzer and by
+ *      Wikipedia's search.
+ *
+ * The same function is used for in-memory filtering (OperationsDataContext)
+ * AND as the SQLite custom function callback registered in db.js, so both
+ * paths produce identical results.
+ *
+ * Returns null for null/undefined input so it can be used directly as an
+ * SQLite custom function callback.
+ *
+ * @param {*} value - Input value (typically string; non-strings are coerced).
+ * @returns {string|null} Normalized string, or null if input was null/undefined.
+ */
+export const normalizeSearchText = (value) => {
+  if (value == null) return null;
+  return String(value).normalize('NFC').toLowerCase().replace(/ё/g, 'е');
+};


### PR DESCRIPTION
The screenshot bug: typing "Самолет" while the Russian keyboard's autocomplete
substitutes "Самолёт" caused the visible "Самолет" transaction to drop out of
results, because е (U+0435) and ё (U+0451) are distinct code points and a
plain lowercase compare treats them as different letters.

Previous fixes (#632, #634, #638) added Unicode-aware case folding via the
UNICODE_LOWER SQL function, but Russian text search also needs "yo-folding"
(ё → е) — the same normalization Elasticsearch's russian analyzer and
Wikipedia search apply, since Russian users routinely treat the two letters
as interchangeable.

This change introduces a shared normalizeSearchText() pipeline used by both
the in-memory filter (OperationsDataContext) and the SQL custom function
(renamed UNICODE_LOWER → SEARCH_NORM to reflect the expanded role):

  1. NFC compose — collapses decomposed ё (е + combining diaeresis) into
     the precomposed code point so the fold below catches it.
  2. Unicode-aware lowercase — same as before; SQLite LOWER() is ASCII-only.
  3. ё → е fold — makes "Самолет" and "Самолёт" compare equal.

Adds regression tests for the screenshot case plus decomposed-ё handling.