### PR TITLE
fix: use Decimal.js for income/expense chart total accumulation (#765)

### DIFF
--- a/__tests__/hooks/useExpenseData.test.js
+++ b/__tests__/hooks/useExpenseData.test.js
@@ -432,6 +432,31 @@ describe('useExpenseData', () => {
       });
     });
 
+    it('should sum totalExpenses without floating-point accumulation errors (#765)', async () => {
+      // 0.1 + 0.2 in native JS = 0.30000000000000004; Decimal.js gives 0.3
+      const mockSpending = [
+        { category_id: 'cat-2', total: '0.10' },
+        { category_id: 'cat-3', total: '0.20' },
+      ];
+
+      OperationsDB.getSpendingByCategoryAndCurrency.mockResolvedValue(mockSpending);
+
+      const { result } = renderHook(() =>
+        useExpenseData(mockYear, mockMonth, mockCurrency, 'all', mockCategories, mockColors, mockT),
+      );
+
+      await act(async () => {
+        await result.current.loadExpenseData();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Must be exactly 0.3, not 0.30000000000000004
+      expect(result.current.totalExpenses).toBe(0.3);
+    });
+
     it('should query all accounts for the currency without an account ID filter', async () => {
       OperationsDB.getSpendingByCategoryAndCurrency.mockResolvedValue([]);
 

--- a/__tests__/hooks/useIncomeData.test.js
+++ b/__tests__/hooks/useIncomeData.test.js
@@ -441,6 +441,31 @@ describe('useIncomeData', () => {
       });
     });
 
+    it('should sum totalIncome without floating-point accumulation errors (#765)', async () => {
+      // 0.1 + 0.2 in native JS = 0.30000000000000004; Decimal.js gives 0.3
+      const mockIncome = [
+        { category_id: 'cat-2', total: '0.10' },
+        { category_id: 'cat-3', total: '0.20' },
+      ];
+
+      OperationsDB.getIncomeByCategoryAndCurrency.mockResolvedValue(mockIncome);
+
+      const { result } = renderHook(() =>
+        useIncomeData(mockYear, mockMonth, mockCurrency, 'all', mockCategories, mockColors, mockT),
+      );
+
+      await act(async () => {
+        await result.current.loadIncomeData();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loadingIncome).toBe(false);
+      });
+
+      // Must be exactly 0.3, not 0.30000000000000004
+      expect(result.current.totalIncome).toBe(0.3);
+    });
+
     it('should query all accounts for the currency without an account ID filter', async () => {
       OperationsDB.getIncomeByCategoryAndCurrency.mockResolvedValue([]);
 

--- a/__tests__/services/currency.test.js
+++ b/__tests__/services/currency.test.js
@@ -551,6 +551,21 @@ describe('Currency Service', () => {
 
   // Critical regression tests for financial accuracy
   describe('Regression Tests - Financial Accuracy', () => {
+    it('summing 0.1 + 0.2 produces 0.30 not 0.30000000000000004 (#765)', () => {
+      // Native JS: 0.1 + 0.2 === 0.30000000000000004
+      // Decimal.js via Currency.add must return '0.30'
+      const result = Currency.add('0.1', '0.2');
+      expect(result).toBe('0.30');
+      expect(parseFloat(result)).toBe(0.3);
+    });
+
+    it('accumulating many small amounts via Currency.add stays exact (#765)', () => {
+      // Simulate the totalExpenses/totalIncome reduce pattern
+      const amounts = ['0.10', '0.20', '0.30', '0.40'];
+      const total = parseFloat(amounts.reduce((sum, amount) => Currency.add(sum, amount), '0'));
+      expect(total).toBe(1.0);
+    });
+
     it('handles repeated additions without accumulating errors', () => {
       let sum = '0';
       for (let i = 0; i < 100; i++) {

--- a/app/hooks/useExpenseData.js
+++ b/app/hooks/useExpenseData.js
@@ -152,7 +152,7 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
   }, [rawSpending, selectedCategory, categories, colors.text, t, selectedCurrency]);
 
   const totalExpenses = useMemo(
-    () => chartData.reduce((sum, item) => sum + item.amount, 0),
+    () => parseFloat(chartData.reduce((sum, item) => Currency.add(sum, item.amount), '0')),
     [chartData],
   );
 

--- a/app/hooks/useIncomeData.js
+++ b/app/hooks/useIncomeData.js
@@ -126,7 +126,7 @@ const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIn
   }, [rawIncome, selectedIncomeCategory, categories, colors.text, selectedCurrency]);
 
   const totalIncome = useMemo(
-    () => incomeChartData.reduce((sum, item) => sum + item.amount, 0),
+    () => parseFloat(incomeChartData.reduce((sum, item) => Currency.add(sum, item.amount), '0')),
     [incomeChartData],
   );
 


### PR DESCRIPTION
## Summary
- Replaced native JS float `+` accumulation in `totalExpenses` and `totalIncome` with `Currency.add` (Decimal.js) to prevent floating-point drift in chart totals
- Added regression tests asserting `0.1 + 0.2 === 0.3` (not `0.30000000000000004`)

## Problem
`useExpenseData` and `useIncomeData` computed final chart totals with a native `reduce((sum, item) => sum + item.amount, 0)`. Per-category aggregation already used `Currency.add` correctly, but the final summation step used float arithmetic, causing rounding errors in displayed totals.

## Changes
- `app/hooks/useExpenseData.js`: final reduce uses `Currency.add`
- `app/hooks/useIncomeData.js`: final reduce uses `Currency.add`
- `__tests__/services/currency.test.js`: 2 precision regression tests
- `__tests__/hooks/useExpenseData.test.js`: regression test for total precision
- `__tests__/hooks/useIncomeData.test.js`: regression test for total precision

Closes #765