### PR TITLE
fix: rewrite getAllPreferences to use queryAll instead of deprecated WebSQL API

### DIFF
--- a/__tests__/services/PreferencesDB.test.js
+++ b/__tests__/services/PreferencesDB.test.js
@@ -15,12 +15,13 @@ import {
   deletePreference,
   getAllPreferences,
 } from '../../app/services/PreferencesDB';
-import { queryFirst, executeQuery } from '../../app/services/db';
+import { queryFirst, executeQuery, queryAll } from '../../app/services/db';
 
 // Mock the database module
 jest.mock('../../app/services/db', () => ({
   queryFirst: jest.fn(),
   executeQuery: jest.fn(),
+  queryAll: jest.fn(),
 }));
 
 describe('PreferencesDB', () => {
@@ -396,16 +397,10 @@ describe('PreferencesDB', () => {
 
   describe('getAllPreferences', () => {
     it('returns all preferences as object', async () => {
-      const mockRows = {
-        rows: {
-          length: 2,
-          item: (i) => [
-            { key: 'theme', value: 'dark' },
-            { key: 'language', value: 'en' },
-          ][i],
-        },
-      };
-      executeQuery.mockResolvedValue(mockRows);
+      queryAll.mockResolvedValue([
+        { key: 'theme', value: 'dark' },
+        { key: 'language', value: 'en' },
+      ]);
 
       const result = await getAllPreferences();
 
@@ -413,32 +408,11 @@ describe('PreferencesDB', () => {
         theme: 'dark',
         language: 'en',
       });
+      expect(queryAll).toHaveBeenCalledWith('SELECT key, value FROM app_metadata');
     });
 
     it('returns empty object when no preferences exist', async () => {
-      const mockRows = {
-        rows: {
-          length: 0,
-          item: () => null,
-        },
-      };
-      executeQuery.mockResolvedValue(mockRows);
-
-      const result = await getAllPreferences();
-
-      expect(result).toEqual({});
-    });
-
-    it('returns empty object when results is null', async () => {
-      executeQuery.mockResolvedValue(null);
-
-      const result = await getAllPreferences();
-
-      expect(result).toEqual({});
-    });
-
-    it('returns empty object when results.rows is undefined', async () => {
-      executeQuery.mockResolvedValue({});
+      queryAll.mockResolvedValue([]);
 
       const result = await getAllPreferences();
 
@@ -446,7 +420,7 @@ describe('PreferencesDB', () => {
     });
 
     it('returns empty object when database query fails', async () => {
-      executeQuery.mockRejectedValue(new Error('Query failed'));
+      queryAll.mockRejectedValue(new Error('Query failed'));
 
       const result = await getAllPreferences();
 
@@ -454,7 +428,7 @@ describe('PreferencesDB', () => {
     });
 
     it('logs error when query fails', async () => {
-      executeQuery.mockRejectedValue(new Error('Query error'));
+      queryAll.mockRejectedValue(new Error('Query error'));
 
       await getAllPreferences();
 
@@ -469,13 +443,7 @@ describe('PreferencesDB', () => {
       for (let i = 0; i < 10; i++) {
         prefs.push({ key: `key_${i}`, value: `value_${i}` });
       }
-      const mockRows = {
-        rows: {
-          length: prefs.length,
-          item: (i) => prefs[i],
-        },
-      };
-      executeQuery.mockResolvedValue(mockRows);
+      queryAll.mockResolvedValue(prefs);
 
       const result = await getAllPreferences();
 

--- a/app/services/PreferencesDB.js
+++ b/app/services/PreferencesDB.js
@@ -1,4 +1,4 @@
-import { queryFirst, executeQuery } from './db';
+import { queryFirst, executeQuery, queryAll } from './db';
 
 // Preference keys
 export const PREF_KEYS = {
@@ -123,13 +123,10 @@ export const deletePreference = async (key) => {
  */
 export const getAllPreferences = async () => {
   try {
-    const results = await executeQuery('SELECT key, value FROM app_metadata');
+    const rows = await queryAll('SELECT key, value FROM app_metadata');
     const preferences = {};
-    if (results && results.rows) {
-      for (let i = 0; i < results.rows.length; i++) {
-        const row = results.rows.item(i);
-        preferences[row.key] = row.value;
-      }
+    for (const row of rows) {
+      preferences[row.key] = row.value;
     }
     return preferences;
   } catch (error) {


### PR DESCRIPTION
executeQuery wraps runAsync (write-only) and returns no rows. getAllPreferences
was iterating results.rows.item(i) — a WebSQL pattern that never worked with the
modern expo-sqlite driver — so the function always silently returned {}.

Switch to queryAll (getAllAsync) and iterate the returned array directly.
Update tests to mock queryAll with plain arrays instead of the old rows.item()
pattern.

Fixes #597