### PR TITLE
feat: show blurred category grid placeholder on initial load

### DIFF
--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -275,6 +275,53 @@ const OperationFormFields = memo(({
     }
   };
 
+  // Placeholder grid shown during initial load in QuickAdd context before categories are available
+  const renderCategoryPickerPlaceholder = () => {
+    const renderPlaceholderChip = (key) => (
+      <View
+        key={key}
+        style={[
+          styles.categoryShortcutButton,
+          compact && styles.categoryShortcutButtonCompact,
+          {
+            backgroundColor: colors.inputBackground,
+            borderColor: colors.border,
+            opacity: 0.35,
+          },
+        ]}
+      >
+        <View style={[styles.placeholderDot, { backgroundColor: colors.mutedText }]} />
+        <View style={[styles.placeholderBar, { backgroundColor: colors.mutedText }]} />
+      </View>
+    );
+
+    return (
+      <View style={[styles.categoryRowsWrapper, compact && styles.categoryRowsWrapperCompact]}>
+        <View style={styles.categoryButtonsContainer}>
+          <Pressable
+            style={[styles.categoryPickerButton, inputStyle, groupBorderStyle]}
+            onPress={() => !disabled && openPicker('category', categories)}
+            disabled={disabled}
+          >
+            <Icon name="menu" size={16} color={disabled ? colors.mutedText : colors.text} />
+            <Text style={[styles.categoryPickerText, { color: disabled ? colors.mutedText : colors.text }]} numberOfLines={2}>
+              {t('all_categories')}
+            </Text>
+          </Pressable>
+          {renderPlaceholderChip('ph-0')}
+          {renderPlaceholderChip('ph-1')}
+          {renderPlaceholderChip('ph-2')}
+        </View>
+        <View style={styles.categoryButtonsContainer}>
+          {renderPlaceholderChip('ph-3')}
+          {renderPlaceholderChip('ph-4')}
+          {renderPlaceholderChip('ph-5')}
+          {renderPlaceholderChip('ph-6')}
+        </View>
+      </View>
+    );
+  };
+
   // Render category picker with shortcuts
   const renderCategoryPicker = () => {
     if (hideCategoryPicker) return null;
@@ -374,6 +421,11 @@ const OperationFormFields = memo(({
           </View>
         </View>
       );
+    }
+
+    // QuickAdd placeholder: categories not yet loaded — show blurred grid to match the loaded layout
+    if (onAutoAddWithCategory) {
+      return renderCategoryPickerPlaceholder();
     }
 
     // Fallback: render single full-width picker (for OperationModal or when no top categories)
@@ -747,6 +799,17 @@ const styles = StyleSheet.create({
   },
   invisible: {
     opacity: 0,
+  },
+  placeholderBar: {
+    borderRadius: 3,
+    height: 7,
+    marginTop: 3,
+    width: '55%',
+  },
+  placeholderDot: {
+    borderRadius: 9,
+    height: 18,
+    width: 18,
   },
   ratePreviewRow: {
     alignItems: 'center',

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -283,10 +283,10 @@ const OperationFormFields = memo(({
         style={[
           styles.categoryShortcutButton,
           compact && styles.categoryShortcutButtonCompact,
+          styles.placeholderChip,
           {
             backgroundColor: colors.inputBackground,
             borderColor: colors.border,
-            opacity: 0.35,
           },
         ]}
       >
@@ -805,6 +805,9 @@ const styles = StyleSheet.create({
     height: 7,
     marginTop: 3,
     width: '55%',
+  },
+  placeholderChip: {
+    opacity: 0.35,
   },
   placeholderDot: {
     borderRadius: 9,


### PR DESCRIPTION
## Summary

- During initial app load, the QuickAdd category area previously showed a single "Select Category" button that looked nothing like the loaded state
- Now it renders the same two-row grid layout used by the real screen: an "All categories" button in row 1 slot 0, plus 3 + 4 faded placeholder chips that match the shape and spacing of real category shortcuts
- The placeholder chips use `opacity: 0.35` with a dot + bar silhouette instead of real icon/name, giving a natural "blurred loading" appearance
- The "All categories" button is fully functional even before categories load
- Detection uses the existing `onAutoAddWithCategory` prop to scope the placeholder to the QuickAdd context only — `OperationModal` retains its existing single-button fallback

## Test plan

- [ ] Launch the app on a fresh/slow device and observe the initial QuickAdd form — should see the two-row blurred grid instead of "Select Category"
- [ ] Wait for categories to load — grid should seamlessly replace placeholder with real chips
- [ ] Tap "All categories" during the loading state — picker opens (may be empty or populated depending on timing)
- [ ] Open an existing operation in OperationModal — category field should still show the single-button fallback, not the placeholder grid
- [ ] Verify the placeholder renders correctly in both light and dark themes

https://claude.ai/code/session_019UNvg1K1rr8qnarAkoF6s8

---
_Generated by [Claude Code](https://claude.ai/code/session_019UNvg1K1rr8qnarAkoF6s8)_