### PR TITLE
fix: replace new Function() with safe expression parser in calculatorUtils

### DIFF
--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -39,6 +39,7 @@ jest.mock('../../app/services/currency', () => ({
   formatAmount: jest.fn((amount) => String(amount)),
   subtract: jest.fn((a, b) => String(parseFloat(a) - parseFloat(b))),
   fetchLiveExchangeRate: jest.fn().mockResolvedValue({ rate: null, source: 'none' }),
+  getDecimalPlaces: jest.fn(() => 2),
 }));
 
 jest.mock('../../app/utils/categoryUtils', () => ({

--- a/__tests__/utils/calculatorUtils.test.js
+++ b/__tests__/utils/calculatorUtils.test.js
@@ -88,6 +88,29 @@ describe('calculatorUtils', () => {
     });
   });
 
+  describe('currency-aware rounding (decimalDigits parameter)', () => {
+    it('rounds to 0 decimal places for zero-decimal currencies (JPY, KRW, AMD)', () => {
+      expect(evaluateExpression('100÷3', 0)).toBe('33');
+      expect(evaluateExpression('50.75+0', 0)).toBe('51');
+      expect(evaluateExpression('10÷3', 0)).toBe('3');
+    });
+
+    it('rounds to 2 decimal places by default', () => {
+      expect(evaluateExpression('10÷3')).toBe('3.33');
+      expect(evaluateExpression('10÷3', 2)).toBe('3.33');
+    });
+
+    it('rounds to 8 decimal places for high-precision currencies', () => {
+      expect(evaluateExpression('1÷3', 8)).toBe('0.33333333');
+      expect(evaluateExpression('0.00000001+0.00000001', 8)).toBe('0.00000002');
+    });
+
+    it('does not add trailing zeros when fewer decimals are needed', () => {
+      expect(evaluateExpression('7÷2', 2)).toBe('3.5');
+      expect(evaluateExpression('10+5', 2)).toBe('15');
+    });
+  });
+
   describe('Regression Tests', () => {
     it('should evaluate expression before saving operation', () => {
       // Simulate user entering "10+5" and clicking category

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -138,7 +138,7 @@ const OperationFormFields = memo(({
     let numericAmount = values.amount;
     if (!numericAmount) return null;
     if (checkHasOperation(numericAmount)) {
-      const ev = evaluateExpression(numericAmount);
+      const ev = evaluateExpression(numericAmount, Currency.getDecimalPlaces(values.operationCurrency));
       if (ev !== null) numericAmount = String(ev);
       else return null;
     }

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -429,7 +429,7 @@ const useOperationForm = ({
     // Automatically evaluate any pending math operation before saving
     let finalAmount = values.amount;
     if (hasOperation(values.amount)) {
-      const evaluated = evaluateExpression(values.amount);
+      const evaluated = evaluateExpression(values.amount, Currency.getDecimalPlaces(sourceAccount?.currency));
       if (evaluated !== null) {
         finalAmount = evaluated;
       }

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -246,7 +246,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     let finalAmount = values.amount;
 
     if (hasOperation(values.amount)) {
-      const evaluated = evaluateExpression(values.amount);
+      const evaluated = evaluateExpression(values.amount, Currency.getDecimalPlaces(sourceAccount?.currency));
       if (evaluated !== null) {
         finalAmount = evaluated;
       }

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -386,7 +386,7 @@ const OperationsScreen = () => {
     let finalAmount = quickAddValues.amount;
 
     if (hasOperation(finalAmount)) {
-      const evaluated = evaluateExpression(finalAmount);
+      const evaluated = evaluateExpression(finalAmount, Currency.getDecimalPlaces(sourceAccount?.currency));
       if (evaluated !== null) {
         finalAmount = evaluated;
       }

--- a/app/utils/calculatorUtils.js
+++ b/app/utils/calculatorUtils.js
@@ -1,45 +1,108 @@
-/**
- * Utility functions for calculator operations
- */
+import Decimal from 'decimal.js';
 
-/**
- * Check if a string contains a mathematical operation
- * @param {string} expr - Expression to check
- * @returns {boolean} True if expression contains +, -, ×, or ÷
- */
 export function hasOperation(expr) {
   if (!expr || typeof expr !== 'string') return false;
   return /[+\-×÷]/.test(expr);
 }
 
-/**
- * Evaluate a mathematical expression
- * @param {string} expr - Expression to evaluate (e.g., "10+5", "100-20")
- * @returns {string|null} Evaluated result as string, or null if invalid
- */
-export function evaluateExpression(expr) {
+function tokenize(expr) {
+  const tokens = [];
+  let i = 0;
+  while (i < expr.length) {
+    if (expr[i] === ' ') { i++; continue; }
+    if (/[\d.]/.test(expr[i])) {
+      let num = '';
+      while (i < expr.length && /[\d.]/.test(expr[i])) num += expr[i++];
+      tokens.push({ type: 'number', value: num });
+    } else if (['+', '-', '*', '/', '(', ')'].includes(expr[i])) {
+      tokens.push({ type: 'op', value: expr[i++] });
+    } else {
+      throw new Error('Invalid character: ' + expr[i]);
+    }
+  }
+  return tokens;
+}
+
+class ExprParser {
+  constructor(tokens) {
+    this.tokens = tokens;
+    this.pos = 0;
+  }
+
+  peek() { return this.tokens[this.pos]; }
+  consume() { return this.tokens[this.pos++]; }
+
+  parse() {
+    if (this.tokens.length === 0) throw new Error('Empty expression');
+    const result = this.addSub();
+    if (this.pos < this.tokens.length) throw new Error('Unexpected token');
+    return result;
+  }
+
+  addSub() {
+    let left = this.mulDiv();
+    while (this.peek()?.value === '+' || this.peek()?.value === '-') {
+      const op = this.consume().value;
+      const right = this.mulDiv();
+      left = op === '+' ? left.plus(right) : left.minus(right);
+    }
+    return left;
+  }
+
+  mulDiv() {
+    let left = this.unary();
+    while (this.peek()?.value === '*' || this.peek()?.value === '/') {
+      const op = this.consume().value;
+      const right = this.unary();
+      if (op === '/' && right.isZero()) throw new Error('Division by zero');
+      left = op === '*' ? left.times(right) : left.dividedBy(right);
+    }
+    return left;
+  }
+
+  unary() {
+    if (this.peek()?.value === '-') {
+      this.consume();
+      return this.primary().negated();
+    }
+    if (this.peek()?.value === '+') {
+      this.consume();
+    }
+    return this.primary();
+  }
+
+  primary() {
+    const token = this.peek();
+    if (!token) throw new Error('Unexpected end of expression');
+    if (token.type === 'number') {
+      this.consume();
+      return new Decimal(token.value);
+    }
+    if (token.value === '(') {
+      this.consume();
+      const result = this.addSub();
+      if (this.peek()?.value !== ')') throw new Error('Missing closing parenthesis');
+      this.consume();
+      return result;
+    }
+    throw new Error('Unexpected token: ' + token.value);
+  }
+}
+
+function stripTrailingZeros(str) {
+  if (!str.includes('.')) return str;
+  return str.replace(/\.?0+$/, '');
+}
+
+export function evaluateExpression(expr, decimalDigits = 2) {
   if (!expr || expr.trim() === '') return null;
-
   try {
-    // Replace '×' with '*' for multiplication and '÷' with '/' for division
-    let sanitized = expr.replace(/×/g, '*').replace(/÷/g, '/');
-
-    // Validate expression (only allow numbers, operators, and decimal points)
-    if (!/^[0-9+\-*/.() ]+$/.test(sanitized)) {
-      return null;
-    }
-
-    // Use Function constructor to safely evaluate (no access to external scope)
-    // Note: This is safer than eval() but still requires validation above
-    const result = Function('"use strict"; return (' + sanitized + ')')();
-
-    if (isNaN(result) || !isFinite(result)) {
-      return null;
-    }
-
-    // Round to 2 decimal places to avoid floating point issues
-    return String(Math.round(result * 100) / 100);
-  } catch (error) {
+    const sanitized = expr.replace(/×/g, '*').replace(/÷/g, '/');
+    const tokens = tokenize(sanitized);
+    const result = new ExprParser(tokens).parse();
+    if (!result.isFinite()) return null;
+    return stripTrailingZeros(result.toDecimalPlaces(decimalDigits).toFixed(decimalDigits));
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
Fixes #596. Removes the new Function() code execution pattern and replaces
it with a proper recursive-descent parser using decimal.js for
floating-point-safe arithmetic. Adds a decimalDigits parameter so call
sites can pass the currency's decimal_digits (e.g. 0 for JPY/KRW/AMD,
8 for BTC) and avoid the hardcoded 2-decimal rounding that caused
precision loss for non-standard currencies.

https://claude.ai/code/session_01QmoaQtxfvX2Cnk9nd9Uq3v