### PR TITLE
fix: use NestableScrollContainer so account drag-to-reorder works

### DIFF
--- a/__tests__/screens/AccountsScreen.test.js
+++ b/__tests__/screens/AccountsScreen.test.js
@@ -39,10 +39,13 @@ jest.mock('react-native-paper', () => {
 
 jest.mock('react-native-draggable-flatlist', () => {
   const React = require('react');
-  const { FlatList } = require('react-native');
+  const { FlatList, ScrollView } = require('react-native');
+  const Draggable = (props) => React.createElement(FlatList, props);
   return {
     __esModule: true,
-    default: (props) => React.createElement(FlatList, props),
+    default: Draggable,
+    NestableDraggableFlatList: Draggable,
+    NestableScrollContainer: (props) => React.createElement(ScrollView, props),
   };
 });
 

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -1,13 +1,13 @@
 import React, { useState, useCallback, useMemo, memo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, ScrollView, Keyboard, FlatList, TouchableOpacity, Pressable, Animated, Dimensions } from 'react-native';
+import { View, StyleSheet, Keyboard, FlatList, TouchableOpacity, Pressable, Animated, Dimensions } from 'react-native';
 import ModalShell from '../components/ModalShell';
 import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
 import { Text, TextInput as PaperTextInput, Button, Portal, Modal, TouchableRipple, Switch } from 'react-native-paper';
 import AddFAB from '../components/AddFAB';
 import LoadingView from '../components/LoadingView';
 import EmptyState from '../components/EmptyState';
-import DraggableFlatList from 'react-native-draggable-flatlist';
+import { NestableScrollContainer, NestableDraggableFlatList } from 'react-native-draggable-flatlist';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 
 import { useThemeConfig } from '../contexts/ThemeConfigContext';
@@ -761,7 +761,7 @@ export default function AccountsScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <ScrollView
+      <NestableScrollContainer
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
@@ -775,13 +775,12 @@ export default function AccountsScreen() {
           {enhancedAccounts.length === 0 ? (
             <EmptyState icon="bank-outline" message={t('no_accounts') || 'No accounts yet.'} />
           ) : (
-            <DraggableFlatList
+            <NestableDraggableFlatList
               data={enhancedAccounts}
               renderItem={renderItem}
               keyExtractor={keyExtractor}
               onDragEnd={handleDragEnd}
               activationDistance={20}
-              scrollEnabled={false}
               ItemSeparatorComponent={renderItemSeparator}
             />
           )}
@@ -808,7 +807,7 @@ export default function AccountsScreen() {
             </View>
           </Pressable>
         )}
-      </ScrollView>
+      </NestableScrollContainer>
 
       <AddFAB
         testID="accounts-add-fab"

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -638,10 +638,13 @@ jest.mock('react-native-safe-area-context', () => {
 // Mock react-native-draggable-flatlist
 jest.mock('react-native-draggable-flatlist', () => {
   const React = require('react');
-  const { FlatList } = require('react-native');
+  const { FlatList, ScrollView } = require('react-native');
+  const Draggable = (props) => React.createElement(FlatList, props);
   return {
     __esModule: true,
-    default: (props) => React.createElement(FlatList, props),
+    default: Draggable,
+    NestableDraggableFlatList: Draggable,
+    NestableScrollContainer: (props) => React.createElement(ScrollView, props),
   };
 });
 


### PR DESCRIPTION
DraggableFlatList was nested inside a regular ScrollView, which intercepted
the pan gestures and prevented long-press-and-drag from tracking finger
movement. Switch to NestableScrollContainer + NestableDraggableFlatList,
the pair the library provides for this exact case.