### PR TITLE
fix: validate currencies before falling back on null destination_amount in transfers

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -41,6 +41,9 @@ describe('OperationsDB Service', () => {
     Currency.add.mockImplementation((a, b) => String(parseFloat(a) + parseFloat(b)));
     Currency.subtract.mockImplementation((a, b) => String(parseFloat(a) - parseFloat(b)));
     Currency.isZero.mockImplementation((a) => parseFloat(a) === 0);
+    Currency.convertAmount.mockImplementation((amount, _from, _to, rate) =>
+      String(parseFloat(amount) * parseFloat(rate)),
+    );
 
     // SEARCH_NORM is available in tests so search SQL uses SEARCH_NORM(...)
     isSearchNormAvailable.mockReturnValue(true);
@@ -223,13 +226,15 @@ describe('OperationsDB Service', () => {
       };
 
       mockDb.getFirstAsync
-        .mockResolvedValueOnce({ balance: '1000' }) // Source account
-        .mockResolvedValueOnce({ balance: '500' });  // Destination account
+        .mockResolvedValueOnce({ currency: null }) // acc1 currency (same-currency: no conversion)
+        .mockResolvedValueOnce({ currency: null }) // acc2 currency
+        .mockResolvedValueOnce({ balance: '1000' }) // Source account balance
+        .mockResolvedValueOnce({ balance: '500' });  // Destination account balance
 
       await OperationsDB.createOperation(operation);
 
       // Should update both accounts
-      expect(mockDb.getFirstAsync).toHaveBeenCalledTimes(2);
+      expect(mockDb.getFirstAsync).toHaveBeenCalledTimes(4);
 
       // Source account should be reduced
       expect(Currency.add).toHaveBeenCalledWith('1000', '-300');
@@ -301,6 +306,8 @@ describe('OperationsDB Service', () => {
       };
 
       mockDb.getFirstAsync
+        .mockResolvedValueOnce({ currency: null }) // acc1 currency (same-currency: no conversion)
+        .mockResolvedValueOnce({ currency: null }) // acc2 currency
         .mockResolvedValueOnce({ balance: '1000' })
         .mockResolvedValueOnce({ balance: '500' });
 
@@ -518,6 +525,8 @@ describe('OperationsDB Service', () => {
 
       mockDb.getFirstAsync
         .mockResolvedValueOnce(operation)
+        .mockResolvedValueOnce({ currency: null }) // acc1 currency (same-currency: no conversion)
+        .mockResolvedValueOnce({ currency: null }) // acc2 currency
         .mockResolvedValueOnce({ balance: '700' })  // acc1
         .mockResolvedValueOnce({ balance: '800' }); // acc2
 
@@ -996,6 +1005,75 @@ describe('OperationsDB Service', () => {
 
       // Both should use transactions
       expect(executeTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses exchange_rate to credit destination when destination_amount is null on cross-currency transfer', async () => {
+      const operation = {
+        type: 'transfer',
+        amount: '100',
+        accountId: 'acc-usd',
+        toAccountId: 'acc-eur',
+        exchangeRate: '0.9',
+        date: '2025-12-05',
+        // destination_amount intentionally omitted (simulates data-loss scenario)
+      };
+
+      mockDb.getFirstAsync
+        .mockResolvedValueOnce({ currency: 'USD' }) // source account currency
+        .mockResolvedValueOnce({ currency: 'EUR' }) // destination account currency
+        .mockResolvedValueOnce({ balance: '1000.00' }) // source account balance
+        .mockResolvedValueOnce({ balance: '500.00' });  // destination account balance
+
+      await OperationsDB.createOperation(operation);
+
+      // Source debited 100 USD
+      expect(Currency.add).toHaveBeenCalledWith('1000.00', '-100');
+      // Destination credited with convertAmount(100, USD, EUR, 0.9) = 90
+      expect(Currency.convertAmount).toHaveBeenCalledWith('100', 'USD', 'EUR', '0.9');
+      expect(Currency.add).toHaveBeenCalledWith('500.00', '90');
+    });
+
+    it('throws when destination_amount is null, currencies differ, and exchange_rate is missing', async () => {
+      const operation = {
+        type: 'transfer',
+        amount: '100',
+        accountId: 'acc-usd',
+        toAccountId: 'acc-eur',
+        // No exchangeRate and no destinationAmount
+        date: '2025-12-05',
+      };
+
+      mockDb.getFirstAsync
+        .mockResolvedValueOnce({ currency: 'USD' })
+        .mockResolvedValueOnce({ currency: 'EUR' });
+
+      await expect(OperationsDB.createOperation(operation)).rejects.toThrow(
+        'missing destination_amount and exchange_rate',
+      );
+    });
+
+    it('falls back to source amount for same-currency transfers missing destination_amount', async () => {
+      const operation = {
+        type: 'transfer',
+        amount: '200',
+        accountId: 'acc1',
+        toAccountId: 'acc2',
+        // No destinationAmount — both accounts share currency
+        date: '2025-12-05',
+      };
+
+      mockDb.getFirstAsync
+        .mockResolvedValueOnce({ currency: 'USD' }) // source
+        .mockResolvedValueOnce({ currency: 'USD' }) // destination — same currency
+        .mockResolvedValueOnce({ balance: '1000.00' })
+        .mockResolvedValueOnce({ balance: '500.00' });
+
+      await OperationsDB.createOperation(operation);
+
+      // Destination receives the source amount unchanged
+      expect(Currency.add).toHaveBeenCalledWith('1000.00', '-200');
+      expect(Currency.add).toHaveBeenCalledWith('500.00', '200');
+      expect(Currency.convertAmount).not.toHaveBeenCalled();
     });
   });
 
@@ -1661,9 +1739,12 @@ describe('OperationsDB Service', () => {
       mockDb.getFirstAsync
         .mockResolvedValueOnce(oldOperation)
         .mockResolvedValueOnce(updatedOperation)
-        .mockResolvedValueOnce({ balance: '1000' })  // acc1
-        .mockResolvedValueOnce({ balance: '500' })   // acc2
-        .mockResolvedValueOnce({ balance: '800' });  // acc3
+        .mockResolvedValueOnce({ currency: null }) // old op acc1 currency (same-currency)
+        .mockResolvedValueOnce({ currency: null }) // old op acc2 currency
+        .mockResolvedValueOnce({ currency: null }) // new op acc1 currency
+        .mockResolvedValueOnce({ currency: null }) // new op acc3 currency
+        .mockResolvedValueOnce({ balance: '500' })  // acc2 balance (acc1 delta is zero, skipped)
+        .mockResolvedValueOnce({ balance: '800' }); // acc3 balance
 
       await OperationsDB.updateOperation(1, { toAccountId: 'acc3' });
 
@@ -1672,6 +1753,7 @@ describe('OperationsDB Service', () => {
         expect.stringContaining('to_account_id = ?'),
         expect.arrayContaining(['acc3', 1]),
       );
+      expect(mockDb.getFirstAsync).toHaveBeenCalledTimes(8);
     });
 
     it('extracts ID from object for toAccountId', async () => {

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -394,11 +394,14 @@ export const getOperationsByType = async (type) => {
 
 /**
  * Calculate balance changes for an operation
- * Handles multi-currency transfers by using destination_amount when available
+ * Handles multi-currency transfers by using destination_amount when available.
+ * When destination_amount is null on a transfer, queries account currencies to
+ * detect cross-currency transfers and recomputes the amount via exchange_rate.
  * @param {Object} operation
- * @returns {Map<string, string>} Map of accountId → string delta (Decimal-safe)
+ * @param {Object} db - Transaction-scoped database instance
+ * @returns {Promise<Map<string, string>>} Map of accountId → string delta (Decimal-safe)
  */
-const calculateBalanceChanges = (operation) => {
+const calculateBalanceChanges = async (operation, db) => {
   const balanceChanges = new Map();
   const amount = String(operation.amount || '0');
 
@@ -407,15 +410,43 @@ const calculateBalanceChanges = (operation) => {
   } else if (operation.type === 'income') {
     balanceChanges.set(operation.account_id, amount);
   } else if (operation.type === 'transfer') {
-    // Deduct from source account
     balanceChanges.set(operation.account_id, Currency.subtract('0', amount));
 
     if (operation.to_account_id) {
-      // For multi-currency transfers, use destination_amount if available
-      // Otherwise fall back to source amount (same currency transfer)
-      const destinationAmount = operation.destination_amount
-        ? String(operation.destination_amount)
-        : amount;
+      let destinationAmount;
+      if (operation.destination_amount) {
+        destinationAmount = String(operation.destination_amount);
+      } else {
+        // Query account currencies to detect cross-currency transfers where
+        // destination_amount was lost (old schema, import, or UI bug).
+        const fromAcc = await db.getFirstAsync(
+          'SELECT currency FROM accounts WHERE id = ?',
+          [operation.account_id],
+        );
+        const toAcc = await db.getFirstAsync(
+          'SELECT currency FROM accounts WHERE id = ?',
+          [operation.to_account_id],
+        );
+        const fromCurrency = fromAcc?.currency;
+        const toCurrency = toAcc?.currency;
+
+        if (fromCurrency && toCurrency && fromCurrency !== toCurrency) {
+          if (!operation.exchange_rate) {
+            throw new Error(
+              `Multi-currency transfer ${operation.id} is missing destination_amount and exchange_rate`,
+            );
+          }
+          const converted = Currency.convertAmount(amount, fromCurrency, toCurrency, operation.exchange_rate);
+          if (!converted) {
+            throw new Error(
+              `Failed to convert transfer ${operation.id} amount from ${fromCurrency} to ${toCurrency}`,
+            );
+          }
+          destinationAmount = converted;
+        } else {
+          destinationAmount = amount;
+        }
+      }
 
       const toChange = balanceChanges.get(operation.to_account_id) || '0';
       balanceChanges.set(operation.to_account_id, Currency.add(toChange, destinationAmount));
@@ -475,7 +506,7 @@ export const createOperationInTx = async (db, operation) => {
 
   operationData.id = result.lastInsertRowId;
 
-  const balanceChanges = calculateBalanceChanges(operationData);
+  const balanceChanges = await calculateBalanceChanges(operationData, db);
   const updateTime = new Date().toISOString();
 
   for (const [accountId, delta] of balanceChanges.entries()) {
@@ -620,13 +651,13 @@ export const updateOperation = async (id, updates) => {
       const balanceChanges = new Map();
 
       // Reverse old operation
-      const oldChanges = calculateBalanceChanges(oldOperation);
+      const oldChanges = await calculateBalanceChanges(oldOperation, db);
       for (const [accountId, delta] of oldChanges.entries()) {
         balanceChanges.set(accountId, Currency.subtract(balanceChanges.get(accountId) || '0', delta));
       }
 
       // Apply new operation
-      const newChanges = calculateBalanceChanges(newOperation);
+      const newChanges = await calculateBalanceChanges(newOperation, db);
       for (const [accountId, delta] of newChanges.entries()) {
         balanceChanges.set(accountId, Currency.add(balanceChanges.get(accountId) || '0', delta));
       }
@@ -766,9 +797,9 @@ export const splitOperation = async (id, updates, newOperationData) => {
         }
       };
 
-      applyChanges(calculateBalanceChanges(oldOperation), true);
-      applyChanges(calculateBalanceChanges(updatedOperation), false);
-      applyChanges(calculateBalanceChanges(createdOperation), false);
+      applyChanges(await calculateBalanceChanges(oldOperation, db), true);
+      applyChanges(await calculateBalanceChanges(updatedOperation, db), false);
+      applyChanges(await calculateBalanceChanges(createdOperation, db), false);
 
       // Step 5: update account balances and balance history
       const updateTime = new Date().toISOString();
@@ -825,7 +856,7 @@ export const deleteOperation = async (id) => {
       await db.runAsync('DELETE FROM operations WHERE id = ?', [id]);
 
       // Reverse balance changes
-      const balanceChanges = calculateBalanceChanges(operation);
+      const balanceChanges = await calculateBalanceChanges(operation, db);
       const reverseChanges = new Map();
       for (const [accountId, delta] of balanceChanges.entries()) {
         reverseChanges.set(accountId, Currency.subtract('0', delta));


### PR DESCRIPTION
calculateBalanceChanges was synchronous and used a bare `: amount` fallback
when destination_amount was null, without verifying that the source and
destination accounts share a currency. Any data path that loses
destination_amount on a multi-currency transfer (old schema, CSV import,
UI bug) silently credited the destination account with the source-currency
number.

The function is now async and accepts the transaction-scoped db instance.
When destination_amount is absent on a transfer it queries both accounts'
currencies. If they differ it recomputes the destination amount via the
stored exchange_rate, matching what should have been persisted. If they
match it falls back to the source amount (same-currency behaviour preserved).
Throws a descriptive error when currencies differ but no exchange_rate is
available, rather than silently using the wrong value.

All callers (createOperationInTx, updateOperation, splitOperation,
deleteOperation) updated to await the result. Three regression tests added.

Fixes #688

https://claude.ai/code/session_01GhY9C91EHCpacvq9apxmZb