### PR TITLE
fix: abort Google Sheets import on DB error instead of silently clearing preferences

### DIFF
--- a/app/services/GoogleSheetsService.js
+++ b/app/services/GoogleSheetsService.js
@@ -349,8 +349,10 @@ export const importFromSheets = async (accessToken, onProgress) => {
     created_at: now,
   }));
 
-  // Preserve current app preferences (language, theme, etc.) so they survive the restore
-  const app_metadata = await queryAll('SELECT * FROM app_metadata WHERE key != ?', ['db_version']).catch(() => []);
+  // Preserve current app preferences (language, theme, etc.) so they survive the restore.
+  // Do NOT catch DB errors here — a locked or corrupted DB must abort the import loudly
+  // rather than silently overwriting all user preferences with an empty set (#747).
+  const app_metadata = await queryAll('SELECT * FROM app_metadata WHERE key != ?', ['db_version']);
 
   report('parse', 'completed');
 


### PR DESCRIPTION
## Summary
`.catch(() => [])` on the `app_metadata` read caused any DB error (locked, corrupted, permission failure) to silently return an empty array. The caller treated this as "no preferences" and proceeded to overwrite all user settings (language, theme, spreadsheet ID) with nothing.

## Fix
Remove the silent catch. The error now propagates and aborts the import — the caller in `SettingsModal.js` already has a `catch` block that surfaces the error to the user via `setSheetsImportError`.

## Changes
- `app/services/GoogleSheetsService.js:353`: removed `.catch(() => [])`

Closes #747