### PR TITLE
fix: check if update APK was already downloaded before re-downloading

### DIFF
--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -4,6 +4,7 @@ import {
   extractApkAsset,
   checkForAppUpdate,
   cleanupOldApks,
+  checkAlreadyDownloaded,
 } from '../../app/services/AppUpdateService';
 
 jest.mock('expo-file-system/legacy', () => ({
@@ -145,6 +146,75 @@ describe('AppUpdateService', () => {
 
     it('returns null when no apk assets exist', () => {
       expect(extractApkAsset([{ name: 'archive.zip', browser_download_url: 'https://example.com/archive.zip' }])).toBeNull();
+    });
+  });
+
+  describe('checkAlreadyDownloaded', () => {
+    it('returns local URI when APK file exists and has content', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345678 });
+
+      const uri = await checkAlreadyDownloaded(
+        'https://github.com/heywood8/money-tracker/releases/download/v1.2.3/penny-v1.2.3.apk',
+        'file:///cache/',
+      );
+
+      expect(uri).toBe('file:///cache/penny-v1.2.3.apk');
+      expect(FileSystem.getInfoAsync).toHaveBeenCalledWith('file:///cache/penny-v1.2.3.apk');
+    });
+
+    it('returns null when APK file does not exist', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: false, size: 0 });
+
+      const uri = await checkAlreadyDownloaded(
+        'https://github.com/heywood8/money-tracker/releases/download/v1.2.3/penny-v1.2.3.apk',
+        'file:///cache/',
+      );
+
+      expect(uri).toBeNull();
+    });
+
+    it('returns null when file exists but has zero size (incomplete download)', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 0 });
+
+      const uri = await checkAlreadyDownloaded(
+        'https://github.com/heywood8/money-tracker/releases/download/v1.2.3/penny-v1.2.3.apk',
+        'file:///cache/',
+      );
+
+      expect(uri).toBeNull();
+    });
+
+    it('returns null when download URL has no APK filename', async () => {
+      const uri = await checkAlreadyDownloaded(
+        'https://github.com/heywood8/money-tracker/releases/tag/v1.2.3',
+        'file:///cache/',
+      );
+
+      expect(uri).toBeNull();
+      expect(FileSystem.getInfoAsync).not.toHaveBeenCalled();
+    });
+
+    it('returns null when getInfoAsync throws', async () => {
+      FileSystem.getInfoAsync.mockRejectedValue(new Error('filesystem error'));
+
+      const uri = await checkAlreadyDownloaded(
+        'https://github.com/heywood8/money-tracker/releases/download/v1.2.3/penny-v1.2.3.apk',
+        'file:///cache/',
+      );
+
+      expect(uri).toBeNull();
+    });
+
+    it('strips query params from URL when building local path', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 5000000 });
+
+      const uri = await checkAlreadyDownloaded(
+        'https://example.com/penny-v1.2.3.apk?sig=abc123',
+        'file:///cache/',
+      );
+
+      expect(FileSystem.getInfoAsync).toHaveBeenCalledWith('file:///cache/penny-v1.2.3.apk');
+      expect(uri).toBe('file:///cache/penny-v1.2.3.apk');
     });
   });
 

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -15,7 +15,7 @@ import { useLogEntries } from '../hooks/useLogEntries';
 import { File, Paths } from 'expo-file-system';
 import * as LegacyFileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
-import { checkForAppUpdate, listDownloadedApks, installApk } from '../services/AppUpdateService';
+import { checkForAppUpdate, listDownloadedApks, installApk, checkAlreadyDownloaded } from '../services/AppUpdateService';
 import { getPreference, setPreference, PREF_KEYS } from '../services/PreferencesDB';
 import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
@@ -561,12 +561,15 @@ export default function SettingsModal({ visible, onClose }) {
       } else if (!result.isUpdateAvailable) {
         setUpdateResult({ type: 'up_to_date' });
       } else {
+        const alreadyDownloadedUri = await checkAlreadyDownloaded(result.downloadUrl);
         setUpdateResult({
           type: 'available',
           latestVersion: result.latestVersion,
           currentVersion: result.currentVersion,
           downloadUrl: result.downloadUrl,
           releaseNotes: result.releaseNotes || null,
+          alreadyDownloaded: !!alreadyDownloadedUri,
+          localUri: alreadyDownloadedUri,
         });
       }
     } catch (error) {
@@ -1380,22 +1383,28 @@ export default function SettingsModal({ visible, onClose }) {
                               <TouchableRipple
                                 onPress={async () => {
                                   await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, updateResult.latestVersion);
-                                  closeSubPanel();
-                                  onClose();
-                                  startDownload(updateResult.downloadUrl, {
-                                    onError: () => {
-                                      showDialog(
-                                        t('error') || 'Error',
-                                        t('update_download_failed') || 'Could not download the update. Please try again.',
-                                        [{ text: t('ok') || 'OK' }],
-                                      );
-                                    },
-                                  });
+                                  if (updateResult.alreadyDownloaded) {
+                                    await handleInstallApk(updateResult.localUri);
+                                  } else {
+                                    closeSubPanel();
+                                    onClose();
+                                    startDownload(updateResult.downloadUrl, {
+                                      onError: () => {
+                                        showDialog(
+                                          t('error') || 'Error',
+                                          t('update_download_failed') || 'Could not download the update. Please try again.',
+                                          [{ text: t('ok') || 'OK' }],
+                                        );
+                                      },
+                                    });
+                                  }
                                 }}
                                 style={[styles.updateButtonCompact, { backgroundColor: colors.primary }]}
                               >
                                 <Text style={styles.importConfirmButtonText}>
-                                  {t('update_now') || 'Update now'}
+                                  {updateResult.alreadyDownloaded
+                                    ? (t('update_install_now') || 'Install now')
+                                    : (t('update_now') || 'Update now')}
                                 </Text>
                               </TouchableRipple>
                             </View>

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -261,6 +261,18 @@ export const listDownloadedApks = async (cacheDir = FileSystem.cacheDirectory) =
   }
 };
 
+export const checkAlreadyDownloaded = async (downloadUrl, cacheDir = FileSystem.cacheDirectory) => {
+  const filename = (downloadUrl.split('/').pop().split('?')[0]) || null;
+  if (!filename || !filename.toLowerCase().endsWith('.apk')) return null;
+  const localUri = `${cacheDir}${filename}`;
+  try {
+    const info = await FileSystem.getInfoAsync(localUri);
+    return (info.exists && info.size > 0) ? localUri : null;
+  } catch {
+    return null;
+  }
+};
+
 export const installApk = async (localUri) => {
   const contentUri = await FileSystem.getContentUriAsync(localUri);
   await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -377,6 +377,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Jetzt installieren",
   "downloaded_apks": "Heruntergeladene APKs",
   "later": "Later",
   "local_backups": "Lokale Backups",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -380,6 +380,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Install now",
   "downloaded_apks": "Downloaded APKs",
   "later": "Later",
   "local_backups": "Local Backups",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -377,6 +377,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Instalar ahora",
   "downloaded_apks": "APKs descargados",
   "later": "Later",
   "local_backups": "Copias de seguridad locales",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -377,6 +377,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Installer maintenant",
   "downloaded_apks": "APKs téléchargés",
   "later": "Later",
   "local_backups": "Sauvegardes locales",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -363,6 +363,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Տեղադրել հիմա",
   "downloaded_apks": "Ներբեռնված APK-ներ",
   "later": "Later",
   "local_backups": "Տեղական կրկնօրինակներ",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -112,6 +112,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Installa ora",
   "downloaded_apks": "APK scaricati",
   "later": "Later",
   "local_backups": "Backup locali",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -377,6 +377,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "今すぐインストール",
   "downloaded_apks": "ダウンロード済みAPK",
   "later": "Later",
   "local_backups": "Local Backups",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -377,6 +377,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "지금 설치",
   "downloaded_apks": "다운로드된 APK",
   "later": "Later",
   "local_backups": "Local Backups",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -377,6 +377,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Instalar agora",
   "downloaded_apks": "APKs baixados",
   "later": "Later",
   "local_backups": "Local Backups",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -375,6 +375,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "Установить сейчас",
   "downloaded_apks": "Загруженные APK",
   "later": "Later",
   "local_backups": "Локальные резервные копии",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -377,6 +377,7 @@
   "update_available_message": "A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.",
   "update_install_hint": "If installation is blocked, allow \"Install unknown apps\" for your browser or file manager in Android settings.",
   "update_now": "Update now",
+  "update_install_now": "立即安装",
   "downloaded_apks": "已下载 APK",
   "later": "Later",
   "local_backups": "本地备份",


### PR DESCRIPTION
When "Check for updates" finds a newer version, checkAlreadyDownloaded()
looks up the cache directory for an APK matching the download URL filename.
If found and non-empty, updateResult carries alreadyDownloaded=true and
localUri, so the action button shows "Install now" and triggers direct
installation instead of a fresh download.

Also adds update_install_now i18n key (11 languages) and tests for
checkAlreadyDownloaded (file exists, missing, zero-size, no-apk-url,
error, query-string stripping).

https://claude.ai/code/session_01Bh53gzdNWmqxZaGezZ7yqk