### PR TITLE
fix: crash when saving account with createAdjustmentOperation checked but no balance change

### DIFF
--- a/__tests__/contexts/AccountsActionsContext.test.js
+++ b/__tests__/contexts/AccountsActionsContext.test.js
@@ -293,7 +293,7 @@ describe('AccountsActionsContext', () => {
       expect(mockShowDialog).toHaveBeenCalled();
     });
 
-    it('supports updating hidden field', async () => {
+    it('supports updating hidden field without balance', async () => {
       const { result } = renderHook(() => useAccounts(), { wrapper });
       await waitFor(() => expect(result.current.accounts).toHaveLength(1));
 
@@ -302,6 +302,39 @@ describe('AccountsActionsContext', () => {
       });
 
       expect(AccountsDB.updateAccount).toHaveBeenCalledWith('acc-1', { hidden: true });
+    });
+
+    it('propagates hidden field when balance also changes with createAdjustmentOperation=true', async () => {
+      // Regression: when balance changes AND createAdjustmentOperation=true, the hidden
+      // field was missing from nonBalanceUpdates, so it would never be saved.
+      const { result } = renderHook(() => useAccounts(), { wrapper });
+      await waitFor(() => expect(result.current.accounts).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.updateAccount('acc-1', { balance: '200', hidden: true }, true);
+      });
+
+      expect(AccountsDB.adjustAccountBalance).toHaveBeenCalledWith('acc-1', '200', '');
+      expect(AccountsDB.updateAccount).toHaveBeenCalledWith('acc-1', { hidden: true });
+    });
+
+    it('does not call adjustAccountBalance when balance is numerically unchanged (string format differs)', async () => {
+      // Regression: "100" vs "100.00" should be treated as equal — numeric comparison
+      // prevents a spurious adjustAccountBalance call that would try to INSERT a 0.00
+      // adjustment operation and crash with NativeDatabase.prepareAsync rejection.
+      const accountWithFormattedBalance = { id: 'acc-1', name: 'Old Name', balance: '100.00', currency: 'USD' };
+      AccountsDB.getAllAccounts.mockResolvedValue([accountWithFormattedBalance]);
+
+      const { result } = renderHook(() => useAccounts(), { wrapper });
+      await waitFor(() => expect(result.current.accounts).toHaveLength(1));
+
+      await act(async () => {
+        // balance "100" is numerically equal to stored "100.00"
+        await result.current.updateAccount('acc-1', { balance: '100', hidden: true }, true);
+      });
+
+      expect(AccountsDB.adjustAccountBalance).not.toHaveBeenCalled();
+      expect(AccountsDB.updateAccount).toHaveBeenCalledWith('acc-1', expect.objectContaining({ hidden: true }));
     });
   });
 

--- a/__tests__/services/AccountsDB.test.js
+++ b/__tests__/services/AccountsDB.test.js
@@ -966,6 +966,55 @@ describe('AccountsDB', () => {
       await expect(AccountsDB.adjustAccountBalance('acc-1', '100.00'))
         .rejects.toThrow('Adjustment failed');
     });
+
+    it('does nothing when balance is unchanged and no existing adjustment for today', async () => {
+      // Regression: calling adjustAccountBalance with the same balance (delta = 0) and
+      // no prior adjustment today used to attempt an INSERT with amount "0.00", which
+      // crashed with NativeDatabase.prepareAsync rejection.
+      const mockDb = {
+        getFirstAsync: jest.fn()
+          .mockResolvedValueOnce({ balance: '896500.00' }) // current balance
+          .mockResolvedValueOnce(null), // no existing adjustment operation
+        getAllAsync: jest.fn().mockResolvedValue([
+          { id: 'shadow-expense', category_type: 'expense', is_shadow: 1 },
+          { id: 'shadow-income', category_type: 'income', is_shadow: 1 },
+        ]),
+        runAsync: jest.fn(),
+      };
+
+      jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => {
+        await callback(mockDb);
+      });
+
+      // Same balance — no change
+      await AccountsDB.adjustAccountBalance('acc-1', '896500.00');
+
+      // No INSERT or UPDATE should have been issued
+      expect(mockDb.runAsync).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when balance string format differs but value is unchanged', async () => {
+      // Regression: "896500" vs "896500.00" — numerically the same, should not INSERT
+      const mockDb = {
+        getFirstAsync: jest.fn()
+          .mockResolvedValueOnce({ balance: '896500.00' }) // stored with decimals
+          .mockResolvedValueOnce(null),
+        getAllAsync: jest.fn().mockResolvedValue([
+          { id: 'shadow-expense', category_type: 'expense', is_shadow: 1 },
+          { id: 'shadow-income', category_type: 'income', is_shadow: 1 },
+        ]),
+        runAsync: jest.fn(),
+      };
+
+      jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => {
+        await callback(mockDb);
+      });
+
+      // Balance passed without decimals — same numeric value
+      await AccountsDB.adjustAccountBalance('acc-1', '896500');
+
+      expect(mockDb.runAsync).not.toHaveBeenCalled();
+    });
   });
 
   // Regression tests for data integrity

--- a/app/contexts/AccountsActionsContext.js
+++ b/app/contexts/AccountsActionsContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import * as AccountsDB from '../services/AccountsDB';
+import * as Currency from '../services/currency';
 import { dropAllTables, getDatabase, closeDatabase } from '../services/db';
 import { forceDeleteDatabase } from '../utils/emergencyReset';
 import { appEvents, EVENTS } from '../services/eventEmitter';
@@ -64,8 +65,10 @@ export const AccountsActionsProvider = ({ children }) => {
         throw new Error('Account not found');
       }
 
-      // Check if balance is being changed
-      const balanceChanged = updated.balance !== undefined && currentAccount.balance !== String(updated.balance);
+      // Check if balance is being changed (numeric comparison avoids false positives
+      // when the string format differs, e.g. "100" vs "100.00" after Currency.add)
+      const balanceChanged = updated.balance !== undefined &&
+        Currency.compare(currentAccount.balance, updated.balance) !== 0;
 
       if (balanceChanged && createAdjustmentOperation) {
         // Use adjustAccountBalance for balance changes to create adjustment operations
@@ -78,6 +81,9 @@ export const AccountsActionsProvider = ({ children }) => {
         }
         if (updated.currency !== undefined && updated.currency !== currentAccount.currency) {
           nonBalanceUpdates.currency = updated.currency;
+        }
+        if (updated.hidden !== undefined && updated.hidden !== currentAccount.hidden) {
+          nonBalanceUpdates.hidden = updated.hidden;
         }
 
         if (Object.keys(nonBalanceUpdates).length > 0) {

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -591,6 +591,14 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
           await BalanceHistoryDB.updateTodayBalance(accountId, newBalanceValue, db);
         }
       } else {
+        // No existing adjustment for today — if delta is zero there is nothing to do.
+        // This guards against calling adjustAccountBalance when the balance hasn't
+        // actually changed (e.g. only a non-balance field like 'hidden' was edited)
+        // which would otherwise try to INSERT a zero-amount operation and crash.
+        if (Currency.isZero(totalDeltaStr)) {
+          return;
+        }
+
         // Create new adjustment operation, recording original_balance in its own column
         console.log('Creating new adjustment operation:', {
           type: operationType,


### PR DESCRIPTION
Three related bugs caused an account edit to always fail when the
"create adjustment operation" toggle was on but only a non-balance
field (e.g. hidden) changed:

1. adjustAccountBalance: no guard for zero-delta new operation
   When called with the same balance and no prior adjustment today
   the code fell into the "new operation" path and tried to INSERT
   an operation with amount "0.00", which crashes with
   NativeDatabase.prepareAsync rejection. The existing-operation path
   already had this guard (it deletes the op); add the same early
   return to the new-operation path.

2. AccountsActionsContext: string-vs-string comparison for balanceChanged
   currentAccount.balance could be "896500.00" while the form's
   editValues.balance is "896500" (loaded before a Currency.add
   normalization ran). The strict !== comparison treated these as
   different, incorrectly triggering adjustAccountBalance. Switch to
   Currency.compare so only a true numeric difference triggers the
   adjustment path.

3. AccountsActionsContext: hidden field lost in balanceChanged path
   When balanceChanged && createAdjustmentOperation the non-balance
   update block handled name and currency but not hidden. Add hidden
   to nonBalanceUpdates so the field is always persisted.

https://claude.ai/code/session_01VqoYBnZdGBxTWw9BwCmoqH