### PR TITLE
fix(settings): center up-to-date message in settings update modal

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1415,11 +1415,13 @@ export default function SettingsModal({ visible, onClose }) {
                       )}
                       {updateResult.type === 'up_to_date' && (
                         <View style={styles.upToDateContent}>
-                          <View style={styles.upToDateHeader}>
-                            <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
-                            <Text style={[styles.updateVersionText, { color: colors.text }]}>
-                              {t('up_to_date') || 'You already have the latest version installed.'}
-                            </Text>
+                          <View style={styles.upToDateHeaderSpacer}>
+                            <View style={styles.upToDateHeader}>
+                              <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
+                              <Text style={[styles.updateVersionText, { color: colors.text }]}>
+                                {t('up_to_date') || 'You already have the latest version installed.'}
+                              </Text>
+                            </View>
                           </View>
                           {downloadedApks.length > 0 && (
                             <View style={styles.downloadedApksSection}>
@@ -1882,12 +1884,15 @@ const styles = StyleSheet.create({
   },
   upToDateContent: {
     flex: 1,
-    paddingVertical: SPACING.xl,
   },
   upToDateHeader: {
     alignItems: 'center',
-    paddingBottom: SPACING.lg,
     paddingHorizontal: HORIZONTAL_PADDING * 2,
+  },
+  upToDateHeaderSpacer: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
   },
   updateActionColumn: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary
Improved the visual layout of the "up to date" message in the Settings modal's update check section by centering it vertically on the screen.

## Changes
- Wrapped the `upToDateHeader` view in a new `upToDateHeaderSpacer` container that uses `flex: 1` and `justifyContent: 'center'` to vertically center the content
- Removed `paddingVertical` from `upToDateContent` style (no longer needed with flex centering)
- Removed `paddingBottom` from `upToDateHeader` style (spacing now handled by the spacer container)
- Added new `upToDateHeaderSpacer` style with flexbox centering properties

## Implementation Details
The change uses a common React Native pattern of wrapping content in a flex container to achieve vertical centering. This provides better visual balance when displaying the success message, especially on larger screens where the modal takes up significant vertical space.

https://claude.ai/code/session_01XDxYU9gbwBkQD5u46wEQvZ