### PR TITLE
fix: locale-aware week start for weekly budget periods

### DIFF
--- a/__tests__/services/BudgetsDB.test.js
+++ b/__tests__/services/BudgetsDB.test.js
@@ -720,13 +720,64 @@ describe('BudgetsDB Service', () => {
   });
 
   describe('Period Date Calculations', () => {
+    describe('getWeekStartDay', () => {
+      it('returns 7 (Sunday) for en-US', () => {
+        expect(BudgetsDB.getWeekStartDay('en-US')).toBe(7);
+      });
+
+      it('returns 1 (Monday) for en-GB', () => {
+        expect(BudgetsDB.getWeekStartDay('en-GB')).toBe(1);
+      });
+
+      it('returns 1 (Monday) for ru', () => {
+        expect(BudgetsDB.getWeekStartDay('ru')).toBe(1);
+      });
+
+      it('returns 1 (Monday) for unknown locale (ISO 8601 default)', () => {
+        expect(BudgetsDB.getWeekStartDay('xx-UNKNOWN')).toBe(1);
+      });
+
+      it('returns 1 (Monday) for null locale (ISO 8601 default)', () => {
+        expect(BudgetsDB.getWeekStartDay(null)).toBe(1);
+      });
+
+      it('returns 1 (Monday) for undefined locale (ISO 8601 default)', () => {
+        expect(BudgetsDB.getWeekStartDay(undefined)).toBe(1);
+      });
+
+      it('returns locale-determined day for en (generic English, engine-dependent)', () => {
+        // 'en' without a region subtag is ambiguous — different JS engines may resolve
+        // it to en-US (Sunday=7) or en-001 (Monday=1). Just verify it returns a valid value.
+        const result = BudgetsDB.getWeekStartDay('en');
+        expect([1, 7]).toContain(result);
+      });
+
+      it('returns 1 (Monday) for fr', () => {
+        expect(BudgetsDB.getWeekStartDay('fr')).toBe(1);
+      });
+
+      it('returns 1 (Monday) for de', () => {
+        expect(BudgetsDB.getWeekStartDay('de')).toBe(1);
+      });
+    });
+
     describe('getCurrentPeriodDates', () => {
-      it('calculates weekly period dates', () => {
-        const referenceDate = new Date('2025-12-10'); // Wednesday
+      it('calculates weekly period dates defaulting to Monday start (ISO 8601)', () => {
+        // 2025-12-10 is a Wednesday; Monday of that week is Dec 8, Sunday is Dec 14
+        const referenceDate = new Date('2025-12-10');
         const { start, end } = BudgetsDB.getCurrentPeriodDates('weekly', referenceDate);
 
+        expect(start.getDay()).toBe(1); // Monday
+        expect(end.getDay()).toBe(0);   // Sunday
+      });
+
+      it('calculates weekly period dates with Sunday start for en-US locale', () => {
+        // 2025-12-10 is a Wednesday; Sunday of that week is Dec 7, Saturday is Dec 13
+        const referenceDate = new Date('2025-12-10');
+        const { start, end } = BudgetsDB.getCurrentPeriodDates('weekly', referenceDate, 'en-US');
+
         expect(start.getDay()).toBe(0); // Sunday
-        expect(end.getDay()).toBe(6); // Saturday
+        expect(end.getDay()).toBe(6);   // Saturday
       });
 
       it('calculates monthly period dates', () => {
@@ -755,11 +806,13 @@ describe('BudgetsDB Service', () => {
     });
 
     describe('getNextPeriodDates', () => {
-      it('calculates next weekly period', () => {
-        const currentStart = new Date('2025-12-07'); // Sunday
+      it('calculates next weekly period (Monday-start default)', () => {
+        // 2025-12-08 is a Monday — start of the week with ISO 8601 default
+        const currentStart = new Date('2025-12-08');
         const { start } = BudgetsDB.getNextPeriodDates('weekly', currentStart);
 
-        expect(start.getDate()).toBe(14); // Next Sunday
+        expect(start.getDate()).toBe(15); // Next Monday
+        expect(start.getDay()).toBe(1);
       });
 
       it('calculates next monthly period', () => {
@@ -779,11 +832,13 @@ describe('BudgetsDB Service', () => {
     });
 
     describe('getPreviousPeriodDates', () => {
-      it('calculates previous weekly period', () => {
-        const currentStart = new Date('2025-12-07'); // Sunday
+      it('calculates previous weekly period (Monday-start default)', () => {
+        // 2025-12-08 is a Monday; previous week's Monday is Dec 1
+        const currentStart = new Date('2025-12-08');
         const { start } = BudgetsDB.getPreviousPeriodDates('weekly', currentStart);
 
-        expect(start.getDate()).toBe(30); // Previous Sunday (Nov 30)
+        expect(start.getDate()).toBe(1);  // Dec 1
+        expect(start.getDay()).toBe(1);   // Monday
       });
 
       it('calculates previous monthly period', () => {

--- a/app/services/BudgetsDB.js
+++ b/app/services/BudgetsDB.js
@@ -385,20 +385,91 @@ export const findDuplicateBudget = async (categoryId, currency, periodType, excl
 };
 
 /**
+ * Fallback lookup table for locales where Intl.Locale.weekInfo is unavailable.
+ * Values follow the weekInfo.firstDay convention: 1 = Monday, 7 = Sunday.
+ * All locales supported by the app are listed. Sources: CLDR / ISO 8601.
+ * en-US and a few others start on Sunday; the rest on Monday.
+ */
+const LOCALE_WEEK_START = {
+  // Sunday-start (7)
+  'en-US': 7,
+  'en-CA': 7, // Canada uses Sunday in many regions
+  'zh-TW': 7,
+  'ko-KR': 7,
+  'ja-JP': 7,
+  // Monday-start (1) — ISO 8601 default, covers most of the app's locales
+  'en':    1,
+  'en-GB': 1,
+  'it':    1,
+  'ru':    1,
+  'es':    1,
+  'fr':    1,
+  'zh':    1,
+  'de':    1,
+  'hy':    1,
+  'ja':    1,
+  'ko':    1,
+  'pt':    1,
+};
+
+/**
+ * Return the first day of the week for a given BCP-47 locale tag.
+ * Uses Intl.Locale.weekInfo when available (Android/Hermes may not support it),
+ * falls back to LOCALE_WEEK_START lookup, then defaults to Monday (1, ISO 8601).
+ *
+ * @param {string|null} locale - BCP-47 language tag (e.g. 'en-US', 'ru', 'fr')
+ * @returns {number} First day of week: 1 = Monday … 7 = Sunday
+ */
+export const getWeekStartDay = (locale) => {
+  if (locale) {
+    // Attempt Intl.Locale weekInfo (supported in V8 ≥ 9.9, Hermes experimental)
+    try {
+      const localeObj = new Intl.Locale(locale);
+      if (localeObj.weekInfo && typeof localeObj.weekInfo.firstDay === 'number') {
+        return localeObj.weekInfo.firstDay; // 1–7, Monday–Sunday
+      }
+    } catch (_e) {
+      // Intl.Locale constructor threw (invalid tag) — fall through
+    }
+
+    // Exact match first, then language-only prefix match
+    if (LOCALE_WEEK_START[locale] !== undefined) {
+      return LOCALE_WEEK_START[locale];
+    }
+    const lang = locale.split('-')[0];
+    if (LOCALE_WEEK_START[lang] !== undefined) {
+      return LOCALE_WEEK_START[lang];
+    }
+  }
+
+  // ISO 8601 default: Monday
+  return 1;
+};
+
+/**
  * Calculate current period dates for a given period type
  * @param {string} periodType - 'weekly' | 'monthly' | 'yearly'
  * @param {Date} referenceDate - Reference date (default: today)
+ * @param {string|null} locale - BCP-47 locale tag used to determine week start day (default: null → Monday)
  * @returns {Object} { start: Date, end: Date }
  */
-export const getCurrentPeriodDates = (periodType, referenceDate = new Date()) => {
+export const getCurrentPeriodDates = (periodType, referenceDate = new Date(), locale = null) => {
   const start = new Date(referenceDate);
   const end = new Date(referenceDate);
 
   switch (periodType) {
   case 'weekly': {
-    // Week starts on Sunday (0) and ends on Saturday (6)
-    const dayOfWeek = start.getDay();
-    start.setDate(start.getDate() - dayOfWeek);
+    // Determine the locale's first day of the week.
+    // weekInfo.firstDay: 1 = Monday … 7 = Sunday.
+    // JS getDay():        0 = Sunday … 6 = Saturday.
+    // Convert firstDay (1-7) → JS day index (0-6): Monday=1→0, …, Sunday=7→0 mod 7.
+    const firstDayRaw = getWeekStartDay(locale); // 1–7
+    const firstDayJS = firstDayRaw % 7; // Monday=1→1? No: 1%7=1, 7%7=0 ✓ Sunday→0
+
+    // Days since the week start (always 0–6)
+    const dayOfWeek = start.getDay(); // 0=Sun … 6=Sat
+    const diff = (dayOfWeek - firstDayJS + 7) % 7;
+    start.setDate(start.getDate() - diff);
     end.setDate(start.getDate() + 6);
     break;
   }


### PR DESCRIPTION
## Summary
- `getCurrentPeriodDates('weekly')` was hardcoded to Sunday-start, wrong for ISO 8601 locales (most of the world)
- Now derives week start from `Intl.Locale.weekInfo.firstDay` with a CLDR-sourced fallback table
- Defaults to Monday (ISO 8601) when locale is unknown or omitted

## Changes
- `app/services/BudgetsDB.js`: added `getWeekStartDay(locale)` helper and updated `getCurrentPeriodDates` to accept an optional `locale` param (third arg, default `null`)
- `__tests__/services/BudgetsDB.test.js`: added 9 `getWeekStartDay` unit tests covering en-US→Sunday, en-GB→Monday, ru→Monday, null/unknown→Monday; updated weekly period tests to match new Monday-start default

closes #600
