### PR TITLE
fix: abort restore early when backup has unmapped account IDs, add skip counter and pre-restore snapshot

### DIFF
--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -1042,4 +1042,202 @@ op-2,normal`;
       expect(typeof backup.data.accounts[0].balance).toBe('string');
     });
   });
+
+  describe('Regression Tests — Issue #686 (account ID remapping)', () => {
+    const makeDbInstance = () => {
+      let insertCount = 0;
+      return {
+        runAsync: jest.fn().mockImplementation(() =>
+          Promise.resolve({ lastInsertRowId: ++insertCount }),
+        ),
+        getAllAsync: jest.fn().mockResolvedValue([
+          { id: 'shadow-adjustment-expense' },
+          { id: 'shadow-adjustment-income' },
+        ]),
+      };
+    };
+
+    it('aborts before clearing data when an operation references an account not in the backup', async () => {
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [{ id: 'acc-1', name: 'Cash', balance: '0', currency: 'USD' }],
+          categories: [],
+          operations: [
+            { id: 'op-1', type: 'expense', amount: '10', account_id: 'unknown-uuid' },
+          ],
+        },
+      };
+
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(dbInstance);
+      });
+
+      await expect(BackupRestore.restoreBackup(backup)).rejects.toThrow(
+        /account IDs not found in the backup.*Restore aborted/,
+      );
+
+      // The transaction must NOT have run — no DELETE calls should have happened
+      expect(mockDb.executeTransaction).not.toHaveBeenCalled();
+    });
+
+    it('includes all unmapped account IDs in the error message', async () => {
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [],
+          categories: [],
+          operations: [
+            { id: 'op-1', type: 'expense', amount: '10', account_id: 'uuid-A' },
+            { id: 'op-2', type: 'expense', amount: '5', account_id: 'uuid-B' },
+          ],
+        },
+      };
+
+      await expect(BackupRestore.restoreBackup(backup)).rejects.toThrow(/uuid-A/);
+    });
+
+    it('does not abort when operation.account_id is null (counted as skip instead)', async () => {
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [{ id: 'acc-1', name: 'Cash', balance: '0', currency: 'USD' }],
+          categories: [],
+          operations: [
+            { id: 'op-1', type: 'expense', amount: '10', account_id: null },
+          ],
+        },
+      };
+
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(dbInstance);
+      });
+
+      // Should resolve, not throw
+      await expect(BackupRestore.restoreBackup(backup)).resolves.toBeUndefined();
+    });
+
+    it('emits complete event with skippedOperations count when operations are null-skipped', async () => {
+      const appEvents = require('../../app/services/eventEmitter').appEvents;
+      const emitSpy = jest.spyOn(appEvents, 'emit');
+
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [{ id: 'acc-1', name: 'Cash', balance: '0', currency: 'USD' }],
+          categories: [],
+          operations: [
+            { id: 'op-1', type: 'expense', amount: '10', account_id: null },
+            { id: 'op-2', type: 'expense', amount: '5', account_id: null },
+          ],
+        },
+      };
+
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(dbInstance);
+      });
+
+      await BackupRestore.restoreBackup(backup);
+
+      const completeCall = emitSpy.mock.calls.find(
+        ([, payload]) => payload?.stepId === 'complete' && payload?.status === 'completed',
+      );
+      expect(completeCall).toBeDefined();
+      expect(completeCall[1].data.skippedOperations).toBe(2);
+    });
+
+    it('creates a pre-restore snapshot file before clearing live data', async () => {
+      // Make createBackup return mock data so it can write the snapshot
+      mockDb.queryAll.mockResolvedValue([]);
+
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [],
+          categories: [],
+          operations: [],
+        },
+      };
+
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(dbInstance);
+      });
+
+      await BackupRestore.restoreBackup(backup);
+
+      // writeAsStringAsync should have been called at least once for the snapshot
+      const snapshotWrite = mockFileSystem.writeAsStringAsync.mock.calls.find(
+        ([uri]) => uri.includes('pre_restore_'),
+      );
+      expect(snapshotWrite).toBeDefined();
+    });
+
+    it('snapshot URI is included in the complete event data', async () => {
+      const appEvents = require('../../app/services/eventEmitter').appEvents;
+      const emitSpy = jest.spyOn(appEvents, 'emit');
+
+      mockDb.queryAll.mockResolvedValue([]);
+
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [],
+          categories: [],
+          operations: [],
+        },
+      };
+
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(dbInstance);
+      });
+
+      await BackupRestore.restoreBackup(backup);
+
+      const completeCall = emitSpy.mock.calls.find(
+        ([, payload]) => payload?.stepId === 'complete' && payload?.status === 'completed',
+      );
+      expect(completeCall).toBeDefined();
+      expect(completeCall[1].data.snapshotUri).toContain('pre_restore_');
+    });
+
+    it('proceeds with restore even if snapshot creation fails', async () => {
+      mockFileSystem.writeAsStringAsync.mockRejectedValueOnce(new Error('disk full'));
+
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [],
+          categories: [],
+          operations: [],
+        },
+      };
+
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(dbInstance);
+      });
+
+      // Should still succeed despite snapshot failure
+      await expect(BackupRestore.restoreBackup(backup)).resolves.toBeUndefined();
+    });
+  });
 });

--- a/app/contexts/ImportProgressContext.js
+++ b/app/contexts/ImportProgressContext.js
@@ -64,6 +64,9 @@ export const ImportProgressProvider = ({ children }) => {
   useEffect(() => {
     const unsubscribe = appEvents.on(IMPORT_PROGRESS_EVENT, ({ stepId, status, data }) => {
       updateStep(stepId, status, data);
+      if (stepId === 'complete' && status === 'completed') {
+        setCurrentStep('complete');
+      }
     });
 
     return unsubscribe;

--- a/app/modals/ImportProgressModal.js
+++ b/app/modals/ImportProgressModal.js
@@ -79,6 +79,13 @@ export default function ImportProgressModal() {
         return `Restored ${step.data} budgets`;
       case 'metadata':
         return `Restored ${step.data} metadata entries`;
+      case 'complete': {
+        const skipped = step.data?.skippedOperations;
+        if (skipped > 0) {
+          return `Database restored successfully (${skipped} operation${skipped === 1 ? '' : 's'} skipped — see logs)`;
+        }
+        return step.label;
+      }
       default:
         return step.label;
       }

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -361,8 +361,47 @@ export const restoreBackup = async (backup) => {
     console.log('Restoring database from backup...');
     appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'restore', status: 'in_progress' });
 
-    // Validate backup
+    // Validate backup structure and enum fields
     validateBackup(backup);
+
+    // Pre-validate account ID references before touching live data.
+    // Build the set of account IDs that will actually be inserted (skipped accounts excluded).
+    const accountIdsInBackup = new Set();
+    for (const account of backup.data.accounts) {
+      if (!account.name) continue;
+      if (account.id != null) accountIdsInBackup.add(account.id);
+    }
+
+    const unmappedAccountIds = [];
+    for (const operation of backup.data.operations) {
+      if (operation.account_id == null) continue;
+      if (!accountIdsInBackup.has(operation.account_id)) {
+        unmappedAccountIds.push(operation.account_id);
+      }
+    }
+
+    if (unmappedAccountIds.length > 0) {
+      const uniqueIds = [...new Set(unmappedAccountIds.map(String))];
+      const sample = uniqueIds.slice(0, 3).join(', ');
+      const extra = uniqueIds.length > 3 ? ` (and ${uniqueIds.length - 3} more)` : '';
+      throw new Error(
+        `Backup references account IDs not found in the backup's accounts list: ${sample}${extra}. Restore aborted — your data has not been changed.`,
+      );
+    }
+
+    // Create a pre-restore snapshot so the user can recover if something goes wrong.
+    let snapshotUri = null;
+    try {
+      const snapshot = await createBackup();
+      const snapshotTimestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+      snapshotUri = `${FileSystem.documentDirectory}pre_restore_${snapshotTimestamp}.json`;
+      await FileSystem.writeAsStringAsync(snapshotUri, JSON.stringify(snapshot, null, 2));
+      console.log('Pre-restore snapshot saved:', snapshotUri);
+    } catch (snapshotError) {
+      console.warn('Failed to create pre-restore snapshot:', snapshotError);
+    }
+
+    let skippedOperations = 0;
 
     await executeTransaction(async (db) => {
       appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'restore', status: 'completed' });
@@ -507,6 +546,7 @@ export const restoreBackup = async (backup) => {
         // Validate that account_id is not null/undefined
         if (mappedAccountId == null) {
           console.warn('Skipping operation with null account_id:', operation);
+          skippedOperations++;
           continue;
         }
 
@@ -778,7 +818,11 @@ export const restoreBackup = async (backup) => {
     });
 
     console.log('Database restored successfully');
-    appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'complete', status: 'completed' });
+    appEvents.emit(IMPORT_PROGRESS_EVENT, {
+      stepId: 'complete',
+      status: 'completed',
+      data: { skippedOperations, snapshotUri },
+    });
   } catch (error) {
     console.error('Failed to restore backup:', error);
     throw error;

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
     },
   },
   "overrides": {
+    "jest-environment-node": "30.4.1",
     "jest-mock": "30.4.1",
   },
   "packages": {
@@ -1311,7 +1312,7 @@
 
     "jest-environment-jsdom": ["jest-environment-jsdom@29.7.0", "", { "dependencies": { "@jest/environment": "^29.7.0", "@jest/fake-timers": "^29.7.0", "@jest/types": "^29.6.3", "@types/jsdom": "^20.0.0", "@types/node": "*", "jest-mock": "^29.7.0", "jest-util": "^29.7.0", "jsdom": "^20.0.0" }, "peerDependencies": { "canvas": "^2.5.0" }, "optionalPeers": ["canvas"] }, "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA=="],
 
-    "jest-environment-node": ["jest-environment-node@29.7.0", "", { "dependencies": { "@jest/environment": "^29.7.0", "@jest/fake-timers": "^29.7.0", "@jest/types": "^29.6.3", "@types/node": "*", "jest-mock": "^29.7.0", "jest-util": "^29.7.0" } }, "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw=="],
+    "jest-environment-node": ["jest-environment-node@30.4.1", "", { "dependencies": { "@jest/environment": "30.4.1", "@jest/fake-timers": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "jest-mock": "30.4.1", "jest-util": "30.4.1", "jest-validate": "30.4.1" } }, "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw=="],
 
     "jest-expo": ["jest-expo@54.0.16", "", { "dependencies": { "@expo/config": "~12.0.12", "@expo/json-file": "^10.0.8", "@jest/create-cache-key-function": "^29.2.1", "@jest/globals": "^29.2.1", "babel-jest": "^29.2.1", "jest-environment-jsdom": "^29.2.1", "jest-snapshot": "^29.2.1", "jest-watch-select-projects": "^2.0.0", "jest-watch-typeahead": "2.2.1", "json5": "^2.2.3", "lodash": "^4.17.19", "react-test-renderer": "19.1.0", "server-only": "^0.0.1", "stacktrace-js": "^2.0.2" }, "peerDependencies": { "expo": "*", "react-native": "*", "react-server-dom-webpack": "~19.0.3 || ~19.1.4 || ~19.2.3" }, "optionalPeers": ["react-server-dom-webpack"], "bin": { "jest": "bin/jest.js" } }, "sha512-wPV5dddlNMORNSA7ZjEjePA+ztks3G5iKCOHLIauURnKQPTscnaat5juXPboK1Bv2I+c/RDfkt4uZtAmXdlu/g=="],
 
@@ -2243,8 +2244,6 @@
 
     "jest-config/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
-    "jest-config/jest-environment-node": ["jest-environment-node@30.4.1", "", { "dependencies": { "@jest/environment": "30.4.1", "@jest/fake-timers": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "jest-mock": "30.4.1", "jest-util": "30.4.1", "jest-validate": "30.4.1" } }, "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw=="],
-
     "jest-config/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
 
     "jest-each/pretty-format": ["pretty-format@30.4.1", "", { "dependencies": { "@jest/schemas": "30.4.1", "ansi-styles": "^5.2.0", "react-is-18": "npm:react-is@^18.3.1", "react-is-19": "npm:react-is@^19.2.5" } }, "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw=="],
@@ -2253,9 +2252,9 @@
 
     "jest-environment-jsdom/jest-util": ["jest-util@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA=="],
 
-    "jest-environment-node/@jest/types": ["@jest/types@29.6.3", "", { "dependencies": { "@jest/schemas": "^29.6.3", "@types/istanbul-lib-coverage": "^2.0.0", "@types/istanbul-reports": "^3.0.0", "@types/node": "*", "@types/yargs": "^17.0.8", "chalk": "^4.0.0" } }, "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw=="],
+    "jest-environment-node/@jest/environment": ["@jest/environment@30.4.1", "", { "dependencies": { "@jest/fake-timers": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "jest-mock": "30.4.1" } }, "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w=="],
 
-    "jest-environment-node/jest-util": ["jest-util@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@types/node": "*", "chalk": "^4.0.0", "ci-info": "^3.2.0", "graceful-fs": "^4.2.9", "picomatch": "^2.2.3" } }, "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA=="],
+    "jest-environment-node/@jest/fake-timers": ["@jest/fake-timers@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@sinonjs/fake-timers": "^15.4.0", "@types/node": "*", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ=="],
 
     "jest-haste-map/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
@@ -2268,8 +2267,6 @@
     "jest-resolve-dependencies/jest-snapshot": ["jest-snapshot@30.4.1", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/generator": "^7.27.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/types": "^7.27.3", "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "@jest/snapshot-utils": "30.4.1", "@jest/transform": "30.4.1", "@jest/types": "30.4.1", "babel-preset-current-node-syntax": "^1.2.0", "chalk": "^4.1.2", "expect": "30.4.1", "graceful-fs": "^4.2.11", "jest-diff": "30.4.1", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-util": "30.4.1", "pretty-format": "30.4.1", "semver": "^7.7.2", "synckit": "^0.11.8" } }, "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw=="],
 
     "jest-runner/@jest/environment": ["@jest/environment@30.4.1", "", { "dependencies": { "@jest/fake-timers": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "jest-mock": "30.4.1" } }, "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w=="],
-
-    "jest-runner/jest-environment-node": ["jest-environment-node@30.4.1", "", { "dependencies": { "@jest/environment": "30.4.1", "@jest/fake-timers": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "jest-mock": "30.4.1", "jest-util": "30.4.1", "jest-validate": "30.4.1" } }, "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw=="],
 
     "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
@@ -2535,10 +2532,6 @@
 
     "jest-config/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "jest-config/jest-environment-node/@jest/environment": ["@jest/environment@30.4.1", "", { "dependencies": { "@jest/fake-timers": "30.4.1", "@jest/types": "30.4.1", "@types/node": "*", "jest-mock": "30.4.1" } }, "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w=="],
-
-    "jest-config/jest-environment-node/@jest/fake-timers": ["@jest/fake-timers@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@sinonjs/fake-timers": "^15.4.0", "@types/node": "*", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ=="],
-
     "jest-config/pretty-format/@jest/schemas": ["@jest/schemas@30.4.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q=="],
 
     "jest-each/pretty-format/@jest/schemas": ["@jest/schemas@30.4.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q=="],
@@ -2547,9 +2540,7 @@
 
     "jest-environment-jsdom/jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "jest-environment-node/jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
-
-    "jest-environment-node/jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "jest-environment-node/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
     "jest-leak-detector/pretty-format/@jest/schemas": ["@jest/schemas@30.4.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q=="],
 
@@ -2568,8 +2559,6 @@
     "jest-resolve-dependencies/jest-snapshot/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "jest-runner/@jest/environment/@jest/fake-timers": ["@jest/fake-timers@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@sinonjs/fake-timers": "^15.4.0", "@types/node": "*", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ=="],
-
-    "jest-runner/jest-environment-node/@jest/fake-timers": ["@jest/fake-timers@30.4.1", "", { "dependencies": { "@jest/types": "30.4.1", "@sinonjs/fake-timers": "^15.4.0", "@types/node": "*", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ=="],
 
     "jest-runner/source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -2697,8 +2686,6 @@
 
     "jest-config/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "jest-config/jest-environment-node/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
-
     "jest-config/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.46", "", {}, "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ=="],
 
     "jest-each/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.34.46", "", {}, "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ=="],
@@ -2710,8 +2697,6 @@
     "jest-resolve-dependencies/jest-snapshot/pretty-format/@jest/schemas": ["@jest/schemas@30.4.1", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q=="],
 
     "jest-runner/@jest/environment/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
-
-    "jest-runner/jest-environment-node/@jest/fake-timers/@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.4.0", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA=="],
 
     "jest-runtime/@jest/globals/@jest/expect/expect": ["expect@30.4.1", "", { "dependencies": { "@jest/expect-utils": "30.4.1", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.4.1", "jest-message-util": "30.4.1", "jest-mock": "30.4.1", "jest-util": "30.4.1" } }, "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA=="],
 


### PR DESCRIPTION
Addresses three failure modes from issue #686:

1. Pre-validation: walk backup.data.operations before opening the transaction
   and verify every non-null account_id resolves to an account in the backup's
   accounts list. If any don't, throw a descriptive error before any DELETE
   runs, so live data is never touched.

2. Skip counter: replace the silent `continue` for null-account_id operations
   with a counter that is surfaced in the 'complete' progress event as
   `data.skippedOperations`, shown to the user in the import progress modal
   ("N operations skipped — see logs").

3. Pre-restore snapshot: write a pre_restore_<timestamp>.json backup before
   the transaction begins so the user can recover even if the restore fails
   mid-flight. The snapshot URI is included in the complete event data.

Also fix ImportProgressContext to set currentStep = 'complete' when the
complete event fires (so the OK button in ImportProgressModal enables).

Adds 7 regression tests covering all three fixes.

https://claude.ai/code/session_01PnQGd4DomuXsfBrGqZDcjB
Closes #686