### PR TITLE
fix: NativeDatabase.prepareAsync errors during account balance adjustment

### DIFF
--- a/__tests__/services/AccountsDB.test.js
+++ b/__tests__/services/AccountsDB.test.js
@@ -665,10 +665,7 @@ describe('AccountsDB', () => {
 
   describe('reorderAccounts', () => {
     it('reorders accounts with new display orders', async () => {
-      const mockWhere = jest.fn().mockResolvedValue(undefined);
-      const mockSet = jest.fn().mockReturnValue({ where: mockWhere });
-      const mockUpdate = jest.fn().mockReturnValue({ set: mockSet });
-      const mockTxDb = { update: mockUpdate };
+      const mockTxDb = { runAsync: jest.fn().mockResolvedValue(undefined) };
 
       jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => {
         await callback(mockTxDb);
@@ -683,17 +680,23 @@ describe('AccountsDB', () => {
       await AccountsDB.reorderAccounts(orderedAccounts);
 
       expect(db.executeTransaction).toHaveBeenCalledWith(expect.any(Function));
-      expect(mockUpdate).toHaveBeenCalledTimes(3);
-      expect(mockSet).toHaveBeenCalledTimes(3);
-      expect(mockWhere).toHaveBeenCalledTimes(3);
-      expect(mockSet).toHaveBeenCalledWith({
-        displayOrder: 0,
-        updatedAt: expect.any(String),
-      });
+      expect(mockTxDb.runAsync).toHaveBeenCalledTimes(3);
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE accounts SET display_order = ?, updated_at = ? WHERE id = ?',
+        [0, expect.any(String), 'acc-1'],
+      );
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE accounts SET display_order = ?, updated_at = ? WHERE id = ?',
+        [1, expect.any(String), 'acc-2'],
+      );
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE accounts SET display_order = ?, updated_at = ? WHERE id = ?',
+        [2, expect.any(String), 'acc-3'],
+      );
     });
 
     it('handles empty array', async () => {
-      const mockTxDb = { update: jest.fn() };
+      const mockTxDb = { runAsync: jest.fn().mockResolvedValue(undefined) };
 
       jest.spyOn(db, 'executeTransaction').mockImplementation(async (callback) => {
         await callback(mockTxDb);
@@ -701,7 +704,7 @@ describe('AccountsDB', () => {
 
       await AccountsDB.reorderAccounts([]);
 
-      expect(mockTxDb.update).not.toHaveBeenCalled();
+      expect(mockTxDb.runAsync).not.toHaveBeenCalled();
     });
 
     it('throws error when reorder fails', async () => {

--- a/__tests__/services/db.test.js
+++ b/__tests__/services/db.test.js
@@ -29,6 +29,7 @@ describe('Database Service', () => {
       getAllAsync: jest.fn(() => Promise.resolve([])),
       closeAsync: jest.fn(() => Promise.resolve()),
       withTransactionAsync: jest.fn((callback) => callback()),
+      withExclusiveTransactionAsync: jest.fn((callback) => callback(mockDb)),
       createCustomFunctionAsync: jest.fn(() => Promise.resolve()),
       createFunctionAsync: jest.fn(() => Promise.resolve()),
     };
@@ -196,7 +197,7 @@ describe('Database Service', () => {
 
       const result = await executeTransaction(callback);
 
-      expect(mockDb.withTransactionAsync).toHaveBeenCalled();
+      expect(mockDb.withExclusiveTransactionAsync).toHaveBeenCalled();
       expect(callback).toHaveBeenCalledWith(mockDb);
       expect(result).toBe('success');
     });

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -406,12 +406,10 @@ export const reorderAccounts = async (orderedAccounts) => {
 
     await executeTransaction(async (db) => {
       for (const { id, display_order } of orderedAccounts) {
-        await db.update(accounts)
-          .set({
-            displayOrder: display_order,
-            updatedAt: now,
-          })
-          .where(eq(accounts.id, id));
+        await db.runAsync(
+          'UPDATE accounts SET display_order = ?, updated_at = ? WHERE id = ?',
+          [display_order, now, id],
+        );
       }
     });
   } catch (error) {

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -357,13 +357,20 @@ export const queryFirst = async (sqlStr, params = []) => {
  * Execute multiple statements in a transaction (legacy compatibility)
  * @param {Function} callback - Async function that receives the db instance
  * @returns {Promise<any>}
+ *
+ * Uses withExclusiveTransactionAsync so that:
+ *   1. No other async queries can interleave between statements in this
+ *      transaction (withTransactionAsync is non-exclusive and can be
+ *      interrupted, which corrupts multi-step operations like adjustAccountBalance).
+ *   2. The callback receives the transaction-bound `txn` object — callers
+ *      must use this object (not an outer db reference) for all queries.
  */
 export const executeTransaction = async (callback) => {
   const { raw } = await getDatabase();
   try {
     let result;
-    await raw.withTransactionAsync(async () => {
-      result = await callback(raw);
+    await raw.withExclusiveTransactionAsync(async (txn) => {
+      result = await callback(txn);
     });
     return result;
   } catch (error) {


### PR DESCRIPTION
## Summary

- Switch `executeTransaction` from `withTransactionAsync` to `withExclusiveTransactionAsync` so the multi-step `adjustAccountBalance` transaction cannot be interleaved by concurrent async queries triggered by React re-renders and `RELOAD_ALL` events
- Convert `reorderAccounts` to use raw SQL `runAsync` since the `txn` object passed by `withExclusiveTransactionAsync` does not expose Drizzle ORM methods
- Update tests for `executeTransaction` and `reorderAccounts` to match the new implementation

## Root Cause

`withTransactionAsync` in expo-sqlite v16 is **non-exclusive** — other async queries can run between `await` points inside the transaction callback. The multi-step `adjustAccountBalance` (read balance → check existing op → read shadow categories → INSERT/UPDATE operation → UPDATE balance → INSERT history) has many `await` suspension points. Meanwhile, calling `setEditingId(null)` immediately after the (unawaited) `updateAccount` call triggers a React re-render that fires `RELOAD_ALL`, queuing DB reads that interleave with the ongoing write transaction, corrupting it and causing `NativeDatabase.prepareAsync` failures.

`withExclusiveTransactionAsync` blocks all other database access for the duration of the transaction, eliminating the interleaving.

## Test plan

- [ ] All 3428 existing tests pass (`npm test`)
- [ ] Update an account with "Create adjustment operation" enabled — no errors in the log viewer
- [ ] Reorder accounts — still works correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01N16kmLXBTKx4Kx5s5HZsxo)_