### PR TITLE
feat(currencies): add Georgian Lari (GEL)

### DIFF
--- a/assets/currencies.json
+++ b/assets/currencies.json
@@ -20,5 +20,6 @@
   "RUB": {"symbol": "₽", "name": "Russian Ruble", "symbol_native": "₽", "decimal_digits": 0, "rounding": 0, "code": "RUB", "name_plural": "Russian rubles"},
   "AMD": {"symbol": "֏", "name": "Armenian Dram", "symbol_native": "֏", "decimal_digits": 0, "rounding": 0, "code": "AMD", "name_plural": "Armenian drams"},
   "THB": {"symbol": "฿", "name": "Thai Baht", "symbol_native": "฿", "decimal_digits": 0, "rounding": 0, "code": "THB", "name_plural": "Thai baht"},
-  "TRY": {"symbol": "₺", "name": "Turkish Lira", "symbol_native": "₺", "decimal_digits": 0, "rounding": 0, "code": "TRY", "name_plural": "Turkish lira"}
+  "TRY": {"symbol": "₺", "name": "Turkish Lira", "symbol_native": "₺", "decimal_digits": 0, "rounding": 0, "code": "TRY", "name_plural": "Turkish lira"},
+  "GEL": {"symbol": "₾", "name": "Georgian Lari", "symbol_native": "₾", "decimal_digits": 2, "rounding": 0, "code": "GEL", "name_plural": "Georgian lari"}
 }


### PR DESCRIPTION
## Summary

- Adds Georgian Lari (GEL) to `assets/currencies.json`
- Symbol: ₾, 2 decimal digits, code: GEL

## Test plan

- [ ] Open the account creation/edit screen and verify Georgian Lari (GEL ₾) appears in the currency picker
- [ ] Create an account with GEL currency and confirm it displays correctly

https://claude.ai/code/session_01DnHQLpEjSW7sPFJLJeFrvy

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnHQLpEjSW7sPFJLJeFrvy)_