### PR TITLE
fix: reverse downloaded APKs list order so newest appears first

### DIFF
--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -532,7 +532,7 @@ export default function SettingsModal({ visible, onClose }) {
 
   const loadDownloadedApks = useCallback(async () => {
     const apks = await listDownloadedApks();
-    setDownloadedApks(apks);
+    setDownloadedApks(apks.slice().reverse());
   }, []);
 
   const handleInstallApk = useCallback(async (uri) => {


### PR DESCRIPTION
## Summary
Reverse the downloaded APKs list so the newest build appears first (leftmost) in the horizontal scroll list on the updates modal.

## Problem
APKs were displayed in the order returned by `listDownloadedApks()` — oldest first — making the most recent download the hardest to find.

## Solution
Reverse the array in `loadDownloadedApks` before setting state. Applies to both the compact and expanded update modal views since they share the same `downloadedApks` state.

## Changes
- `app/modals/SettingsModal.js`: `apks.slice().reverse()` before `setDownloadedApks`

**BEGIN_COMMIT_OVERRIDE**
```
fix(settings): reverse downloaded APKs list order so newest appears first
```
**END_COMMIT_OVERRIDE**
