### PR TITLE
fix: wrap deleteCategory and deleteAccount check-then-delete in single transaction

### DIFF
--- a/__tests__/services/AccountsDB.test.js
+++ b/__tests__/services/AccountsDB.test.js
@@ -254,32 +254,38 @@ describe('AccountsDB', () => {
 
   describe('deleteAccount', () => {
     it('deletes account when no operations are associated', async () => {
-      jest.spyOn(db, 'queryFirst').mockResolvedValue({ count: 0 });
-      mockDrizzle.where.mockResolvedValue(undefined);
+      const mockTxDb = {
+        getFirstAsync: jest.fn().mockResolvedValue({ count: 0 }),
+        runAsync: jest.fn().mockResolvedValue(undefined),
+      };
+      jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => callback(mockTxDb));
 
       await AccountsDB.deleteAccount('1');
 
-      expect(db.queryFirst).toHaveBeenCalledWith(
-        expect.stringContaining('SELECT COUNT(*) as count FROM operations'),
-        ['1', '1'],
+      expect(db.executeTransaction).toHaveBeenCalled();
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'DELETE FROM accounts WHERE id = ?',
+        ['1'],
       );
-      expect(mockDrizzle.delete).toHaveBeenCalled();
-      expect(mockDrizzle.where).toHaveBeenCalled();
     });
 
     it('throws error when account has associated operations', async () => {
-      jest.spyOn(db, 'queryFirst').mockResolvedValue({ count: 5 });
+      const mockTxDb = {
+        getFirstAsync: jest.fn().mockResolvedValue({ count: 5 }),
+        runAsync: jest.fn(),
+      };
+      jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => callback(mockTxDb));
 
       await expect(AccountsDB.deleteAccount('1')).rejects.toThrow(
         'Cannot delete account: 5 transaction(s) are associated with this account',
       );
 
-      expect(mockDrizzle.delete).not.toHaveBeenCalled();
+      expect(mockTxDb.runAsync).not.toHaveBeenCalled();
     });
 
     it('throws error when database query fails', async () => {
       const error = new Error('Query failed');
-      jest.spyOn(db, 'queryFirst').mockRejectedValue(error);
+      jest.spyOn(db, 'executeTransaction').mockRejectedValue(error);
 
       await expect(AccountsDB.deleteAccount('1')).rejects.toThrow('Query failed');
     });
@@ -611,29 +617,32 @@ describe('AccountsDB', () => {
 
   describe('deleteAccount with transfer', () => {
     it('transfers operations before deleting account', async () => {
-      // Mock getOperationCount
-      jest.spyOn(db, 'queryFirst').mockResolvedValue({ count: 3 });
-
-      // Mock transferOperations transaction
-      const mockDb = {
+      const mockTxDb = {
         getFirstAsync: jest.fn()
-          .mockResolvedValueOnce({ id: 'to-delete', currency: 'USD' })
-          .mockResolvedValueOnce({ id: 'transfer-to', currency: 'USD' }),
-        runAsync: jest.fn()
-          .mockResolvedValueOnce({ changes: 2 })
-          .mockResolvedValueOnce({ changes: 1 }),
+          .mockResolvedValueOnce({ count: 3 }) // operation count
+          .mockResolvedValueOnce({ id: 'to-delete', currency: 'USD' }) // fromAccount
+          .mockResolvedValueOnce({ id: 'transfer-to', currency: 'USD' }), // toAccount
+        runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
       };
       jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => {
-        return await callback(mockDb);
+        return await callback(mockTxDb);
       });
-
-      // Mock delete operation
-      mockDrizzle.where.mockResolvedValue(undefined);
 
       await AccountsDB.deleteAccount('to-delete', 'transfer-to');
 
       expect(db.executeTransaction).toHaveBeenCalled();
-      expect(mockDrizzle.delete).toHaveBeenCalled();
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE operations SET account_id = ? WHERE account_id = ?',
+        ['transfer-to', 'to-delete'],
+      );
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE operations SET to_account_id = ? WHERE to_account_id = ?',
+        ['transfer-to', 'to-delete'],
+      );
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'DELETE FROM accounts WHERE id = ?',
+        ['to-delete'],
+      );
     });
   });
 
@@ -962,7 +971,11 @@ describe('AccountsDB', () => {
   // Regression tests for data integrity
   describe('Regression Tests - Data Integrity', () => {
     it('prevents deletion of accounts with operations', async () => {
-      jest.spyOn(db, 'queryFirst').mockResolvedValue({ count: 1 });
+      const mockTxDb = {
+        getFirstAsync: jest.fn().mockResolvedValue({ count: 1 }),
+        runAsync: jest.fn(),
+      };
+      jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => callback(mockTxDb));
 
       await expect(AccountsDB.deleteAccount('1')).rejects.toThrow(
         'Cannot delete account',

--- a/__tests__/services/CategoriesDB.test.js
+++ b/__tests__/services/CategoriesDB.test.js
@@ -532,58 +532,75 @@ describe('CategoriesDB', () => {
 
   describe('deleteCategory', () => {
     it('deletes category when no children or operations exist', async () => {
-      mockDb.queryFirst
-        .mockResolvedValueOnce({ count: 0 }) // No child categories
-        .mockResolvedValueOnce({ count: 0 }); // No operations
-      mockDb.executeQuery.mockResolvedValue();
+      const mockTxDb = {
+        getFirstAsync: jest.fn()
+          .mockResolvedValueOnce({ count: 0 }) // No child categories
+          .mockResolvedValueOnce({ count: 0 }), // No operations
+        runAsync: jest.fn().mockResolvedValue(undefined),
+      };
+      mockDb.executeTransaction.mockImplementation(async (callback) => callback(mockTxDb));
 
       await CategoriesDB.deleteCategory('cat-1');
 
-      expect(db.executeQuery).toHaveBeenCalledWith(
+      expect(db.executeTransaction).toHaveBeenCalled();
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
         'DELETE FROM categories WHERE id = ?',
         ['cat-1'],
       );
     });
 
     it('throws error when category has child categories', async () => {
-      mockDb.queryFirst.mockResolvedValueOnce({ count: 3 }); // Has 3 children
+      const mockTxDb = {
+        getFirstAsync: jest.fn().mockResolvedValueOnce({ count: 3 }),
+        runAsync: jest.fn(),
+      };
+      mockDb.executeTransaction.mockImplementation(async (callback) => callback(mockTxDb));
 
       await expect(CategoriesDB.deleteCategory('cat-1')).rejects.toThrow(
         'Cannot delete category: 3 subcategory(ies) exist',
       );
 
-      expect(db.executeQuery).not.toHaveBeenCalled();
+      expect(mockTxDb.runAsync).not.toHaveBeenCalled();
     });
 
     it('throws error when category has associated operations', async () => {
-      mockDb.queryFirst
-        .mockResolvedValueOnce({ count: 0 }) // No children
-        .mockResolvedValueOnce({ count: 5 }); // Has 5 operations
+      const mockTxDb = {
+        getFirstAsync: jest.fn()
+          .mockResolvedValueOnce({ count: 0 }) // No children
+          .mockResolvedValueOnce({ count: 5 }), // Has 5 operations
+        runAsync: jest.fn(),
+      };
+      mockDb.executeTransaction.mockImplementation(async (callback) => callback(mockTxDb));
 
       await expect(CategoriesDB.deleteCategory('cat-1')).rejects.toThrow(
         'Cannot delete category: 5 transaction(s) use this category',
       );
 
-      expect(db.executeQuery).not.toHaveBeenCalled();
+      expect(mockTxDb.runAsync).not.toHaveBeenCalled();
     });
 
     it('checks children before checking operations', async () => {
-      mockDb.queryFirst
-        .mockResolvedValueOnce({ count: 2 }) // Has children
-        .mockResolvedValueOnce({ count: 0 }); // Has no operations (not reached)
+      const mockTxDb = {
+        getFirstAsync: jest.fn().mockResolvedValueOnce({ count: 2 }),
+        runAsync: jest.fn(),
+      };
+      mockDb.executeTransaction.mockImplementation(async (callback) => callback(mockTxDb));
 
       await expect(CategoriesDB.deleteCategory('cat-1')).rejects.toThrow('subcategory');
 
       // Should only check children, not operations
-      expect(db.queryFirst).toHaveBeenCalledTimes(1);
+      expect(mockTxDb.getFirstAsync).toHaveBeenCalledTimes(1);
     });
 
     it('throws error when database delete fails', async () => {
-      mockDb.queryFirst
-        .mockResolvedValueOnce({ count: 0 })
-        .mockResolvedValueOnce({ count: 0 });
       const error = new Error('Database error');
-      mockDb.executeQuery.mockRejectedValue(error);
+      const mockTxDb = {
+        getFirstAsync: jest.fn()
+          .mockResolvedValueOnce({ count: 0 })
+          .mockResolvedValueOnce({ count: 0 }),
+        runAsync: jest.fn().mockRejectedValue(error),
+      };
+      mockDb.executeTransaction.mockImplementation(async (callback) => callback(mockTxDb));
 
       await expect(CategoriesDB.deleteCategory('cat-1')).rejects.toThrow('Database error');
     });

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -199,25 +199,53 @@ export const getOperationCount = async (id) => {
  */
 export const deleteAccount = async (id, transferToAccountId = null) => {
   try {
-    // Check if account has any operations (expense, income, or transfers)
-    const operationCount = await getOperationCount(id);
+    await executeTransaction(async (db) => {
+      const result = await db.getFirstAsync(
+        'SELECT COUNT(*) as count FROM operations WHERE account_id = ? OR to_account_id = ?',
+        [id, id],
+      );
+      const operationCount = result ? result.count : 0;
 
-    if (operationCount > 0) {
-      if (!transferToAccountId) {
-        // No transfer account specified, throw error with count
-        throw new Error(
-          `Cannot delete account: ${operationCount} transaction(s) are associated with this account. Please delete or reassign the transactions first.`,
+      if (operationCount > 0) {
+        if (!transferToAccountId) {
+          throw new Error(
+            `Cannot delete account: ${operationCount} transaction(s) are associated with this account. Please delete or reassign the transactions first.`,
+          );
+        }
+
+        const fromAccount = await db.getFirstAsync(
+          'SELECT id, currency FROM accounts WHERE id = ?',
+          [id],
+        );
+        const toAccount = await db.getFirstAsync(
+          'SELECT id, currency FROM accounts WHERE id = ?',
+          [transferToAccountId],
+        );
+
+        if (!fromAccount) {
+          throw new Error(`Source account ${id} not found`);
+        }
+        if (!toAccount) {
+          throw new Error(`Destination account ${transferToAccountId} not found`);
+        }
+        if (fromAccount.currency !== toAccount.currency) {
+          throw new Error(
+            `Cannot transfer operations: accounts have different currencies (${fromAccount.currency} → ${toAccount.currency})`,
+          );
+        }
+
+        await db.runAsync(
+          'UPDATE operations SET account_id = ? WHERE account_id = ?',
+          [transferToAccountId, id],
+        );
+        await db.runAsync(
+          'UPDATE operations SET to_account_id = ? WHERE to_account_id = ?',
+          [transferToAccountId, id],
         );
       }
 
-      // Transfer operations to the specified account
-      await transferOperations(id, transferToAccountId);
-      console.log(`Transferred ${operationCount} operations before deleting account ${id}`);
-    }
-
-    // Safe to delete - no operations are linked or they've been transferred
-    const db = await getDrizzle();
-    await db.delete(accounts).where(eq(accounts.id, id));
+      await db.runAsync('DELETE FROM accounts WHERE id = ?', [id]);
+    });
   } catch (error) {
     console.error('Failed to delete account:', error);
     throw error;

--- a/app/services/CategoriesDB.js
+++ b/app/services/CategoriesDB.js
@@ -301,32 +301,31 @@ export const updateCategory = async (id, updates) => {
  */
 export const deleteCategory = async (id) => {
   try {
-    // Check if category has child categories
-    const childCheck = await queryFirst(
-      'SELECT COUNT(*) as count FROM categories WHERE parent_id = ?',
-      [id],
-    );
-
-    if (childCheck && childCheck.count > 0) {
-      throw new Error(
-        `Cannot delete category: ${childCheck.count} subcategory(ies) exist. Please delete or reassign the subcategories first.`,
+    await executeTransaction(async (db) => {
+      const childCheck = await db.getFirstAsync(
+        'SELECT COUNT(*) as count FROM categories WHERE parent_id = ?',
+        [id],
       );
-    }
 
-    // Check if category is used in any operations
-    const operationCheck = await queryFirst(
-      'SELECT COUNT(*) as count FROM operations WHERE category_id = ?',
-      [id],
-    );
+      if (childCheck && childCheck.count > 0) {
+        throw new Error(
+          `Cannot delete category: ${childCheck.count} subcategory(ies) exist. Please delete or reassign the subcategories first.`,
+        );
+      }
 
-    if (operationCheck && operationCheck.count > 0) {
-      throw new Error(
-        `Cannot delete category: ${operationCheck.count} transaction(s) use this category. Please reassign or delete the transactions first.`,
+      const operationCheck = await db.getFirstAsync(
+        'SELECT COUNT(*) as count FROM operations WHERE category_id = ?',
+        [id],
       );
-    }
 
-    // Safe to delete - no child categories or operations are linked
-    await executeQuery('DELETE FROM categories WHERE id = ?', [id]);
+      if (operationCheck && operationCheck.count > 0) {
+        throw new Error(
+          `Cannot delete category: ${operationCheck.count} transaction(s) use this category. Please reassign or delete the transactions first.`,
+        );
+      }
+
+      await db.runAsync('DELETE FROM categories WHERE id = ?', [id]);
+    });
   } catch (error) {
     console.error('Failed to delete category:', error);
     throw error;


### PR DESCRIPTION
Closes #602. The TOCTOU gap where a SELECT count was performed outside a
transaction before the DELETE meant concurrent writes could slip through
after the guard check. Both functions now execute the guard queries and
the mutation inside a single executeTransaction() call, ensuring the
check and delete are atomic.

https://claude.ai/code/session_01JTM1JS9n3xMQkZkLb1CoJC

Closes #602