### PR TITLE
feat: tap to expand log entries, long-press to copy

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, TouchableOpacity, Animated, Easing, ScrollView, FlatList, Linking, ActivityIndicator } from 'react-native'; // FlatList used for backups list
+import * as Clipboard from 'expo-clipboard';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Portal, Modal, Text, Divider, TouchableRipple } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
@@ -71,6 +72,7 @@ export default function SettingsModal({ visible, onClose }) {
   const { startDownload } = useUpdateDownload();
   const [activeSubPanel, setActiveSubPanel] = useState(null); // 'language' | 'export' | 'logs' | 'backups' | null
   const [logFilter, setLogFilter] = useState('all');
+  const [expandedLogIds, setExpandedLogIds] = useState(new Set());
   const [storedBackups, setStoredBackups] = useState([]);
   const [backupsLoading, setBackupsLoading] = useState(false);
   const [pendingDeleteUri, setPendingDeleteUri] = useState(null);
@@ -703,19 +705,39 @@ export default function SettingsModal({ visible, onClose }) {
     );
   }, [colors, t, formatBackupLabel, handleImportLocalBackupSelect, handleDeleteLocalBackup, handleConfirmDeleteLocalBackup, pendingDeleteUri]);
 
-  const renderLogEntry = useCallback(({ item }) => (
-    <View style={styles.logEntry}>
-      <Text style={[styles.logTimestamp, { color: colors.mutedText }]}>
-        {item.timestamp.substring(11, 19)}
-      </Text>
-      <Text style={[styles.logLevel, { color: LOG_LEVEL_COLORS[item.level] }]}>
-        {item.level.toUpperCase()}
-      </Text>
-      <Text style={[styles.logMessage, { color: colors.text }]} numberOfLines={3}>
-        {item.message}
-      </Text>
-    </View>
-  ), [colors]);
+  const toggleLogExpand = useCallback((id) => {
+    setExpandedLogIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const renderLogEntry = useCallback(({ item }) => {
+    const isExpanded = expandedLogIds.has(item.id);
+    return (
+      <TouchableOpacity
+        onPress={() => toggleLogExpand(item.id)}
+        onLongPress={() => Clipboard.setStringAsync(`${item.timestamp} [${item.level.toUpperCase()}] ${item.message}`)}
+        activeOpacity={0.7}
+        style={styles.logEntry}
+      >
+        <Text style={[styles.logTimestamp, { color: colors.mutedText }]}>
+          {item.timestamp.substring(11, 19)}
+        </Text>
+        <Text style={[styles.logLevel, { color: LOG_LEVEL_COLORS[item.level] }]}>
+          {item.level.toUpperCase()}
+        </Text>
+        <Text style={[styles.logMessage, { color: colors.text }]} numberOfLines={isExpanded ? undefined : 3}>
+          {item.message}
+        </Text>
+      </TouchableOpacity>
+    );
+  }, [colors, expandedLogIds, toggleLogExpand]);
 
 
   return (

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-auth-session": "~7.0.11",
     "expo-blur": "~15.0.8",
     "expo-build-properties": "^1.0.10",
+    "expo-clipboard": "^56.0.3",
     "expo-dev-client": "~6.0.20",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "^19.0.21",


### PR DESCRIPTION
## Summary
- Tapping a log entry toggles between 3-line truncation and full display
- Long-pressing a log entry copies the full text (timestamp + level + message) to the clipboard
- Adds `expo-clipboard` dependency for clipboard write access

## Test plan
- [ ] Open Settings → Logs
- [ ] Find a log entry that is truncated (more than 3 lines)
- [ ] Tap it — it should expand to show the full message
- [ ] Tap again — it should collapse back to 3 lines
- [ ] Long-press any entry — the full entry text should be copied to clipboard (Android 13+ shows a system toast; paste elsewhere to verify on older versions)
- [ ] All existing tests pass (`npm test`)

https://claude.ai/code/session_011MNyAWryrNvtA7h1EzHK7p

---
_Generated by [Claude Code](https://claude.ai/code/session_011MNyAWryrNvtA7h1EzHK7p)_