### PR TITLE
fix: warn on sparse CSV rows during import to prevent silent data loss

### DIFF
--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -830,6 +830,56 @@ op-2,normal`;
       expect(backup.data.operations[1].description).toBe('normal');
     });
 
+    it('regression #764 — sparse rows (fewer columns than header) default missing fields to null without throwing', async () => {
+      // Row 0 has all 3 columns; row 1 only has 2.  The missing 3rd column
+      // (description) should become null, not crash, and a console.warn should fire.
+      const csvContent = `# Money Tracker Backup
+# Version: 1
+
+[ACCOUNTS]
+id,name,balance
+acc-1,Cash,100
+acc-2,Savings
+
+[OPERATIONS]
+id,type,amount,account_id,category_id,description
+op-1,expense,10,acc-1,cat-1,Full row
+op-2,income,20,acc-1,cat-1`;
+
+      mockDocumentPicker.getDocumentAsync.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file:///mock/backup.csv', name: 'backup.csv' }],
+      });
+
+      mockFileSystem.readAsStringAsync.mockResolvedValue(csvContent);
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback({
+          runAsync: jest.fn().mockImplementation(() => Promise.resolve({ lastInsertRowId: Math.floor(Math.random() * 1000) })),
+          getAllAsync: jest.fn().mockResolvedValue([]),
+        });
+      });
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const backup = await BackupRestore.importBackup();
+
+      // Sparse account row (acc-2 missing balance)
+      expect(backup.data.accounts).toHaveLength(2);
+      expect(backup.data.accounts[1].balance).toBeNull();
+
+      // Sparse operation row (op-2 missing description)
+      expect(backup.data.operations).toHaveLength(2);
+      expect(backup.data.operations[1].description).toBeNull();
+
+      // Warn must have fired for each sparse row
+      const sparseWarnings = warnSpy.mock.calls.filter(([msg]) =>
+        typeof msg === 'string' && msg.includes('[BackupRestore] parseCSV'),
+      );
+      expect(sparseWarnings.length).toBeGreaterThanOrEqual(2);
+
+      warnSpy.mockRestore();
+    });
+
     it('handles empty CSV sections', async () => {
       const csvContent = `# Money Tracker Backup
 # Version: 1

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -930,9 +930,21 @@ const parseCSV = (csvContent) => {
     const values = rows[r];
     if (values.every(v => v.trim() === '')) continue;
 
+    // Warn when a row has fewer columns than the header — this is the sparse-row
+    // bug described in issue #764.  Values for missing columns default to null
+    // (same as an explicit empty cell) but we surface it so callers can detect
+    // data loss rather than silently swallowing it.
+    if (values.length < headers.length) {
+      console.warn(
+        `[BackupRestore] parseCSV: row ${r} has ${values.length} column(s) but header has ${headers.length}. ` +
+        `Missing fields will default to null: ${headers.slice(values.length).join(', ')}`,
+      );
+    }
+
     const obj = {};
     headers.forEach((header, index) => {
-      const value = values[index]?.trim() || '';
+      const raw = values[index];
+      const value = raw !== undefined ? raw.trim() : '';
       obj[header] = value === '' ? null : value;
     });
     data.push(obj);


### PR DESCRIPTION
Fixes #764

## Summary
- `parseCSV` was silently converting missing fields to `null` via `values[index]?.trim() || ''`
- Now logs a `console.warn` listing the missing field names when a row has fewer columns than the header
- Export path was already using explicit `TABLE_FIELDS` lists (no changes needed there)

## Changes
- `app/services/BackupRestore.js`: added explicit missing-field detection in `parseCSV`; emits `[BackupRestore] parseCSV` warning per sparse row
- `__tests__/services/BackupRestore.test.js`: added regression test `'regression #764 — sparse rows'`

## Test plan
- [ ] Import a CSV where some rows are missing trailing fields — console.warn fires, null values preserved
- [ ] Full CSV import of well-formed backup still works correctly
- [ ] All 3498 tests pass