### PR TITLE
Fix 3 critical issues: float precision, balance corruption, backup enum injection

### DIFF
--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -65,6 +65,7 @@ export const operations = sqliteTable('operations', {
   destinationAmount: text('destination_amount'),
   sourceCurrency: text('source_currency'),
   destinationCurrency: text('destination_currency'),
+  originalBalance: text('original_balance'),
 }, (table) => ({
   dateIdx: index('idx_operations_date').on(table.date),
   accountIdx: index('idx_operations_account').on(table.accountId),

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -412,8 +412,8 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
         throw new Error(`Account ${accountId} not found`);
       }
 
-      const currentBalance = parseFloat(account.balance);
-      const targetBalance = parseFloat(newBalance);
+      const currentBalanceStr = account.balance || '0';
+      const targetBalanceStr = String(newBalance) || '0';
 
       // Check if there's already an adjustment operation for today
       const today = new Date().toISOString().split('T')[0];
@@ -428,42 +428,47 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
         [accountId, today],
       );
 
-      let originalBalance;
+      let originalBalanceStr;
       let adjustmentHistory = [];
 
       if (existingOperation) {
-        // Parse the existing description to extract original balance and history
-        const descMatch = existingOperation.description?.match(/from\s+([\d.]+)/);
-        originalBalance = descMatch ? parseFloat(descMatch[1]) : currentBalance;
+        // Prefer the stored original_balance column; fall back to parsing description
+        // (negative numbers included via [-\d.] group for older records)
+        if (existingOperation.original_balance != null) {
+          originalBalanceStr = existingOperation.original_balance;
+        } else {
+          const descMatch = existingOperation.description?.match(/from\s+(-?[\d.]+)/);
+          originalBalanceStr = descMatch ? descMatch[1] : currentBalanceStr;
+        }
 
         // Extract adjustment history from description
-        const historyMatch = existingOperation.description?.match(/→\s*([\d.\s→]+)$/);
+        const historyMatch = existingOperation.description?.match(/→\s*([-\d.\s→]+)$/);
         if (historyMatch) {
-          adjustmentHistory = historyMatch[1].split('→').map(v => v.trim());
+          adjustmentHistory = historyMatch[1].split('→').map(v => v.trim()).filter(Boolean);
         }
       } else {
         // First adjustment of the day - current balance is the original
-        originalBalance = currentBalance;
+        originalBalanceStr = currentBalanceStr;
       }
 
-      // Add current balance to history if it's different from the last entry
+      // Add current balance to history if it differs from the last recorded entry
       const lastHistoryValue = adjustmentHistory.length > 0
-        ? parseFloat(adjustmentHistory[adjustmentHistory.length - 1])
-        : originalBalance;
+        ? adjustmentHistory[adjustmentHistory.length - 1]
+        : originalBalanceStr;
 
-      if (Math.abs(currentBalance - lastHistoryValue) > 0.0001) {
-        adjustmentHistory.push(currentBalance.toFixed(2));
+      if (Currency.compare(currentBalanceStr, lastHistoryValue) !== 0) {
+        adjustmentHistory.push(Currency.formatAmount(currentBalanceStr));
       }
 
       // Add target balance to history
-      adjustmentHistory.push(targetBalance.toFixed(2));
+      adjustmentHistory.push(Currency.formatAmount(targetBalanceStr));
 
-      // Calculate total adjustment from original balance
-      const totalDelta = targetBalance - originalBalance;
-      const absoluteDelta = Math.abs(totalDelta);
+      // Calculate total cumulative adjustment from original balance (precise)
+      const totalDeltaStr = Currency.subtract(targetBalanceStr, originalBalanceStr);
+      const absoluteDeltaStr = Currency.abs(totalDeltaStr);
 
       // Determine operation type based on cumulative delta
-      const operationType = totalDelta < 0 ? 'expense' : 'income';
+      const operationType = Currency.isNegative(totalDeltaStr) ? 'expense' : 'income';
 
       // Get shadow categories
       const shadowCategories = await db.getAllAsync(
@@ -487,24 +492,25 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
 
       // Build description with adjustment history
       const historyString = adjustmentHistory.join(' → ');
+      const originalFormatted = Currency.formatAmount(originalBalanceStr);
       const fullDescription = description
-        ? `${description}\nBalance adjusted from ${originalBalance.toFixed(2)} → ${historyString}`
-        : `Balance adjusted from ${originalBalance.toFixed(2)} → ${historyString}`;
+        ? `${description}\nBalance adjusted from ${originalFormatted} → ${historyString}`
+        : `Balance adjusted from ${originalFormatted} → ${historyString}`;
 
       if (existingOperation) {
         // Check if total delta is 0 - if so, delete the operation
-        if (Math.abs(totalDelta) < 0.0001) {
+        if (Currency.isZero(totalDeltaStr)) {
           console.log('Cumulative delta is 0, deleting adjustment operation:', existingOperation.id);
 
-          // Calculate balance adjustment needed - reverse the old operation's effect
-          const oldAmount = parseFloat(existingOperation.amount);
+          // Reverse the old operation's effect on balance
+          const oldAmountStr = existingOperation.amount || '0';
           const oldType = existingOperation.type;
-          let balanceAdjustment = 0;
+          let balanceAdjustmentStr = '0';
 
           if (oldType === 'expense') {
-            balanceAdjustment += oldAmount; // Add back the expense
+            balanceAdjustmentStr = oldAmountStr; // add back the expense
           } else if (oldType === 'income') {
-            balanceAdjustment -= oldAmount; // Remove the income
+            balanceAdjustmentStr = Currency.subtract('0', oldAmountStr); // remove the income
           }
 
           // Delete the operation
@@ -512,7 +518,7 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
           console.log('Adjustment operation deleted successfully');
 
           // Update account balance
-          const newBalanceValue = Currency.add(currentBalance, balanceAdjustment);
+          const newBalanceValue = Currency.add(currentBalanceStr, balanceAdjustmentStr);
           await db.runAsync(
             'UPDATE accounts SET balance = ?, updated_at = ? WHERE id = ?',
             [newBalanceValue, new Date().toISOString(), accountId],
@@ -521,35 +527,33 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
           // Update today's balance history
           await BalanceHistoryDB.updateTodayBalance(accountId, newBalanceValue, db);
         } else {
-          // Update existing operation
+          // Update existing operation (preserve original_balance from first creation)
           console.log('Updating existing adjustment operation:', existingOperation.id);
           await db.runAsync(
             'UPDATE operations SET type = ?, amount = ?, category_id = ?, description = ? WHERE id = ?',
-            [operationType, absoluteDelta.toFixed(2), categoryId, fullDescription, existingOperation.id],
+            [operationType, absoluteDeltaStr, categoryId, fullDescription, existingOperation.id],
           );
           console.log('Adjustment operation updated successfully');
 
-          // Calculate balance adjustment needed
-          // First, reverse the old operation's effect on balance
-          const oldAmount = parseFloat(existingOperation.amount);
+          // Reverse old operation's effect, then apply new effect
+          const oldAmountStr = existingOperation.amount || '0';
           const oldType = existingOperation.type;
-          let balanceAdjustment = 0;
+          let balanceAdjustmentStr = '0';
 
           if (oldType === 'expense') {
-            balanceAdjustment += oldAmount; // Add back the expense
+            balanceAdjustmentStr = oldAmountStr; // add back the expense
           } else if (oldType === 'income') {
-            balanceAdjustment -= oldAmount; // Remove the income
+            balanceAdjustmentStr = Currency.subtract('0', oldAmountStr); // remove the income
           }
 
-          // Then apply the new operation's effect
           if (operationType === 'expense') {
-            balanceAdjustment -= absoluteDelta;
+            balanceAdjustmentStr = Currency.subtract(balanceAdjustmentStr, absoluteDeltaStr);
           } else if (operationType === 'income') {
-            balanceAdjustment += absoluteDelta;
+            balanceAdjustmentStr = Currency.add(balanceAdjustmentStr, absoluteDeltaStr);
           }
 
           // Update account balance
-          const newBalanceValue = Currency.add(currentBalance, balanceAdjustment);
+          const newBalanceValue = Currency.add(currentBalanceStr, balanceAdjustmentStr);
           await db.runAsync(
             'UPDATE accounts SET balance = ?, updated_at = ? WHERE id = ?',
             [newBalanceValue, new Date().toISOString(), accountId],
@@ -559,33 +563,36 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
           await BalanceHistoryDB.updateTodayBalance(accountId, newBalanceValue, db);
         }
       } else {
-        // Create new adjustment operation
+        // Create new adjustment operation, recording original_balance in its own column
         console.log('Creating new adjustment operation:', {
           type: operationType,
-          amount: absoluteDelta.toFixed(2),
+          amount: absoluteDeltaStr,
           categoryId,
           date: today,
         });
 
         const result = await db.runAsync(
-          'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+          'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, original_balance) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
           [
             operationType,
-            absoluteDelta.toFixed(2),
+            absoluteDeltaStr,
             accountId,
             categoryId,
             null,
             today,
             new Date().toISOString(),
             fullDescription,
+            originalBalanceStr,
           ],
         );
         const newOperationId = result.lastInsertRowId;
         console.log('Adjustment operation created successfully with ID:', newOperationId);
 
-        // Update account balance based on operation type
-        const delta = operationType === 'expense' ? -absoluteDelta : absoluteDelta;
-        const newBalanceValue = Currency.add(currentBalance, delta);
+        // Apply delta to account balance
+        const deltaStr = operationType === 'expense'
+          ? Currency.subtract('0', absoluteDeltaStr)
+          : absoluteDeltaStr;
+        const newBalanceValue = Currency.add(currentBalanceStr, deltaStr);
 
         await db.runAsync(
           'UPDATE accounts SET balance = ?, updated_at = ? WHERE id = ?',

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -260,8 +260,15 @@ export const exportBackup = async (format = 'json') => {
   }
 };
 
+const VALID_OPERATION_TYPES = ['expense', 'income', 'transfer'];
+const VALID_CATEGORY_TYPES = ['folder', 'entry'];
+const VALID_CATEGORY_KINDS = ['expense', 'income'];
+const VALID_BUDGET_PERIODS = ['weekly', 'monthly', 'yearly'];
+
 /**
- * Validate backup data structure
+ * Validate backup data structure and enum fields.
+ * Throws on structural errors; rows with invalid enum values are flagged so
+ * the caller can skip them rather than poisoning the database.
  * @param {Object} backup - Backup object to validate
  * @returns {boolean} True if valid, throws error if invalid
  */
@@ -290,6 +297,55 @@ const validateBackup = (backup) => {
     if (!Array.isArray(backup.data[table])) {
       throw new Error(`Invalid backup format: missing or invalid ${table} data`);
     }
+  }
+
+  // Validate enum fields across all rows — collect all violations before throwing
+  const errors = [];
+
+  for (let i = 0; i < backup.data.operations.length; i++) {
+    const op = backup.data.operations[i];
+    const t = op.type || 'expense';
+    if (!VALID_OPERATION_TYPES.includes(t)) {
+      errors.push(`operations[${i}] has invalid type "${t}"`);
+    }
+  }
+
+  for (let i = 0; i < backup.data.categories.length; i++) {
+    const cat = backup.data.categories[i];
+    const t = cat.type || 'folder';
+    const k = cat.category_type || 'expense';
+    if (!VALID_CATEGORY_TYPES.includes(t)) {
+      errors.push(`categories[${i}] has invalid type "${t}"`);
+    }
+    if (!VALID_CATEGORY_KINDS.includes(k)) {
+      errors.push(`categories[${i}] has invalid category_type "${k}"`);
+    }
+  }
+
+  if (Array.isArray(backup.data.budgets)) {
+    for (let i = 0; i < backup.data.budgets.length; i++) {
+      const b = backup.data.budgets[i];
+      const p = b.period_type || 'monthly';
+      if (!VALID_BUDGET_PERIODS.includes(p)) {
+        errors.push(`budgets[${i}] has invalid period_type "${p}"`);
+      }
+    }
+  }
+
+  if (Array.isArray(backup.data.planned_operations)) {
+    for (let i = 0; i < backup.data.planned_operations.length; i++) {
+      const po = backup.data.planned_operations[i];
+      const t = po.type || 'expense';
+      if (!VALID_OPERATION_TYPES.includes(t)) {
+        errors.push(`planned_operations[${i}] has invalid type "${t}"`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Backup contains invalid enum values:\n${errors.join('\n')}`,
+    );
   }
 
   return true;
@@ -409,13 +465,15 @@ export const restoreBackup = async (backup) => {
           continue;
         }
 
+        const catType = VALID_CATEGORY_TYPES.includes(category.type) ? category.type : 'folder';
+        const catKind = VALID_CATEGORY_KINDS.includes(category.category_type) ? category.category_type : 'expense';
         await db.runAsync(
           'INSERT INTO categories (id, name, type, category_type, parent_id, icon, color, is_shadow, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
           [
             category.id,
             category.name,
-            category.type || 'folder',
-            category.category_type || 'expense',
+            catType,
+            catKind,
             category.parent_id || null,
             category.icon || null,
             category.color || null,
@@ -461,10 +519,11 @@ export const restoreBackup = async (backup) => {
         }
 
         // Note: id is omitted as it's now auto-increment integer
+        const opType = VALID_OPERATION_TYPES.includes(operation.type) ? operation.type : 'expense';
         await db.runAsync(
           'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
           [
-            operation.type || 'expense',
+            opType,
             operation.amount || '0',
             mappedAccountId,
             operation.category_id || null,
@@ -536,6 +595,7 @@ export const restoreBackup = async (backup) => {
             continue;
           }
 
+          const budgetPeriod = VALID_BUDGET_PERIODS.includes(budget.period_type) ? budget.period_type : 'monthly';
           await db.runAsync(
             'INSERT INTO budgets (id, category_id, amount, currency, period_type, start_date, end_date, is_recurring, rollover_enabled, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
@@ -543,7 +603,7 @@ export const restoreBackup = async (backup) => {
               budget.category_id,
               budget.amount,
               budget.currency,
-              budget.period_type || 'monthly',
+              budgetPeriod,
               budget.start_date || new Date().toISOString(),
               budget.end_date || null,
               budget.is_recurring ?? 1,
@@ -625,12 +685,13 @@ export const restoreBackup = async (backup) => {
             mappedToAccountId = accountIdMapping.get(planned.to_account_id) ?? planned.to_account_id;
           }
 
+          const plannedType = VALID_OPERATION_TYPES.includes(planned.type) ? planned.type : 'expense';
           await db.runAsync(
             'INSERT INTO planned_operations (id, name, type, amount, account_id, category_id, to_account_id, description, is_recurring, last_executed_month, display_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
               planned.id,
               planned.name,
-              planned.type || 'expense',
+              plannedType,
               planned.amount || '0',
               mappedAccountId,
               planned.category_id || null,

--- a/drizzle/0006_add_original_balance.js
+++ b/drizzle/0006_add_original_balance.js
@@ -1,0 +1,12 @@
+/**
+ * Migration 0006: Add original_balance column to operations table
+ *
+ * Stores the account balance before the first balance adjustment on a given
+ * day directly as a column, instead of encoding it in the description string.
+ * This prevents data corruption when users edit the description field and
+ * fixes handling of negative balances (the old regex only matched digits).
+ */
+
+const sql = `ALTER TABLE \`operations\` ADD COLUMN \`original_balance\` text;`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1766000000000,
       "tag": "0005_planned_operations",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1747267200000,
+      "tag": "0006_add_original_balance",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -7,6 +7,7 @@ import m0002 from './0002_illegal_apocalypse.js';
 import m0003, { postMigration as m0003PostMigration } from './0003_slow_grandmaster.js';
 import m0004 from './0004_remove_exclude_from_forecast.js';
 import m0005 from './0005_planned_operations.js';
+import m0006 from './0006_add_original_balance.js';
 
 export default {
   journal,
@@ -17,6 +18,7 @@ export default {
     m0003,
     m0004,
     m0005,
+    m0006,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,


### PR DESCRIPTION
Issue #585: Replace all parseFloat() in adjustAccountBalance with Currency
(Decimal.js) operations. Removes hardcoded epsilon 0.0001, uses
Currency.compare/isZero/isNegative/abs/formatAmount throughout so
high-decimal currencies (Bitcoin, JPY) are handled correctly.

Issue #586: Add original_balance column to operations table (migration 0006)
so adjustment operations record the pre-adjustment balance in a dedicated
column rather than encoding it in the description string. Removes the
fragile /from\s+([\d.]+)/ regex (which silently dropped negative balances)
in favour of the column, with a corrected /-?[\d.]+/ regex as fallback for
older records.

Issue #589: validateBackup() now checks every row's enum fields before any
data is written. Invalid operation.type, categories.type/category_type,
budgets.period_type, or planned_operations.type causes the entire restore to
be rejected with a descriptive error. Secondary INSERT-level guards clamp
values to safe defaults for defence-in-depth.

https://claude.ai/code/session_01LyGqkThBEBnE5GziNQwTZa