### PR TITLE
feat(settings): accounts and categories as proper subpanels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .trash/
 # Git worktrees
 .worktrees/
+.claude/worktrees/
 # React Native
 node_modules/
 npm-debug.log*

--- a/__tests__/screens/AccountsScreen.test.js
+++ b/__tests__/screens/AccountsScreen.test.js
@@ -874,16 +874,16 @@ describe('AccountsScreen', () => {
         getOperationCount: mockGetOperationCount,
       }));
 
-      const { getByLabelText, getAllByText, getByText } = render(<AccountsScreen />);
+      const { getByLabelText, getByTestId } = render(<AccountsScreen />);
 
       // Open edit modal for account
       const accountRow = getByLabelText('edit_account');
       fireEvent.press(accountRow);
 
       await waitFor(() => {
-        // Find and press delete button
-        const deleteButtons = getAllByText('delete_account');
-        fireEvent.press(deleteButtons[0]);
+        // Find and press delete icon in form panel header
+        const deleteIcon = getByTestId('icon-trash-can-outline');
+        fireEvent.press(deleteIcon);
       });
 
       // Operation count should be checked
@@ -919,16 +919,16 @@ describe('AccountsScreen', () => {
         getOperationCount: mockGetOperationCount,
       }));
 
-      const { getByLabelText, getAllByText, getByText } = render(<AccountsScreen />);
+      const { getAllByText, getByTestId } = render(<AccountsScreen />);
 
       // Open edit modal for first account
       const accountRows = getAllByText('Cash');
       fireEvent.press(accountRows[0]);
 
       await waitFor(() => {
-        // Find and press delete button
-        const deleteButtons = getAllByText('delete_account');
-        fireEvent.press(deleteButtons[0]);
+        // Find and press delete icon in form panel header
+        const deleteIcon = getByTestId('icon-trash-can-outline');
+        fireEvent.press(deleteIcon);
       });
 
       // Should show transfer operations dialog
@@ -965,16 +965,16 @@ describe('AccountsScreen', () => {
         getOperationCount: mockGetOperationCount,
       }));
 
-      const { getByLabelText, getAllByText, getByText } = render(<AccountsScreen />);
+      const { getByLabelText, getAllByText, getByTestId } = render(<AccountsScreen />);
 
       // Open edit modal for account
       const accountRow = getByLabelText('edit_account');
       fireEvent.press(accountRow);
 
       await waitFor(() => {
-        // Find and press delete button
-        const deleteButtons = getAllByText('delete_account');
-        fireEvent.press(deleteButtons[0]);
+        // Find and press delete icon in form panel header
+        const deleteIcon = getByTestId('icon-trash-can-outline');
+        fireEvent.press(deleteIcon);
       });
 
       // Wait for confirmation dialog to appear and then confirm

--- a/__tests__/screens/AccountsScreen.test.js
+++ b/__tests__/screens/AccountsScreen.test.js
@@ -148,18 +148,6 @@ describe('AccountsScreen', () => {
       expect(() => render(<AccountsScreen />)).not.toThrow();
     });
 
-    it('zeroes top padding when embedded', () => {
-      const AccountsScreen = require('../../app/screens/AccountsScreen').default;
-      const { View, StyleSheet } = require('react-native');
-
-      const { UNSAFE_getAllByType } = render(<AccountsScreen embedded />);
-      // First View in the tree is the root container
-      const rootView = UNSAFE_getAllByType(View)[0];
-      const resolved = StyleSheet.flatten(rootView.props.style);
-      // containerEmbedded overrides paddingTop to 0
-      expect(resolved.paddingTop).toBe(0);
-    });
-
     it('uses ThemeContext for styling', () => {
       const AccountsScreen = require('../../app/screens/AccountsScreen').default;
       const { useThemeConfig } = require('../../app/contexts/ThemeConfigContext');

--- a/__tests__/screens/CategoriesScreen.test.js
+++ b/__tests__/screens/CategoriesScreen.test.js
@@ -76,9 +76,11 @@ jest.mock('../../app/contexts/CategoriesContext', () => ({
   useCategories: jest.fn(() => ({
     categories: [],
     loading: false,
-    expandedIds: new Set(),
-    toggleExpanded: jest.fn(),
     getChildren: jest.fn(() => []),
+    addCategory: jest.fn(),
+    updateCategory: jest.fn(),
+    deleteCategory: jest.fn(),
+    validateCategory: jest.fn(() => null),
   })),
 }));
 
@@ -122,10 +124,10 @@ describe('CategoriesScreen', () => {
       expect(() => render(<CategoriesScreen />)).not.toThrow();
     });
 
-    it('renders without crashing when embedded prop is true', () => {
+    it('renders without crashing with no props', () => {
       const CategoriesScreen = require('../../app/screens/CategoriesScreen').default;
 
-      expect(() => render(<CategoriesScreen embedded />)).not.toThrow();
+      expect(() => render(<CategoriesScreen />)).not.toThrow();
     });
 
     it('uses ThemeContext for styling', () => {
@@ -173,9 +175,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: [],
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -188,9 +192,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: [],
         loading: true,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -209,9 +215,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: mockCategories,
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -230,9 +238,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: mockCategories,
         loading: false,
-        expandedIds: new Set(['1']),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn((id) => mockCategories.filter(c => c.parentId === id)),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -250,9 +260,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: mockCategories,
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       // Component should filter out shadow categories internally
@@ -325,9 +337,11 @@ describe('CategoriesScreen', () => {
           { id: '2', name: 'Groceries', parentId: '1' },
         ],
         loading: false,
-        expandedIds: new Set(['1']),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn((id) => id === '1' ? [{ id: '2', name: 'Groceries', parentId: '1' }] : []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -343,9 +357,11 @@ describe('CategoriesScreen', () => {
           { id: '2', name: 'Groceries', parentId: '1' },
         ],
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -421,9 +437,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: mockCategories,
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -438,9 +456,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: [],
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       // Context should always provide an array, even when empty
@@ -454,9 +474,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: [],
         loading: true,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -474,9 +496,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: mockCategories,
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -496,9 +520,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: mockCategories,
         loading: false,
-        expandedIds: new Set(['1', '2', '3']),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn((id) => mockCategories.filter(c => c.parentId === id)),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => render(<CategoriesScreen />)).not.toThrow();
@@ -527,9 +553,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: initialCategories,
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       const { rerender } = render(<CategoriesScreen />);
@@ -537,9 +565,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: updatedCategories,
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => rerender(<CategoriesScreen />)).not.toThrow();
@@ -552,9 +582,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: [{ id: '1', name: 'Food', isFolder: true }],
         loading: false,
-        expandedIds: new Set(),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       const { rerender } = render(<CategoriesScreen />);
@@ -562,9 +594,11 @@ describe('CategoriesScreen', () => {
       useCategories.mockReturnValue({
         categories: [{ id: '1', name: 'Food', isFolder: true }],
         loading: false,
-        expandedIds: new Set(['1']),
-        toggleExpanded: jest.fn(),
         getChildren: jest.fn(() => []),
+        addCategory: jest.fn(),
+        updateCategory: jest.fn(),
+        deleteCategory: jest.fn(),
+        validateCategory: jest.fn(() => null),
       });
 
       expect(() => rerender(<CategoriesScreen />)).not.toThrow();

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -455,10 +455,12 @@ export default function AccountsScreen() {
 
   const balanceInputRef = useRef(null);
 
+  const SCREEN_WIDTH = Dimensions.get('window').width;
+
   // Form panel interpolations
   const formPanelTranslateX = formPanelAnim.interpolate({
     inputRange: [0, 1],
-    outputRange: [300, 0],
+    outputRange: [SCREEN_WIDTH, 0],
   });
   const formPanelOpacity = formPanelAnim.interpolate({
     inputRange: [0, 1],
@@ -466,6 +468,8 @@ export default function AccountsScreen() {
   });
 
   const openFormPanel = useCallback((id, values) => {
+    setCurrencyPanelVisible(false);
+    currencySlideAnim.setValue(Dimensions.get('window').width);
     setEditingId(id);
     setEditValues(values);
     Animated.timing(formPanelAnim, {
@@ -474,7 +478,7 @@ export default function AccountsScreen() {
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
-  }, [formPanelAnim]);
+  }, [formPanelAnim, currencySlideAnim]);
 
   const closeFormPanel = useCallback(() => {
     Animated.timing(formPanelAnim, {
@@ -581,6 +585,7 @@ export default function AccountsScreen() {
     Animated.timing(currencySlideAnim, {
       toValue: 0,
       duration: 260,
+      easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
   }, [currencySlideAnim]);
@@ -962,38 +967,6 @@ export default function AccountsScreen() {
                 />
               </View>
             </View>
-
-            {/* In-panel currency picker — slides in from the right */}
-            {currencyPanelVisible && (
-              <Animated.View
-                style={[styles.currencyPanel, { backgroundColor: colors.card, transform: [{ translateX: currencySlideAnim }] }]}
-              >
-                <View style={[styles.currencyPanelHeader, { borderBottomColor: colors.border }]}>
-                  <TouchableOpacity onPress={handleClosePicker} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-                    <Icon name="arrow-left" size={22} color={colors.text} />
-                  </TouchableOpacity>
-                  <Text style={[styles.currencyPanelTitle, { color: colors.text }]}>
-                    {t('select_currency') || 'Currency'}
-                  </Text>
-                </View>
-                <FlatList
-                  data={Object.entries(currencies)}
-                  keyExtractor={([code]) => code}
-                  renderItem={({ item: [code, cur] }) => (
-                    <TouchableRipple
-                      onPress={() => handleCurrencySelect(code)}
-                      style={styles.currencyPanelItem}
-                      rippleColor="rgba(0,0,0,0.08)"
-                    >
-                      <Text style={[styles.currencyPanelItemText, { color: colors.text }]}>
-                        {cur.name} ({cur.symbol})
-                      </Text>
-                    </TouchableRipple>
-                  )}
-                  ItemSeparatorComponent={() => <View style={[styles.divider, { backgroundColor: colors.border }]} />}
-                />
-              </Animated.View>
-            )}
           </ScrollView>
 
           {/* Footer with Save/Cancel buttons */}
@@ -1005,6 +978,38 @@ export default function AccountsScreen() {
               <Text style={styles.formFooterBtnPrimaryText}>{t('save') || 'Save'}</Text>
             </TouchableRipple>
           </View>
+
+          {/* In-panel currency picker — absolute overlay, slides in from the right */}
+          {currencyPanelVisible && (
+            <Animated.View
+              style={[styles.currencyPanel, { backgroundColor: colors.card, transform: [{ translateX: currencySlideAnim }] }]}
+            >
+              <View style={[styles.currencyPanelHeader, { borderBottomColor: colors.border }]}>
+                <TouchableOpacity onPress={handleClosePicker} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+                  <Icon name="arrow-left" size={22} color={colors.text} />
+                </TouchableOpacity>
+                <Text style={[styles.currencyPanelTitle, { color: colors.text }]}>
+                  {t('select_currency') || 'Currency'}
+                </Text>
+              </View>
+              <FlatList
+                data={Object.entries(currencies)}
+                keyExtractor={([code]) => code}
+                renderItem={({ item: [code, cur] }) => (
+                  <TouchableRipple
+                    onPress={() => handleCurrencySelect(code)}
+                    style={styles.currencyPanelItem}
+                    rippleColor="rgba(0,0,0,0.08)"
+                  >
+                    <Text style={[styles.currencyPanelItemText, { color: colors.text }]}>
+                      {cur.name} ({cur.symbol})
+                    </Text>
+                  </TouchableRipple>
+                )}
+                ItemSeparatorComponent={() => <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+              />
+            </Animated.View>
+          )}
         </Animated.View>
       )}
 
@@ -1160,13 +1165,12 @@ const styles = StyleSheet.create({
     paddingTop: TOP_CONTENT_SPACING,
   },
   currencyPanel: {
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
     bottom: 0,
     left: 0,
     position: 'absolute',
     right: 0,
     top: 0,
+    zIndex: 20,
   },
   currencyPanelHeader: {
     alignItems: 'center',

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, useMemo, memo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, Keyboard, FlatList, TouchableOpacity, Pressable, Animated, Dimensions } from 'react-native';
-import ModalShell from '../components/ModalShell';
+import { View, StyleSheet, Keyboard, FlatList, TouchableOpacity, Pressable, Animated, Dimensions, ScrollView, Easing } from 'react-native';
 import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
 import { Text, TextInput as PaperTextInput, Button, Portal, Modal, TouchableRipple, Switch } from 'react-native-paper';
 import AddFAB from '../components/AddFAB';
@@ -424,7 +423,7 @@ AccountRow.defaultProps = {
   isActive: false,
 };
 
-export default function AccountsScreen({ embedded }) {
+export default function AccountsScreen() {
 
   const [editingId, setEditingId] = useState(null);
   const [editValues, setEditValues] = useState({});
@@ -432,6 +431,7 @@ export default function AccountsScreen({ embedded }) {
   const [createAdjustmentOperation, setCreateAdjustmentOperation] = useState(true);
   const [currencyPanelVisible, setCurrencyPanelVisible] = useState(false);
   const currencySlideAnim = useRef(new Animated.Value(Dimensions.get('window').width)).current;
+  const formPanelAnim = useRef(new Animated.Value(0)).current;
   const [transferModalVisible, setTransferModalVisible] = useState(false);
   const [accountToDelete, setAccountToDelete] = useState(null);
   const [accountToDeleteCurrency, setAccountToDeleteCurrency] = useState(null);
@@ -455,8 +455,42 @@ export default function AccountsScreen({ embedded }) {
 
   const balanceInputRef = useRef(null);
 
-  const startEdit = useCallback((id) => {
+  // Form panel interpolations
+  const formPanelTranslateX = formPanelAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [300, 0],
+  });
+  const formPanelOpacity = formPanelAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 1],
+  });
+
+  const openFormPanel = useCallback((id, values) => {
     setEditingId(id);
+    setEditValues(values);
+    Animated.timing(formPanelAnim, {
+      toValue: 1,
+      duration: 260,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [formPanelAnim]);
+
+  const closeFormPanel = useCallback(() => {
+    Animated.timing(formPanelAnim, {
+      toValue: 0,
+      duration: 200,
+      easing: Easing.in(Easing.quad),
+      useNativeDriver: true,
+    }).start(() => {
+      setEditingId(null);
+      setEditValues({});
+      setErrors({});
+      setCurrencyPanelVisible(false);
+    });
+  }, [formPanelAnim]);
+
+  const startEdit = useCallback((id) => {
     const acc = accounts.find(a => a.id === id);
     const decimals = currencies[acc.currency]?.decimal_digits ?? 2;
     let balance = String(acc.balance ?? '');
@@ -468,10 +502,10 @@ export default function AccountsScreen({ embedded }) {
         balance = balance.substring(0, dotIndex + 1) + balance.substring(dotIndex + 1).substring(0, decimals);
       }
     }
-    setEditValues({ ...acc, balance });
     setErrors({});
     setCreateAdjustmentOperation(true);
-  }, [accounts]);
+    openFormPanel(id, { ...acc, balance });
+  }, [accounts, openFormPanel]);
 
   const saveEdit = useCallback(() => {
     const validation = validateAccount(editValues, t);
@@ -484,18 +518,14 @@ export default function AccountsScreen({ embedded }) {
     } else {
       updateAccount(editingId, editValues, createAdjustmentOperation);
     }
-    setEditingId(null);
-    setEditValues({});
-    setErrors({});
-    setCreateAdjustmentOperation(true);
-  }, [validateAccount, editValues, editingId, addAccount, updateAccount, createAdjustmentOperation, t]);
+    closeFormPanel();
+  }, [validateAccount, editValues, editingId, addAccount, updateAccount, createAdjustmentOperation, t, closeFormPanel]);
 
   const addAccountHandler = useCallback(() => {
-    setEditingId('new');
-    setEditValues({ name: '', balance: '', currency: Object.keys(currencies)[0], hidden: 0 });
     setErrors({});
     setCreateAdjustmentOperation(true);
-  }, [currencies]);
+    openFormPanel('new', { name: '', balance: '', currency: Object.keys(currencies)[0], hidden: 0 });
+  }, [openFormPanel]);
 
   const deleteAccountHandler = useCallback(async (id) => {
     try {
@@ -542,10 +572,8 @@ export default function AccountsScreen({ embedded }) {
 
   const handleCloseModal = useCallback(() => {
     Keyboard.dismiss();
-    setEditingId(null);
-    setErrors({});
-    setCreateAdjustmentOperation(true);
-  }, []);
+    closeFormPanel();
+  }, [closeFormPanel]);
 
   const handleOpenPicker = useCallback(() => {
     currencySlideAnim.setValue(Dimensions.get('window').width);
@@ -670,9 +698,7 @@ export default function AccountsScreen({ embedded }) {
     try {
       await deleteAccount(deleteConfirmAccountId);
       if (editingId === deleteConfirmAccountId) {
-        setEditingId(null);
-        setEditValues({});
-        setErrors({});
+        closeFormPanel();
       }
     } catch (err) {
       console.error('Failed to delete account:', err);
@@ -680,7 +706,7 @@ export default function AccountsScreen({ embedded }) {
       setNoCurrencyMatchVisible(true);
     }
     setDeleteConfirmAccountId(null);
-  }, [deleteConfirmAccountId, deleteAccount, editingId, t]);
+  }, [deleteConfirmAccountId, deleteAccount, editingId, t, closeFormPanel]);
 
   // Handle transfer and delete confirmation
   const handleConfirmTransferAndDelete = useCallback(async () => {
@@ -690,9 +716,7 @@ export default function AccountsScreen({ embedded }) {
 
       // Clear edit state if we were editing the deleted account
       if (editingId === accountToDelete) {
-        setEditingId(null);
-        setEditValues({});
-        setErrors({});
+        closeFormPanel();
       }
 
       // Reset transfer modal state
@@ -705,7 +729,7 @@ export default function AccountsScreen({ embedded }) {
       setNoCurrencyMatchMessage(t('failed_to_delete_account') || 'Failed to delete account. Please try again.');
       setNoCurrencyMatchVisible(true);
     }
-  }, [accountToDelete, transferConfirmDestinationId, deleteAccount, editingId, t]);
+  }, [accountToDelete, transferConfirmDestinationId, deleteAccount, editingId, t, closeFormPanel]);
 
   // Enhance accounts with currency symbol for better performance
   const enhancedAccounts = useMemo(() => {
@@ -751,7 +775,7 @@ export default function AccountsScreen({ embedded }) {
 
   if (error) {
     return (
-      <View style={[styles.container, styles.errorContainer, embedded && styles.containerEmbedded, { backgroundColor: colors.background }]}>
+      <View style={[styles.container, styles.errorContainer, { backgroundColor: colors.background }]}>
         <Text variant="bodyLarge" style={[styles.centeredErrorText, { color: colors.delete }]}>
           {t('error_loading_accounts') || 'Failed to load accounts'}
         </Text>
@@ -760,7 +784,7 @@ export default function AccountsScreen({ embedded }) {
   }
 
   return (
-    <View style={[styles.container, embedded && styles.containerEmbedded, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
       <NestableScrollContainer
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
@@ -816,141 +840,174 @@ export default function AccountsScreen({ embedded }) {
         accessibilityHint={t('add_account_hint') || 'Opens form to create a new account'}
       />
 
-      <ModalShell
-        visible={!!editingId}
-        onDismiss={handleCloseModal}
-        title={editingId === 'new' ? (t('add_account') || 'New Account') : (t('edit_account') || 'Edit Account')}
-        subtitle={editingId !== 'new' && editValues.name ? editValues.name : undefined}
-        onSave={saveEdit}
-        onCancel={handleCloseModal}
-        onDelete={editingId !== 'new' ? handleDeleteEditingAccount : undefined}
-        deleteLabel={t('delete_account') || 'Delete account'}
-        showBlurOverlay
-      >
-        {/* Account name */}
-        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
-          {(t('account_name') || 'Account name').toUpperCase()}
-        </Text>
-        <PaperTextInput
-          mode="outlined"
-          theme={paperInputTheme}
-          value={editValues.name}
-          onChangeText={handleNameChange}
-          error={!!errors.name}
-          autoFocus={editingId === 'new'}
-          returnKeyType="next"
-          onSubmitEditing={() => balanceInputRef.current?.focus()}
-          blurOnSubmit={false}
-          style={modalSharedStyles.textInput}
-        />
-        {errors.name && <Text variant="bodySmall" style={styles.error}>{errors.name}</Text>}
-
-        {/* Balance */}
-        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
-          {(t('balance') || 'Balance').toUpperCase()}
-        </Text>
-        <PaperTextInput
-          ref={balanceInputRef}
-          mode="outlined"
-          theme={paperInputTheme}
-          value={editValues.balance}
-          onChangeText={handleBalanceChange}
-          error={!!errors.balance}
-          keyboardType="numeric"
-          returnKeyType="done"
-          placeholder={(() => {
-            const dec = currencies[editValues.currency]?.decimal_digits ?? 2;
-            return dec === 0 ? '0' : `0.${'0'.repeat(dec)}`;
-          })()}
-          onSubmitEditing={Keyboard.dismiss}
-          style={modalSharedStyles.textInput}
-        />
-        {errors.balance && <Text variant="bodySmall" style={styles.error}>{errors.balance}</Text>}
-
-        {/* Currency selector */}
-        <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
-          {(t('currency') || 'Currency').toUpperCase()}
-        </Text>
-        <TouchableRipple onPress={handleOpenPicker} style={[modalSharedStyles.pickerRow, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-          <View style={modalSharedStyles.pickerRowInner}>
-            <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
-              {editValues.currency
-                ? `${currencies[editValues.currency]?.name} · ${currencies[editValues.currency]?.symbol}`
-                : (t('select_currency') || 'Select currency')}
+      {/* Inline form panel — slides in from the right */}
+      {editingId && (
+        <Animated.View
+          style={[
+            styles.formPanel,
+            {
+              backgroundColor: colors.background,
+              transform: [{ translateX: formPanelTranslateX }],
+              opacity: formPanelOpacity,
+            },
+          ]}
+        >
+          {/* Header */}
+          <View style={[styles.formPanelHeader, { borderBottomColor: colors.border }]}>
+            <TouchableOpacity onPress={handleCloseModal} style={styles.formPanelBack} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+              <Icon name="arrow-left" size={22} color={colors.text} />
+            </TouchableOpacity>
+            <Text style={[styles.formPanelTitle, { color: colors.text }]}>
+              {editingId === 'new' ? (t('add_account') || 'New Account') : (t('edit_account') || 'Edit Account')}
             </Text>
-            <Icon name="chevron-right" size={22} color={colors.mutedText} />
-          </View>
-        </TouchableRipple>
-        {errors.currency && <Text variant="bodySmall" style={styles.error}>{errors.currency}</Text>}
-
-        {/* Settings group */}
-        <View style={[styles.settingsGroup, { borderColor: colors.border, backgroundColor: colors.surface }]}>
-          {editingId !== 'new' && (
-            <View style={[styles.settingItem, styles.settingItemBorder, { borderBottomColor: colors.border }]}>
-              <View style={styles.settingItemText}>
-                <Text style={[styles.settingTitle, { color: colors.text }]}>
-                  {t('create_adjustment_operation') || 'Log adjustment'}
-                </Text>
-                <Text style={[styles.settingHint, { color: colors.mutedText }]}>
-                  {t('create_adjustment_operation_hint') || 'Record balance change as a transaction'}
-                </Text>
-              </View>
-              <Switch
-                value={createAdjustmentOperation}
-                onValueChange={handleToggleAdjustmentSwitch}
-                color={colors.primary}
-              />
-            </View>
-          )}
-          <View style={styles.settingItem}>
-            <View style={styles.settingItemText}>
-              <Text style={[styles.settingTitle, { color: colors.text }]}>
-                {t('hidden_account') || 'Hidden account'}
-              </Text>
-              <Text style={[styles.settingHint, { color: colors.mutedText }]}>
-                {t('hidden_account_hint') || 'Hide from main list and operations'}
-              </Text>
-            </View>
-            <Switch
-              value={!!editValues.hidden}
-              onValueChange={handleToggleHiddenSwitch}
-              color={colors.primary}
-            />
-          </View>
-        </View>
-
-        {/* In-sheet currency picker — slides in from the right */}
-        {currencyPanelVisible && (
-          <Animated.View
-            style={[styles.currencyPanel, { backgroundColor: colors.card, transform: [{ translateX: currencySlideAnim }] }]}
-          >
-            <View style={[styles.currencyPanelHeader, { borderBottomColor: colors.border }]}>
-              <TouchableOpacity onPress={handleClosePicker} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
-                <Icon name="arrow-left" size={22} color={colors.text} />
+            {editingId !== 'new' ? (
+              <TouchableOpacity onPress={handleDeleteEditingAccount} style={styles.formPanelBack} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+                <Icon name="trash-can-outline" size={22} color={colors.delete} />
               </TouchableOpacity>
-              <Text style={[styles.currencyPanelTitle, { color: colors.text }]}>
-                {t('select_currency') || 'Currency'}
-              </Text>
-            </View>
-            <FlatList
-              data={Object.entries(currencies)}
-              keyExtractor={([code]) => code}
-              renderItem={({ item: [code, cur] }) => (
-                <TouchableRipple
-                  onPress={() => handleCurrencySelect(code)}
-                  style={styles.currencyPanelItem}
-                  rippleColor="rgba(0,0,0,0.08)"
-                >
-                  <Text style={[styles.currencyPanelItemText, { color: colors.text }]}>
-                    {cur.name} ({cur.symbol})
-                  </Text>
-                </TouchableRipple>
-              )}
-              ItemSeparatorComponent={() => <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+            ) : (
+              <View style={styles.formPanelBack} />
+            )}
+          </View>
+
+          {/* Form content */}
+          <ScrollView style={styles.formPanelScroll} contentContainerStyle={styles.formPanelScrollContent} keyboardShouldPersistTaps="handled">
+            {/* Account name */}
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('account_name') || 'Account name').toUpperCase()}
+            </Text>
+            <PaperTextInput
+              mode="outlined"
+              theme={paperInputTheme}
+              value={editValues.name}
+              onChangeText={handleNameChange}
+              error={!!errors.name}
+              autoFocus={editingId === 'new'}
+              returnKeyType="next"
+              onSubmitEditing={() => balanceInputRef.current?.focus()}
+              blurOnSubmit={false}
+              style={modalSharedStyles.textInput}
             />
-          </Animated.View>
-        )}
-      </ModalShell>
+            {errors.name && <Text variant="bodySmall" style={styles.error}>{errors.name}</Text>}
+
+            {/* Balance */}
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('balance') || 'Balance').toUpperCase()}
+            </Text>
+            <PaperTextInput
+              ref={balanceInputRef}
+              mode="outlined"
+              theme={paperInputTheme}
+              value={editValues.balance}
+              onChangeText={handleBalanceChange}
+              error={!!errors.balance}
+              keyboardType="numeric"
+              returnKeyType="done"
+              placeholder={(() => {
+                const dec = currencies[editValues.currency]?.decimal_digits ?? 2;
+                return dec === 0 ? '0' : `0.${'0'.repeat(dec)}`;
+              })()}
+              onSubmitEditing={Keyboard.dismiss}
+              style={modalSharedStyles.textInput}
+            />
+            {errors.balance && <Text variant="bodySmall" style={styles.error}>{errors.balance}</Text>}
+
+            {/* Currency selector */}
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('currency') || 'Currency').toUpperCase()}
+            </Text>
+            <TouchableRipple onPress={handleOpenPicker} style={[modalSharedStyles.pickerRow, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+                  {editValues.currency
+                    ? `${currencies[editValues.currency]?.name} · ${currencies[editValues.currency]?.symbol}`
+                    : (t('select_currency') || 'Select currency')}
+                </Text>
+                <Icon name="chevron-right" size={22} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+            {errors.currency && <Text variant="bodySmall" style={styles.error}>{errors.currency}</Text>}
+
+            {/* Settings group */}
+            <View style={[styles.settingsGroup, { borderColor: colors.border, backgroundColor: colors.surface }]}>
+              {editingId !== 'new' && (
+                <View style={[styles.settingItem, styles.settingItemBorder, { borderBottomColor: colors.border }]}>
+                  <View style={styles.settingItemText}>
+                    <Text style={[styles.settingTitle, { color: colors.text }]}>
+                      {t('create_adjustment_operation') || 'Log adjustment'}
+                    </Text>
+                    <Text style={[styles.settingHint, { color: colors.mutedText }]}>
+                      {t('create_adjustment_operation_hint') || 'Record balance change as a transaction'}
+                    </Text>
+                  </View>
+                  <Switch
+                    value={createAdjustmentOperation}
+                    onValueChange={handleToggleAdjustmentSwitch}
+                    color={colors.primary}
+                  />
+                </View>
+              )}
+              <View style={styles.settingItem}>
+                <View style={styles.settingItemText}>
+                  <Text style={[styles.settingTitle, { color: colors.text }]}>
+                    {t('hidden_account') || 'Hidden account'}
+                  </Text>
+                  <Text style={[styles.settingHint, { color: colors.mutedText }]}>
+                    {t('hidden_account_hint') || 'Hide from main list and operations'}
+                  </Text>
+                </View>
+                <Switch
+                  value={!!editValues.hidden}
+                  onValueChange={handleToggleHiddenSwitch}
+                  color={colors.primary}
+                />
+              </View>
+            </View>
+
+            {/* In-panel currency picker — slides in from the right */}
+            {currencyPanelVisible && (
+              <Animated.View
+                style={[styles.currencyPanel, { backgroundColor: colors.card, transform: [{ translateX: currencySlideAnim }] }]}
+              >
+                <View style={[styles.currencyPanelHeader, { borderBottomColor: colors.border }]}>
+                  <TouchableOpacity onPress={handleClosePicker} hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}>
+                    <Icon name="arrow-left" size={22} color={colors.text} />
+                  </TouchableOpacity>
+                  <Text style={[styles.currencyPanelTitle, { color: colors.text }]}>
+                    {t('select_currency') || 'Currency'}
+                  </Text>
+                </View>
+                <FlatList
+                  data={Object.entries(currencies)}
+                  keyExtractor={([code]) => code}
+                  renderItem={({ item: [code, cur] }) => (
+                    <TouchableRipple
+                      onPress={() => handleCurrencySelect(code)}
+                      style={styles.currencyPanelItem}
+                      rippleColor="rgba(0,0,0,0.08)"
+                    >
+                      <Text style={[styles.currencyPanelItemText, { color: colors.text }]}>
+                        {cur.name} ({cur.symbol})
+                      </Text>
+                    </TouchableRipple>
+                  )}
+                  ItemSeparatorComponent={() => <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+                />
+              </Animated.View>
+            )}
+          </ScrollView>
+
+          {/* Footer with Save/Cancel buttons */}
+          <View style={[styles.formPanelFooter, { borderTopColor: colors.border }]}>
+            <TouchableRipple onPress={handleCloseModal} style={[styles.formFooterBtn, { borderColor: colors.border }]}>
+              <Text style={{ color: colors.text }}>{t('cancel') || 'Cancel'}</Text>
+            </TouchableRipple>
+            <TouchableRipple onPress={saveEdit} style={[styles.formFooterBtn, styles.formFooterBtnPrimary, { backgroundColor: colors.primary }]}>
+              <Text style={styles.formFooterBtnPrimaryText}>{t('save') || 'Save'}</Text>
+            </TouchableRipple>
+          </View>
+        </Animated.View>
+      )}
+
       <TransferAccountPickerModal
         visible={transferModalVisible}
         onClose={handleCloseTransferModal}
@@ -1005,13 +1062,9 @@ export default function AccountsScreen({ embedded }) {
   );
 }
 
-AccountsScreen.propTypes = {
-  embedded: PropTypes.bool,
-};
+AccountsScreen.propTypes = {};
 
-AccountsScreen.defaultProps = {
-  embedded: false,
-};
+AccountsScreen.defaultProps = {};
 
 const styles = StyleSheet.create({
   accountBalance: {
@@ -1106,9 +1159,6 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingTop: TOP_CONTENT_SPACING,
   },
-  containerEmbedded: {
-    paddingTop: 0,
-  },
   currencyPanel: {
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
@@ -1153,6 +1203,60 @@ const styles = StyleSheet.create({
   errorContainer: {
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  formFooterBtn: {
+    alignItems: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 44,
+    justifyContent: 'center',
+  },
+  formFooterBtnPrimary: {
+    borderWidth: 0,
+  },
+  formFooterBtnPrimaryText: {
+    color: '#fff',
+  },
+  formPanel: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 10,
+  },
+  formPanelBack: {
+    alignItems: 'center',
+    height: 44,
+    justifyContent: 'center',
+    width: 44,
+  },
+  formPanelFooter: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: 8,
+    padding: 12,
+  },
+  formPanelHeader: {
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    height: 56,
+    paddingHorizontal: 8,
+  },
+  formPanelScroll: {
+    flex: 1,
+  },
+  formPanelScrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  formPanelTitle: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: '600',
+    textAlign: 'center',
   },
   hiddenBalance: {
     backgroundColor: 'rgba(120, 120, 120, 0.25)',

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -1,41 +1,209 @@
-import React, { useState, useMemo, useCallback } from 'react';
-import PropTypes from 'prop-types';
-import { View, StyleSheet, FlatList, TouchableOpacity, Dimensions } from 'react-native';
-import { Text } from 'react-native-paper';
-import LoadingView from '../components/LoadingView';
+import React, { useState, useMemo, useCallback, useRef } from 'react';
+import {
+  View,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  Dimensions,
+  Animated,
+  Easing,
+  Pressable,
+  ScrollView,
+  Keyboard,
+} from 'react-native';
+import { Text, TouchableRipple, TextInput as PaperTextInput } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS } from '../styles/designTokens';
 import AddFAB from '../components/AddFAB';
 import EmptyState from '../components/EmptyState';
+import LoadingView from '../components/LoadingView';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useCategories } from '../contexts/CategoriesContext';
-import CategoryModal from '../modals/CategoryModal';
+import IconPicker from '../components/IconPicker';
+import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
 
-const CategoriesScreen = ({ embedded } = {}) => {
+const DEFAULT_FORM_VALUES = {
+  name: '',
+  type: 'folder',
+  parentId: null,
+  icon: 'folder',
+  category_type: 'expense',
+};
+
+const CategoriesScreen = () => {
   const { colors } = useThemeColors();
+  const { paperInputTheme } = makeModalStyles(colors);
+  const themed = useMemo(() => ({
+    pickerItemText: { color: colors.text, fontSize: 18 },
+    parentText: { color: colors.text, fontSize: 18, marginLeft: 12 },
+    saveButtonText: { color: '#fff' },
+    cancelButtonText: { color: colors.text },
+  }), [colors]);
   const { t } = useLocalization();
   const { showDialog } = useDialog();
-  const { categories, loading, getChildren } = useCategories();
+  const { categories, loading, getChildren, addCategory, updateCategory, deleteCategory, validateCategory } = useCategories();
 
-  const [modalVisible, setModalVisible] = useState(false);
-  const [editingCategory, setEditingCategory] = useState(null);
-  const [isNew, setIsNew] = useState(false);
-
+  // Grid navigation state
   const [gridParentId, setGridParentId] = useState(null);
 
-  const handleAddCategory = () => {
-    setEditingCategory(null);
-    setIsNew(true);
-    setModalVisible(true);
-  };
+  // Form panel state
+  const [activePanel, setActivePanel] = useState(null); // null | 'form'
+  const [formValues, setFormValues] = useState(DEFAULT_FORM_VALUES);
+  const [formErrors, setFormErrors] = useState({});
+  const [formIsNew, setFormIsNew] = useState(true);
+  const [formEditingCategory, setFormEditingCategory] = useState(null);
+  const [iconPickerVisible, setIconPickerVisible] = useState(false);
+  const [activePicker, setActivePicker] = useState(null); // null | 'type' | 'categoryType' | 'parent'
 
-  const handleEditCategory = (category) => {
-    setEditingCategory(category);
-    setIsNew(false);
-    setModalVisible(true);
-  };
+  // Animation refs
+  const listAnim = useRef(new Animated.Value(0)).current;
+  const formAnim = useRef(new Animated.Value(0)).current;
+  const pickerSlideAnim = useRef(new Animated.Value(Dimensions.get('window').width)).current;
+
+  // Interpolations for list layer
+  const listTranslateX = listAnim.interpolate({ inputRange: [0, 1], outputRange: [0, -50] });
+  const listOpacity = listAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 0] });
+
+  // Interpolations for form panel
+  const formTranslateX = formAnim.interpolate({ inputRange: [0, 1], outputRange: [300, 0] });
+  const formOpacity = formAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 1] });
+
+  const openForm = useCallback((category) => {
+    if (category) {
+      setFormValues({
+        ...category,
+        category_type: category.category_type || category.categoryType || 'expense',
+      });
+      setFormIsNew(false);
+      setFormEditingCategory(category);
+    } else {
+      setFormValues(DEFAULT_FORM_VALUES);
+      setFormIsNew(true);
+      setFormEditingCategory(null);
+    }
+    setFormErrors({});
+    setActivePanel('form');
+    Animated.parallel([
+      Animated.timing(listAnim, { toValue: 1, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+      Animated.timing(formAnim, { toValue: 1, duration: 260, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+    ]).start();
+  }, [listAnim, formAnim]);
+
+  const closeForm = useCallback(() => {
+    Keyboard.dismiss();
+    Animated.parallel([
+      Animated.timing(formAnim, { toValue: 0, duration: 180, easing: Easing.in(Easing.quad), useNativeDriver: true }),
+      Animated.timing(listAnim, { toValue: 0, duration: 240, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+    ]).start(() => {
+      setActivePanel(null);
+      setFormErrors({});
+      setActivePicker(null);
+    });
+  }, [listAnim, formAnim]);
+
+  const handleSave = useCallback(() => {
+    const error = validateCategory(formValues, t);
+    if (error) {
+      setFormErrors({ general: error });
+      return;
+    }
+
+    if (formIsNew) {
+      addCategory(formValues);
+    } else {
+      updateCategory(formEditingCategory.id, formValues);
+    }
+
+    closeForm();
+  }, [validateCategory, formValues, formIsNew, addCategory, updateCategory, formEditingCategory, closeForm, t]);
+
+  const handleDelete = useCallback(() => {
+    showDialog(
+      t('delete_category'),
+      t('delete_category_confirm'),
+      [
+        { text: t('cancel'), style: 'cancel' },
+        {
+          text: t('delete'),
+          style: 'destructive',
+          onPress: () => {
+            deleteCategory(formEditingCategory.id);
+            closeForm();
+          },
+        },
+      ],
+    );
+  }, [formEditingCategory, deleteCategory, closeForm, t, showDialog]);
+
+  const handleOpenPicker = useCallback((pickerKey) => {
+    pickerSlideAnim.setValue(Dimensions.get('window').width);
+    setActivePicker(pickerKey);
+    Animated.timing(pickerSlideAnim, {
+      toValue: 0,
+      duration: 220,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [pickerSlideAnim]);
+
+  const handleClosePicker = useCallback(() => {
+    Animated.timing(pickerSlideAnim, {
+      toValue: Dimensions.get('window').width,
+      duration: 180,
+      easing: Easing.in(Easing.quad),
+      useNativeDriver: true,
+    }).start(() => setActivePicker(null));
+  }, [pickerSlideAnim]);
+
+  const potentialParents = useMemo(() => {
+    return categories.filter(c => {
+      const catType = c.category_type || c.categoryType;
+      return catType === formValues.category_type && c.id !== formEditingCategory?.id && !c.isShadow;
+    });
+  }, [categories, formValues.category_type, formEditingCategory]);
+
+  const getParentName = useCallback((parentId) => {
+    if (!parentId) return t('none');
+    const parent = categories.find(c => c.id === parentId);
+    return parent ? (parent.nameKey ? t(parent.nameKey) : parent.name) : t('none');
+  }, [categories, t]);
+
+  const hasChildren = useMemo(() => {
+    if (!formEditingCategory?.id) return false;
+    return categories.some(cat => cat.parentId === formEditingCategory.id);
+  }, [formEditingCategory, categories]);
+
+  const CATEGORY_TYPES = useMemo(() => [
+    { key: 'expense', label: t('expense') },
+    { key: 'income', label: t('income') },
+  ], [t]);
+
+  const TYPE_OPTIONS = useMemo(() => [
+    { key: 'folder', label: t('folder') },
+    { key: 'entry', label: t('entry') },
+  ], [t]);
+
+  const pickerTitle = activePicker === 'type'
+    ? t('select_type')
+    : activePicker === 'categoryType'
+      ? t('category_type')
+      : t('parent_category');
+
+  const gridCategories = useMemo(() => {
+    const visible = categories.filter(c => !c.isShadow);
+    return visible.filter(c => (gridParentId === null ? !c.parentId : c.parentId === gridParentId));
+  }, [categories, gridParentId]);
+
+  const gridParentCategory = useMemo(() => {
+    if (gridParentId === null) return null;
+    return categories.find(c => c.id === gridParentId) || null;
+  }, [categories, gridParentId]);
+
+  const handleEditCategory = useCallback((category) => {
+    openForm(category);
+  }, [openForm]);
 
   const handleCategoryLongPress = useCallback((category) => {
     const categoryName = category.nameKey ? t(category.nameKey) : category.name;
@@ -56,19 +224,9 @@ const CategoriesScreen = ({ embedded } = {}) => {
     );
   }, [t, handleEditCategory, showDialog]);
 
-  const gridCategories = useMemo(() => {
-    const visible = categories.filter(c => !c.isShadow);
-    return visible.filter(c => (gridParentId === null ? !c.parentId : c.parentId === gridParentId));
-  }, [categories, gridParentId]);
-
-  const gridParentCategory = useMemo(() => {
-    if (gridParentId === null) return null;
-    return categories.find(c => c.id === gridParentId) || null;
-  }, [categories, gridParentId]);
-
   const handleGridCellPress = useCallback((category) => {
-    const hasChildren = getChildren(category.id).filter(c => !c.isShadow).length > 0;
-    if (hasChildren) {
+    const hasChildItems = getChildren(category.id).filter(c => !c.isShadow).length > 0;
+    if (hasChildItems) {
       setGridParentId(category.id);
     } else {
       handleEditCategory(category);
@@ -79,7 +237,7 @@ const CategoriesScreen = ({ embedded } = {}) => {
     const categoryType = category.category_type || category.categoryType || 'expense';
     const iconColor = categoryType === 'income' ? colors.income : colors.expense;
     const name = category.nameKey ? t(category.nameKey) : category.name;
-    const hasChildren = getChildren(category.id).filter(c => !c.isShadow).length > 0;
+    const hasChildItems = getChildren(category.id).filter(c => !c.isShadow).length > 0;
 
     return (
       <TouchableOpacity
@@ -94,7 +252,7 @@ const CategoriesScreen = ({ embedded } = {}) => {
         <Text style={[styles.gridCellName, { color: colors.text }]} numberOfLines={2}>
           {name}
         </Text>
-        {hasChildren && (
+        {hasChildItems && (
           <View style={styles.folderBadge}>
             <Icon name="folder-outline" size={12} color={colors.mutedText} accessible={false} />
           </View>
@@ -108,56 +266,302 @@ const CategoriesScreen = ({ embedded } = {}) => {
   }
 
   return (
-    <View style={[styles.container, embedded && styles.containerEmbedded, { backgroundColor: colors.background }]}>
-      {gridParentId !== null && (
-        <View style={[styles.toggleBar, { borderBottomColor: colors.border }]}>
-          <TouchableOpacity
-            onPress={() => setGridParentId(null)}
-            style={styles.backButton}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            accessibilityRole="button"
-            accessibilityLabel="Back to all categories"
-          >
-            <Icon name="chevron-left" size={18} color={colors.primary} />
-            <Text style={[styles.backLabel, { color: colors.primary }]}>
-              {gridParentCategory?.nameKey ? t(gridParentCategory.nameKey) : gridParentCategory?.name}
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      {/* Layer 1: Category list (fades/shifts left when form opens) */}
+      <Animated.View style={[styles.listLayer, { transform: [{ translateX: listTranslateX }], opacity: listOpacity }]}>
+        {gridParentId !== null && (
+          <View style={[styles.toggleBar, { borderBottomColor: colors.border }]}>
+            <TouchableOpacity
+              onPress={() => setGridParentId(null)}
+              style={styles.backButton}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Back to all categories"
+            >
+              <Icon name="chevron-left" size={18} color={colors.primary} />
+              <Text style={[styles.backLabel, { color: colors.primary }]}>
+                {gridParentCategory?.nameKey ? t(gridParentCategory.nameKey) : gridParentCategory?.name}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        <FlatList
+          data={gridCategories}
+          renderItem={renderGridCell}
+          keyExtractor={item => item.id}
+          numColumns={3}
+          columnWrapperStyle={styles.gridRow}
+          ListEmptyComponent={
+            <EmptyState icon="shape-outline" message={t('no_categories')} />
+          }
+          contentContainerStyle={gridCategories.length === 0 ? styles.emptyList : styles.gridContent}
+          windowSize={10}
+          removeClippedSubviews={true}
+        />
+
+        <AddFAB
+          testID="categories-add-fab"
+          onPress={() => openForm(null)}
+          accessibilityLabel={t('add_category')}
+          accessibilityHint={t('add_category_hint') || 'Opens form to create a new category'}
+        />
+      </Animated.View>
+
+      {/* Layer 2: Form panel (slides in from right) */}
+      {activePanel === 'form' && (
+        <Animated.View
+          style={[
+            styles.formPanel,
+            { backgroundColor: colors.background, transform: [{ translateX: formTranslateX }], opacity: formOpacity },
+          ]}
+        >
+          {/* Form header */}
+          <View style={[styles.formPanelHeader, { borderBottomColor: colors.border }]}>
+            <TouchableOpacity onPress={closeForm} style={styles.formPanelBack} accessibilityRole="button" accessibilityLabel="Back">
+              <Icon name="arrow-left" size={24} color={colors.text} />
+            </TouchableOpacity>
+            <Text style={[styles.formPanelTitle, { color: colors.text }]}>
+              {formIsNew ? (t('add_category') || 'New Category') : (t('edit_category') || 'Edit Category')}
             </Text>
-          </TouchableOpacity>
-        </View>
+            {!formIsNew ? (
+              <TouchableOpacity onPress={handleDelete} style={styles.formPanelBack} accessibilityRole="button" accessibilityLabel={t('delete_category')}>
+                <Icon name="trash-can-outline" size={22} color={colors.delete || '#ef4444'} />
+              </TouchableOpacity>
+            ) : (
+              <View style={styles.formPanelBack} />
+            )}
+          </View>
+
+          {/* Form body */}
+          <ScrollView style={styles.formPanelScroll} contentContainerStyle={styles.formPanelScrollContent} keyboardShouldPersistTaps="handled">
+            {/* Name */}
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('category_name') || 'Name').toUpperCase()}
+            </Text>
+            <PaperTextInput
+              mode="outlined"
+              value={formValues.name}
+              onChangeText={text => setFormValues(v => ({ ...v, name: text }))}
+              placeholder={t('category_name')}
+              returnKeyType="done"
+              onSubmitEditing={Keyboard.dismiss}
+              theme={paperInputTheme}
+              style={modalSharedStyles.textInput}
+            />
+
+            {/* Type (Folder / Entry) */}
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('select_type') || 'Type').toUpperCase()}
+            </Text>
+            <TouchableRipple
+              style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+              onPress={() => handleOpenPicker('type')}
+              rippleColor="rgba(0,0,0,0.05)"
+              borderless={false}
+            >
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+                  {TYPE_OPTIONS.find(to => to.key === formValues.type)?.label}
+                </Text>
+                <Icon name="chevron-right" size={22} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+
+            {/* Category Type (Income / Expense) */}
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('category_type') || 'Category Type').toUpperCase()}
+            </Text>
+            <TouchableRipple
+              style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+              onPress={() => handleOpenPicker('categoryType')}
+              rippleColor="rgba(0,0,0,0.05)"
+              borderless={false}
+            >
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+                  {CATEGORY_TYPES.find(ct => ct.key === formValues.category_type)?.label}
+                </Text>
+                <Icon name="chevron-right" size={22} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+
+            {/* Parent Category */}
+            <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
+              {(t('parent_category') || 'Parent').toUpperCase()}
+            </Text>
+            <TouchableRipple
+              style={[modalSharedStyles.pickerRow, { borderColor: colors.border, backgroundColor: colors.card }]}
+              onPress={() => handleOpenPicker('parent')}
+              rippleColor="rgba(0,0,0,0.05)"
+              borderless={false}
+            >
+              <View style={modalSharedStyles.pickerRowInner}>
+                <Text style={[modalSharedStyles.pickerRowValue, { color: colors.text }]}>
+                  {getParentName(formValues.parentId)}
+                </Text>
+                <Icon name="chevron-right" size={22} color={colors.mutedText} />
+              </View>
+            </TouchableRipple>
+
+            {/* Icon picker button */}
+            <Pressable
+              testID="category-icon-picker"
+              style={[styles.iconPickerButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder || colors.border }]}
+              onPress={() => setIconPickerVisible(true)}
+            >
+              <Icon name={formValues.icon || 'folder'} size={32} color={colors.text} />
+              <Text style={[styles.iconPickerText, { color: colors.mutedText }]}>
+                {t('select_icon')}
+              </Text>
+            </Pressable>
+
+            {formErrors.general && (
+              <Text style={styles.errorText}>{formErrors.general}</Text>
+            )}
+          </ScrollView>
+
+          {/* Form footer */}
+          <View style={[styles.formPanelFooter, { borderTopColor: colors.border }]}>
+            <TouchableRipple
+              onPress={closeForm}
+              style={[styles.formFooterBtn, { borderColor: colors.border }]}
+              borderless={false}
+            >
+              <Text style={themed.cancelButtonText}>{t('cancel') || 'Cancel'}</Text>
+            </TouchableRipple>
+            <TouchableRipple
+              onPress={handleSave}
+              style={[styles.formFooterBtn, styles.formFooterBtnPrimary, { backgroundColor: colors.primary }]}
+              borderless={false}
+            >
+              <Text style={themed.saveButtonText}>{t('save') || 'Save'}</Text>
+            </TouchableRipple>
+          </View>
+
+          {/* Inline picker panel — slides in from right within the form */}
+          {activePicker && (
+            <Animated.View
+              style={[
+                styles.pickerPanel,
+                { backgroundColor: colors.card, transform: [{ translateX: pickerSlideAnim }] },
+              ]}
+            >
+              <View style={[styles.pickerPanelHeader, { borderBottomColor: colors.border }]}>
+                <TouchableOpacity
+                  testID="picker-back-button"
+                  onPress={handleClosePicker}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                >
+                  <Icon name="arrow-left" size={22} color={colors.text} />
+                </TouchableOpacity>
+                <Text style={[styles.pickerPanelTitle, { color: colors.text }]}>
+                  {pickerTitle}
+                </Text>
+              </View>
+
+              {activePicker === 'type' && (
+                <FlatList
+                  data={TYPE_OPTIONS}
+                  keyExtractor={item => item.key}
+                  renderItem={({ item }) => {
+                    const isDisabled = !formIsNew && hasChildren && item.key === 'entry';
+                    return (
+                      <Pressable
+                        onPress={() => {
+                          if (isDisabled) {
+                            showDialog(
+                              t('error'),
+                              t('cannot_change_to_entry_with_children') || 'Cannot change to entry type while category has subcategories',
+                              [{ text: t('ok') }],
+                            );
+                            return;
+                          }
+                          setFormValues(v => ({ ...v, type: item.key }));
+                          handleClosePicker();
+                        }}
+                        style={({ pressed }) => [
+                          styles.pickerOption,
+                          { borderColor: colors.border },
+                          pressed && !isDisabled && { backgroundColor: colors.selected },
+                          isDisabled && styles.disabledOption,
+                        ]}
+                      >
+                        <Text style={[themed.pickerItemText, isDisabled && { color: colors.mutedText }]}>
+                          {item.label}{isDisabled && ' ⚠️'}
+                        </Text>
+                      </Pressable>
+                    );
+                  }}
+                />
+              )}
+
+              {activePicker === 'categoryType' && (
+                <FlatList
+                  data={CATEGORY_TYPES}
+                  keyExtractor={item => item.key}
+                  renderItem={({ item }) => (
+                    <Pressable
+                      onPress={() => {
+                        setFormValues(v => ({ ...v, category_type: item.key, parentId: null }));
+                        handleClosePicker();
+                      }}
+                      style={({ pressed }) => [
+                        styles.pickerOption,
+                        { borderColor: colors.border },
+                        pressed && { backgroundColor: colors.selected },
+                      ]}
+                    >
+                      <Text style={themed.pickerItemText}>{item.label}</Text>
+                    </Pressable>
+                  )}
+                />
+              )}
+
+              {activePicker === 'parent' && (
+                <FlatList
+                  data={[{ id: null, name: t('none'), icon: 'folder-outline' }, ...potentialParents]}
+                  keyExtractor={item => item.id || 'none'}
+                  renderItem={({ item }) => (
+                    <Pressable
+                      onPress={() => {
+                        setFormValues(v => ({ ...v, parentId: item.id }));
+                        handleClosePicker();
+                      }}
+                      style={({ pressed }) => [
+                        styles.pickerOption,
+                        { borderColor: colors.border },
+                        pressed && { backgroundColor: colors.selected },
+                      ]}
+                    >
+                      <View style={styles.parentOption}>
+                        <Icon name={item.icon || 'folder'} size={24} color={colors.text} />
+                        <Text style={themed.parentText}>
+                          {item.nameKey ? t(item.nameKey) : item.name}
+                        </Text>
+                      </View>
+                    </Pressable>
+                  )}
+                />
+              )}
+            </Animated.View>
+          )}
+        </Animated.View>
       )}
 
-      <FlatList
-        data={gridCategories}
-        renderItem={renderGridCell}
-        keyExtractor={item => item.id}
-        numColumns={3}
-        columnWrapperStyle={styles.gridRow}
-        ListEmptyComponent={
-          <EmptyState icon="shape-outline" message={t('no_categories')} />
-        }
-        contentContainerStyle={gridCategories.length === 0 ? styles.emptyList : styles.gridContent}
-        windowSize={10}
-        removeClippedSubviews={true}
-      />
-
-      <AddFAB
-        testID="categories-add-fab"
-        onPress={handleAddCategory}
-        accessibilityLabel={t('add_category')}
-        accessibilityHint={t('add_category_hint') || 'Opens form to create a new category'}
-      />
-
-      <CategoryModal
-        visible={modalVisible}
-        onClose={() => setModalVisible(false)}
-        category={editingCategory}
-        isNew={isNew}
+      {/* Icon Picker — rendered outside the form panel so it can cover everything */}
+      <IconPicker
+        visible={iconPickerVisible}
+        onClose={() => setIconPickerVisible(false)}
+        onSelect={(icon) => setFormValues(v => ({ ...v, icon }))}
+        selectedIcon={formValues.icon}
       />
     </View>
   );
 };
 
 const styles = StyleSheet.create({
+  // Grid / list layer
   backButton: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -171,16 +575,74 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingTop: TOP_CONTENT_SPACING,
   },
-  containerEmbedded: {
-    paddingTop: 0,
+  disabledOption: {
+    opacity: 0.5,
   },
   emptyList: {
     flex: 1,
+  },
+  errorText: {
+    color: '#ff6b6b',
+    fontSize: 12,
+    marginBottom: SPACING.sm,
   },
   folderBadge: {
     position: 'absolute',
     right: 4,
     top: 4,
+  },
+  // Form footer buttons
+  formFooterBtn: {
+    alignItems: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+    flex: 1,
+    height: 44,
+    justifyContent: 'center',
+  },
+  formFooterBtnPrimary: {
+    borderWidth: 0,
+  },
+  // Form panel
+  formPanel: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 10,
+  },
+  formPanelBack: {
+    alignItems: 'center',
+    height: 44,
+    justifyContent: 'center',
+    width: 44,
+  },
+  formPanelFooter: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: 8,
+    padding: 12,
+  },
+  formPanelHeader: {
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    height: 56,
+    paddingHorizontal: 8,
+  },
+  formPanelScroll: {
+    flex: 1,
+  },
+  formPanelScrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  formPanelTitle: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: '600',
+    textAlign: 'center',
   },
   gridCell: {
     alignItems: 'center',
@@ -204,6 +666,49 @@ const styles = StyleSheet.create({
   gridRow: {
     justifyContent: 'flex-start',
   },
+  iconPickerButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
+    flexDirection: 'row',
+    marginBottom: SPACING.sm,
+    marginTop: SPACING.sm,
+    padding: SPACING.md,
+  },
+  iconPickerText: {
+    marginLeft: SPACING.md,
+  },
+  listLayer: {
+    flex: 1,
+  },
+  parentOption: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  pickerOption: {
+    borderBottomWidth: 1,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.md,
+  },
+  pickerPanel: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  pickerPanelHeader: {
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    gap: SPACING.md,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+  },
+  pickerPanelTitle: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
   toggleBar: {
     alignItems: 'center',
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -212,13 +717,5 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.sm,
   },
 });
-
-CategoriesScreen.propTypes = {
-  embedded: PropTypes.bool,
-};
-
-CategoriesScreen.defaultProps = {
-  embedded: false,
-};
 
 export default CategoriesScreen;

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -944,7 +944,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
             {activeSubPanel === 'accounts' && (
               <View style={styles.accountsPanelWrapper}>
-                <AccountsScreen embedded />
+                <AccountsScreen />
               </View>
             )}
 

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -950,7 +950,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
             {activeSubPanel === 'categories' && (
               <View style={styles.accountsPanelWrapper}>
-                <CategoriesScreen embedded />
+                <CategoriesScreen />
               </View>
             )}
 


### PR DESCRIPTION
## Summary

- AccountsScreen: replaced `ModalShell` bottom-sheet with an inline animated slide panel for add/edit account form
- CategoriesScreen: replaced `CategoryModal` with inline animated slide panel; ported all form logic (name, type, icon, parent pickers) directly into the screen
- SettingsScreen: removed `embedded` prop from both screen usages

## Problem

When accounts or categories were shown as subpanels inside Settings, editing an entry opened a bottom-sheet modal on top of the slide panel — violating the project's subpanel pattern rule: *never open a new modal for secondary views inside an existing modal*.

## Solution

Both screens now use internal animated panels that slide in from the right, exactly matching the `SettingsScreen` subpanel pattern. No modals are opened. The currency picker within the account form and the field pickers within the category form remain as inline animated panels (already consistent with the pattern).

## Changes

- `app/screens/AccountsScreen.js` — removed `ModalShell`; added `formPanelAnim`, `openFormPanel`, `closeFormPanel`; inline form panel with header/scroll/footer; removed `embedded` prop
- `app/screens/CategoriesScreen.js` — removed `CategoryModal`; added `listAnim`/`formAnim`/`pickerSlideAnim`; ported all form fields and picker logic inline; removed `embedded` prop
- `app/screens/SettingsScreen.js` — removed `embedded` prop from `<AccountsScreen />` and `<CategoriesScreen />`
- `.gitignore` — added `.claude/worktrees/` entry