### PR TITLE
fix: log database transaction errors instead of silently swallowing them (#752)

### DIFF
--- a/__tests__/services/db.test.js
+++ b/__tests__/services/db.test.js
@@ -210,6 +210,19 @@ describe('Database Service', () => {
       await expect(executeTransaction(callback)).rejects.toThrow('Transaction error');
     });
 
+    it('logs transaction errors via console.error', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const err = new Error('DB write failed');
+      const failingCallback = jest.fn(async () => { throw err; });
+
+      await expect(executeTransaction(failingCallback)).rejects.toThrow('DB write failed');
+
+      // Give the _lastTransaction catch handler a chance to run
+      await Promise.resolve();
+      expect(errorSpy).toHaveBeenCalledWith('[DB] Transaction failed:', err);
+      errorSpy.mockRestore();
+    });
+
     it('does not block subsequent transactions after a failed one', async () => {
       const failingCallback = jest.fn(async () => {
         throw new Error('Deliberate failure');

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -440,8 +440,11 @@ export const executeTransaction = async (callback) => {
     return callbackResult;
   });
 
-  // Swallow rejection so the next queued transaction always starts.
-  _lastTransaction = txPromise.catch(() => {});
+  // Keep the chain always-resolved so the next queued transaction can start,
+  // but log and re-throw the error so callers can handle it.
+  _lastTransaction = txPromise.catch((err) => {
+    console.error('[DB] Transaction failed:', err);
+  });
   return txPromise;
 };
 


### PR DESCRIPTION
## Summary
- `executeTransaction` now logs transaction failures via `console.error` before the queue anchor resolves, making DB errors visible in Metro/ADB logs
- Added regression test verifying both error propagation to callers and the new logging behavior

## Problem
The internal serialization anchor `_lastTransaction` used `.catch(() => {})` — errors were silently dropped with no trace, making transaction failures nearly impossible to diagnose. Errors did reach callers (the returned `txPromise` rejected correctly), but left no log trail.

## Changes
- `app/services/db.js`: `.catch(() => {})` → `.catch((err) => { console.error('[DB] Transaction failed:', err); })`
- `__tests__/services/db.test.js`: regression test asserting both error propagation and logging

Closes #752