### PR TITLE
fix: downgrade SEARCH_NORM fallback log from warn to info

### DIFF
--- a/app/services/db.js
+++ b/app/services/db.js
@@ -53,7 +53,7 @@ export const getDatabase = async () => {
           await dbInstance.createFunctionAsync('SEARCH_NORM', normalizeSearchText, { deterministic: true });
           searchNormAvailable = true;
         } else {
-          console.warn('SEARCH_NORM: no custom function API found, Cyrillic/yo search will use LOWER()');
+          console.log('SEARCH_NORM: no custom function API found, Cyrillic/yo search will use LOWER()');
         }
       } catch (fnError) {
         console.warn('SEARCH_NORM registration failed, Cyrillic/yo search will use LOWER():', fnError.message);


### PR DESCRIPTION
expo-sqlite 16.x has no createCustomFunctionAsync / createFunctionAsync
API, so this branch is always taken on startup. Using LOWER() as the
SQL fallback is correct expected behavior, not a warning condition.
Demoting to console.log keeps the Warn log filter clean.

https://claude.ai/code/session_01Y232QMg9sNANGDHNgykMBj