### PR TITLE
perf: wrap context values in useMemo to prevent cascade re-renders

### DIFF
--- a/app/contexts/DialogContext.js
+++ b/app/contexts/DialogContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback } from 'react';
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import MaterialDialog from '../components/MaterialDialog';
 
@@ -29,8 +29,10 @@ export const DialogProvider = ({ children }) => {
     setDialog(null);
   }, []);
 
+  const value = useMemo(() => ({ showDialog, hideDialog }), [showDialog, hideDialog]);
+
   return (
-    <DialogContext.Provider value={{ showDialog, hideDialog }}>
+    <DialogContext.Provider value={value}>
       {children}
       {dialog && (
         <MaterialDialog

--- a/app/contexts/DisplaySettingsContext.js
+++ b/app/contexts/DisplaySettingsContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { getPreference, setPreference, PREF_KEYS } from '../services/PreferencesDB';
 
@@ -13,13 +13,15 @@ export const DisplaySettingsProvider = ({ children }) => {
     });
   }, []);
 
-  const setHideBalances = async (value) => {
+  const setHideBalances = useCallback(async (value) => {
     setHideBalancesState(value);
     await setPreference(PREF_KEYS.HIDE_BALANCES, value ? 'true' : 'false');
-  };
+  }, []);
+
+  const ctxValue = useMemo(() => ({ hideBalances, setHideBalances }), [hideBalances, setHideBalances]);
 
   return (
-    <DisplaySettingsContext.Provider value={{ hideBalances, setHideBalances }}>
+    <DisplaySettingsContext.Provider value={ctxValue}>
       {children}
     </DisplaySettingsContext.Provider>
   );

--- a/app/contexts/ImportProgressContext.js
+++ b/app/contexts/ImportProgressContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { appEvents } from '../services/eventEmitter';
 import { IMPORT_PROGRESS_EVENT } from '../services/BackupRestore';
@@ -78,7 +78,7 @@ export const ImportProgressProvider = ({ children }) => {
     setCurrentStep(null);
   }, []);
 
-  const value = {
+  const value = useMemo(() => ({
     isImporting,
     steps,
     currentStep,
@@ -87,7 +87,7 @@ export const ImportProgressProvider = ({ children }) => {
     completeImport,
     cancelImport,
     finishImport,
-  };
+  }), [isImporting, steps, currentStep, startImport, updateStep, completeImport, cancelImport, finishImport]);
 
   return (
     <ImportProgressContext.Provider value={value}>

--- a/app/contexts/ThemeColorsContext.js
+++ b/app/contexts/ThemeColorsContext.js
@@ -63,12 +63,12 @@ const darkTheme = {
 export const ThemeColorsProvider = ({ children }) => {
   const { colorScheme } = useThemeConfig();
 
-  const colors = useMemo(() => {
-    return colorScheme === 'dark' ? darkTheme.colors : lightTheme.colors;
-  }, [colorScheme]);
+  const value = useMemo(() => ({
+    colors: colorScheme === 'dark' ? darkTheme.colors : lightTheme.colors,
+  }), [colorScheme]);
 
   return (
-    <ThemeColorsContext.Provider value={{ colors }}>
+    <ThemeColorsContext.Provider value={value}>
       {children}
     </ThemeColorsContext.Provider>
   );

--- a/app/contexts/UpdateDownloadContext.js
+++ b/app/contexts/UpdateDownloadContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useRef } from 'react';
+import React, { createContext, useContext, useState, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { downloadAndInstallApk } from '../services/AppUpdateService';
 
@@ -22,9 +22,15 @@ export function UpdateDownloadProvider({ children }) {
     }
   }, []);
 
+  const value = useMemo(() => ({
+    downloadProgress,
+    isDownloading: downloadProgress !== null,
+    startDownload,
+  }), [downloadProgress, startDownload]);
+
   return (
     <UpdateDownloadContext.Provider
-      value={{ downloadProgress, isDownloading: downloadProgress !== null, startDownload }}
+      value={value}
     >
       {children}
     </UpdateDownloadContext.Provider>


### PR DESCRIPTION
## Summary
Wraps plain object literal context values in `useMemo` across 5 context providers that were missing it, preventing unnecessary cascade re-renders.

## Affected files
- `app/contexts/ImportProgressContext.js`
- `app/contexts/UpdateDownloadContext.js`
- `app/contexts/DialogContext.js`
- `app/contexts/DisplaySettingsContext.js`
- `app/contexts/ThemeColorsContext.js`

## Problem
Each provider was passing `value={{ ... }}` directly — a new object on every render forces all consumers to re-render even when state hasn't changed. `DialogContext` wraps the entire app; `UpdateDownloadContext` fires on every download progress tick.

## Solution
Wrap all context values in `useMemo` with the appropriate dependency arrays. `DisplaySettingsContext.setHideBalances` was also missing `useCallback`, which was added so it can be a stable dep.

Closes #761
Closes #766
