### PR TITLE
fix(transfer): fix race condition in multi-currency destination amount on save

### DIFF
--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -1174,6 +1174,117 @@ describe('useOperationForm', () => {
     });
   });
 
+  describe('Regression: destinationAmount race condition (issue #587)', () => {
+    it('should use user-entered destinationAmount when lastEditedField is destinationAmount (multi-currency transfer)', async () => {
+      // Race condition: user edits destinationAmount but saves before the back-calc useEffect
+      // runs. prepareOperationData must not overwrite the user-entered value with amount × stale rate.
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: null, source: 'none' });
+      mockAddOperation.mockResolvedValue();
+
+      const { result } = renderHook(() => useOperationForm(defaultProps));
+
+      await waitFor(() => expect(result.current.values.accountId).toBeTruthy());
+
+      await act(async () => {
+        result.current.setValues(prev => ({
+          ...prev,
+          type: 'transfer',
+          accountId: 'acc-1',
+          toAccountId: 'acc-2',
+          amount: '100',
+          exchangeRate: '0.85',
+          destinationAmount: '90', // user overrode the auto-calculated 85
+        }));
+        result.current.setLastEditedField('destinationAmount');
+      });
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+
+      expect(mockAddOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          destinationAmount: '90',
+          // rate should be back-calculated: 90/100 = 0.9
+          exchangeRate: '0.900000',
+        }),
+      );
+    });
+
+    it('should still forward-calculate destinationAmount when lastEditedField is amount (multi-currency transfer)', async () => {
+      // Existing forward-calc behaviour must not regress.
+      Currency.convertAmount.mockReturnValue('170.00');
+      mockAddOperation.mockResolvedValue();
+
+      const { result } = renderHook(() => useOperationForm(defaultProps));
+
+      await waitFor(() => expect(result.current.values.accountId).toBeTruthy());
+
+      await act(async () => {
+        result.current.setValues(prev => ({
+          ...prev,
+          type: 'transfer',
+          accountId: 'acc-1',
+          toAccountId: 'acc-2',
+          amount: '200',
+          exchangeRate: '0.85',
+          destinationAmount: '85', // stale value from previous state
+        }));
+        result.current.setLastEditedField('amount');
+      });
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+
+      expect(Currency.convertAmount).toHaveBeenCalledWith('200', 'USD', 'EUR', '0.85');
+      expect(mockAddOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ destinationAmount: '170.00' }),
+      );
+    });
+
+    it('should use user-entered destinationAmount when lastEditedField is destinationAmount (foreign currency op)', async () => {
+      // Same race condition for foreign currency expense/income.
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: null, source: 'none' });
+      mockAddOperation.mockResolvedValue();
+
+      const { result } = renderHook(() => useOperationForm(defaultProps));
+
+      await waitFor(() => expect(result.current.values.accountId).toBeTruthy());
+
+      // Form model for foreign currency op: amount=foreign, destinationAmount=account currency.
+      await act(async () => {
+        result.current.setValues(prev => ({
+          ...prev,
+          type: 'expense',
+          accountId: 'acc-1',
+          categoryId: 'cat-1',
+          date: '2024-01-15',
+          operationCurrency: 'EUR',
+          amount: '100',       // EUR (foreign)
+          exchangeRate: '1.08', // EUR→USD
+          destinationAmount: '105', // user overrode the auto-calculated 108
+        }));
+        result.current.setLastEditedField('destinationAmount');
+      });
+
+      await act(async () => {
+        await result.current.handleSave();
+      });
+
+      // DB model swaps: amount=account(USD), destinationAmount=foreign(EUR).
+      // back-calc rate EUR→USD: 105/100 = 1.05; inverted to USD→EUR: 1/1.05 ≈ 0.952381
+      expect(mockAddOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: '105',       // account currency (USD) — swapped
+          destinationAmount: '100', // foreign currency (EUR) — swapped
+          sourceCurrency: 'EUR',
+          destinationCurrency: 'USD',
+        }),
+      );
+    });
+  });
+
   describe('Foreign Currency Expense/Income', () => {
     const foreignCurrencyExpense = {
       id: 'op-fx',

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -351,9 +351,17 @@ const useOperationForm = ({
     if (isMultiCurrencyTransfer && sourceAccount && destinationAccount) {
       data.sourceCurrency = sourceAccount.currency;
       data.destinationCurrency = destinationAccount.currency;
-      // Recompute synchronously so a save before the async useEffect resolves
-      // never stores a destinationAmount that is inconsistent with amount × rate.
-      if (data.amount && data.exchangeRate) {
+      if (lastEditedField === 'destinationAmount' && data.amount && data.destinationAmount) {
+        // User edited destination amount directly; back-calculate the rate synchronously
+        // so the saved record is self-consistent even if the useEffect hasn't run yet.
+        const srcAmt = parseFloat(data.amount);
+        const dstAmt = parseFloat(data.destinationAmount);
+        if (!isNaN(srcAmt) && !isNaN(dstAmt) && srcAmt > 0) {
+          data.exchangeRate = String((dstAmt / srcAmt).toFixed(6));
+        }
+      } else if (data.amount && data.exchangeRate) {
+        // Recompute synchronously so a save before the async useEffect resolves
+        // never stores a destinationAmount that is inconsistent with amount × rate.
         const recomputed = Currency.convertAmount(
           data.amount,
           sourceAccount.currency,
@@ -365,9 +373,17 @@ const useOperationForm = ({
     } else if (isForeignCurrencyOp && sourceAccount && values.operationCurrency) {
       data.sourceCurrency = values.operationCurrency;
       data.destinationCurrency = sourceAccount.currency;
-      // Recompute destinationAmount (account currency) from foreign amount × rate
-      // before the swap so stale form state is never persisted.
-      if (data.amount && data.exchangeRate) {
+      if (lastEditedField === 'destinationAmount' && data.amount && data.destinationAmount) {
+        // User edited the account-currency destination amount directly; back-calculate rate
+        // synchronously so the saved record is self-consistent even if the useEffect hasn't run.
+        const srcAmt = parseFloat(data.amount);       // foreign currency
+        const dstAmt = parseFloat(data.destinationAmount);  // account currency
+        if (!isNaN(srcAmt) && !isNaN(dstAmt) && srcAmt > 0) {
+          data.exchangeRate = String((dstAmt / srcAmt).toFixed(6));  // foreign→account
+        }
+      } else if (data.amount && data.exchangeRate) {
+        // Recompute destinationAmount (account currency) from foreign amount × rate
+        // before the swap so stale form state is never persisted.
         const recomputed = Currency.convertAmount(
           data.amount,
           values.operationCurrency,
@@ -406,7 +422,7 @@ const useOperationForm = ({
     }
 
     return data;
-  }, [values, isMultiCurrencyTransfer, isForeignCurrencyOp, sourceAccount, destinationAccount, isNew, operation]);
+  }, [values, isMultiCurrencyTransfer, isForeignCurrencyOp, sourceAccount, destinationAccount, isNew, operation, lastEditedField]);
 
   // Save operation (add or update)
   const handleSave = useCallback(async () => {


### PR DESCRIPTION
When a user directly edits the destination amount in a multi-currency
transfer (or foreign currency expense), the back-calculation of the
exchange rate happens asynchronously in a useEffect. If the user saves
before that effect runs, prepareOperationData would overwrite the
user-entered destinationAmount by recomputing it from amount × stale rate.

Fix: when lastEditedField === 'destinationAmount', back-calculate the rate
synchronously in prepareOperationData instead of forward-calculating the
destination amount, ensuring the persisted record always matches what the
user entered. Also adds lastEditedField to the useCallback dependency array
so the closure is never stale.

Fixes #587

https://claude.ai/code/session_017psAyDRHuY8FjT6C3wkfwV