### PR TITLE
fix: reset sqlite_sequence for all auto-increment tables on restore

### DIFF
--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -432,7 +432,7 @@ export const restoreBackup = async (backup) => {
       await db.runAsync('DELETE FROM app_metadata WHERE key != ?', ['db_version']);
 
       // Reset auto-increment counters to allow ID preservation
-      await db.runAsync('DELETE FROM sqlite_sequence WHERE name IN (?, ?)', ['accounts', 'operations']);
+      await db.runAsync('DELETE FROM sqlite_sequence WHERE name IN (?, ?, ?)', ['accounts', 'operations', 'accounts_balance_history']);
 
       console.log('Existing data cleared and auto-increment counters reset');
       appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'clear', status: 'completed' });


### PR DESCRIPTION
## Summary
Expands the sqlite_sequence reset on restore to cover accounts_balance_history, the only auto-increment table that was missing. Categories, budgets, and planned_operations use UUID text primary keys and do not need sequence resets.

## Problem
After restore, new balance history records resumed auto-increment from the pre-restore max ID, creating sequence inconsistency.

## Solution
Add accounts_balance_history to the DELETE FROM sqlite_sequence WHERE name IN (...) query.

Closes #776
