### PR TITLE
fix: restore downloaded APKs list in up-to-date changelog view

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1465,6 +1465,37 @@ export default function SettingsModal({ visible, onClose }) {
                                   </TouchableOpacity>
                                 )}
                               </ScrollView>
+                              {downloadedApks.length > 0 && (
+                                <View style={styles.downloadedApksSection}>
+                                  <Divider />
+                                  <Text style={[styles.downloadedApksTitle, { color: colors.mutedText }]}>
+                                    {t('downloaded_apks') || 'Downloaded'}
+                                  </Text>
+                                  <FlatList
+                                    horizontal
+                                    data={downloadedApks}
+                                    keyExtractor={(item) => item.uri}
+                                    renderItem={({ item }) => (
+                                      <TouchableOpacity
+                                        onPress={() => handleInstallApk(item.uri)}
+                                        style={styles.apkChip}
+                                        accessibilityRole="button"
+                                        accessibilityLabel={`Install version ${item.version || item.filename}`}
+                                      >
+                                        <Ionicons name="archive-outline" size={28} color={colors.primary} />
+                                        <Text style={[styles.apkChipVersion, { color: colors.text }]}>
+                                          {item.version ? `v${item.version}` : item.filename.replace(/\.apk$/i, '')}
+                                        </Text>
+                                        <Text style={[styles.apkChipDate, { color: colors.mutedText }]}>
+                                          {formatApkDate(item.modificationTime)}
+                                        </Text>
+                                      </TouchableOpacity>
+                                    )}
+                                    showsHorizontalScrollIndicator={false}
+                                    contentContainerStyle={styles.apkListContent}
+                                  />
+                                </View>
+                              )}
                             </>
                           ) : (
                             <>


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #713: the downloaded APKs strip was missing from the up-to-date subpanel when release history is shown.

The changelog branch of the conditional rendered the header + ScrollView but omitted the `downloadedApksSection` block that exists in the fallback layout. This PR adds it back below the ScrollView so cached APK files are always visible regardless of whether release notes are available.

## Test plan

- [ ] Open Settings → Check for updates (already on latest version)
- [ ] If locally cached APKs exist, confirm the "Downloaded" strip appears below the release history
- [ ] Confirm the strip is absent when no APKs are cached (no regression)
- [ ] Confirm the fallback layout (no release notes) still shows downloaded APKs correctly

BEGIN_COMMIT_OVERRIDE
fix: restore downloaded APKs list in up-to-date changelog view
END_COMMIT_OVERRIDE

https://claude.ai/code/session_01MSmARHjVzL75WFYhzW2zYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSmARHjVzL75WFYhzW2zYe)_