### PR TITLE
fix: refresh quick-add suggestions on RELOAD_ALL event

### DIFF
--- a/__tests__/hooks/useQuickAddForm.test.js
+++ b/__tests__/hooks/useQuickAddForm.test.js
@@ -1000,5 +1000,46 @@ describe('useQuickAddForm', () => {
 
       expect(mockGetTopCategories).not.toHaveBeenCalled();
     });
+
+    it('reloads suggestions when RELOAD_ALL fires', async () => {
+      mockGetTopCategories.mockResolvedValue([]);
+      mockGetTopTransferTargets.mockResolvedValue([]);
+
+      renderHook(() => useQuickAddForm(mockAccounts, mockAccounts, mockCategories, mockT));
+
+      await waitFor(() => {
+        expect(mockGetTopCategories).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        appEvents.emit(EVENTS.RELOAD_ALL);
+      });
+
+      await waitFor(() => {
+        expect(mockGetTopCategories).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('cleans up RELOAD_ALL subscription on unmount', async () => {
+      mockGetTopCategories.mockResolvedValue([]);
+      mockGetTopTransferTargets.mockResolvedValue([]);
+
+      const { unmount } = renderHook(() =>
+        useQuickAddForm(mockAccounts, mockAccounts, mockCategories, mockT),
+      );
+
+      await waitFor(() => {
+        expect(mockGetTopCategories).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+      mockGetTopCategories.mockClear();
+
+      await act(async () => {
+        appEvents.emit(EVENTS.RELOAD_ALL);
+      });
+
+      expect(mockGetTopCategories).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/hooks/useQuickAddForm.js
+++ b/app/hooks/useQuickAddForm.js
@@ -177,6 +177,11 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
     return unsubscribe;
   }, [loadSuggestions]);
 
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, loadSuggestions);
+    return unsubscribe;
+  }, [loadSuggestions]);
+
   // Filtered categories for quick add form (excluding shadow categories)
   const filteredCategories = useMemo(() => {
     return categories.filter(cat => {


### PR DESCRIPTION
## Summary
Suggestions (top categories + transfer targets) were loaded once on mount and refreshed on OPERATION_CHANGED, but not on RELOAD_ALL — so a backup restore, Google Sheets import, or account seeding left stale suggestions until app restart.

## Changes
- Added RELOAD_ALL subscription to useQuickAddForm.js (mirrors existing OPERATION_CHANGED pattern)
- Added 2 regression tests: fires on RELOAD_ALL, cleans up on unmount

Closes #755