### PR TITLE
fix: use precise string arithmetic in budget spending calculations

### DIFF
--- a/__tests__/components/BudgetProgressBar.test.js
+++ b/__tests__/components/BudgetProgressBar.test.js
@@ -41,7 +41,8 @@ jest.mock('../../app/contexts/BudgetsContext', () => ({
 
 // Mock Currency service
 jest.mock('../../app/services/currency', () => ({
-  formatAmount: (amount, currency) => `${currency} ${amount.toFixed(2)}`,
+  formatAmount: (amount, currency) => `${currency} ${parseFloat(amount).toFixed(2)}`,
+  abs: (amount) => Math.abs(parseFloat(amount)).toFixed(2),
 }));
 
 describe('BudgetProgressBar', () => {

--- a/__tests__/contexts/BudgetsContext.test.js
+++ b/__tests__/contexts/BudgetsContext.test.js
@@ -767,7 +767,7 @@ describe('BudgetsContext', () => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect(result.current.getRemainingBudget('non-existent')).toBe(0);
+      expect(result.current.getRemainingBudget('non-existent')).toBe('0');
     });
   });
 
@@ -1048,7 +1048,7 @@ describe('BudgetsContext', () => {
       expect(result.current.getBudgetStatus('any-id')).toBeNull();
       expect(result.current.isBudgetExceeded('any-id')).toBe(false);
       expect(result.current.getBudgetProgress('any-id')).toBe(0);
-      expect(result.current.getRemainingBudget('any-id')).toBe(0);
+      expect(result.current.getRemainingBudget('any-id')).toBe('0');
     });
   });
 });

--- a/__tests__/services/BudgetsDB.test.js
+++ b/__tests__/services/BudgetsDB.test.js
@@ -770,7 +770,7 @@ describe('BudgetsDB Service', () => {
           false,
         );
 
-        expect(result).toBe(250.50);
+        expect(result).toBe('250.5');
       });
 
       it('includes child categories when requested', async () => {
@@ -807,7 +807,7 @@ describe('BudgetsDB Service', () => {
           false,
         );
 
-        expect(result).toBe(0);
+        expect(result).toBe('0');
       });
     });
 
@@ -838,8 +838,8 @@ describe('BudgetsDB Service', () => {
 
         expect(result.budgetId).toBe('budget1');
         expect(result.amount).toBe('500.00');
-        expect(result.spent).toBe(300);
-        expect(result.remaining).toBe(200);
+        expect(result.spent).toBe('300');
+        expect(result.remaining).toBe('200.00');
         expect(result.percentage).toBe(60);
         expect(result.isExceeded).toBe(false);
         expect(result.status).toBe('safe');

--- a/app/components/BudgetProgressBar.js
+++ b/app/components/BudgetProgressBar.js
@@ -69,7 +69,7 @@ const BudgetProgressBar = ({ budgetId, compact = false, showDetails = true, styl
             ]}
           >
             {status.isExceeded
-              ? `${t('over_budget_by')} ${formatAmount(Math.abs(status.remaining))}`
+              ? `${t('over_budget_by')} ${formatAmount(Currency.abs(status.remaining))}`
               : `${t('remaining_budget')}: ${formatAmount(status.remaining)}`
             }
           </Text>

--- a/app/contexts/BudgetsContext.js
+++ b/app/contexts/BudgetsContext.js
@@ -259,7 +259,7 @@ export const BudgetsProvider = ({ children }) => {
    */
   const getRemainingBudget = useCallback((budgetId) => {
     const status = budgetStatuses.get(budgetId);
-    return status ? status.remaining : 0;
+    return status ? status.remaining : '0';
   }, [budgetStatuses]);
 
   /**

--- a/app/services/BudgetsDB.js
+++ b/app/services/BudgetsDB.js
@@ -1,5 +1,6 @@
 import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
 import * as CategoriesDB from './CategoriesDB';
+import * as Currency from './currency';
 
 /**
  * Map database field names to camelCase for application use
@@ -513,7 +514,7 @@ export const calculateSpendingForBudget = async (
     const params = [...categoryIds, currency, startDate, endDate];
     const result = await queryFirst(query, params);
 
-    return result && result.total ? parseFloat(result.total) : 0;
+    return result && result.total != null ? String(result.total) : '0';
   } catch (error) {
     console.error('Failed to calculate spending:', error);
     throw error;
@@ -548,10 +549,10 @@ export const calculateBudgetStatus = async (budgetId, referenceDate = new Date()
     );
 
     // Calculate metrics
-    const budgetAmount = parseFloat(budget.amount);
-    const remaining = budgetAmount - spent;
-    const percentage = budgetAmount > 0 ? (spent / budgetAmount) * 100 : 0;
-    const isExceeded = spent > budgetAmount;
+    const remaining = Currency.subtract(budget.amount, spent);
+    const isExceeded = Currency.compare(spent, budget.amount) > 0;
+    const budgetAmountNum = parseFloat(budget.amount);
+    const percentage = budgetAmountNum > 0 ? (parseFloat(spent) / budgetAmountNum) * 100 : 0;
 
     // Determine status
     let status;


### PR DESCRIPTION
calculateSpendingForBudget now returns the SQL SUM result as a string
instead of parseFloat(), avoiding float promotion in the JS layer.
calculateBudgetStatus uses Currency.subtract() and Currency.compare()
for remaining and isExceeded so downstream arithmetic stays in
decimal.js rather than IEEE 754 floats. BudgetProgressBar switches
Math.abs() to Currency.abs() for the string-typed remaining value.

https://claude.ai/code/session_01ERA11LPPx4c3ysHvfJdJc5

Closes #599