### PR TITLE
fix(ui): restore flex layout on Check for updates panel

### DIFF
--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -431,6 +431,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   resultContainer: {
+    flex: 1,
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.lg,
   },


### PR DESCRIPTION
## Problem

The **Check for updates** panel in Settings rendered as an empty modal (header visible, body blank) as shown in the bug report screenshot.

## Root Cause

When the update panel was extracted into the shared `UpdateContentPanel` component (commit c3652e1), the opacity-animated result container lost its `flex: 1`:

- **Before:** `updateResultContainer: { flex: 1 }`
- **After:** `resultContainer: { paddingHorizontal, paddingVertical }` (no flex)

The panel is rendered inside an absolutely-positioned settings subpanel (`subPanelContent` with `top/bottom: 0`). The `up_to_date`, `error`, and centered states rely on `flex: 1` propagating down to fill that height. Without `flex: 1` on the result container, those flex children collapsed and the content failed to lay out, leaving the modal appearing blank.

## Fix

Restore `flex: 1` on `resultContainer` so the panel fills its container, matching the pre-refactor behavior. The `available` state (changelog scroll + update button) and the `UpdateAvailableModal` usage remain correct since `flex: 1` resolves to content height inside a content-sized modal.

https://claude.ai/code/session_01FkMU7QYKZzAyWCHq4yiHR8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkMU7QYKZzAyWCHq4yiHR8)_