### PR TITLE
Show 10 latest release changelogs on update page (always)

### DIFF
--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -275,6 +275,67 @@ describe('AppUpdateService', () => {
       expect(result.isUpdateAvailable).toBe(false);
     });
 
+    it('includes recentReleaseNotes with up to 10 APK releases when up to date', async () => {
+      const apk = (v) => ({ name: `penny-v${v}.apk`, browser_download_url: `https://example.com/penny-v${v}.apk` });
+      const releases = Array.from({ length: 12 }, (_, i) => ({
+        tag_name: `v0.50.${i + 1}`,
+        assets: [apk(`0.50.${i + 1}`)],
+        body: `Release notes for 0.50.${i + 1}`,
+      }));
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => releases,
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.12',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isUpdateAvailable).toBe(false);
+      expect(result.recentReleaseNotes).not.toBeNull();
+      expect(result.recentReleaseNotes.length).toBe(10);
+      expect(result.releasesUrl).toBe('https://github.com/heywood8/money-tracker/releases');
+    });
+
+    it('includes recentReleaseNotes in available result and excludes releases without notes', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([
+          {
+            tag_name: 'v0.50.5',
+            assets: [{ name: 'penny-v0.50.5.apk', browser_download_url: 'https://example.com/penny-v0.50.5.apk' }],
+            html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v0.50.5',
+            body: 'New features in 0.50.5',
+          },
+          {
+            tag_name: 'v0.50.4',
+            assets: [{ name: 'penny-v0.50.4.apk', browser_download_url: 'https://example.com/penny-v0.50.4.apk' }],
+            // no body — should be excluded from recentReleaseNotes
+          },
+          {
+            tag_name: 'v0.50.3',
+            assets: [{ name: 'penny-v0.50.3.apk', browser_download_url: 'https://example.com/penny-v0.50.3.apk' }],
+            body: 'Fixes in 0.50.3',
+          },
+        ]),
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.3',
+        fetchImpl,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.isUpdateAvailable).toBe(true);
+      expect(result.recentReleaseNotes).not.toBeNull();
+      expect(result.recentReleaseNotes.length).toBe(2); // 0.50.5 and 0.50.3 have bodies; 0.50.4 does not
+      expect(result.recentReleaseNotes[0].version).toBe('0.50.5');
+      expect(result.recentReleaseNotes[1].version).toBe('0.50.3');
+      expect(result.releasesUrl).toBe('https://github.com/heywood8/money-tracker/releases');
+    });
+
     it('handles GitHub rate limiting response gracefully', async () => {
       const fetchImpl = jest.fn().mockResolvedValue({
         ok: false,

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -559,7 +559,11 @@ export default function SettingsModal({ visible, onClose }) {
       if (!result.success) {
         setUpdateResult({ type: 'error', errorCode: result.errorCode });
       } else if (!result.isUpdateAvailable) {
-        setUpdateResult({ type: 'up_to_date' });
+        setUpdateResult({
+          type: 'up_to_date',
+          recentReleaseNotes: result.recentReleaseNotes || null,
+          releasesUrl: result.releasesUrl || null,
+        });
       } else {
         const alreadyDownloadedUri = await checkAlreadyDownloaded(result.downloadUrl);
         setUpdateResult({
@@ -569,6 +573,8 @@ export default function SettingsModal({ visible, onClose }) {
           downloadUrl: result.downloadUrl,
           checksumUrl: result.checksumUrl || null,
           releaseNotes: result.releaseNotes || null,
+          recentReleaseNotes: result.recentReleaseNotes || null,
+          releasesUrl: result.releasesUrl || null,
           alreadyDownloaded: !!alreadyDownloadedUri,
           localUri: alreadyDownloadedUri,
         });
@@ -1315,25 +1321,34 @@ export default function SettingsModal({ visible, onClose }) {
                     <Animated.View style={[styles.updateResultContainer, { opacity: updateContentAnim }]}>
                       {updateResult.type === 'available' && (
                         <>
-                          {updateResult.releaseNotes ? (
+                          {(updateResult.recentReleaseNotes || updateResult.releaseNotes) ? (
                             <>
                               <Divider style={styles.updateDivider} />
                               <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
                                 {t('whats_new') || "What's new"}
                               </Text>
                               <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
-                                {updateResult.releaseNotes.map(({ version, notes }) => (
+                                {(updateResult.recentReleaseNotes || updateResult.releaseNotes).map(({ version, notes }) => (
                                   <View key={version} style={styles.changelogSection}>
-                                    {updateResult.releaseNotes.length > 1 && (
-                                      <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
-                                        v{version}
-                                      </Text>
-                                    )}
+                                    <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
+                                      v{version}
+                                    </Text>
                                     <Text style={[styles.changelogText, { color: colors.text }]}>
                                       {stripMarkdown(notes)}
                                     </Text>
                                   </View>
                                 ))}
+                                {updateResult.releasesUrl && (
+                                  <TouchableOpacity
+                                    onPress={() => Linking.openURL(updateResult.releasesUrl)}
+                                    style={styles.moreReleasesLink}
+                                  >
+                                    <Text style={[styles.moreReleasesLinkText, { color: colors.primary }]}>
+                                      {t('more_releases') || 'More on GitHub'}
+                                    </Text>
+                                    <Ionicons name="open-outline" size={14} color={colors.primary} />
+                                  </TouchableOpacity>
+                                )}
                               </ScrollView>
                             </>
                           ) : (
@@ -1415,44 +1430,84 @@ export default function SettingsModal({ visible, onClose }) {
                       )}
                       {updateResult.type === 'up_to_date' && (
                         <View style={styles.upToDateContent}>
-                          <View style={styles.upToDateHeaderSpacer}>
-                            <View style={styles.upToDateHeader}>
-                              <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
-                              <Text style={[styles.updateVersionText, { color: colors.text }]}>
-                                {t('up_to_date') || 'You already have the latest version installed.'}
+                          {updateResult.recentReleaseNotes ? (
+                            <>
+                              <View style={styles.upToDateHeaderRow}>
+                                <Ionicons name="checkmark-circle-outline" size={24} color="#4caf50" />
+                                <Text style={[styles.upToDateHeaderText, { color: colors.text }]}>
+                                  {t('up_to_date') || 'You already have the latest version installed.'}
+                                </Text>
+                              </View>
+                              <Divider style={styles.updateDivider} />
+                              <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
+                                {t('release_history') || 'Release history'}
                               </Text>
-                            </View>
-                          </View>
-                          {downloadedApks.length > 0 && (
-                            <View style={styles.downloadedApksSection}>
-                              <Divider />
-                              <Text style={[styles.downloadedApksTitle, { color: colors.mutedText }]}>
-                                {t('downloaded_apks') || 'Downloaded'}
-                              </Text>
-                              <FlatList
-                                horizontal
-                                data={downloadedApks}
-                                keyExtractor={(item) => item.uri}
-                                renderItem={({ item }) => (
+                              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
+                                {updateResult.recentReleaseNotes.map(({ version, notes }) => (
+                                  <View key={version} style={styles.changelogSection}>
+                                    <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
+                                      v{version}
+                                    </Text>
+                                    <Text style={[styles.changelogText, { color: colors.text }]}>
+                                      {stripMarkdown(notes)}
+                                    </Text>
+                                  </View>
+                                ))}
+                                {updateResult.releasesUrl && (
                                   <TouchableOpacity
-                                    onPress={() => handleInstallApk(item.uri)}
-                                    style={styles.apkChip}
-                                    accessibilityRole="button"
-                                    accessibilityLabel={`Install version ${item.version || item.filename}`}
+                                    onPress={() => Linking.openURL(updateResult.releasesUrl)}
+                                    style={styles.moreReleasesLink}
                                   >
-                                    <Ionicons name="archive-outline" size={28} color={colors.primary} />
-                                    <Text style={[styles.apkChipVersion, { color: colors.text }]}>
-                                      {item.version ? `v${item.version}` : item.filename.replace(/\.apk$/i, '')}
+                                    <Text style={[styles.moreReleasesLinkText, { color: colors.primary }]}>
+                                      {t('more_releases') || 'More on GitHub'}
                                     </Text>
-                                    <Text style={[styles.apkChipDate, { color: colors.mutedText }]}>
-                                      {formatApkDate(item.modificationTime)}
-                                    </Text>
+                                    <Ionicons name="open-outline" size={14} color={colors.primary} />
                                   </TouchableOpacity>
                                 )}
-                                showsHorizontalScrollIndicator={false}
-                                contentContainerStyle={styles.apkListContent}
-                              />
-                            </View>
+                              </ScrollView>
+                            </>
+                          ) : (
+                            <>
+                              <View style={styles.upToDateHeaderSpacer}>
+                                <View style={styles.upToDateHeader}>
+                                  <Ionicons name="checkmark-circle-outline" size={48} color="#4caf50" style={styles.importWarningIcon} />
+                                  <Text style={[styles.updateVersionText, { color: colors.text }]}>
+                                    {t('up_to_date') || 'You already have the latest version installed.'}
+                                  </Text>
+                                </View>
+                              </View>
+                              {downloadedApks.length > 0 && (
+                                <View style={styles.downloadedApksSection}>
+                                  <Divider />
+                                  <Text style={[styles.downloadedApksTitle, { color: colors.mutedText }]}>
+                                    {t('downloaded_apks') || 'Downloaded'}
+                                  </Text>
+                                  <FlatList
+                                    horizontal
+                                    data={downloadedApks}
+                                    keyExtractor={(item) => item.uri}
+                                    renderItem={({ item }) => (
+                                      <TouchableOpacity
+                                        onPress={() => handleInstallApk(item.uri)}
+                                        style={styles.apkChip}
+                                        accessibilityRole="button"
+                                        accessibilityLabel={`Install version ${item.version || item.filename}`}
+                                      >
+                                        <Ionicons name="archive-outline" size={28} color={colors.primary} />
+                                        <Text style={[styles.apkChipVersion, { color: colors.text }]}>
+                                          {item.version ? `v${item.version}` : item.filename.replace(/\.apk$/i, '')}
+                                        </Text>
+                                        <Text style={[styles.apkChipDate, { color: colors.mutedText }]}>
+                                          {formatApkDate(item.modificationTime)}
+                                        </Text>
+                                      </TouchableOpacity>
+                                    )}
+                                    showsHorizontalScrollIndicator={false}
+                                    contentContainerStyle={styles.apkListContent}
+                                  />
+                                </View>
+                              )}
+                            </>
                           )}
                         </View>
                       )}
@@ -1882,6 +1937,16 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 44,
   },
+  moreReleasesLink: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    paddingVertical: SPACING.md,
+  },
+  moreReleasesLinkText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
   upToDateContent: {
     flex: 1,
   },
@@ -1889,10 +1954,21 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: HORIZONTAL_PADDING * 2,
   },
+  upToDateHeaderRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingVertical: SPACING.sm,
+  },
   upToDateHeaderSpacer: {
     alignItems: 'center',
     flex: 1,
     justifyContent: 'center',
+  },
+  upToDateHeaderText: {
+    flex: 1,
+    fontSize: 14,
+    lineHeight: 20,
   },
   updateActionColumn: {
     alignItems: 'center',

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1831,6 +1831,16 @@ const styles = StyleSheet.create({
     ...centeredModal,
     overflow: 'hidden',
   },
+  moreReleasesLink: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    paddingVertical: SPACING.md,
+  },
+  moreReleasesLinkText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
   resetSpacer: {
     height: SPACING.sm,
   },
@@ -1936,16 +1946,6 @@ const styles = StyleSheet.create({
     height: 24,
     justifyContent: 'center',
     width: 44,
-  },
-  moreReleasesLink: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: SPACING.xs,
-    paddingVertical: SPACING.md,
-  },
-  moreReleasesLinkText: {
-    fontSize: 13,
-    fontWeight: '600',
   },
   upToDateContent: {
     flex: 1,

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -100,6 +100,7 @@ const fetchWithTimeout = async (url, options = {}, timeoutMs = UPDATE_CHECK_TIME
 };
 
 const MAX_RELEASES_TO_CHECK = 20;
+const MAX_CHANGELOG_ENTRIES = 10;
 
 export const checkForAppUpdate = async ({
   currentVersion = APP_VERSION,
@@ -158,6 +159,7 @@ export const checkForAppUpdate = async ({
     let bestRelease = null; // highest-version release with a downloadable APK
     let foundReleasesWithoutApk = false;
     const newerReleases = []; // all releases with version > current, for changelog
+    const recentReleasesWithApk = []; // up to MAX_CHANGELOG_ENTRIES recent releases with APKs (any version)
 
     for (const release of releases) {
       const releaseVersion = parseVersionFromRelease(release);
@@ -165,11 +167,17 @@ export const checkForAppUpdate = async ({
         continue;
       }
 
+      const apkAsset = extractApkAsset(release.assets);
+
+      // Collect recent releases with APKs for changelog display regardless of version
+      if (apkAsset && release.body && recentReleasesWithApk.length < MAX_CHANGELOG_ENTRIES) {
+        recentReleasesWithApk.push({ version: releaseVersion, notes: release.body });
+      }
+
       if (compareVersions(releaseVersion, currentNormalized) <= 0) {
         continue; // not newer than current — skip
       }
 
-      const apkAsset = extractApkAsset(release.assets);
       newerReleases.push({ version: releaseVersion, notes: release.body || null, hasApk: !!apkAsset });
 
       if (apkAsset && (!bestRelease || compareVersions(releaseVersion, bestRelease.version) > 0)) {
@@ -187,12 +195,17 @@ export const checkForAppUpdate = async ({
       }
     }
 
+    const releasesUrl = `https://github.com/${owner}/${repo}/releases`;
+    const recentReleaseNotes = recentReleasesWithApk.length > 0 ? recentReleasesWithApk : null;
+
     if (newerReleases.length === 0) {
       // Nothing newer found at all — either up to date or all releases lacked versions
       return {
         success: true,
         isUpdateAvailable: false,
         currentVersion: currentNormalized,
+        releasesUrl,
+        recentReleaseNotes,
       };
     }
 
@@ -220,6 +233,8 @@ export const checkForAppUpdate = async ({
       publishedAt: bestRelease.publishedAt,
       releaseName: bestRelease.releaseName,
       releaseNotes: releaseNotes.length > 0 ? releaseNotes : null,
+      releasesUrl,
+      recentReleaseNotes,
     };
 
   } catch (error) {


### PR DESCRIPTION
## Summary

- The update subpanel in Settings now always shows the 10 most recent releases that have an APK attachment and release notes — even when you're already on the latest version
- A "More on GitHub" link at the bottom of the changelog opens the full releases page
- The **up-to-date** state gains a compact header (checkmark + message) followed by a scrollable release history, replacing the empty centered layout
- The **update available** state shows all 10 recent releases in the changelog instead of only the releases newer than the installed version

## Test plan

- [ ] Open Settings → tap "Check for updates" when already on the latest version → confirm the release history list appears with version headers and a "More on GitHub" link
- [ ] Tap "More on GitHub" → confirm it opens `https://github.com/heywood8/money-tracker/releases` in the browser
- [ ] Simulate an available update → confirm the "What's new" section shows up to 10 releases (not just the new ones) with version headers and the "More on GitHub" link
- [ ] Confirm all 3428 existing tests still pass (`npm test`)

BEGIN_COMMIT_OVERRIDE
feat: always show 10 latest release changelogs on the update page
END_COMMIT_OVERRIDE

https://claude.ai/code/session_01MSmARHjVzL75WFYhzW2zYe