### PR TITLE
fix: rewrite parseCSV to handle multiline quoted values

### DIFF
--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -798,6 +798,36 @@ op-1,"Mom's ""special"" food"`;
       expect(backup.data.operations[0].description).toBe('Mom\'s "special" food');
     });
 
+    it('parses CSV with multiline quoted values (regression #590)', async () => {
+      const csvContent = `# Money Tracker Backup
+# Version: 1
+
+[OPERATIONS]
+id,description
+op-1,"line one
+line two"
+op-2,normal`;
+
+      mockDocumentPicker.getDocumentAsync.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file:///mock/backup.csv', name: 'backup.csv' }],
+      });
+
+      mockFileSystem.readAsStringAsync.mockResolvedValue(csvContent);
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback({
+          runAsync: jest.fn().mockImplementation(() => Promise.resolve({ lastInsertRowId: Math.floor(Math.random() * 1000) })),
+          getAllAsync: jest.fn().mockResolvedValue([]),
+        });
+      });
+
+      const backup = await BackupRestore.importBackup();
+
+      expect(backup.data.operations).toHaveLength(2);
+      expect(backup.data.operations[0].description).toBe('line one\nline two');
+      expect(backup.data.operations[1].description).toBe('normal');
+    });
+
     it('handles empty CSV sections', async () => {
       const csvContent = `# Money Tracker Backup
 # Version: 1

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -791,42 +791,72 @@ export const restoreBackup = async (backup) => {
  * @returns {Array} Array of objects
  */
 const parseCSV = (csvContent) => {
-  const lines = csvContent.trim().split('\n');
-  if (lines.length === 0) return [];
+  const content = csvContent.trim();
+  if (!content) return [];
 
-  const headers = lines[0].split(',').map(h => h.trim());
-  const data = [];
+  // Parse the entire content character-by-character so that quoted fields
+  // containing newlines are treated as a single value rather than split into
+  // separate rows (the pre-split-by-newline approach broke multiline values).
+  const rows = [];
+  let currentRow = [];
+  let currentValue = '';
+  let insideQuotes = false;
+  let i = 0;
 
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.trim()) continue;
+  while (i < content.length) {
+    const char = content[i];
 
-    const values = [];
-    let currentValue = '';
-    let insideQuotes = false;
-
-    // Parse CSV considering quoted values
-    for (let j = 0; j < line.length; j++) {
-      const char = line[j];
-      const nextChar = line[j + 1];
-
+    if (insideQuotes) {
       if (char === '"') {
-        if (insideQuotes && nextChar === '"') {
+        if (content[i + 1] === '"') {
           currentValue += '"';
-          j++; // Skip next quote
+          i += 2;
         } else {
-          insideQuotes = !insideQuotes;
+          insideQuotes = false;
+          i++;
         }
-      } else if (char === ',' && !insideQuotes) {
-        values.push(currentValue);
-        currentValue = '';
       } else {
         currentValue += char;
+        i++;
+      }
+    } else {
+      if (char === '"') {
+        insideQuotes = true;
+        i++;
+      } else if (char === ',') {
+        currentRow.push(currentValue);
+        currentValue = '';
+        i++;
+      } else if (char === '\r' || char === '\n') {
+        currentRow.push(currentValue);
+        currentValue = '';
+        rows.push(currentRow);
+        currentRow = [];
+        i++;
+        // Consume the \n of a \r\n pair
+        if (char === '\r' && content[i] === '\n') i++;
+      } else {
+        currentValue += char;
+        i++;
       }
     }
-    values.push(currentValue); // Add last value
+  }
 
-    // Create object from headers and values
+  // Flush the final field and row
+  currentRow.push(currentValue);
+  if (currentRow.some(v => v.trim() !== '')) {
+    rows.push(currentRow);
+  }
+
+  if (rows.length === 0) return [];
+
+  const headers = rows[0].map(h => h.trim());
+  const data = [];
+
+  for (let r = 1; r < rows.length; r++) {
+    const values = rows[r];
+    if (values.every(v => v.trim() === '')) continue;
+
     const obj = {};
     headers.forEach((header, index) => {
       const value = values[index]?.trim() || '';


### PR DESCRIPTION
Pre-splitting the entire CSV content by newline before parsing quoted
fields caused descriptions containing embedded newlines to be split
across rows, breaking the round-trip for CSV export/import.

Rewrites parseCSV to scan the content character-by-character, treating
newlines inside double-quoted fields as part of the value rather than
as record terminators. Adds a regression test for the multiline case.

Fixes #590