### PR TITLE
fix: harden APK download against path traversal and missing checksum verification

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -86,11 +86,21 @@ jobs:
           echo "Renamed to: $NEW_NAME"
           ls -lh "$NEW_NAME"
 
-      - name: 📤 Upload APK to Release
+      - name: 🔒 Generate SHA-256 checksum
+        id: checksum
+        run: |
+          APK="${{ steps.find_apk.outputs.apk_path }}"
+          sha256sum "$APK" > "${APK}.sha256"
+          echo "checksum_path=${APK}.sha256" >> $GITHUB_OUTPUT
+          echo "SHA-256: $(cat ${APK}.sha256)"
+
+      - name: 📤 Upload APK and checksum to Release
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v3
         with:
-          files: ${{ steps.find_apk.outputs.apk_path }}
+          files: |
+            ${{ steps.find_apk.outputs.apk_path }}
+            ${{ steps.checksum.outputs.checksum_path }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post build summary
@@ -101,3 +111,4 @@ jobs:
           echo "**Profile:** preview" >> $GITHUB_STEP_SUMMARY
           echo "**Tag:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "**APK:** ${{ steps.find_apk.outputs.apk_path }}" >> $GITHUB_STEP_SUMMARY
+          echo "**SHA-256:** $(cat ${{ steps.checksum.outputs.checksum_path }})" >> $GITHUB_STEP_SUMMARY

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -2,9 +2,13 @@ import {
   parseVersionFromRelease,
   compareVersions,
   extractApkAsset,
+  extractChecksumAsset,
   checkForAppUpdate,
   cleanupOldApks,
   checkAlreadyDownloaded,
+  sanitizeFilename,
+  fetchExpectedChecksum,
+  computeSha256,
 } from '../../app/services/AppUpdateService';
 
 jest.mock('expo-file-system/legacy', () => ({
@@ -14,6 +18,8 @@ jest.mock('expo-file-system/legacy', () => ({
   deleteAsync: jest.fn(),
   createDownloadResumable: jest.fn(),
   getContentUriAsync: jest.fn(),
+  readAsStringAsync: jest.fn(),
+  EncodingType: { Base64: 'base64' },
 }));
 
 const FileSystem = require('expo-file-system/legacy');
@@ -452,6 +458,159 @@ describe('AppUpdateService', () => {
         expect.stringContaining('/releases?per_page=20'),
         expect.any(Object),
       );
+    });
+
+    it('includes checksumUrl in result when checksum asset is present', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([
+          {
+            tag_name: 'v1.0.0',
+            assets: [
+              { name: 'penny-v1.0.0.apk', browser_download_url: 'https://example.com/penny-v1.0.0.apk' },
+              { name: 'penny-v1.0.0.apk.sha256', browser_download_url: 'https://example.com/penny-v1.0.0.apk.sha256' },
+            ],
+            html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v1.0.0',
+          },
+        ]),
+      });
+
+      const result = await checkForAppUpdate({ currentVersion: '0.50.3', fetchImpl });
+
+      expect(result.checksumUrl).toBe('https://example.com/penny-v1.0.0.apk.sha256');
+    });
+
+    it('returns checksumUrl null when no checksum asset present', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([
+          {
+            tag_name: 'v1.0.0',
+            assets: [{ name: 'penny-v1.0.0.apk', browser_download_url: 'https://example.com/penny-v1.0.0.apk' }],
+          },
+        ]),
+      });
+
+      const result = await checkForAppUpdate({ currentVersion: '0.50.3', fetchImpl });
+
+      expect(result.checksumUrl).toBeNull();
+    });
+  });
+
+  describe('sanitizeFilename', () => {
+    it('passes through a safe APK filename unchanged', () => {
+      expect(sanitizeFilename('penny-v1.2.3.apk')).toBe('penny-v1.2.3.apk');
+    });
+
+    it('removes path separators preventing traversal outside the cache directory', () => {
+      const result = sanitizeFilename('../../../evil.apk');
+      // The slash is stripped so the result is a flat filename, not a traversal path.
+      expect(result).not.toContain('/');
+      // The sanitized name is still a valid (if ugly) flat filename within the cache directory.
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('replaces path separators in filenames', () => {
+      const result = sanitizeFilename('foo/bar.apk');
+      expect(result).not.toContain('/');
+      expect(result).toBe('foo_bar.apk');
+    });
+
+    it('returns default when result has no .apk extension', () => {
+      expect(sanitizeFilename('malicious')).toBe('penny-update.apk');
+    });
+
+    it('returns default for null input', () => {
+      expect(sanitizeFilename(null)).toBe('penny-update.apk');
+    });
+
+    it('returns default for empty string', () => {
+      expect(sanitizeFilename('')).toBe('penny-update.apk');
+    });
+  });
+
+  describe('extractChecksumAsset', () => {
+    it('finds a checksum asset matching the APK filename', () => {
+      const assets = [
+        { name: 'penny-v1.0.0.apk', browser_download_url: 'https://example.com/penny.apk' },
+        { name: 'penny-v1.0.0.apk.sha256', browser_download_url: 'https://example.com/penny.apk.sha256' },
+      ];
+      const asset = extractChecksumAsset(assets, 'penny-v1.0.0.apk');
+      expect(asset.browser_download_url).toBe('https://example.com/penny.apk.sha256');
+    });
+
+    it('returns null when no checksum asset is present', () => {
+      const assets = [{ name: 'penny-v1.0.0.apk', browser_download_url: 'https://example.com/penny.apk' }];
+      expect(extractChecksumAsset(assets, 'penny-v1.0.0.apk')).toBeNull();
+    });
+
+    it('returns null when apkFilename is missing', () => {
+      expect(extractChecksumAsset([], null)).toBeNull();
+    });
+  });
+
+  describe('fetchExpectedChecksum', () => {
+    it('parses sha256sum output and returns the hash for a matching filename', async () => {
+      const checksumText = 'abc123def456abc123def456abc123def456abc123def456abc123def456abcd  penny-v1.0.0.apk\n';
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: true, text: async () => checksumText });
+      const hash = await fetchExpectedChecksum('https://example.com/checksum.sha256', 'penny-v1.0.0.apk', fetchImpl);
+      expect(hash).toBe('abc123def456abc123def456abc123def456abc123def456abc123def456abcd');
+    });
+
+    it('handles binary-mode indicator (*) in sha256sum output', async () => {
+      const checksumText = 'abc123def456abc123def456abc123def456abc123def456abc123def456abcd *penny-v1.0.0.apk\n';
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: true, text: async () => checksumText });
+      const hash = await fetchExpectedChecksum('https://example.com/checksum.sha256', 'penny-v1.0.0.apk', fetchImpl);
+      expect(hash).toBe('abc123def456abc123def456abc123def456abc123def456abc123def456abcd');
+    });
+
+    it('returns null when filename does not match', async () => {
+      const checksumText = 'abc123def456abc123def456abc123def456abc123def456abc123def456abcd  other-file.apk\n';
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: true, text: async () => checksumText });
+      const hash = await fetchExpectedChecksum('https://example.com/checksum.sha256', 'penny-v1.0.0.apk', fetchImpl);
+      expect(hash).toBeNull();
+    });
+
+    it('returns null when fetch fails', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: false });
+      const hash = await fetchExpectedChecksum('https://example.com/checksum.sha256', 'penny-v1.0.0.apk', fetchImpl);
+      expect(hash).toBeNull();
+    });
+
+    it('returns null when network error occurs', async () => {
+      const fetchImpl = jest.fn().mockRejectedValue(new Error('network error'));
+      const hash = await fetchExpectedChecksum('https://example.com/checksum.sha256', 'penny-v1.0.0.apk', fetchImpl);
+      expect(hash).toBeNull();
+    });
+  });
+
+  describe('checkAlreadyDownloaded - path traversal prevention', () => {
+    it('sanitizes path traversal in URL filename before checking cache', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 5000000 });
+
+      const uri = await checkAlreadyDownloaded(
+        'https://example.com/../../../evil.apk',
+        'file:///cache/',
+      );
+
+      // getInfoAsync must be called with a sanitized path that stays within the cache
+      const calledWith = FileSystem.getInfoAsync.mock.calls[0]?.[0] || '';
+      expect(calledWith).not.toContain('../');
+      expect(calledWith).toMatch(/^file:\/\/\/cache\//);
+      expect(uri).not.toBeNull();
+    });
+
+    it('uses sanitized filename even when URL has encoded separators replaced', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: false });
+
+      await checkAlreadyDownloaded(
+        'https://example.com/foo%2Fbar.apk',
+        'file:///cache/',
+      );
+
+      const calledWith = FileSystem.getInfoAsync.mock.calls[0]?.[0] || '';
+      expect(calledWith).not.toContain('/bar.apk');
     });
   });
 });

--- a/app/contexts/UpdateDownloadContext.js
+++ b/app/contexts/UpdateDownloadContext.js
@@ -8,12 +8,12 @@ export function UpdateDownloadProvider({ children }) {
   const [downloadProgress, setDownloadProgress] = useState(null);
   const isDownloadingRef = useRef(false);
 
-  const startDownload = useCallback(async (downloadUrl, { onError } = {}) => {
+  const startDownload = useCallback(async (downloadUrl, { onError, checksumUrl = null } = {}) => {
     if (isDownloadingRef.current) return;
     isDownloadingRef.current = true;
     setDownloadProgress(0);
     try {
-      await downloadAndInstallApk(downloadUrl, setDownloadProgress);
+      await downloadAndInstallApk(downloadUrl, setDownloadProgress, { checksumUrl });
     } catch (e) {
       onError?.(e);
     } finally {

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -567,6 +567,7 @@ export default function SettingsModal({ visible, onClose }) {
           latestVersion: result.latestVersion,
           currentVersion: result.currentVersion,
           downloadUrl: result.downloadUrl,
+          checksumUrl: result.checksumUrl || null,
           releaseNotes: result.releaseNotes || null,
           alreadyDownloaded: !!alreadyDownloadedUri,
           localUri: alreadyDownloadedUri,
@@ -1389,6 +1390,7 @@ export default function SettingsModal({ visible, onClose }) {
                                     closeSubPanel();
                                     onClose();
                                     startDownload(updateResult.downloadUrl, {
+                                      checksumUrl: updateResult.checksumUrl || null,
                                       onError: () => {
                                         showDialog(
                                           t('error') || 'Error',

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -58,6 +58,7 @@ const AppInitializer = () => {
             latestVersion: result.latestVersion,
             currentVersion: result.currentVersion,
             downloadUrl: result.downloadUrl,
+            checksumUrl: result.checksumUrl || null,
             releaseNotes: result.releaseNotes || null,
           });
         } catch (error) {
@@ -84,8 +85,10 @@ const AppInitializer = () => {
     if (pendingUpdate) {
       await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, pendingUpdate.latestVersion);
     }
+    const checksumUrl = pendingUpdate?.checksumUrl || null;
     setPendingUpdate(null);
     startDownload(downloadUrl, {
+      checksumUrl,
       onError: () => {
         showDialog(
           t('error') || 'Error',

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -9,6 +9,14 @@ const DEFAULT_GITHUB_REPO = 'money-tracker';
 const GITHUB_API_VERSION = '2022-11-28';
 const UPDATE_CHECK_TIMEOUT_MS = 8000;
 
+// Only allow safe characters in filenames downloaded to the cache directory.
+// Prevents path traversal attacks (e.g. "../../../data/data/com.pkg/databases/penny.db").
+export const sanitizeFilename = (raw) => {
+  if (!raw || typeof raw !== 'string') return 'penny-update.apk';
+  const safe = raw.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return safe.toLowerCase().endsWith('.apk') && safe.length > 4 ? safe : 'penny-update.apk';
+};
+
 const normalizeVersion = (value) => {
   if (!value || typeof value !== 'string') {
     return null;
@@ -59,6 +67,19 @@ export const extractApkAsset = (assets = []) => {
       return false;
     }
     return asset.name.toLowerCase().endsWith('.apk') && !!asset.browser_download_url;
+  }) || null;
+};
+
+// Finds a SHA-256 checksum asset matching the APK filename.
+// The release pipeline uploads "<apkName>.sha256" produced by sha256sum.
+export const extractChecksumAsset = (assets = [], apkFilename) => {
+  if (!Array.isArray(assets) || !apkFilename) {
+    return null;
+  }
+  const expected = `${apkFilename}.sha256`;
+  return assets.find((asset) => {
+    if (!asset || typeof asset.name !== 'string') return false;
+    return asset.name === expected && !!asset.browser_download_url;
   }) || null;
 };
 
@@ -152,9 +173,11 @@ export const checkForAppUpdate = async ({
       newerReleases.push({ version: releaseVersion, notes: release.body || null, hasApk: !!apkAsset });
 
       if (apkAsset && (!bestRelease || compareVersions(releaseVersion, bestRelease.version) > 0)) {
+        const checksumAsset = extractChecksumAsset(release.assets, apkAsset.name);
         bestRelease = {
           version: releaseVersion,
           downloadUrl: apkAsset.browser_download_url,
+          checksumUrl: checksumAsset ? checksumAsset.browser_download_url : null,
           releaseUrl: release.html_url || apkAsset.browser_download_url,
           publishedAt: release.published_at || null,
           releaseName: release.name || release.tag_name || null,
@@ -192,6 +215,7 @@ export const checkForAppUpdate = async ({
       currentVersion: currentNormalized,
       latestVersion: bestRelease.version,
       downloadUrl: bestRelease.downloadUrl,
+      checksumUrl: bestRelease.checksumUrl,
       releaseUrl: bestRelease.releaseUrl,
       publishedAt: bestRelease.publishedAt,
       releaseName: bestRelease.releaseName,
@@ -262,12 +286,51 @@ export const listDownloadedApks = async (cacheDir = FileSystem.cacheDirectory) =
 };
 
 export const checkAlreadyDownloaded = async (downloadUrl, cacheDir = FileSystem.cacheDirectory) => {
-  const filename = (downloadUrl.split('/').pop().split('?')[0]) || null;
-  if (!filename || !filename.toLowerCase().endsWith('.apk')) return null;
+  const raw = (downloadUrl.split('/').pop().split('?')[0]) || null;
+  const filename = sanitizeFilename(raw);
+  if (filename === 'penny-update.apk' && raw && !raw.toLowerCase().endsWith('.apk')) return null;
   const localUri = `${cacheDir}${filename}`;
   try {
     const info = await FileSystem.getInfoAsync(localUri);
     return (info.exists && info.size > 0) ? localUri : null;
+  } catch {
+    return null;
+  }
+};
+
+// Compute the SHA-256 hex digest of a local file using the Web Crypto API (Hermes).
+export const computeSha256 = async (fileUri) => {
+  const base64 = await FileSystem.readAsStringAsync(fileUri, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  const binaryStr = atob(base64);
+  const bytes = new Uint8Array(binaryStr.length);
+  for (let i = 0; i < binaryStr.length; i++) {
+    bytes[i] = binaryStr.charCodeAt(i);
+  }
+  const hashBuffer = await crypto.subtle.digest('SHA-256', bytes.buffer);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+// Downloads the sha256sum-format checksum file and returns the expected hex hash for apkFilename.
+// Returns null if the checksum cannot be fetched or parsed.
+export const fetchExpectedChecksum = async (checksumUrl, apkFilename, fetchImpl = fetch) => {
+  try {
+    const response = await fetchImpl(checksumUrl);
+    if (!response.ok) return null;
+    const text = await response.text();
+    for (const line of text.trim().split('\n')) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 2) continue;
+      const hash = parts[0];
+      const name = parts[parts.length - 1].replace(/^\*/, ''); // strip binary-mode indicator
+      if ((name === apkFilename || name.endsWith(`/${apkFilename}`)) && /^[0-9a-f]{64}$/i.test(hash)) {
+        return hash.toLowerCase();
+      }
+    }
+    return null;
   } catch {
     return null;
   }
@@ -282,8 +345,9 @@ export const installApk = async (localUri) => {
   });
 };
 
-export const downloadAndInstallApk = async (downloadUrl, onProgress) => {
-  const filename = (downloadUrl.split('/').pop().split('?')[0]) || 'penny-update.apk';
+export const downloadAndInstallApk = async (downloadUrl, onProgress, { checksumUrl = null } = {}) => {
+  const raw = (downloadUrl.split('/').pop().split('?')[0]) || null;
+  const filename = sanitizeFilename(raw);
   const localUri = `${FileSystem.cacheDirectory}${filename}`;
 
   const downloadResumable = FileSystem.createDownloadResumable(
@@ -300,6 +364,19 @@ export const downloadAndInstallApk = async (downloadUrl, onProgress) => {
   const result = await downloadResumable.downloadAsync();
   if (!result?.uri) {
     throw new Error('Download failed');
+  }
+
+  if (checksumUrl) {
+    const expectedHash = await fetchExpectedChecksum(checksumUrl, filename);
+    if (expectedHash) {
+      const actualHash = await computeSha256(result.uri);
+      if (actualHash !== expectedHash) {
+        await FileSystem.deleteAsync(result.uri, { idempotent: true });
+        throw new Error('APK checksum mismatch — file deleted');
+      }
+    } else {
+      console.warn('[AppUpdate] checksum file unavailable; skipping verification');
+    }
   }
 
   await cleanupOldApks();


### PR DESCRIPTION
Addresses issue #591 (HIGH severity):

- Filename sanitization: `sanitizeFilename()` strips all characters outside
  [a-zA-Z0-9._-] before writing to the cache directory, preventing path
  traversal attacks (e.g. `../../../data/data/com.pkg/...`).

- SHA-256 checksum verification: release workflow now generates
  `<apk>.sha256` via sha256sum and uploads it alongside the APK.
  `downloadAndInstallApk` downloads the checksum file, computes the
  SHA-256 of the downloaded APK using `crypto.subtle.digest`, and
  rejects (deletes) the file if hashes do not match. Missing checksum
  files log a warning and allow installation to proceed so older
  releases remain installable.

- `checksumUrl` is propagated through `checkForAppUpdate` →
  `UpdateDownloadContext.startDownload` → `downloadAndInstallApk`
  in all three call sites (SettingsModal, AppInitializer).

- 14 new tests covering sanitizeFilename, extractChecksumAsset,
  fetchExpectedChecksum, path traversal prevention, and checksumUrl
  propagation in checkForAppUpdate.