### PR TITLE
fix: refuse to write empty snapshots over real backup data (issue #690)

### DIFF
--- a/__tests__/services/DailyBackupService.test.js
+++ b/__tests__/services/DailyBackupService.test.js
@@ -34,6 +34,7 @@ jest.mock('expo-file-system/legacy', () => ({
   makeDirectoryAsync: jest.fn(),
   readDirectoryAsync: jest.fn(),
   writeAsStringAsync: jest.fn(),
+  readAsStringAsync: jest.fn(),
   deleteAsync: jest.fn(),
 }));
 
@@ -47,6 +48,20 @@ const TODAY = '2026-02-26';
 const THIS_WEEK = '2026-W09'; // ISO week containing 2026-02-26
 
 const makeSampleBackup = () => ({
+  version: 1,
+  timestamp: `${TODAY}T10:00:00.000Z`,
+  platform: 'native',
+  data: {
+    accounts: [{ id: 'acc-1', name: 'Checking', balance: '1000.00', currency: 'USD' }],
+    categories: [],
+    operations: [],
+    budgets: [],
+    app_metadata: [],
+    balance_history: [],
+  },
+});
+
+const makeEmptyBackup = () => ({
   version: 1,
   timestamp: `${TODAY}T10:00:00.000Z`,
   platform: 'native',
@@ -83,6 +98,7 @@ describe('DailyBackupService', () => {
     mockFileSystem.getInfoAsync.mockResolvedValue({ exists: true });
     mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
     mockFileSystem.writeAsStringAsync.mockResolvedValue(undefined);
+    mockFileSystem.readAsStringAsync.mockResolvedValue(JSON.stringify(makeSampleBackup()));
     mockFileSystem.deleteAsync.mockResolvedValue(undefined);
 
     mockBackupRestore.createBackup.mockResolvedValue(makeSampleBackup());
@@ -465,6 +481,102 @@ describe('DailyBackupService', () => {
         await performDailyBackupIfNeeded();
 
         expect(mockFileSystem.deleteAsync).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('empty snapshot protection', () => {
+      beforeEach(() => mockPrefs({ daily: null, weekly: null }));
+
+      it('skips the write when the new snapshot has 0 accounts but a prior backup had data', async () => {
+        mockBackupRestore.createBackup.mockResolvedValue(makeEmptyBackup());
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(['daily_2026-02-25.json']);
+        mockFileSystem.readAsStringAsync.mockResolvedValue(
+          JSON.stringify({ data: { accounts: [{ id: 'acc-1' }, { id: 'acc-2' }] } }),
+        );
+
+        const result = await performDailyBackupIfNeeded();
+
+        expect(result).toBe(false);
+        expect(mockFileSystem.writeAsStringAsync).not.toHaveBeenCalled();
+      });
+
+      it('does not update preferences when the snapshot is rejected', async () => {
+        mockBackupRestore.createBackup.mockResolvedValue(makeEmptyBackup());
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(['daily_2026-02-25.json']);
+        mockFileSystem.readAsStringAsync.mockResolvedValue(
+          JSON.stringify({ data: { accounts: [{ id: 'acc-1' }] } }),
+        );
+
+        await performDailyBackupIfNeeded();
+
+        expect(mockPreferencesDB.setPreference).not.toHaveBeenCalled();
+      });
+
+      it('does not trigger cleanup when the snapshot is rejected', async () => {
+        mockBackupRestore.createBackup.mockResolvedValue(makeEmptyBackup());
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(['daily_2026-02-25.json']);
+        mockFileSystem.readAsStringAsync.mockResolvedValue(
+          JSON.stringify({ data: { accounts: [{ id: 'acc-1' }] } }),
+        );
+
+        await performDailyBackupIfNeeded();
+
+        expect(mockFileSystem.deleteAsync).not.toHaveBeenCalled();
+      });
+
+      it('allows the write when the new snapshot has 0 accounts and there are no prior backups', async () => {
+        mockBackupRestore.createBackup.mockResolvedValue(makeEmptyBackup());
+        mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
+
+        const result = await performDailyBackupIfNeeded();
+
+        expect(result).toBe(true);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalled();
+      });
+
+      it('allows the write when the prior backup also had 0 accounts', async () => {
+        mockBackupRestore.createBackup.mockResolvedValue(makeEmptyBackup());
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(['daily_2026-02-25.json']);
+        mockFileSystem.readAsStringAsync.mockResolvedValue(
+          JSON.stringify({ data: { accounts: [] } }),
+        );
+
+        const result = await performDailyBackupIfNeeded();
+
+        expect(result).toBe(true);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalled();
+      });
+
+      it('allows the write when the prior backup cannot be parsed', async () => {
+        mockBackupRestore.createBackup.mockResolvedValue(makeEmptyBackup());
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(['daily_2026-02-25.json']);
+        mockFileSystem.readAsStringAsync.mockResolvedValue('not-valid-json{{{');
+
+        const result = await performDailyBackupIfNeeded();
+
+        expect(result).toBe(true);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalled();
+      });
+
+      it('allows the write when readAsStringAsync throws', async () => {
+        mockBackupRestore.createBackup.mockResolvedValue(makeEmptyBackup());
+        mockFileSystem.readDirectoryAsync.mockResolvedValue(['daily_2026-02-25.json']);
+        mockFileSystem.readAsStringAsync.mockRejectedValue(new Error('File not found'));
+
+        const result = await performDailyBackupIfNeeded();
+
+        expect(result).toBe(true);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalled();
+      });
+
+      it('proceeds normally when the snapshot has real account data', async () => {
+        // makeSampleBackup has 1 account — isSnapshotValid returns true immediately
+        const result = await performDailyBackupIfNeeded();
+
+        expect(result).toBe(true);
+        expect(mockFileSystem.writeAsStringAsync).toHaveBeenCalled();
+        // readAsStringAsync should NOT be called — the fast path (accountCount > 0) exits early
+        expect(mockFileSystem.readAsStringAsync).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/services/DailyBackupService.js
+++ b/app/services/DailyBackupService.js
@@ -127,6 +127,48 @@ const cleanupBackups = async (backups, maxToKeep) => {
 };
 
 /**
+ * Returns false when the snapshot looks like a silent DB read failure.
+ * If accounts is empty, we compare against the most recent backup on disk.
+ * A snapshot with zero accounts is rejected when any prior backup recorded
+ * real accounts — that pattern is the fingerprint of a locked/mid-migration DB
+ * returning empty arrays, not a user who deleted everything.
+ */
+const isSnapshotValid = async (backup) => {
+  const accountCount = backup?.data?.accounts?.length ?? 0;
+
+  // Snapshot has at least one account — no concern
+  if (accountCount > 0) return true;
+
+  // Zero accounts: compare against the most recent backup file on disk
+  const existingFiles = [
+    ...(await getDailyBackups()),
+    ...(await getWeeklyBackups()),
+  ].sort();
+
+  const latestUri = existingFiles[existingFiles.length - 1];
+  if (!latestUri) {
+    // No prior backup to compare against — allow writing (first-run / fresh install)
+    return true;
+  }
+
+  try {
+    const prevJson = await FileSystem.readAsStringAsync(latestUri);
+    const prev = JSON.parse(prevJson);
+    const prevAccounts = prev?.data?.accounts?.length ?? 0;
+    if (prevAccounts > 0) {
+      console.warn(
+        `[DailyBackup] Refusing empty snapshot: previous backup had ${prevAccounts} account(s) — skipping to protect existing backups`,
+      );
+      return false;
+    }
+  } catch {
+    // Can't read/parse the previous backup — allow writing rather than blocking indefinitely
+  }
+
+  return true;
+};
+
+/**
  * Create daily and/or weekly backups if not yet done for the current day/week.
  * Safe to call on every app open – no-ops when both are already up to date.
  * A single createBackup() snapshot is reused for both file types when both are needed.
@@ -155,6 +197,13 @@ export const performDailyBackupIfNeeded = async () => {
 
     // One snapshot serves both daily and weekly writes if both are needed
     const backup = await createBackup();
+
+    // Guard: never overwrite good backups with a snapshot that looks like a DB read failure
+    if (!(await isSnapshotValid(backup))) {
+      console.warn('[DailyBackup] Snapshot rejected; skipping write to protect existing backups');
+      return false;
+    }
+
     const backupJson = JSON.stringify(backup);
 
     if (needsDaily) {


### PR DESCRIPTION
When createBackup() silently returns empty arrays (DB lock, mid-migration,
or any caught error that falls back to []), performDailyBackupIfNeeded was
writing those empty snapshots and triggering cleanup rotation, which after
7 consecutive bad days would delete every valid backup the user had.

The fix adds isSnapshotValid(): if the new snapshot has zero accounts, it
reads the most recent existing backup from disk and refuses to write if
that prior backup recorded real accounts. This pattern precisely matches
the DB-error failure mode (empty arrays despite live data) while allowing
writes for genuinely empty databases and fresh installs (no prior backup
to compare against). Prior backup read failures are caught and treated
as "allow write" so a corrupted backup file cannot block all future writes.

Tests updated: makeSampleBackup now includes a real account (more
realistic), readAsStringAsync added to the FileSystem mock, and 8 new
test cases cover the empty-snapshot rejection path and all its edge cases.

https://claude.ai/code/session_01AsiMxVyvubXRT3ZAgThVVh