### PR TITLE
fix: guard async setState calls after unmount in LocalizationContext and OperationsDataContext

### DIFF
--- a/__tests__/contexts/LocalizationContext.test.js
+++ b/__tests__/contexts/LocalizationContext.test.js
@@ -330,4 +330,21 @@ describe('LocalizationContext', () => {
       expect(result.current.language).toBe('ru'); // Language should still change in memory
     });
   });
+
+  describe('unmount safety', () => {
+    it('does not update state after unmount when async load is pending', async () => {
+      let resolvePreference;
+      PreferencesDB.getPreference.mockImplementation(
+        () => new Promise(resolve => { resolvePreference = resolve; }),
+      );
+
+      const { unmount } = renderHook(() => useLocalization(), { wrapper });
+
+      unmount();
+
+      await act(async () => {
+        resolvePreference('fr');
+      });
+    });
+  });
 });

--- a/app/contexts/LocalizationContext.js
+++ b/app/contexts/LocalizationContext.js
@@ -49,9 +49,11 @@ export function LocalizationProvider({ children }) {
 
   // Load language from PreferencesDB on mount
   useEffect(() => {
+    let mounted = true;
     (async () => {
       try {
         const storedLang = await getPreference(PREF_KEYS.LANGUAGE);
+        if (!mounted) return;
         if (storedLang && i18nData[storedLang]) {
           setLanguageState(storedLang);
           setIsFirstLaunch(false);
@@ -62,28 +64,31 @@ export function LocalizationProvider({ children }) {
       } catch (e) {
         // ignore
       } finally {
-        setIsLoading(false);
+        if (mounted) setIsLoading(false);
       }
     })();
+    return () => { mounted = false; };
   }, []);
 
   // Listen for DATABASE_RESET event to reset language preference
   useEffect(() => {
+    let mounted = true;
     const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, async () => {
       console.log('LocalizationContext: Database reset detected, clearing language preference');
       try {
         // Clear language preference from PreferencesDB
         await deletePreference(PREF_KEYS.LANGUAGE);
 
+        if (!mounted) return;
         // Reset to first launch state
         setIsFirstLaunch(true);
         setLanguageState(defaultLang);
       } catch (e) {
-        console.error('Failed to clear language preference:', e);
+        if (mounted) console.error('Failed to clear language preference:', e);
       }
     });
 
-    return unsubscribe;
+    return () => { mounted = false; unsubscribe(); };
   }, []);
 
   // Save language to PreferencesDB when it changes

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -245,9 +245,11 @@ export const OperationsDataProvider = ({ children }) => {
 
   // Load filters from PreferencesDB on mount
   useEffect(() => {
+    let mounted = true;
     const loadFilters = async () => {
       try {
         const filters = await getJsonPreference(PREF_KEYS.OPERATIONS_FILTERS);
+        if (!mounted) return;
         if (filters) {
           // convert legacy activeFilters format to searchState format
           setSearchState({
@@ -261,10 +263,11 @@ export const OperationsDataProvider = ({ children }) => {
           setFiltersActive(hasActiveFilters(filters));
         }
       } catch (error) {
-        console.error('Failed to load filters:', error);
+        if (mounted) console.error('Failed to load filters:', error);
       }
     };
     loadFilters();
+    return () => { mounted = false; };
   }, [hasActiveFilters]);
 
   // Listen for DATABASE_RESET event to clear operations state


### PR DESCRIPTION
## Summary
Adds `mounted` flag cleanup to `useEffect` hooks in `LocalizationContext` and `OperationsDataContext` that start async operations. State updates are now skipped if the component unmounts before the async work completes.

## Problem
Calling `setState` on an unmounted component produces React warnings and represents a minor memory leak. These warnings also obscure legitimate errors in the console.

## Solution
Standard `mounted` flag pattern: set true on entry, set false in cleanup, guard every `setState` call with `if (mounted)`.

Closes #774
