### PR TITLE
fix: refresh quick-add suggestions when operations change

### DIFF
--- a/__tests__/hooks/useQuickAddForm.test.js
+++ b/__tests__/hooks/useQuickAddForm.test.js
@@ -2,6 +2,7 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import useQuickAddForm from '../../app/hooks/useQuickAddForm';
 import * as LastAccount from '../../app/services/LastAccount';
 import * as Currency from '../../app/services/currency';
+import { appEvents, EVENTS } from '../../app/services/eventEmitter';
 
 // Mock OperationsDB
 const mockGetTopCategories = jest.fn().mockResolvedValue([]);
@@ -955,6 +956,49 @@ describe('useQuickAddForm', () => {
 
       expect(result.current.quickAddValues.amount).toBe('100');
       expect(result.current.quickAddValues.description).toBe('Test');
+    });
+  });
+
+  describe('event subscription', () => {
+    it('reloads suggestions when OPERATION_CHANGED fires', async () => {
+      mockGetTopCategories.mockResolvedValue([]);
+      mockGetTopTransferTargets.mockResolvedValue([]);
+
+      renderHook(() => useQuickAddForm(mockAccounts, mockAccounts, mockCategories, mockT));
+
+      await waitFor(() => {
+        expect(mockGetTopCategories).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        appEvents.emit(EVENTS.OPERATION_CHANGED);
+      });
+
+      await waitFor(() => {
+        expect(mockGetTopCategories).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('cleans up event subscription on unmount', async () => {
+      mockGetTopCategories.mockResolvedValue([]);
+      mockGetTopTransferTargets.mockResolvedValue([]);
+
+      const { unmount } = renderHook(() =>
+        useQuickAddForm(mockAccounts, mockAccounts, mockCategories, mockT),
+      );
+
+      await waitFor(() => {
+        expect(mockGetTopCategories).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+      mockGetTopCategories.mockClear();
+
+      await act(async () => {
+        appEvents.emit(EVENTS.OPERATION_CHANGED);
+      });
+
+      expect(mockGetTopCategories).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/hooks/useQuickAddForm.js
+++ b/app/hooks/useQuickAddForm.js
@@ -3,6 +3,7 @@ import { getLastAccessedAccount } from '../services/LastAccount';
 import { getCategoryDisplayName, getCategoryNames } from '../utils/categoryUtils';
 import * as Currency from '../services/currency';
 import * as OperationsDB from '../services/OperationsDB';
+import { appEvents, EVENTS } from '../services/eventEmitter';
 import currencies from '../../assets/currencies.json';
 
 /**
@@ -150,29 +151,31 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
   // Top transfer target accounts from last 90 days
   const [topTransferTargets, setTopTransferTargets] = useState([]);
 
-  // Load top categories and transfer targets from last 3 months
-  useEffect(() => {
-    async function loadTopCategories() {
-      try {
-        const topCats = await OperationsDB.getTopCategoriesFromLastMonth(10);
-        setTopCategories(topCats);
-      } catch (error) {
-        console.error('Failed to load top categories:', error);
-        setTopCategories([]);
-      }
+  const loadSuggestions = useCallback(async () => {
+    try {
+      const topCats = await OperationsDB.getTopCategoriesFromLastMonth(10);
+      setTopCategories(topCats);
+    } catch (error) {
+      console.error('Failed to load top categories:', error);
+      setTopCategories([]);
     }
-    async function loadTopTransferTargets() {
-      try {
-        const targets = await OperationsDB.getTopTransferTargetAccounts(10);
-        setTopTransferTargets(targets);
-      } catch (error) {
-        console.error('Failed to load top transfer targets:', error);
-        setTopTransferTargets([]);
-      }
+    try {
+      const targets = await OperationsDB.getTopTransferTargetAccounts(10);
+      setTopTransferTargets(targets);
+    } catch (error) {
+      console.error('Failed to load top transfer targets:', error);
+      setTopTransferTargets([]);
     }
-    loadTopCategories();
-    loadTopTransferTargets();
   }, []);
+
+  useEffect(() => {
+    loadSuggestions();
+  }, [loadSuggestions]);
+
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.OPERATION_CHANGED, loadSuggestions);
+    return unsubscribe;
+  }, [loadSuggestions]);
 
   // Filtered categories for quick add form (excluding shadow categories)
   const filteredCategories = useMemo(() => {


### PR DESCRIPTION
## Summary
Subscribes `useQuickAddForm` to the app's event bus so that top-category and transfer-target suggestions are refreshed whenever operations change, instead of being stale for the lifetime of the session.

## Problem
Top categories and transfer targets were loaded once on mount with no refresh. After adding transactions during a session, the suggestions reflected an outdated frequency ranking.

## Solution
Extract the suggestion loading into a named `useCallback` and re-invoke it on `EVENTS.OPERATION_CHANGED`. Cleans up the subscription in the effect's return function, matching the pattern used by `useCategoryMonthlySpending`, `useExpenseData`, and `useIncomeData`.

Closes #775
