### PR TITLE
feat: skeleton placeholder for operations list during initial load

### DIFF
--- a/__tests__/components/operations/OperationsList.test.js
+++ b/__tests__/components/operations/OperationsList.test.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
-import { ActivityIndicator, FlatList } from 'react-native';
+import { FlatList } from 'react-native';
 import OperationsList from '../../../app/components/operations/OperationsList';
 
 jest.mock('../../../app/components/operations/DateSeparator', () => {
@@ -33,6 +33,13 @@ jest.mock('../../../app/components/operations/OperationListItem', () => {
     return React.createElement('View', { testID: `op-item-${operation.id}` });
   };
   /* eslint-enable react/prop-types */
+});
+
+jest.mock('../../../app/components/operations/OperationsListPlaceholder', () => {
+  const React = require('react');
+  return function MockOperationsListPlaceholder() {
+    return React.createElement('View', { testID: 'operations-list-placeholder' });
+  };
 });
 
 jest.mock('../../../assets/currencies.json', () => ({
@@ -105,10 +112,10 @@ describe('OperationsList', () => {
   // ── initialLoading: ListEmptyComponent branch ─────────────────────────────
 
   describe('initialLoading prop', () => {
-    it('ListEmptyComponent shows ActivityIndicator when initialLoading=true', () => {
+    it('ListEmptyComponent shows skeleton placeholder when initialLoading=true', () => {
       const { fp } = getFlatListProps({ initialLoading: true });
-      const { UNSAFE_getAllByType } = render(fp.ListEmptyComponent);
-      expect(UNSAFE_getAllByType(ActivityIndicator).length).toBeGreaterThan(0);
+      const { getByTestId } = render(fp.ListEmptyComponent);
+      expect(getByTestId('operations-list-placeholder')).toBeTruthy();
     });
 
     it('ListEmptyComponent shows empty-state text when initialLoading=false', () => {

--- a/__tests__/components/operations/OperationsList.test.js
+++ b/__tests__/components/operations/OperationsList.test.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
-import { FlatList } from 'react-native';
+import { ActivityIndicator, FlatList } from 'react-native';
 import OperationsList from '../../../app/components/operations/OperationsList';
 
 jest.mock('../../../app/components/operations/DateSeparator', () => {

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -4,6 +4,7 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import DateSeparator from './DateSeparator';
 import OperationListItem from './OperationListItem';
+import OperationsListPlaceholder from './OperationsListPlaceholder';
 import currencies from '../../../assets/currencies.json';
 import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
 
@@ -194,9 +195,7 @@ const OperationsList = forwardRef(({
       ListFooterComponent={renderFooter}
       ListEmptyComponent={
         initialLoading ? (
-          <View style={styles.emptyContainer}>
-            <ActivityIndicator size="large" color={colors.primary} />
-          </View>
+          <OperationsListPlaceholder colors={colors} />
         ) : (
           <View style={styles.emptyContainer}>
             <Icon name="cash-multiple" size={64} color={colors.mutedText} />
@@ -206,7 +205,13 @@ const OperationsList = forwardRef(({
           </View>
         )
       }
-      contentContainerStyle={groupedOperations.length === 0 ? styles.emptyList : styles.listContent}
+      contentContainerStyle={
+        initialLoading
+          ? styles.listContent
+          : groupedOperations.length === 0
+            ? styles.emptyList
+            : styles.listContent
+      }
       onScroll={onScroll}
       scrollEventThrottle={16}
       onEndReached={handleEndReached}

--- a/app/components/operations/OperationsListPlaceholder.js
+++ b/app/components/operations/OperationsListPlaceholder.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { View, Animated, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
 import { SPACING, BORDER_RADIUS, HEIGHTS } from '../../styles/designTokens';
 
 // Pre-defined widths so every row looks distinct from its neighbours
@@ -73,6 +74,13 @@ const OperationsListPlaceholder = ({ colors }) => {
       </View>
     </View>
   );
+};
+
+OperationsListPlaceholder.propTypes = {
+  colors: PropTypes.shape({
+    border: PropTypes.string.isRequired,
+    surface: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 const BAR_RADIUS = BORDER_RADIUS.sm;

--- a/app/components/operations/OperationsListPlaceholder.js
+++ b/app/components/operations/OperationsListPlaceholder.js
@@ -1,0 +1,146 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Animated, StyleSheet } from 'react-native';
+import { SPACING, BORDER_RADIUS, HEIGHTS } from '../../styles/designTokens';
+
+// Pre-defined widths so every row looks distinct from its neighbours
+const ROW_WIDTHS = [
+  { title: '65%', subtitle: '45%', amount: 52 },
+  { title: '80%', subtitle: '55%', amount: 44 },
+  { title: '55%', subtitle: '40%', amount: 60 },
+  { title: '70%', subtitle: '50%', amount: 48 },
+  { title: '60%', subtitle: '35%', amount: 56 },
+  { title: '75%', subtitle: '48%', amount: 42 },
+  { title: '50%', subtitle: '42%', amount: 50 },
+  { title: '68%', subtitle: '52%', amount: 58 },
+  { title: '73%', subtitle: '38%', amount: 46 },
+  { title: '58%', subtitle: '45%', amount: 54 },
+];
+
+const OperationsListPlaceholder = ({ colors }) => {
+  const pulse = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const anim = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 1, duration: 750, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 0, duration: 750, useNativeDriver: true }),
+      ]),
+    );
+    anim.start();
+    return () => anim.stop();
+  }, [pulse]);
+
+  const opacity = pulse.interpolate({ inputRange: [0, 1], outputRange: [0.35, 0.75] });
+  const barStyle = { backgroundColor: colors.border };
+
+  return (
+    <View style={styles.groupContainer}>
+      {/* Date separator placeholder */}
+      <View style={styles.separatorRow}>
+        <Animated.View style={[styles.dateBar, barStyle, { opacity }]} />
+        <Animated.View style={[styles.totalBar, barStyle, { opacity }]} />
+      </View>
+
+      {/* Operations card */}
+      <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+        {ROW_WIDTHS.map((widths, index) => (
+          <View key={index}>
+            <View style={styles.row}>
+              {/* Icon circle */}
+              <Animated.View style={[styles.iconCircle, barStyle, { opacity }]} />
+
+              {/* Title + subtitle */}
+              <View style={styles.textContainer}>
+                <Animated.View
+                  style={[styles.titleBar, barStyle, { opacity, width: widths.title }]}
+                />
+                <Animated.View
+                  style={[styles.subtitleBar, barStyle, { opacity, width: widths.subtitle }]}
+                />
+              </View>
+
+              {/* Amount */}
+              <Animated.View
+                style={[styles.amountBar, barStyle, { opacity, width: widths.amount }]}
+              />
+            </View>
+
+            {index < ROW_WIDTHS.length - 1 && (
+              <View style={[styles.separator, { backgroundColor: colors.border }]} />
+            )}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+const BAR_RADIUS = BORDER_RADIUS.sm;
+
+const styles = StyleSheet.create({
+  amountBar: {
+    borderRadius: BAR_RADIUS,
+    height: 10,
+    marginLeft: SPACING.md,
+  },
+  card: {
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    marginHorizontal: SPACING.lg,
+    overflow: 'hidden',
+  },
+  dateBar: {
+    borderRadius: BAR_RADIUS,
+    height: 8,
+    width: 64,
+  },
+  groupContainer: {
+    marginBottom: SPACING.sm,
+  },
+  iconCircle: {
+    borderRadius: 11,
+    height: 22,
+    marginRight: SPACING.md,
+    width: 22,
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    minHeight: HEIGHTS.listItem,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+  },
+  separator: {
+    height: 1,
+    marginLeft: SPACING.lg + 22 + SPACING.md,
+  },
+  separatorRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingBottom: SPACING.xs,
+    paddingHorizontal: SPACING.lg + SPACING.sm,
+    paddingTop: SPACING.lg,
+  },
+  subtitleBar: {
+    borderRadius: BAR_RADIUS,
+    height: 8,
+    marginTop: 4,
+  },
+  textContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    minWidth: 0,
+  },
+  titleBar: {
+    borderRadius: BAR_RADIUS,
+    height: 10,
+  },
+  totalBar: {
+    borderRadius: BAR_RADIUS,
+    height: 8,
+    width: 52,
+  },
+});
+
+export default OperationsListPlaceholder;


### PR DESCRIPTION
## Summary

- Adds `OperationsListPlaceholder` component: a single date-group skeleton with a DateSeparator row and a card containing 10 operation rows
- Each placeholder row mirrors the real `OperationListItem` layout (icon circle, title bar, subtitle bar, amount bar) with varied widths per row for a realistic look
- All bars pulse between 35%–75% opacity on a looped 750 ms `Animated.sequence` (native driver)
- `OperationsList` now renders the placeholder instead of a centred spinner when `initialLoading` is true; the centred empty state is preserved for the true-empty case

## Test plan

- [ ] Launch app cold — operations screen should show the skeleton group while data loads, then transition to the real list
- [ ] Verify the placeholder scrolls with the QuickAdd form header above it
- [ ] Confirm the empty state (no operations) still shows the cash icon + message after loading completes with no data
- [ ] Check light and dark themes — bars should use `colors.border` against `colors.surface`/`colors.background`

https://claude.ai/code/session_01QRXJHVhR6sAycFLXAD32S8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRXJHVhR6sAycFLXAD32S8)_