### PR TITLE
test: add regression test for DB error aborting Sheets import (#760)

### DIFF
--- a/__tests__/services/GoogleSheetsService.test.js
+++ b/__tests__/services/GoogleSheetsService.test.js
@@ -14,6 +14,10 @@ jest.mock('../../app/services/PreferencesDB', () => ({
   setPreference: jest.fn(),
 }));
 
+jest.mock('../../app/services/db', () => ({
+  queryAll: jest.fn(() => Promise.resolve([])),
+}));
+
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -489,6 +493,12 @@ describe('GoogleSheetsService', () => {
       });
       await expect(importFromSheets('token')).rejects.toThrow('refresh_failed');
       expect(GoogleSignin.signOut).toHaveBeenCalled();
+    });
+
+    it('throws when the DB read for app_metadata fails (#760)', async () => {
+      const { queryAll } = require('../../app/services/db');
+      queryAll.mockRejectedValueOnce(new Error('database is locked'));
+      await expect(importFromSheets('token')).rejects.toThrow('database is locked');
     });
 
     it('returns a valid backup object on success', async () => {


### PR DESCRIPTION
## Summary
- The code fix (removing `.catch(() => [])`) was already applied in a prior commit
- This PR adds a regression test locking in the correct behavior

## Problem
Issue #760: `GoogleSheetsService.importFromSheets` silently swallowed DB read errors by catching and returning `[]`, then overwriting all user preferences with the empty result.

## Solution
The fix is already in `main` — `queryAll` is now called without a `.catch()`. The caller (`SettingsModal`) already handles the propagated error with a user-facing message.

This PR adds a regression test that mocks `queryAll` to reject and asserts `importFromSheets` throws rather than resolving silently.

## Changes
- `__tests__/services/GoogleSheetsService.test.js` — regression test in the import describe block

## Test plan
- [x] 77/77 GoogleSheetsService tests pass

Closes #760

**BEGIN_COMMIT_OVERRIDE**
```
test(GoogleSheetsService): add regression test for DB error aborting import (#760)
```
**END_COMMIT_OVERRIDE**