### PR TITLE
fix: add defensive fallback for original_balance column migration

### DIFF
--- a/app/services/db.js
+++ b/app/services/db.js
@@ -213,6 +213,18 @@ const initializeDatabase = async (rawDb, db) => {
     // Run Drizzle migrations
     await migrate(db, migrationsConfig);
 
+    // Defensive: ensure original_balance column exists on operations table.
+    // Migration 0006 can silently fail on existing databases if the Drizzle
+    // migrator rolls back the transaction but records the hash, leaving the
+    // column absent. We detect and fix that here.
+    const opsColumns = await rawDb.getAllAsync('PRAGMA table_info(operations)').catch(() => []);
+    const hasOriginalBalance = (opsColumns || []).some(col => col.name === 'original_balance');
+    if (!hasOriginalBalance) {
+      console.warn('original_balance column missing from operations — adding it directly');
+      await rawDb.runAsync('ALTER TABLE `operations` ADD COLUMN `original_balance` text');
+      console.log('original_balance column added via fallback');
+    }
+
     // Defensive: ensure planned_operations table exists after migrations.
     // The beta Drizzle migrator can silently fail to apply a migration (transaction
     // rolls back, hash not recorded), so we create the table directly as a fallback.


### PR DESCRIPTION
## Summary

- Adds a defensive `PRAGMA table_info(operations)` check after `migrate()` runs
- If `original_balance` column is missing, runs `ALTER TABLE` directly as a fallback
- Same pattern already in place for `planned_operations` table

## Problem

Users on existing installs hit `table operations has no column named original_balance` when updating account balance via adjustment operation. Migration 0006 added this column but the Drizzle migrator can silently roll back a transaction while still recording the hash — leaving the column absent with no retry on next launch.

## Solution

Post-migration column existence check using `PRAGMA table_info`. If absent, applies the `ALTER TABLE` directly. Cheap on every startup (SQLite schema cache), only fires when actually needed.

## Test Plan

- [ ] Existing install without `original_balance` column: column is added on next launch, balance adjustment works
- [ ] Fresh install: PRAGMA check finds column present, no ALTER runs
- [ ] All 3430 tests passing

**BEGIN_COMMIT_OVERRIDE**
```
fix(db): add defensive fallback for original_balance column migration
```
**END_COMMIT_OVERRIDE**
