### PR TITLE
fix: add cycle detection to getCategoryPath to prevent infinite loop

### DIFF
--- a/__tests__/services/CategoriesDB.test.js
+++ b/__tests__/services/CategoriesDB.test.js
@@ -674,6 +674,22 @@ describe('CategoriesDB', () => {
 
       await expect(CategoriesDB.getCategoryPath('cat-1')).rejects.toThrow('Database error');
     });
+
+    it('throws when category parents form a cycle', async () => {
+      mockDb.queryFirst
+        .mockResolvedValueOnce({ id: 'cat-a', name: 'A', parent_id: 'cat-b' })
+        .mockResolvedValueOnce({ id: 'cat-b', name: 'B', parent_id: 'cat-a' });
+
+      await expect(CategoriesDB.getCategoryPath('cat-a')).rejects.toThrow('Cycle detected');
+    });
+
+    it('cycle error message includes the offending id', async () => {
+      mockDb.queryFirst
+        .mockResolvedValueOnce({ id: 'cat-a', name: 'A', parent_id: 'cat-b' })
+        .mockResolvedValueOnce({ id: 'cat-b', name: 'B', parent_id: 'cat-a' });
+
+      await expect(CategoriesDB.getCategoryPath('cat-a')).rejects.toThrow('cat-a');
+    });
   });
 
   describe('moveCategory', () => {

--- a/app/services/CategoriesDB.js
+++ b/app/services/CategoriesDB.js
@@ -359,8 +359,11 @@ export const getCategoryPath = async (id) => {
   try {
     const path = [];
     let currentId = id;
+    const visited = new Set();
 
     while (currentId) {
+      if (visited.has(currentId)) throw new Error('Cycle detected in category parents at id: ' + currentId);
+      visited.add(currentId);
       const category = await getCategoryById(currentId);
       if (!category) break;
 


### PR DESCRIPTION
## Summary
Adds a `visited` Set guard to `getCategoryPath()` in `CategoriesDB.js`. If a circular parent reference is encountered, the function now throws a descriptive error instead of hanging the JS thread indefinitely.

## Problem
A migration bug or data corruption that creates a cycle (A→B→C→A) in category parent links would cause `getCategoryPath()` to loop infinitely, freezing the app with no recovery path.

## Solution
Track visited IDs in a `Set`; throw on the first repeat.

Closes #768
