### PR TITLE
feat: remove logo and app name from header, slim header height

### DIFF
--- a/__tests__/components/Header.test.js
+++ b/__tests__/components/Header.test.js
@@ -81,13 +81,8 @@ describe('Header', () => {
 
   describe('Rendering', () => {
     it('renders without crashing', () => {
-      const { getByText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
-      expect(getByText('Penny')).toBeTruthy();
-    });
-
-    it('renders app title', () => {
-      const { getByText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
-      expect(getByText('Penny')).toBeTruthy();
+      const { getByTestId } = render(<Header onOpenSettings={mockOnOpenSettings} />);
+      expect(getByTestId('settings-button')).toBeTruthy();
     });
 
     it('does not render version text in header', () => {
@@ -104,11 +99,6 @@ describe('Header', () => {
     it('renders theme toggle icon (sunny for light mode)', () => {
       const { getByTestId } = render(<Header onOpenSettings={mockOnOpenSettings} />);
       expect(getByTestId('icon-sunny')).toBeTruthy();
-    });
-
-    it('renders app icon image', () => {
-      const { getByLabelText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
-      expect(getByLabelText('Penny app icon')).toBeTruthy();
     });
   });
 

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity, StyleSheet, Image, Animated } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Animated } from 'react-native';
 import { useEffect, useCallback, useRef } from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import SearchBar from './search/SearchBar';
@@ -13,8 +13,6 @@ import FilterBadge from './search/FilterBadge';
 import FilterChipStrip from './search/FilterChipStrip';
 import { useOperationsData } from '../contexts/OperationsDataContext';
 import { useOperationsActions } from '../contexts/OperationsActionsContext';
-
-const APP_VERSION = require('../../package.json').version;
 
 export default function Header({ onOpenSettings, rightContent, activeScreen, operationsData }) {
   console.debug('[Header] Rendering - activeScreen:', activeScreen, ', operationsData exists:', !!operationsData);
@@ -100,14 +98,6 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
         </>
       ) : (
         <>
-          <View style={styles.titleContainer}>
-            <Image
-              source={require('../../assets/icon.png')}
-              style={styles.icon}
-              accessibilityLabel="Penny app icon"
-            />
-            <Text style={[styles.title, { color: colors.text }]}>Penny</Text>
-          </View>
           <View style={styles.buttonContainer}>
             {rightContent || (
               <>
@@ -226,8 +216,9 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
     paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: 8,
   },
   containerSearchMode: {
     alignItems: 'stretch',
@@ -242,11 +233,6 @@ const styles = StyleSheet.create({
     fontSize: 9,
     fontVariant: ['tabular-nums'],
   },
-  icon: {
-    height: 50,
-    marginRight: 4,
-    width: 50,
-  },
   searchButton: {
     padding: 8,
   },
@@ -258,10 +244,5 @@ const styles = StyleSheet.create({
   },
   themeButton: {
     padding: 8,
-  },
-  title: { fontSize: 14, fontWeight: '700' },
-  titleContainer: {
-    alignItems: 'center',
-    flexDirection: 'row',
   },
 });

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -97,97 +97,95 @@ export default function Header({ onOpenSettings, rightContent, activeScreen, ope
           )}
         </>
       ) : (
-        <>
-          <View style={styles.buttonContainer}>
-            {rightContent || (
-              <>
-                {isDownloading && (
-                  <View
-                    style={styles.downloadIndicator}
-                    accessibilityLabel={`${t('downloading_update') || 'Downloading update'} ${Math.round((downloadProgress ?? 0) * 100)}%`}
-                    accessibilityRole="progressbar"
-                    testID="download-indicator"
-                  >
-                    <Animated.View style={{ transform: [{ translateY: downloadArrowAnim }] }}>
-                      <Ionicons name="arrow-down-outline" size={20} color={colors.primary} />
-                    </Animated.View>
-                    <Text style={[styles.downloadPercent, { color: colors.mutedText }]}>
-                      {`${Math.round((downloadProgress ?? 0) * 100)}%`}
-                    </Text>
-                  </View>
-                )}
-                {activeScreen === 'Operations' && (
-                  <View style={styles.searchButtonContainer}>
-                    <TouchableOpacity
-                      onPress={() => {
-                        console.debug('[Header] Search button pressed, mode:', searchMode);
-                        if (searchMode === 'collapsed') {
-                          // Reopen with smart logic: auto-expand the filter panel when
-                          // any non-text filter is active.
-                          const hasOtherFilters =
-                            (searchState?.types?.length > 0) ||
-                            (searchState?.accountIds?.length > 0) ||
-                            (searchState?.categoryIds?.length > 0) ||
-                            !!searchState?.dateRange?.startDate ||
-                            !!searchState?.dateRange?.endDate ||
-                            (searchState?.amountRange?.min !== null && searchState?.amountRange?.min !== undefined) ||
-                            (searchState?.amountRange?.max !== null && searchState?.amountRange?.max !== undefined);
+        <View style={styles.buttonContainer}>
+          {rightContent || (
+            <>
+              {isDownloading && (
+                <View
+                  style={styles.downloadIndicator}
+                  accessibilityLabel={`${t('downloading_update') || 'Downloading update'} ${Math.round((downloadProgress ?? 0) * 100)}%`}
+                  accessibilityRole="progressbar"
+                  testID="download-indicator"
+                >
+                  <Animated.View style={{ transform: [{ translateY: downloadArrowAnim }] }}>
+                    <Ionicons name="arrow-down-outline" size={20} color={colors.primary} />
+                  </Animated.View>
+                  <Text style={[styles.downloadPercent, { color: colors.mutedText }]}>
+                    {`${Math.round((downloadProgress ?? 0) * 100)}%`}
+                  </Text>
+                </View>
+              )}
+              {activeScreen === 'Operations' && (
+                <View style={styles.searchButtonContainer}>
+                  <TouchableOpacity
+                    onPress={() => {
+                      console.debug('[Header] Search button pressed, mode:', searchMode);
+                      if (searchMode === 'collapsed') {
+                        // Reopen with smart logic: auto-expand the filter panel when
+                        // any non-text filter is active.
+                        const hasOtherFilters =
+                          (searchState?.types?.length > 0) ||
+                          (searchState?.accountIds?.length > 0) ||
+                          (searchState?.categoryIds?.length > 0) ||
+                          !!searchState?.dateRange?.startDate ||
+                          !!searchState?.dateRange?.endDate ||
+                          (searchState?.amountRange?.min !== null && searchState?.amountRange?.min !== undefined) ||
+                          (searchState?.amountRange?.max !== null && searchState?.amountRange?.max !== undefined);
 
-                          reopenSearch(searchState?.text !== '', hasOtherFilters, (shouldExpand) => {
-                            if (shouldExpand !== filtersExpanded) {
-                              toggleFilters();
-                            }
-                          });
-                        } else {
-                          openSearch();
-                        }
-                      }}
-                      testID="search-button"
-                      accessibilityLabel="Search operations"
-                      accessibilityRole="button"
-                      style={styles.searchButton}
-                      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                    >
-                      <Ionicons name="search-outline" size={24} color={colors.text} />
-                    </TouchableOpacity>
-                    {searchMode === 'collapsed' && hasActiveSearch && (
-                      <FilterBadge
-                        count={getSearchFilterCount()}
-                        colors={colors}
-                      />
-                    )}
-                  </View>
-                )}
-                <TouchableOpacity
-                  onPress={toggleTheme}
-                  testID="theme-toggle-button"
-                  accessibilityLabel={colorScheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-                  accessibilityRole="button"
-                  accessibilityHint="Toggles between light and dark theme"
-                  style={styles.themeButton}
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                >
-                  <Ionicons
-                    name={colorScheme === 'dark' ? 'moon' : 'sunny'}
-                    size={24}
-                    color={colors.text}
-                  />
-                </TouchableOpacity>
-                <TouchableOpacity
-                  onPress={onOpenSettings}
-                  testID="settings-button"
-                  accessibilityLabel={t('settings')}
-                  accessibilityRole="button"
-                  accessibilityHint="Opens settings menu"
-                  style={styles.settingsButton}
-                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                >
-                  <Ionicons name="settings-outline" size={24} color={colors.text} />
-                </TouchableOpacity>
-              </>
-            )}
-          </View>
-        </>
+                        reopenSearch(searchState?.text !== '', hasOtherFilters, (shouldExpand) => {
+                          if (shouldExpand !== filtersExpanded) {
+                            toggleFilters();
+                          }
+                        });
+                      } else {
+                        openSearch();
+                      }
+                    }}
+                    testID="search-button"
+                    accessibilityLabel="Search operations"
+                    accessibilityRole="button"
+                    style={styles.searchButton}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  >
+                    <Ionicons name="search-outline" size={24} color={colors.text} />
+                  </TouchableOpacity>
+                  {searchMode === 'collapsed' && hasActiveSearch && (
+                    <FilterBadge
+                      count={getSearchFilterCount()}
+                      colors={colors}
+                    />
+                  )}
+                </View>
+              )}
+              <TouchableOpacity
+                onPress={toggleTheme}
+                testID="theme-toggle-button"
+                accessibilityLabel={colorScheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+                accessibilityRole="button"
+                accessibilityHint="Toggles between light and dark theme"
+                style={styles.themeButton}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <Ionicons
+                  name={colorScheme === 'dark' ? 'moon' : 'sunny'}
+                  size={24}
+                  color={colors.text}
+                />
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={onOpenSettings}
+                testID="settings-button"
+                accessibilityLabel={t('settings')}
+                accessibilityRole="button"
+                accessibilityHint="Opens settings menu"
+                style={styles.settingsButton}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <Ionicons name="settings-outline" size={24} color={colors.text} />
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
       )}
     </View>
   );

--- a/docs/superpowers/plans/2026-05-22-header-cleanup.md
+++ b/docs/superpowers/plans/2026-05-22-header-cleanup.md
@@ -1,0 +1,233 @@
+# Header Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the logo image and "Penny" text from the header, and slim the header height to fit only the icon buttons.
+
+**Architecture:** Single-file change in `app/components/Header.js` — remove JSX, dead styles, dead imports, and dead constant. Three existing tests reference the removed elements and must be updated before the implementation change (TDD order).
+
+**Tech Stack:** React Native, Jest, React Native Testing Library
+
+---
+
+### Task 1: Update tests that reference removed elements
+
+**Files:**
+- Modify: `__tests__/components/Header.test.js`
+
+Three tests will break once the logo and title are removed:
+- `renders without crashing` (line 84) — asserts `getByText('Penny')`
+- `renders app title` (line 88) — asserts `getByText('Penny')`
+- `renders app icon image` (line 109) — asserts `getByLabelText('Penny app icon')`
+
+- [ ] **Step 1: Update `renders without crashing` — replace the Penny assertion**
+
+In `__tests__/components/Header.test.js`, change the test at line 83–86:
+
+```js
+it('renders without crashing', () => {
+  const { getByTestId } = render(<Header onOpenSettings={mockOnOpenSettings} />);
+  expect(getByTestId('settings-button')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Delete the `renders app title` test**
+
+Remove lines 88–91 entirely:
+
+```js
+// DELETE this block:
+it('renders app title', () => {
+  const { getByText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
+  expect(getByText('Penny')).toBeTruthy();
+});
+```
+
+- [ ] **Step 3: Delete the `renders app icon image` test**
+
+Remove lines 109–113 entirely:
+
+```js
+// DELETE this block:
+it('renders app icon image', () => {
+  const { getByLabelText } = render(<Header onOpenSettings={mockOnOpenSettings} />);
+  expect(getByLabelText('Penny app icon')).toBeTruthy();
+});
+```
+
+- [ ] **Step 4: Run the Header tests to confirm they now fail (implementation not yet changed)**
+
+```bash
+npm test -- --silent __tests__/components/Header.test.js
+```
+
+Expected: `renders without crashing` FAILS with "Unable to find an element by: [testId="settings-button"]" — wait, actually `settings-button` already exists in the current implementation, so this test will PASS. That's fine — it just means our updated test is compatible with both old and new code. The deleted tests are gone so they can't fail.
+
+Actually the correct TDD check here: run the full Header test suite and confirm it passes with the test updates applied but before touching the implementation. This verifies we didn't break anything else.
+
+```bash
+npm test -- --silent __tests__/components/Header.test.js
+```
+
+Expected: All remaining tests PASS.
+
+- [ ] **Step 5: Commit the test updates**
+
+```bash
+git add __tests__/components/Header.test.js
+git commit -m "test: update Header tests for logo/title removal"
+```
+
+---
+
+### Task 2: Implement the Header changes
+
+**Files:**
+- Modify: `app/components/Header.js`
+
+- [ ] **Step 1: Remove the `Image` import and `APP_VERSION` constant**
+
+In `app/components/Header.js`, change line 1 (`Image` is removed; `Text` stays because it's still used in the download indicator):
+
+```js
+// FROM:
+import { View, Text, TouchableOpacity, StyleSheet, Image, Animated } from 'react-native';
+
+// TO:
+import { View, Text, TouchableOpacity, StyleSheet, Animated } from 'react-native';
+```
+
+Remove line 17:
+
+```js
+// DELETE:
+const APP_VERSION = require('../../package.json').version;
+```
+
+- [ ] **Step 2: Remove the `titleContainer` JSX block**
+
+In the non-search-mode branch (around line 102–110), remove the entire `titleContainer` View:
+
+```jsx
+// DELETE this block:
+<View style={styles.titleContainer}>
+  <Image
+    source={require('../../assets/icon.png')}
+    style={styles.icon}
+    accessibilityLabel="Penny app icon"
+  />
+  <Text style={[styles.title, { color: colors.text }]}>Penny</Text>
+</View>
+```
+
+The non-search-mode branch should now contain only the `buttonContainer`:
+
+```jsx
+) : (
+  <>
+    <View style={styles.buttonContainer}>
+      {rightContent || (
+        <>
+          {isDownloading && (
+            // ... download indicator unchanged
+          )}
+          {activeScreen === 'Operations' && (
+            // ... search button unchanged
+          )}
+          <TouchableOpacity
+            // ... theme toggle unchanged
+          />
+          <TouchableOpacity
+            // ... settings button unchanged
+          />
+        </>
+      )}
+    </View>
+  </>
+)}
+```
+
+- [ ] **Step 3: Add `paddingVertical: 8` to the container style and remove dead styles**
+
+In the `StyleSheet.create` block, update `container` and remove `titleContainer`, `icon`, and `title`:
+
+```js
+const styles = StyleSheet.create({
+  buttonContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+  },
+  container: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: 8,
+  },
+  containerSearchMode: {
+    alignItems: 'stretch',
+    flexDirection: 'column',
+    paddingHorizontal: 0,
+  },
+  downloadIndicator: {
+    alignItems: 'center',
+    gap: 2,
+  },
+  downloadPercent: {
+    fontSize: 9,
+    fontVariant: ['tabular-nums'],
+  },
+  searchButton: {
+    padding: 8,
+  },
+  searchButtonContainer: {
+    position: 'relative',
+  },
+  settingsButton: {
+    padding: 8,
+  },
+  themeButton: {
+    padding: 8,
+  },
+});
+```
+
+Note: `justifyContent` changes from `'space-between'` to `'flex-end'` since there is no longer a left element to push against.
+
+The final import line (set in Task 2 Step 1) should be:
+
+```js
+import { View, Text, TouchableOpacity, StyleSheet, Animated } from 'react-native';
+```
+
+- [ ] **Step 4: Run the full Header test suite**
+
+```bash
+npm test -- --silent __tests__/components/Header.test.js __tests__/components/Header-rightContent.test.js
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run the broader integration tests that touch Header**
+
+```bash
+npm test -- --silent __tests__/integration/HeaderSearchIntegration.test.js __tests__/integration/SearchLayout.test.js
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+npm test -- --silent
+```
+
+Expected: 0 failed tests.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add app/components/Header.js
+git commit -m "feat: remove logo and app name from header, slim header height"
+```

--- a/docs/superpowers/specs/2026-05-22-header-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-22-header-cleanup-design.md
@@ -1,0 +1,47 @@
+# Header Cleanup Design
+
+**Date:** 2026-05-22
+
+## Goal
+
+Remove the logo image and "Penny" app name from the header, and shrink the header height to the minimum needed to contain the icon buttons.
+
+## Scope
+
+Single file: `app/components/Header.js`
+
+## Changes
+
+### JSX
+
+Remove the `titleContainer` block entirely:
+
+```jsx
+// DELETE this entire block
+<View style={styles.titleContainer}>
+  <Image
+    source={require('../../assets/icon.png')}
+    style={styles.icon}
+    accessibilityLabel="Penny app icon"
+  />
+  <Text style={[styles.title, { color: colors.text }]}>Penny</Text>
+</View>
+```
+
+The `buttonContainer` remains. With nothing on the left, icons sit flush right via the existing `justifyContent: 'space-between'`.
+
+### Styles
+
+- Add `paddingVertical: 8` to `container` — header height becomes ~56px (8 + 40 + 8)
+- Remove unused styles: `titleContainer`, `icon`, `title`
+
+### Imports and constants
+
+- Remove `Image` from the `react-native` import (no longer used)
+- Remove the `APP_VERSION` constant (declared but never rendered)
+
+## What does not change
+
+- Search mode layout (`containerSearchMode`) is unaffected
+- All button logic, theme toggle, settings, search, download indicator — unchanged
+- No other files need editing


### PR DESCRIPTION
## Summary
- Removed the 50px logo image and "Penny" text from the header
- Header now contains only the action icons (search, theme toggle, settings)
- Header height reduced to ~56px via explicit `paddingVertical: 8` on the container

## Test Plan
- [ ] All 3428 tests pass (`npm test`)
- [ ] Visually verify header shows only icons, no logo or app name
- [ ] Confirm search mode (Operations tab) still works correctly
