### PR TITLE
fix(settings): use safe area insets for subpanel bottom padding

### DIFF
--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -6,6 +6,7 @@ import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Text, Divider, TouchableRipple } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { runOnJS } from 'react-native-reanimated';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -53,6 +54,7 @@ const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 
 
 export default function SettingsScreen({ setSubPanelActive }) {
+  const insets = useSafeAreaInsets();
   const { colors } = useThemeColors();
   const { t, language, setLanguage, availableLanguages } = useLocalization();
   const { hideBalances, setHideBalances } = useDisplaySettings();
@@ -879,6 +881,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
             styles.subPanelContent,
             { backgroundColor: colors.background },
             (activeSubPanel === 'accounts' || activeSubPanel === 'categories') && styles.subPanelContentFlush,
+            !(activeSubPanel === 'accounts' || activeSubPanel === 'categories') && { paddingBottom: insets.bottom + 80 },
             {
               transform: [{ translateX: subPanelTranslateX }],
               opacity: subPanelOpacity,


### PR DESCRIPTION
## Summary

- The "Update now" button in the Settings update subpanel was unpressable on devices with large bottom navigation bars (3-button nav ~48px, Samsung gesture nav ~68px+)
- Root cause: hardcoded `paddingBottom: 96` on the subpanel `Animated.View` was insufficient — the floating tab bar occupies `insets.bottom + 72px` from the screen bottom, so buttons near the panel bottom were being touch-intercepted by the tab bar
- Fix: replace the hardcoded value with `insets.bottom + 80` computed via `useSafeAreaInsets`, guaranteeing clearance on any device

## Test plan

- [ ] Launch app, open Settings, tap "Check for updates" — verify the Update now / Install now button is tappable
- [ ] Test on a device/emulator with 3-button navigation bar (large insets)
- [ ] Test on a device/emulator with gesture navigation (small insets)
- [ ] Verify accounts and categories subpanels are unaffected (they use `subPanelContentFlush` and are excluded from the dynamic padding)