### PR TITLE
Remove unused expo-secure-store dependency

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -759,13 +759,6 @@ jest.mock('expo-web-browser', () => ({
   openBrowserAsync: jest.fn(),
 }));
 
-// Mock expo-secure-store
-jest.mock('expo-secure-store', () => ({
-  getItemAsync: jest.fn(),
-  setItemAsync: jest.fn(),
-  deleteItemAsync: jest.fn(),
-}));
-
 // Mock expo-local-authentication
 jest.mock('expo-local-authentication', () => ({
   hasHardwareAsync: jest.fn(() => Promise.resolve(true)),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "expo-file-system": "^19.0.21",
     "expo-intent-launcher": "~13.0.8",
     "expo-local-authentication": "~17.0.8",
-    "expo-secure-store": "~15.0.8",
     "expo-sharing": "~14.0.8",
     "expo-sqlite": "~16.0.10",
     "expo-updates": "~29.0.15",


### PR DESCRIPTION
expo-secure-store was listed in package.json but never imported anywhere in the
app source. Removing it reduces bundle size and attack surface (fixes #594).
Also removes the corresponding dead jest.setup.js mock.

https://claude.ai/code/session_01TYWmUUzH7mm3v6EKjNAoQH