### PR TITLE
feat: add Android back gesture for subpanels and tab navigation

### DIFF
--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback, useRef, useLayoutEffect, memo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, Dimensions, Platform } from 'react-native';
+import { View, StyleSheet, Dimensions, Platform, BackHandler } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { TouchableRipple, Text } from 'react-native-paper';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
@@ -219,6 +219,18 @@ export default function SimpleTabs() {
     });
     pillPosition.value = withSpring(newIndex, springConfig);
   }, [overlay, translateX, overlayTranslateX, pillPosition, completeOverlayTransition]);
+
+  // Android hardware back button navigates to Operations from any other tab
+  React.useEffect(() => {
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (active !== 'Operations' && !overlay) {
+        handleTabPress('Operations');
+        return true;
+      }
+      return false;
+    });
+    return () => subscription.remove();
+  }, [active, overlay, handleTabPress]);
 
   // Pan gesture for swipe navigation with real-time feedback
   const panGesture = useMemo(() => {

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, Animated, Easing, ScrollView, FlatList, Linking, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, Animated, Easing, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Text, Divider, TouchableRipple } from 'react-native-paper';
@@ -183,6 +183,16 @@ export default function SettingsScreen({ setSubPanelActive }) {
       }),
   [activeSubPanel, closeSubPanel],
   );
+
+  // Android hardware back button closes the active subpanel
+  useEffect(() => {
+    if (!activeSubPanel) return;
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      closeSubPanel();
+      return true;
+    });
+    return () => subscription.remove();
+  }, [activeSubPanel, closeSubPanel]);
 
   const handleLanguageSelect = useCallback((lng) => {
     setLanguage(lng);


### PR DESCRIPTION
## Summary

- **Settings subpanels**: pressing the Android back button (or triggering the back gesture) closes the active subpanel and returns to the settings list — same as the existing right-swipe gesture
- **Non-Operations tabs**: pressing the Android back button on Graphs, Planned, or Settings navigates directly to the Operations tab; no-ops when already on Operations so the OS default (minimize/exit) is preserved
- Right-swipe tab navigation is unchanged

## Test plan

- [ ] Open Settings → tap any row that opens a subpanel (e.g. Language) → press back button → subpanel closes, settings list reappears
- [ ] Navigate to Graphs, Planned, or Settings tab → press back button → app jumps to Operations tab
- [ ] On Operations tab → press back button → default OS behaviour (app minimizes)
- [ ] Verify right-swipe between tabs still works as before

https://claude.ai/code/session_01UGSt5bTLz5GVdZAimnZRuw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGSt5bTLz5GVdZAimnZRuw)_