### PR TITLE
fix: correct January balance history boundary and normalize date comparisons

### DIFF
--- a/app/hooks/useBalanceHistory.js
+++ b/app/hooks/useBalanceHistory.js
@@ -55,8 +55,12 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
       // Get balance history from database
       const history = await getBalanceHistory(selectedAccount, startDateStr, endDateStr);
 
-      // Calculate previous month dates
-      const prevMonthStart = new Date(selectedYear, selectedMonth - 1, 1);
+      // Calculate previous month dates.
+      // When selectedMonth is 0 (January), selectedMonth - 1 = -1 which JS rolls
+      // to December of the *same* year instead of decrementing the year — fix explicitly.
+      const prevMonth = selectedMonth === 0 ? 11 : selectedMonth - 1;
+      const prevYear  = selectedMonth === 0 ? selectedYear - 1 : selectedYear;
+      const prevMonthStart = new Date(prevYear, prevMonth, 1);
       const prevMonthEnd = new Date(selectedYear, selectedMonth, 0);
       const prevStartDateStr = formatDate(prevMonthStart);
       const prevEndDateStr = formatDate(prevMonthEnd);

--- a/app/services/BalanceHistoryDB.js
+++ b/app/services/BalanceHistoryDB.js
@@ -59,7 +59,7 @@ const calculateBalanceOnDate = async (accountId, targetDate, db = null) => {
       operations = await db.getAllAsync(
         `SELECT * FROM operations
          WHERE (account_id = ? OR to_account_id = ?)
-           AND date > ?
+           AND date(date) > date(?)
          ORDER BY date DESC, created_at DESC`,
         [accountId, accountId, targetDate],
       );
@@ -68,7 +68,7 @@ const calculateBalanceOnDate = async (accountId, targetDate, db = null) => {
       operations = await queryAll(
         `SELECT * FROM operations
          WHERE (account_id = ? OR to_account_id = ?)
-           AND date > ?
+           AND date(date) > date(?)
          ORDER BY date DESC, created_at DESC`,
         [accountId, accountId, targetDate],
       );


### PR DESCRIPTION
## Summary
Two date bugs in the balance history subsystem.

**#744 — January prev-month boundary wrong**
`new Date(year, -1, 1)` in JavaScript rolls to December of the *same* year, not the previous year. Fixed by computing `prevMonth` and `prevYear` explicitly before constructing the Date object.

**#753 — Lexicographic date comparison fails for non-ISO formats**
`AND date > ?` in `calculateBalanceOnDate` did a raw string compare. ISO 8601 sorts correctly, but CSV-imported DD/MM/YYYY dates produce wrong results. Wrapped both sides with SQLite `date()` to normalize before comparing; malformed dates return NULL and are safely excluded.

## Changes
- `app/hooks/useBalanceHistory.js`: explicit prevYear/prevMonth for January
- `app/services/BalanceHistoryDB.js`: `date(date) > date(?)` in both query branches of `calculateBalanceOnDate`

Closes #744
Closes #753