### PR TITLE
fix: today marker x-position alignment in balance history chart

### DIFF
--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -362,12 +362,12 @@ const BalanceHistoryCard = ({
                       }}
                       decorator={() => {
                         // react-native-chart-kit places data using paddingRight (default 64) as
-                        // the left origin: x = paddingRight + i*(width-paddingRight)/(n-1)
+                        // the left origin: x = paddingRight + i*(width-paddingRight)/n
                         const chartWidth = screenWidth - 33; // must match width prop
                         const chartPaddingRight = 64; // library default, acts as left margin
                         const usableWidth = chartWidth - chartPaddingRight;
                         const dataLength = balanceHistoryData.labels.length;
-                        const xStep = usableWidth / (dataLength - 1);
+                        const xStep = usableWidth / dataLength;
                         const chartTop = 12;
                         const chartBottom = 181;
 


### PR DESCRIPTION
## Summary

- The "today" dashed vertical line in the balance history chart was positioned slightly to the right of where it should be
- Root cause: the decorator computed `xStep = usableWidth / (dataLength - 1)` but `react-native-chart-kit` positions data points using `usableWidth / dataLength` (divides by length, not length−1)
- Fix: change denominator from `(dataLength - 1)` to `dataLength` to match the library's actual formula

## Test plan

- [ ] Open the Graphs tab on a current month to see the balance history chart
- [ ] Confirm the dashed "today" vertical line aligns with the actual data point for today on the chart line
- [ ] Verify the label number above the dashed line is directly above the line
- [ ] Check on different screen widths (smaller/larger phones) that alignment holds
- [ ] All 3428 existing tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVWX3aNsKKzCugQSza5Kkk)_