### PR TITLE
feat: pre-restore snapshot for undo-able restore

### DIFF
--- a/__tests__/modals/SettingsModal.test.js
+++ b/__tests__/modals/SettingsModal.test.js
@@ -95,18 +95,21 @@ const mockPickImportFile = jest.fn(() => Promise.resolve({ fileUri: '/mock/file.
 const mockImportBackupFromFile = jest.fn(() => Promise.resolve());
 const mockRestoreBackup = jest.fn(() => Promise.resolve());
 const mockCreateBackup = jest.fn(() => Promise.resolve({ version: 1, data: {} }));
+const mockGetPreRestoreSnapshots = jest.fn(() => Promise.resolve([]));
 jest.mock('../../app/services/BackupRestore', () => ({
   exportBackup: (...args) => mockExportBackup(...args),
   pickImportFile: (...args) => mockPickImportFile(...args),
   importBackupFromFile: (...args) => mockImportBackupFromFile(...args),
   restoreBackup: (...args) => mockRestoreBackup(...args),
   createBackup: (...args) => mockCreateBackup(...args),
+  getPreRestoreSnapshots: (...args) => mockGetPreRestoreSnapshots(...args),
 }));
 
 // Mock DailyBackupService
 const mockGetStoredBackups = jest.fn(() => Promise.resolve([]));
 jest.mock('../../app/services/DailyBackupService', () => ({
   getStoredBackups: (...args) => mockGetStoredBackups(...args),
+  DAILY_BACKUP_DIR: '/mock/docs/daily_backups/',
 }));
 
 // Mock expo-file-system/legacy
@@ -169,6 +172,7 @@ describe('SettingsModal Component', () => {
     mockRestoreBackup.mockClear();
     mockCreateBackup.mockClear();
     mockGetStoredBackups.mockClear();
+    mockGetPreRestoreSnapshots.mockClear();
     mockSetHideBalances.mockClear();
     mockAuthenticateWithBiometrics.mockClear();
     displaySettingsMockState.hideBalances = false;

--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -16,6 +16,7 @@ jest.mock('expo-file-system/legacy', () => ({
   getInfoAsync: jest.fn(),
   writeAsStringAsync: jest.fn(),
   readAsStringAsync: jest.fn(),
+  readDirectoryAsync: jest.fn(),
   copyAsync: jest.fn(),
   deleteAsync: jest.fn(),
   makeDirectoryAsync: jest.fn(),
@@ -140,6 +141,7 @@ describe('BackupRestore', () => {
     mockFileSystem.getInfoAsync.mockResolvedValue({ exists: true });
     mockFileSystem.writeAsStringAsync.mockResolvedValue();
     mockFileSystem.readAsStringAsync.mockResolvedValue('');
+    mockFileSystem.readDirectoryAsync.mockResolvedValue([]);
     mockFileSystem.copyAsync.mockResolvedValue();
     mockFileSystem.deleteAsync.mockResolvedValue();
     mockFileSystem.makeDirectoryAsync.mockResolvedValue();

--- a/app/modals/SettingsModal.js
+++ b/app/modals/SettingsModal.js
@@ -10,7 +10,7 @@ import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useImportProgress } from '../contexts/ImportProgressContext';
-import { exportBackup, pickImportFile, importBackupFromFile, restoreBackup, createBackup } from '../services/BackupRestore';
+import { exportBackup, pickImportFile, importBackupFromFile, restoreBackup, createBackup, getPreRestoreSnapshots } from '../services/BackupRestore';
 import { getStoredBackups, DAILY_BACKUP_DIR } from '../services/DailyBackupService';
 import { useLogEntries } from '../hooks/useLogEntries';
 import { File, Paths } from 'expo-file-system';
@@ -365,15 +365,19 @@ export default function SettingsModal({ visible, onClose }) {
   const loadStoredBackups = useCallback(async () => {
     setBackupsLoading(true);
     try {
-      const uris = await getStoredBackups();
+      const [regularUris, snapshotUris] = await Promise.all([
+        getStoredBackups(),
+        getPreRestoreSnapshots(),
+      ]);
+      const allUris = [...regularUris.reverse(), ...snapshotUris];
       const infos = await Promise.all(
-        uris.map(async (uri) => {
+        allUris.map(async (uri) => {
           const filename = uri.split('/').pop();
           const info = await LegacyFileSystem.getInfoAsync(uri);
           return { uri, filename, size: info.size || 0 };
         }),
       );
-      setStoredBackups(infos.reverse());
+      setStoredBackups(infos);
     } catch (error) {
       console.error('Failed to load stored backups:', error);
       setStoredBackups([]);
@@ -659,24 +663,49 @@ export default function SettingsModal({ visible, onClose }) {
         return dateLabel;
       }
     }
+    if (filename.startsWith('pre_restore_')) {
+      // filename: pre_restore_YYYY-MM-DDTHH-MM-SS.json
+      const inner = filename.replace('pre_restore_', '').replace('.json', '');
+      // inner looks like: 2024-01-15T14-30-00
+      const datePart = inner.split('T')[0];
+      const timePart = inner.split('T')[1];
+      if (datePart) {
+        const [year, month, day] = datePart.split('-').map(Number);
+        const dateLabel = new Date(year, month - 1, day).toLocaleDateString(undefined, {
+          month: 'short', day: 'numeric', year: 'numeric',
+        });
+        if (timePart) {
+          const parts = timePart.split('-');
+          const hh = parts[0] || '00';
+          const mm = parts[1] || '00';
+          return `${dateLabel} · ${hh}:${mm}`;
+        }
+        return dateLabel;
+      }
+    }
     return filename;
   }, [t]);
 
   const renderBackupItem = useCallback(({ item }) => {
     const isDaily = item.filename.startsWith('daily_');
     const isManual = item.filename.startsWith('manual_');
+    const isPreRestore = item.filename.startsWith('pre_restore_');
     const label = formatBackupLabel(item.filename);
-    const typeLabel = isDaily ? 'Daily' : isManual ? 'Manual' : (t('weekly') || 'Weekly');
+    const typeLabel = isPreRestore
+      ? (t('pre_restore_snapshot') || 'Pre-restore snapshot')
+      : isDaily ? 'Daily' : isManual ? 'Manual' : (t('weekly') || 'Weekly');
     const sizeKB = item.size ? `${(item.size / 1024).toFixed(1)} KB` : '';
     const isPending = pendingDeleteUri === item.uri;
     return (
       <View style={[styles.backupItem, { borderBottomColor: colors.border }]}>
         <View style={styles.backupItemLeft}>
-          <Ionicons name={isDaily ? 'calendar-outline' : isManual ? 'save-outline' : 'calendar-number-outline'} size={22} color={isPending ? colors.mutedText : colors.text} />
+          <Ionicons name={isPreRestore ? 'shield-checkmark-outline' : isDaily ? 'calendar-outline' : isManual ? 'save-outline' : 'calendar-number-outline'} size={22} color={isPending ? colors.mutedText : isPreRestore ? colors.primary : colors.text} />
           <View style={styles.backupItemText}>
-            <Text style={[styles.backupItemLabel, { color: isPending ? colors.mutedText : colors.text }]}>{label}</Text>
+            <Text style={[styles.backupItemLabel, { color: isPending ? colors.mutedText : isPreRestore ? colors.primary : colors.text }]}>
+              {isPreRestore ? `${typeLabel} — ${label}` : label}
+            </Text>
             <Text style={[styles.backupItemMeta, { color: colors.mutedText }]}>
-              {isPending ? (t('delete_backup_confirm') || 'Delete this backup?') : `${typeLabel}${sizeKB ? ` · ${sizeKB}` : ''}`}
+              {isPending ? (t('delete_backup_confirm') || 'Delete this backup?') : isPreRestore ? sizeKB : `${typeLabel}${sizeKB ? ` · ${sizeKB}` : ''}`}
             </Text>
           </View>
         </View>

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -397,6 +397,21 @@ export const restoreBackup = async (backup) => {
       snapshotUri = `${FileSystem.documentDirectory}pre_restore_${snapshotTimestamp}.json`;
       await FileSystem.writeAsStringAsync(snapshotUri, JSON.stringify(snapshot, null, 2));
       console.log('Pre-restore snapshot saved:', snapshotUri);
+
+      // Keep only the 3 most recent pre-restore snapshots.
+      try {
+        const allFiles = await FileSystem.readDirectoryAsync(FileSystem.documentDirectory);
+        const snapshots = allFiles
+          .filter(name => name.startsWith('pre_restore_') && name.endsWith('.json'))
+          .sort(); // ISO timestamps sort lexicographically = chronologically
+        const excess = snapshots.slice(0, Math.max(0, snapshots.length - 3));
+        for (const name of excess) {
+          await FileSystem.deleteAsync(`${FileSystem.documentDirectory}${name}`, { idempotent: true });
+          console.log('Deleted old pre-restore snapshot:', name);
+        }
+      } catch (cleanupError) {
+        console.warn('Failed to clean up old pre-restore snapshots:', cleanupError);
+      }
     } catch (snapshotError) {
       console.warn('Failed to create pre-restore snapshot:', snapshotError);
     }
@@ -1203,6 +1218,25 @@ export const importBackupFromFile = async ({ fileUri, filename }) => {
 export const importBackup = async () => {
   const fileInfo = await pickImportFile();
   return importBackupFromFile(fileInfo);
+};
+
+/**
+ * List all pre-restore snapshot files stored in documentDirectory.
+ * Returns URIs sorted newest-first (filenames sort lexicographically by timestamp).
+ * @returns {Promise<string[]>} Array of file URIs
+ */
+export const getPreRestoreSnapshots = async () => {
+  try {
+    const allFiles = await FileSystem.readDirectoryAsync(FileSystem.documentDirectory);
+    return allFiles
+      .filter(name => name.startsWith('pre_restore_') && name.endsWith('.json'))
+      .sort()
+      .reverse()
+      .map(name => `${FileSystem.documentDirectory}${name}`);
+  } catch (error) {
+    console.warn('Failed to list pre-restore snapshots:', error);
+    return [];
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary
restoreBackup now takes a snapshot of the current DB before overwriting it, giving users a path back if they restored the wrong file. Pre-restore snapshots appear in the local backups list with a distinct shield icon and label so users can identify and restore from them.

## Changes
- `BackupRestore.js`: after writing `pre_restore_<timestamp>.json`, reads `documentDirectory`, filters `pre_restore_*.json`, sorts lexicographically, and deletes any beyond the 3 most recent. Cleanup errors are swallowed so a failing cleanup never blocks the restore.
- `BackupRestore.js`: exports `getPreRestoreSnapshots()` to list pre-restore snapshots newest-first, for use by the UI.
- `SettingsModal.js`: `loadStoredBackups` now fetches pre-restore snapshots alongside daily/weekly/manual backups via `Promise.all` and merges them into the displayed list.
- `SettingsModal.js`: `formatBackupLabel` handles `pre_restore_` filenames; `renderBackupItem` renders them with a shield icon, primary-color text, and "Pre-restore snapshot — date" label so users can distinguish them from regular backups.
- Tests: added `readDirectoryAsync` to `BackupRestore` test mock and `getPreRestoreSnapshots` to `SettingsModal` test mock so existing tests stay green.

closes #694
