### PR TITLE
fix: make planned-operation execution atomic to prevent duplicate charges

### DIFF
--- a/__tests__/contexts/PlannedOperationsContext.test.js
+++ b/__tests__/contexts/PlannedOperationsContext.test.js
@@ -13,6 +13,7 @@ jest.mock('../../app/services/PlannedOperationsDB');
 jest.mock('../../app/services/BalanceHistoryDB', () => ({
   formatDate: jest.fn((date) => date.toISOString().split('T')[0]),
 }));
+
 jest.mock('../../app/services/eventEmitter', () => ({
   appEvents: {
     on: jest.fn(() => jest.fn()),
@@ -21,6 +22,7 @@ jest.mock('../../app/services/eventEmitter', () => ({
   EVENTS: {
     RELOAD_ALL: 'RELOAD_ALL',
     DATABASE_RESET: 'DATABASE_RESET',
+    OPERATION_CHANGED: 'OPERATION_CHANGED',
   },
 }));
 
@@ -41,13 +43,6 @@ jest.mock('../../app/contexts/LocalizationContext', () => ({
   }),
 }));
 
-const mockAddOperation = jest.fn();
-jest.mock('../../app/contexts/OperationsActionsContext', () => ({
-  useOperationsActions: () => ({
-    addOperation: mockAddOperation,
-  }),
-}));
-
 let mockUuidCounter = 0;
 jest.mock('react-native-uuid', () => ({
   v4: jest.fn(() => `test-uuid-${++mockUuidCounter}`),
@@ -57,7 +52,6 @@ describe('PlannedOperationsContext', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockShowDialog.mockClear();
-    mockAddOperation.mockClear();
     mockUuidCounter = 0;
 
     PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([]);
@@ -65,6 +59,7 @@ describe('PlannedOperationsContext', () => {
     PlannedOperationsDB.updatePlannedOperation.mockResolvedValue(undefined);
     PlannedOperationsDB.deletePlannedOperation.mockResolvedValue(undefined);
     PlannedOperationsDB.markExecuted.mockResolvedValue(undefined);
+    PlannedOperationsDB.executeAndMark.mockResolvedValue({ id: 100, type: 'expense' });
     PlannedOperationsDB.validatePlannedOperation.mockReturnValue(null);
   });
 
@@ -170,7 +165,7 @@ describe('PlannedOperationsContext', () => {
   });
 
   describe('Execute Planned Operation', () => {
-    it('creates a real operation and marks as executed for recurring', async () => {
+    it('calls executeAndMark atomically and updates state for recurring', async () => {
       const plannedOp = {
         id: '1',
         name: 'Rent',
@@ -182,7 +177,7 @@ describe('PlannedOperationsContext', () => {
         lastExecutedMonth: null,
       };
       PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
-      mockAddOperation.mockResolvedValue({ id: 100 });
+      PlannedOperationsDB.executeAndMark.mockResolvedValue({ id: 100, type: 'expense' });
 
       const { result } = renderHook(() => usePlannedOperations(), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -191,24 +186,47 @@ describe('PlannedOperationsContext', () => {
         await result.current.executePlannedOperation(plannedOp);
       });
 
-      // Should have created a real operation
-      expect(mockAddOperation).toHaveBeenCalledWith(
+      // Should have used the atomic executeAndMark, not separate calls
+      expect(PlannedOperationsDB.executeAndMark).toHaveBeenCalledWith(
+        plannedOp,
         expect.objectContaining({
           type: 'expense',
           amount: '500',
           accountId: 1,
           categoryId: 'cat1',
         }),
+        expect.stringMatching(/^\d{4}-\d{2}$/),
       );
 
-      // Should have marked as executed
-      expect(PlannedOperationsDB.markExecuted).toHaveBeenCalledWith('1', expect.stringMatching(/^\d{4}-\d{2}$/));
+      // markExecuted and deletePlannedOperation should NOT be called separately
+      expect(PlannedOperationsDB.markExecuted).not.toHaveBeenCalled();
+      expect(PlannedOperationsDB.deletePlannedOperation).not.toHaveBeenCalled();
 
-      // Recurring should stay in list
+      // Recurring should stay in list with updated lastExecutedMonth
       expect(result.current.plannedOperations).toHaveLength(1);
+      expect(result.current.plannedOperations[0].lastExecutedMonth).toMatch(/^\d{4}-\d{2}$/);
     });
 
-    it('removes one-time planned operation after execution', async () => {
+    it('emits OPERATION_CHANGED and RELOAD_ALL after successful execution', async () => {
+      const plannedOp = {
+        id: '1', name: 'Rent', type: 'expense', amount: '500',
+        accountId: 1, categoryId: 'cat1', isRecurring: true, lastExecutedMonth: null,
+      };
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+      PlannedOperationsDB.executeAndMark.mockResolvedValue({ id: 100 });
+
+      const { result } = renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.executePlannedOperation(plannedOp);
+      });
+
+      expect(appEvents.emit).toHaveBeenCalledWith('OPERATION_CHANGED');
+      expect(appEvents.emit).toHaveBeenCalledWith('RELOAD_ALL');
+    });
+
+    it('removes one-time planned operation from state after execution', async () => {
       const plannedOp = {
         id: '2',
         name: 'One-time',
@@ -220,7 +238,7 @@ describe('PlannedOperationsContext', () => {
         lastExecutedMonth: null,
       };
       PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
-      mockAddOperation.mockResolvedValue({ id: 101 });
+      PlannedOperationsDB.executeAndMark.mockResolvedValue({ id: 101 });
 
       const { result } = renderHook(() => usePlannedOperations(), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -229,8 +247,12 @@ describe('PlannedOperationsContext', () => {
         await result.current.executePlannedOperation(plannedOp);
       });
 
-      // One-time should be removed from list
-      expect(PlannedOperationsDB.deletePlannedOperation).toHaveBeenCalledWith('2');
+      // executeAndMark handles the DB delete atomically; context removes from local state
+      expect(PlannedOperationsDB.executeAndMark).toHaveBeenCalledWith(
+        plannedOp, expect.any(Object), expect.any(String),
+      );
+      // No separate deletePlannedOperation call
+      expect(PlannedOperationsDB.deletePlannedOperation).not.toHaveBeenCalled();
       expect(result.current.plannedOperations).toHaveLength(0);
     });
 
@@ -247,6 +269,7 @@ describe('PlannedOperationsContext', () => {
         lastExecutedMonth: currentMonth,
       };
       PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+      PlannedOperationsDB.executeAndMark.mockResolvedValue({ id: 100 });
 
       const { result } = renderHook(() => usePlannedOperations(), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -256,7 +279,7 @@ describe('PlannedOperationsContext', () => {
         expect(returned).not.toBeNull();
       });
 
-      expect(mockAddOperation).toHaveBeenCalled();
+      expect(PlannedOperationsDB.executeAndMark).toHaveBeenCalled();
     });
   });
 
@@ -448,8 +471,8 @@ describe('PlannedOperationsContext', () => {
   });
 
   describe('executePlannedOperation error handling', () => {
-    it('shows dialog and re-throws when addOperation fails', async () => {
-      mockAddOperation.mockRejectedValue(new Error('add failed'));
+    it('shows dialog and re-throws when executeAndMark fails', async () => {
+      PlannedOperationsDB.executeAndMark.mockRejectedValue(new Error('atomic transaction failed'));
 
       const plannedOp = {
         id: '1', name: 'Test', type: 'expense', amount: '100',
@@ -469,8 +492,12 @@ describe('PlannedOperationsContext', () => {
         }
       });
 
-      expect(caughtError?.message).toBe('add failed');
+      expect(caughtError?.message).toBe('atomic transaction failed');
       expect(mockShowDialog).toHaveBeenCalled();
+      // State must not be changed on failure
+      expect(result.current.plannedOperations).toHaveLength(1);
+      // No events should have been emitted
+      expect(appEvents.emit).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/services/PlannedOperationsDB.test.js
+++ b/__tests__/services/PlannedOperationsDB.test.js
@@ -4,15 +4,25 @@
 
 import * as PlannedOperationsDB from '../../app/services/PlannedOperationsDB';
 import { executeQuery, queryAll, queryFirst, executeTransaction } from '../../app/services/db';
+import { createOperationInTx } from '../../app/services/OperationsDB';
 
 jest.mock('../../app/services/db');
+jest.mock('../../app/services/OperationsDB', () => ({
+  createOperationInTx: jest.fn(),
+}));
 
 describe('PlannedOperationsDB Service', () => {
+  let mockDb;
+
   beforeEach(() => {
     jest.clearAllMocks();
     executeQuery.mockResolvedValue(undefined);
     queryAll.mockResolvedValue([]);
     queryFirst.mockResolvedValue(null);
+
+    mockDb = { runAsync: jest.fn().mockResolvedValue({}) };
+    executeTransaction.mockImplementation(async (callback) => callback(mockDb));
+    createOperationInTx.mockResolvedValue({ id: 999, type: 'expense', amount: '500' });
   });
 
   describe('Validation', () => {
@@ -257,6 +267,92 @@ describe('PlannedOperationsDB Service', () => {
         expect.stringContaining('UPDATE planned_operations SET last_executed_month'),
         expect.arrayContaining(['2026-03', 'test-uuid']),
       );
+    });
+  });
+
+  describe('executeAndMark (atomic execution)', () => {
+    const recurringOp = {
+      id: 'plan-1',
+      isRecurring: true,
+    };
+
+    const oneTimeOp = {
+      id: 'plan-2',
+      isRecurring: false,
+    };
+
+    const operationData = {
+      type: 'expense',
+      amount: '500',
+      accountId: 1,
+      categoryId: 'cat1',
+      date: '2026-05-19',
+      description: 'Rent',
+    };
+
+    it('runs everything in a single transaction', async () => {
+      await PlannedOperationsDB.executeAndMark(recurringOp, operationData, '2026-05');
+
+      expect(executeTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls createOperationInTx inside the transaction', async () => {
+      await PlannedOperationsDB.executeAndMark(recurringOp, operationData, '2026-05');
+
+      expect(createOperationInTx).toHaveBeenCalledWith(mockDb, operationData);
+    });
+
+    it('updates last_executed_month for recurring planned operation', async () => {
+      await PlannedOperationsDB.executeAndMark(recurringOp, operationData, '2026-05');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE planned_operations SET last_executed_month'),
+        expect.arrayContaining(['2026-05', 'plan-1']),
+      );
+    });
+
+    it('does NOT delete a recurring planned operation', async () => {
+      await PlannedOperationsDB.executeAndMark(recurringOp, operationData, '2026-05');
+
+      const deleteCalls = mockDb.runAsync.mock.calls.filter(
+        ([sql]) => sql.includes('DELETE FROM planned_operations'),
+      );
+      expect(deleteCalls).toHaveLength(0);
+    });
+
+    it('deletes a one-time planned operation after marking executed', async () => {
+      await PlannedOperationsDB.executeAndMark(oneTimeOp, operationData, '2026-05');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM planned_operations WHERE id = ?'),
+        ['plan-2'],
+      );
+    });
+
+    it('returns the created operation from createOperationInTx', async () => {
+      const fakeCreated = { id: 42, type: 'expense' };
+      createOperationInTx.mockResolvedValue(fakeCreated);
+
+      const result = await PlannedOperationsDB.executeAndMark(recurringOp, operationData, '2026-05');
+
+      expect(result).toBe(fakeCreated);
+    });
+
+    it('propagates errors and rolls back (no partial state)', async () => {
+      createOperationInTx.mockRejectedValue(new Error('insert failed'));
+      executeTransaction.mockImplementation(async (callback) => {
+        await callback(mockDb);
+      });
+
+      await expect(
+        PlannedOperationsDB.executeAndMark(recurringOp, operationData, '2026-05'),
+      ).rejects.toThrow('insert failed');
+
+      // markExecuted UPDATE should not have been called because transaction failed
+      const markCalls = mockDb.runAsync.mock.calls.filter(
+        ([sql]) => sql.includes('UPDATE planned_operations'),
+      );
+      expect(markCalls).toHaveLength(0);
     });
   });
 });

--- a/app/contexts/PlannedOperationsContext.js
+++ b/app/contexts/PlannedOperationsContext.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import uuid from 'react-native-uuid';
 import * as PlannedOperationsDB from '../services/PlannedOperationsDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
-import { useOperationsActions } from './OperationsActionsContext';
 import { useDialog } from './DialogContext';
 import { useLocalization } from './LocalizationContext';
 import { formatDate } from '../services/BalanceHistoryDB';
@@ -29,7 +28,6 @@ const getCurrentMonth = () => {
 export const PlannedOperationsProvider = ({ children }) => {
   const { showDialog } = useDialog();
   const { t } = useLocalization();
-  const { addOperation } = useOperationsActions();
   const [plannedOperations, setPlannedOperations] = useState([]);
   const [loading, setLoading] = useState(true);
   const [saveError, setSaveError] = useState(null);
@@ -135,13 +133,15 @@ export const PlannedOperationsProvider = ({ children }) => {
   }, [showDialog, t]);
 
   /**
-   * Execute a planned operation — create a real operation with today's date
+   * Execute a planned operation — create a real operation with today's date.
+   * All DB writes (operation insert, balance updates, markExecuted, optional delete)
+   * run in a single transaction so a crash mid-way cannot leave the operation
+   * created but the planned-op still showing as pending.
    */
   const executePlannedOperation = useCallback(async (plannedOp) => {
     try {
       const currentMonth = getCurrentMonth();
 
-      // Build operation data from planned operation template
       const operationData = {
         type: plannedOp.type,
         amount: plannedOp.amount,
@@ -152,25 +152,25 @@ export const PlannedOperationsProvider = ({ children }) => {
         description: plannedOp.name || plannedOp.description || null,
       };
 
-      // Create the real operation
-      const createdOperation = await addOperation(operationData);
+      // Single atomic transaction: insert operation + mark executed + optional delete
+      const createdOperation = await PlannedOperationsDB.executeAndMark(
+        plannedOp, operationData, currentMonth,
+      );
 
-      // Mark as executed
-      await PlannedOperationsDB.markExecuted(plannedOp.id, currentMonth);
-
-      // Update local state
+      // Update local React state after the DB commit succeeds
       if (plannedOp.isRecurring) {
-        // For recurring: update lastExecutedMonth
         setPlannedOperations(prev =>
           prev.map(op => op.id === plannedOp.id
             ? { ...op, lastExecutedMonth: currentMonth }
             : op),
         );
       } else {
-        // For one-time: remove from list after execution
-        await PlannedOperationsDB.deletePlannedOperation(plannedOp.id);
         setPlannedOperations(prev => prev.filter(op => op.id !== plannedOp.id));
       }
+
+      // Trigger reloads in other contexts (operations list, account balances, budgets)
+      appEvents.emit(EVENTS.OPERATION_CHANGED);
+      appEvents.emit(EVENTS.RELOAD_ALL);
 
       return createdOperation;
     } catch (error) {
@@ -178,7 +178,7 @@ export const PlannedOperationsProvider = ({ children }) => {
       showDialog(t('error'), error.message, [{ text: t('ok') }]);
       throw error;
     }
-  }, [addOperation, showDialog, t]);
+  }, [showDialog, t]);
 
   /**
    * Check if a planned operation has been executed this month

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -426,6 +426,82 @@ const calculateBalanceChanges = (operation) => {
 };
 
 /**
+ * Insert a new operation and update account balances within an existing transaction.
+ * Callers that need to combine this work with other SQL (e.g. marking a planned
+ * operation as executed) should call this inside their own executeTransaction so
+ * all writes are committed or rolled back together.
+ *
+ * @param {Object} db - The transaction-scoped database instance
+ * @param {Object} operation - Operation data (camelCase, same shape as createOperation)
+ * @returns {Promise<Object>} Created operation data with snake_case fields and auto-generated id
+ */
+export const createOperationInTx = async (db, operation) => {
+  if (!OPERATION_TYPES.includes(operation.type)) {
+    throw new Error(`Invalid operation type: "${operation.type}". Must be one of: ${OPERATION_TYPES.join(', ')}`);
+  }
+
+  const now = new Date().toISOString();
+
+  const extractId = (value) => {
+    if (value === null || value === undefined || value === '') return null;
+    if (typeof value === 'object' && value !== null && value.id !== undefined) return value.id;
+    return value;
+  };
+
+  const operationData = {
+    type: operation.type,
+    amount: operation.amount,
+    account_id: extractId(operation.accountId),
+    category_id: extractId(operation.categoryId),
+    to_account_id: extractId(operation.toAccountId),
+    date: operation.date,
+    created_at: now,
+    description: operation.description || null,
+    exchange_rate: operation.exchangeRate || null,
+    destination_amount: operation.destinationAmount || null,
+    source_currency: operation.sourceCurrency || null,
+    destination_currency: operation.destinationCurrency || null,
+  };
+
+  const result = await db.runAsync(
+    'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    [
+      operationData.type, operationData.amount, operationData.account_id,
+      operationData.category_id, operationData.to_account_id, operationData.date,
+      operationData.created_at, operationData.description, operationData.exchange_rate,
+      operationData.destination_amount, operationData.source_currency, operationData.destination_currency,
+    ],
+  );
+
+  operationData.id = result.lastInsertRowId;
+
+  const balanceChanges = calculateBalanceChanges(operationData);
+  const updateTime = new Date().toISOString();
+
+  for (const [accountId, delta] of balanceChanges.entries()) {
+    if (Currency.isZero(delta)) continue;
+
+    const account = await db.getFirstAsync('SELECT balance FROM accounts WHERE id = ?', [accountId]);
+
+    if (!account) {
+      console.warn(`Account ${accountId} not found, skipping balance update`);
+      continue;
+    }
+
+    const newBalance = Currency.add(account.balance, delta);
+
+    await db.runAsync(
+      'UPDATE accounts SET balance = ?, updated_at = ? WHERE id = ?',
+      [newBalance, updateTime, accountId],
+    );
+
+    await updateTodayBalance(accountId, newBalance, db);
+  }
+
+  return operationData;
+};
+
+/**
  * Create a new operation
  * @param {Object} operation - Operation data (ID will be auto-generated)
  * @returns {Promise<Object>}
@@ -435,91 +511,10 @@ export const createOperation = async (operation) => {
     if (!OPERATION_TYPES.includes(operation.type)) {
       throw new Error(`Invalid operation type: "${operation.type}". Must be one of: ${OPERATION_TYPES.join(', ')}`);
     }
-
-    const now = new Date().toISOString();
-
-    // Safely extract primitive IDs (handle case where objects might be passed)
-    const extractId = (value) => {
-      if (value === null || value === undefined || value === '') return null;
-      if (typeof value === 'object' && value !== null && value.id !== undefined) return value.id;
-      return value;
-    };
-    
-    const operationData = {
-      type: operation.type,
-      amount: operation.amount,
-      account_id: extractId(operation.accountId),
-      category_id: extractId(operation.categoryId),
-      to_account_id: extractId(operation.toAccountId),
-      date: operation.date,
-      created_at: now,
-      description: operation.description || null,
-      exchange_rate: operation.exchangeRate || null,
-      destination_amount: operation.destinationAmount || null,
-      source_currency: operation.sourceCurrency || null,
-      destination_currency: operation.destinationCurrency || null,
-    };
-
-    let newOperationId;
-
+    let operationData;
     await executeTransaction(async (db) => {
-      // Insert operation (ID will be auto-generated)
-      const insertParams = [
-        operationData.type,
-        operationData.amount,
-        operationData.account_id,
-        operationData.category_id,
-        operationData.to_account_id,
-        operationData.date,
-        operationData.created_at,
-        operationData.description,
-        operationData.exchange_rate,
-        operationData.destination_amount,
-        operationData.source_currency,
-        operationData.destination_currency,
-      ];
-
-      const result = await db.runAsync(
-        'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-        insertParams,
-      );
-
-      // Store the auto-generated ID
-      newOperationId = result.lastInsertRowId;
-      operationData.id = newOperationId;
-
-      // Update account balances within the same transaction
-      const balanceChanges = calculateBalanceChanges(operationData);
-      const updateTime = new Date().toISOString();
-
-      for (const [accountId, delta] of balanceChanges.entries()) {
-        if (Currency.isZero(delta)) continue;
-
-        // Get current balance
-        const account = await db.getFirstAsync(
-          'SELECT balance FROM accounts WHERE id = ?',
-          [accountId],
-        );
-
-        if (!account) {
-          console.warn(`Account ${accountId} not found, skipping balance update`);
-          continue;
-        }
-
-        // Use Currency utilities for precise arithmetic
-        const newBalance = Currency.add(account.balance, delta);
-
-        // Update balance
-        await db.runAsync(
-          'UPDATE accounts SET balance = ?, updated_at = ? WHERE id = ?',
-          [newBalance, updateTime, accountId],
-        );
-
-        // Update today's balance history
-        await updateTodayBalance(accountId, newBalance, db);
-      }
+      operationData = await createOperationInTx(db, operation);
     });
-
     return operationData;
   } catch (error) {
     console.error('Failed to create operation:', error);

--- a/app/services/PlannedOperationsDB.js
+++ b/app/services/PlannedOperationsDB.js
@@ -1,4 +1,5 @@
 import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
+import { createOperationInTx } from './OperationsDB';
 
 /**
  * Map database field names to camelCase for application use
@@ -256,6 +257,42 @@ export const markExecuted = async (id, monthStr) => {
     );
   } catch (error) {
     console.error('Failed to mark planned operation as executed:', error);
+    throw error;
+  }
+};
+
+/**
+ * Atomically execute a planned operation in a single SQLite transaction:
+ * inserts the real operation, adjusts account balances, marks the planned
+ * operation as executed, and (for one-time plans) deletes it.
+ *
+ * This prevents the partial-failure window where a crash between any two of
+ * the formerly separate calls would leave the operation created but the
+ * planned-op still marked as pending, enabling a silent double-charge.
+ *
+ * @param {Object} plannedOp - The planned operation being executed
+ * @param {Object} operationData - Real operation to create (camelCase fields)
+ * @param {string} currentMonth - 'YYYY-MM' string for this execution
+ * @returns {Promise<Object>} The created operation (snake_case fields, auto-generated id)
+ */
+export const executeAndMark = async (plannedOp, operationData, currentMonth) => {
+  let createdOperation;
+  try {
+    await executeTransaction(async (db) => {
+      createdOperation = await createOperationInTx(db, operationData);
+
+      await db.runAsync(
+        'UPDATE planned_operations SET last_executed_month = ?, updated_at = ? WHERE id = ?',
+        [currentMonth, new Date().toISOString(), plannedOp.id],
+      );
+
+      if (!plannedOp.isRecurring) {
+        await db.runAsync('DELETE FROM planned_operations WHERE id = ?', [plannedOp.id]);
+      }
+    });
+    return createdOperation;
+  } catch (error) {
+    console.error('Failed to atomically execute planned operation:', error);
     throw error;
   }
 };


### PR DESCRIPTION
Wraps the three formerly separate DB steps of executePlannedOperation
(operation INSERT + account balance UPDATEs, markExecuted UPDATE, and
one-time plan DELETE) into a single SQLite transaction via a new
PlannedOperationsDB.executeAndMark function.

A crash or DB lock between any of the old steps left the real operation
created but the planned-op still showing as pending, allowing the user
to silently execute it a second time and create a double charge.

Key changes:
- OperationsDB: extract createOperationInTx(db, operation) so callers
  can include the INSERT + balance logic inside a larger transaction
- PlannedOperationsDB: add executeAndMark(plannedOp, operationData,
  month) that runs all three writes in one executeTransaction callback
- PlannedOperationsContext: replace addOperation + markExecuted +
  deletePlannedOperation calls with a single executeAndMark call;
  emit OPERATION_CHANGED and RELOAD_ALL after the commit to refresh
  all contexts (operations list, account balances, budgets)

Fixes #685

https://claude.ai/code/session_011h6k7ys1BP4pr6H5BgNbNH