### PR TITLE
perf: split BudgetsContext into BudgetsDataContext and BudgetsActionsContext

### DIFF
--- a/app/contexts/BudgetsActionsContext.js
+++ b/app/contexts/BudgetsActionsContext.js
@@ -1,0 +1,240 @@
+import React, { createContext, useContext, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import uuid from 'react-native-uuid';
+import * as BudgetsDB from '../services/BudgetsDB';
+import { useDialog } from './DialogContext';
+import { useBudgetsData } from './BudgetsDataContext';
+
+const BudgetsActionsContext = createContext();
+
+export const BudgetsActionsProvider = ({ children }) => {
+  const { showDialog } = useDialog();
+  const {
+    budgets,
+    budgetStatuses,
+    refreshBudgetStatuses,
+    _setBudgets,
+    _setBudgetStatuses,
+    _setSaveError,
+  } = useBudgetsData();
+
+  /**
+   * Create new budget
+   */
+  const addBudget = useCallback(async (budget) => {
+    try {
+      // Validate budget
+      const validationError = BudgetsDB.validateBudget(budget);
+      if (validationError) {
+        throw new Error(validationError);
+      }
+
+      // Check for duplicates
+      const duplicate = await BudgetsDB.findDuplicateBudget(
+        budget.categoryId,
+        budget.currency,
+        budget.periodType,
+      );
+
+      if (duplicate) {
+        throw new Error(
+          'A budget already exists for this category, currency, and period type. ' +
+          'Please edit the existing budget or delete it first.',
+        );
+      }
+
+      // Create budget with UUID
+      const newBudget = {
+        ...budget,
+        id: uuid.v4(),
+      };
+
+      await BudgetsDB.createBudget(newBudget);
+      _setBudgets(prev => [...prev, newBudget]);
+
+      // Refresh statuses
+      await refreshBudgetStatuses();
+
+      _setSaveError(null);
+      return newBudget;
+    } catch (error) {
+      console.error('Failed to create budget:', error);
+      _setSaveError(error.message);
+      showDialog('Error', error.message, [{ text: 'OK' }]);
+      throw error;
+    }
+  }, [refreshBudgetStatuses, showDialog, _setBudgets, _setSaveError]);
+
+  /**
+   * Update existing budget
+   */
+  const updateBudget = useCallback(async (id, updates) => {
+    try {
+      // Validate updates
+      const existingBudget = budgets.find(b => b.id === id);
+      if (!existingBudget) {
+        throw new Error('Budget not found');
+      }
+
+      const updatedBudget = { ...existingBudget, ...updates };
+      const validationError = BudgetsDB.validateBudget(updatedBudget);
+      if (validationError) {
+        throw new Error(validationError);
+      }
+
+      // Check for duplicates (excluding current budget)
+      if (updates.categoryId || updates.currency || updates.periodType) {
+        const duplicate = await BudgetsDB.findDuplicateBudget(
+          updatedBudget.categoryId,
+          updatedBudget.currency,
+          updatedBudget.periodType,
+          id, // Exclude this budget from duplicate check
+        );
+
+        if (duplicate) {
+          throw new Error(
+            'A budget already exists for this category, currency, and period type.',
+          );
+        }
+      }
+
+      await BudgetsDB.updateBudget(id, updates);
+      _setBudgets(prev => prev.map(b => b.id === id ? { ...b, ...updates } : b));
+
+      // Refresh statuses
+      await refreshBudgetStatuses();
+
+      _setSaveError(null);
+    } catch (error) {
+      console.error('Failed to update budget:', error);
+      _setSaveError(error.message);
+      showDialog('Error', error.message, [{ text: 'OK' }]);
+      throw error;
+    }
+  }, [budgets, refreshBudgetStatuses, showDialog, _setBudgets, _setSaveError]);
+
+  /**
+   * Delete budget
+   */
+  const deleteBudget = useCallback(async (id) => {
+    try {
+      await BudgetsDB.deleteBudget(id);
+      _setBudgets(prev => prev.filter(b => b.id !== id));
+
+      // Remove from status map
+      _setBudgetStatuses(prev => {
+        const newMap = new Map(prev);
+        newMap.delete(id);
+        return newMap;
+      });
+
+      _setSaveError(null);
+    } catch (error) {
+      console.error('Failed to delete budget:', error);
+      _setSaveError(error.message);
+      showDialog('Error', 'Failed to delete budget. Please try again.', [{ text: 'OK' }]);
+      throw error;
+    }
+  }, [showDialog, _setBudgets, _setBudgetStatuses, _setSaveError]);
+
+  /**
+   * Get budget for category
+   */
+  const getBudgetForCategory = useCallback((categoryId, currency = null, periodType = null) => {
+    return budgets.find(b => {
+      if (b.categoryId !== categoryId) return false;
+      if (currency && b.currency !== currency) return false;
+      if (periodType && b.periodType !== periodType) return false;
+      return true;
+    });
+  }, [budgets]);
+
+  /**
+   * Get budget status
+   */
+  const getBudgetStatus = useCallback((budgetId) => {
+    return budgetStatuses.get(budgetId) || null;
+  }, [budgetStatuses]);
+
+  /**
+   * Check if budget is exceeded
+   */
+  const isBudgetExceeded = useCallback((budgetId) => {
+    const status = budgetStatuses.get(budgetId);
+    return status ? status.isExceeded : false;
+  }, [budgetStatuses]);
+
+  /**
+   * Get budget progress percentage
+   */
+  const getBudgetProgress = useCallback((budgetId) => {
+    const status = budgetStatuses.get(budgetId);
+    return status ? status.percentage : 0;
+  }, [budgetStatuses]);
+
+  /**
+   * Get remaining budget amount
+   */
+  const getRemainingBudget = useCallback((budgetId) => {
+    const status = budgetStatuses.get(budgetId);
+    return status ? status.remaining : '0';
+  }, [budgetStatuses]);
+
+  /**
+   * Get budgets by period type
+   */
+  const getBudgetsByPeriod = useCallback((periodType) => {
+    return budgets.filter(b => b.periodType === periodType);
+  }, [budgets]);
+
+  /**
+   * Check if category has active budget
+   */
+  const hasActiveBudget = useCallback((categoryId, currency = null) => {
+    return budgets.some(b => {
+      if (b.categoryId !== categoryId) return false;
+      if (currency && b.currency !== currency) return false;
+
+      // Check if budget is active (no end date or end date in future)
+      if (!b.endDate) return true;
+      const endDate = new Date(b.endDate);
+      return endDate >= new Date();
+    });
+  }, [budgets]);
+
+  const value = useMemo(() => ({
+    addBudget,
+    updateBudget,
+    deleteBudget,
+    getBudgetForCategory,
+    getBudgetStatus,
+    isBudgetExceeded,
+    getBudgetProgress,
+    getRemainingBudget,
+    getBudgetsByPeriod,
+    hasActiveBudget,
+  }), [
+    addBudget,
+    updateBudget,
+    deleteBudget,
+    getBudgetForCategory,
+    getBudgetStatus,
+    isBudgetExceeded,
+    getBudgetProgress,
+    getRemainingBudget,
+    getBudgetsByPeriod,
+    hasActiveBudget,
+  ]);
+
+  return (
+    <BudgetsActionsContext.Provider value={value}>
+      {children}
+    </BudgetsActionsContext.Provider>
+  );
+};
+
+BudgetsActionsProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export const useBudgetsActions = () => useContext(BudgetsActionsContext);

--- a/app/contexts/BudgetsContext.js
+++ b/app/contexts/BudgetsContext.js
@@ -1,329 +1,56 @@
-import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import uuid from 'react-native-uuid';
-import * as BudgetsDB from '../services/BudgetsDB';
-import { appEvents, EVENTS } from '../services/eventEmitter';
-import { useDialog } from './DialogContext';
+import { BudgetsDataProvider, useBudgetsData } from './BudgetsDataContext';
+import { BudgetsActionsProvider, useBudgetsActions } from './BudgetsActionsContext';
 
-const BudgetsContext = createContext();
+/**
+ * DEPRECATED: This file provides backward compatibility wrappers.
+ *
+ * BudgetsContext has been split into two separate contexts:
+ * - BudgetsDataContext (frequently-changing data)
+ * - BudgetsActionsContext (stable action functions)
+ *
+ * New code should import useBudgetsData and useBudgetsActions directly.
+ * This wrapper is maintained for backward compatibility with existing consumers.
+ *
+ * Migration guide:
+ * Before:
+ *   const { budgets, loading, addBudget, getBudgetStatus } = useBudgets();
+ *
+ * After:
+ *   const { budgets, loading, reloadBudgets, refreshBudgetStatuses } = useBudgetsData();
+ *   const { addBudget, getBudgetStatus } = useBudgetsActions();
+ */
 
+/**
+ * Deprecated hook that combines both data and actions.
+ * Use useBudgetsData() and useBudgetsActions() separately instead.
+ */
 export const useBudgets = () => {
-  const context = useContext(BudgetsContext);
-  if (!context) {
+  const data = useBudgetsData();
+  const actions = useBudgetsActions();
+
+  if (!data || !actions) {
     throw new Error('useBudgets must be used within a BudgetsProvider');
   }
-  return context;
+
+  return {
+    ...data,
+    ...actions,
+  };
 };
 
+/**
+ * Deprecated provider that wraps both split contexts.
+ * Use BudgetsDataProvider and BudgetsActionsProvider directly in App.js.
+ */
 export const BudgetsProvider = ({ children }) => {
-  const { showDialog } = useDialog();
-  const [budgets, setBudgets] = useState([]);
-  const [budgetStatuses, setBudgetStatuses] = useState(new Map());
-  const [loading, setLoading] = useState(true);
-  const [saveError, setSaveError] = useState(null);
-
-  /**
-   * Load all budgets from database
-   */
-  const reloadBudgets = useCallback(async () => {
-    try {
-      setLoading(true);
-      const budgetsData = await BudgetsDB.getAllBudgets();
-      setBudgets(budgetsData);
-
-      // Refresh statuses for all active budgets
-      await refreshBudgetStatuses();
-
-      setSaveError(null);
-    } catch (error) {
-      console.error('Failed to load budgets:', error);
-      setSaveError(error.message);
-      setBudgets([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  /**
-   * Refresh budget statuses for all active budgets
-   */
-  const refreshBudgetStatuses = useCallback(async () => {
-    try {
-      const statusMap = await BudgetsDB.calculateAllBudgetStatuses();
-      setBudgetStatuses(statusMap);
-    } catch (error) {
-      console.error('Failed to refresh budget statuses:', error);
-    }
-  }, []);
-
-  /**
-   * Load budgets on mount
-   */
-  useEffect(() => {
-    reloadBudgets();
-  }, [reloadBudgets]);
-
-  /**
-   * Listen for operation changes to refresh statuses
-   */
-  useEffect(() => {
-    const unsubscribe = appEvents.on(EVENTS.OPERATION_CHANGED, () => {
-      console.debug('Operation changed, refreshing budget statuses...');
-      refreshBudgetStatuses();
-    });
-
-    return unsubscribe;
-  }, [refreshBudgetStatuses]);
-
-  /**
-   * Listen for budget reload events
-   */
-  useEffect(() => {
-    const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
-      console.debug('Reloading all budgets...');
-      reloadBudgets();
-    });
-
-    return unsubscribe;
-  }, [reloadBudgets]);
-
-  /**
-   * Listen for DATABASE_RESET event to clear budgets
-   */
-  useEffect(() => {
-    const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, () => {
-      console.log('BudgetsContext: Database reset detected, clearing budgets');
-      setBudgets([]);
-      setBudgetStatuses(new Map());
-    });
-
-    return unsubscribe;
-  }, []);
-
-  /**
-   * Create new budget
-   */
-  const addBudget = useCallback(async (budget) => {
-    try {
-      // Validate budget
-      const validationError = BudgetsDB.validateBudget(budget);
-      if (validationError) {
-        throw new Error(validationError);
-      }
-
-      // Check for duplicates
-      const duplicate = await BudgetsDB.findDuplicateBudget(
-        budget.categoryId,
-        budget.currency,
-        budget.periodType,
-      );
-
-      if (duplicate) {
-        throw new Error(
-          'A budget already exists for this category, currency, and period type. ' +
-          'Please edit the existing budget or delete it first.',
-        );
-      }
-
-      // Create budget with UUID
-      const newBudget = {
-        ...budget,
-        id: uuid.v4(),
-      };
-
-      await BudgetsDB.createBudget(newBudget);
-      setBudgets(prev => [...prev, newBudget]);
-
-      // Refresh statuses
-      await refreshBudgetStatuses();
-
-      setSaveError(null);
-      return newBudget;
-    } catch (error) {
-      console.error('Failed to create budget:', error);
-      setSaveError(error.message);
-      showDialog('Error', error.message, [{ text: 'OK' }]);
-      throw error;
-    }
-  }, [refreshBudgetStatuses, showDialog]);
-
-  /**
-   * Update existing budget
-   */
-  const updateBudget = useCallback(async (id, updates) => {
-    try {
-      // Validate updates
-      const existingBudget = budgets.find(b => b.id === id);
-      if (!existingBudget) {
-        throw new Error('Budget not found');
-      }
-
-      const updatedBudget = { ...existingBudget, ...updates };
-      const validationError = BudgetsDB.validateBudget(updatedBudget);
-      if (validationError) {
-        throw new Error(validationError);
-      }
-
-      // Check for duplicates (excluding current budget)
-      if (updates.categoryId || updates.currency || updates.periodType) {
-        const duplicate = await BudgetsDB.findDuplicateBudget(
-          updatedBudget.categoryId,
-          updatedBudget.currency,
-          updatedBudget.periodType,
-          id, // Exclude this budget from duplicate check
-        );
-
-        if (duplicate) {
-          throw new Error(
-            'A budget already exists for this category, currency, and period type.',
-          );
-        }
-      }
-
-      await BudgetsDB.updateBudget(id, updates);
-      setBudgets(prev => prev.map(b => b.id === id ? { ...b, ...updates } : b));
-
-      // Refresh statuses
-      await refreshBudgetStatuses();
-
-      setSaveError(null);
-    } catch (error) {
-      console.error('Failed to update budget:', error);
-      setSaveError(error.message);
-      showDialog('Error', error.message, [{ text: 'OK' }]);
-      throw error;
-    }
-  }, [budgets, refreshBudgetStatuses, showDialog]);
-
-  /**
-   * Delete budget
-   */
-  const deleteBudget = useCallback(async (id) => {
-    try {
-      await BudgetsDB.deleteBudget(id);
-      setBudgets(prev => prev.filter(b => b.id !== id));
-
-      // Remove from status map
-      setBudgetStatuses(prev => {
-        const newMap = new Map(prev);
-        newMap.delete(id);
-        return newMap;
-      });
-
-      setSaveError(null);
-    } catch (error) {
-      console.error('Failed to delete budget:', error);
-      setSaveError(error.message);
-      showDialog('Error', 'Failed to delete budget. Please try again.', [{ text: 'OK' }]);
-      throw error;
-    }
-  }, [showDialog]);
-
-  /**
-   * Get budget for category
-   */
-  const getBudgetForCategory = useCallback((categoryId, currency = null, periodType = null) => {
-    return budgets.find(b => {
-      if (b.categoryId !== categoryId) return false;
-      if (currency && b.currency !== currency) return false;
-      if (periodType && b.periodType !== periodType) return false;
-      return true;
-    });
-  }, [budgets]);
-
-  /**
-   * Get budget status
-   */
-  const getBudgetStatus = useCallback((budgetId) => {
-    return budgetStatuses.get(budgetId) || null;
-  }, [budgetStatuses]);
-
-  /**
-   * Check if budget is exceeded
-   */
-  const isBudgetExceeded = useCallback((budgetId) => {
-    const status = budgetStatuses.get(budgetId);
-    return status ? status.isExceeded : false;
-  }, [budgetStatuses]);
-
-  /**
-   * Get budget progress percentage
-   */
-  const getBudgetProgress = useCallback((budgetId) => {
-    const status = budgetStatuses.get(budgetId);
-    return status ? status.percentage : 0;
-  }, [budgetStatuses]);
-
-  /**
-   * Get remaining budget amount
-   */
-  const getRemainingBudget = useCallback((budgetId) => {
-    const status = budgetStatuses.get(budgetId);
-    return status ? status.remaining : '0';
-  }, [budgetStatuses]);
-
-  /**
-   * Get budgets by period type
-   */
-  const getBudgetsByPeriod = useCallback((periodType) => {
-    return budgets.filter(b => b.periodType === periodType);
-  }, [budgets]);
-
-  /**
-   * Check if category has active budget
-   */
-  const hasActiveBudget = useCallback((categoryId, currency = null) => {
-    return budgets.some(b => {
-      if (b.categoryId !== categoryId) return false;
-      if (currency && b.currency !== currency) return false;
-
-      // Check if budget is active (no end date or end date in future)
-      if (!b.endDate) return true;
-      const endDate = new Date(b.endDate);
-      return endDate >= new Date();
-    });
-  }, [budgets]);
-
-  const value = useMemo(() => ({
-    budgets,
-    budgetStatuses,
-    loading,
-    saveError,
-    addBudget,
-    updateBudget,
-    deleteBudget,
-    getBudgetForCategory,
-    getBudgetStatus,
-    isBudgetExceeded,
-    getBudgetProgress,
-    getRemainingBudget,
-    getBudgetsByPeriod,
-    hasActiveBudget,
-    reloadBudgets,
-    refreshBudgetStatuses,
-  }), [
-    budgets,
-    budgetStatuses,
-    loading,
-    saveError,
-    addBudget,
-    updateBudget,
-    deleteBudget,
-    getBudgetForCategory,
-    getBudgetStatus,
-    isBudgetExceeded,
-    getBudgetProgress,
-    getRemainingBudget,
-    getBudgetsByPeriod,
-    hasActiveBudget,
-    reloadBudgets,
-    refreshBudgetStatuses,
-  ]);
-
   return (
-    <BudgetsContext.Provider value={value}>
-      {children}
-    </BudgetsContext.Provider>
+    <BudgetsDataProvider>
+      <BudgetsActionsProvider>
+        {children}
+      </BudgetsActionsProvider>
+    </BudgetsDataProvider>
   );
 };
 

--- a/app/contexts/BudgetsDataContext.js
+++ b/app/contexts/BudgetsDataContext.js
@@ -1,0 +1,124 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import * as BudgetsDB from '../services/BudgetsDB';
+import { appEvents, EVENTS } from '../services/eventEmitter';
+
+const BudgetsDataContext = createContext();
+
+export const BudgetsDataProvider = ({ children }) => {
+  const [budgets, setBudgets] = useState([]);
+  const [budgetStatuses, setBudgetStatuses] = useState(new Map());
+  const [loading, setLoading] = useState(true);
+  const [saveError, setSaveError] = useState(null);
+
+  /**
+   * Refresh budget statuses for all active budgets
+   */
+  const refreshBudgetStatuses = useCallback(async () => {
+    try {
+      const statusMap = await BudgetsDB.calculateAllBudgetStatuses();
+      setBudgetStatuses(statusMap);
+    } catch (error) {
+      console.error('Failed to refresh budget statuses:', error);
+    }
+  }, []);
+
+  /**
+   * Load all budgets from database
+   */
+  const reloadBudgets = useCallback(async () => {
+    try {
+      setLoading(true);
+      const budgetsData = await BudgetsDB.getAllBudgets();
+      setBudgets(budgetsData);
+
+      // Refresh statuses for all active budgets
+      await refreshBudgetStatuses();
+
+      setSaveError(null);
+    } catch (error) {
+      console.error('Failed to load budgets:', error);
+      setSaveError(error.message);
+      setBudgets([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [refreshBudgetStatuses]);
+
+  /**
+   * Load budgets on mount
+   */
+  useEffect(() => {
+    reloadBudgets();
+  }, [reloadBudgets]);
+
+  /**
+   * Listen for operation changes to refresh statuses
+   */
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.OPERATION_CHANGED, () => {
+      console.debug('Operation changed, refreshing budget statuses...');
+      refreshBudgetStatuses();
+    });
+
+    return unsubscribe;
+  }, [refreshBudgetStatuses]);
+
+  /**
+   * Listen for budget reload events
+   */
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
+      console.debug('Reloading all budgets...');
+      reloadBudgets();
+    });
+
+    return unsubscribe;
+  }, [reloadBudgets]);
+
+  /**
+   * Listen for DATABASE_RESET event to clear budgets
+   */
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, () => {
+      console.log('BudgetsDataContext: Database reset detected, clearing budgets');
+      setBudgets([]);
+      setBudgetStatuses(new Map());
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const value = useMemo(() => ({
+    // Public data
+    budgets,
+    budgetStatuses,
+    loading,
+    saveError,
+    reloadBudgets,
+    refreshBudgetStatuses,
+    // Internal setters for actions context
+    _setBudgets: setBudgets,
+    _setBudgetStatuses: setBudgetStatuses,
+    _setSaveError: setSaveError,
+  }), [
+    budgets,
+    budgetStatuses,
+    loading,
+    saveError,
+    reloadBudgets,
+    refreshBudgetStatuses,
+  ]);
+
+  return (
+    <BudgetsDataContext.Provider value={value}>
+      {children}
+    </BudgetsDataContext.Provider>
+  );
+};
+
+BudgetsDataProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export const useBudgetsData = () => useContext(BudgetsDataContext);


### PR DESCRIPTION
Fixes #769

## Summary
Follows the exact split pattern already used by Accounts and Operations contexts. Action-only consumers no longer re-render when budget data changes.

## Changes
- `app/contexts/BudgetsDataContext.js` (new): `budgets`, `budgetStatuses`, `loading`, `saveError`, event listeners, `reloadBudgets`, `refreshBudgetStatuses`
- `app/contexts/BudgetsActionsContext.js` (new): all 10 stable action callbacks (`addBudget`, `updateBudget`, `deleteBudget`, etc.) — only invalidate when their own deps change
- `app/contexts/BudgetsContext.js` (rewritten): orchestrator that wraps both sub-providers + backward-compat `useBudgets()` shim merging both contexts
- No changes to consumers (`BudgetModal.js`, `BudgetProgressBar.js`, `App.js`) — they all go through the `useBudgets` shim

## Test plan
- [ ] Budget CRUD (add/edit/delete) works correctly
- [ ] Budget progress bars update when operations change
- [ ] Components that only call budget actions don't re-render on budget data changes
- [ ] All 3498 tests pass