### PR TITLE
fix: validate live FX rate values before caching (issue #595)

### DIFF
--- a/app/services/currency.js
+++ b/app/services/currency.js
@@ -543,7 +543,7 @@ export const fetchLiveExchangeRate = async (fromCurrency, toCurrency) => {
   const cached = liveRateCache.get(fromLower);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
     const rate = cached.rates[toLower];
-    if (rate !== undefined) {
+    if (typeof rate === 'number' && rate > 0 && isFinite(rate)) {
       return { rate: rate.toString(), source: 'live' };
     }
   }
@@ -567,13 +567,18 @@ export const fetchLiveExchangeRate = async (fromCurrency, toCurrency) => {
       const data = await response.json();
       const rates = data[fromLower];
       if (rates && typeof rates === 'object') {
-        // Cache the full response
+        const validatedRates = {};
+        for (const [key, value] of Object.entries(rates)) {
+          if (typeof value === 'number' && value > 0 && isFinite(value)) {
+            validatedRates[key] = value;
+          }
+        }
         liveRateCache.set(fromLower, {
-          rates,
+          rates: validatedRates,
           timestamp: Date.now(),
         });
 
-        const rate = rates[toLower];
+        const rate = validatedRates[toLower];
         if (rate !== undefined) {
           return { rate: rate.toString(), source: 'live' };
         }


### PR DESCRIPTION
Filter out any rate values that are not a positive finite number before
storing API responses in the in-memory cache, and apply the same check
on cache reads. This prevents malformed or malicious API responses from
poisoning the rate cache and causing incorrect currency conversions.

https://claude.ai/code/session_01TaEDVx1X3UNCfUHhbPuGnv

Closes #595