### PR TITLE
fix(ui): tab bar width/padding tweaks and categories icon fix

### DIFF
--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -294,12 +294,12 @@ export default function SimpleTabs() {
   // transition type (swipe drag, adjacent spring, non-adjacent timing).
   const pillAnimatedStyle = useAnimatedStyle(() => {
     const tabWidth = tabBarWidthShared.value / TABS.length;
-    const pillPadding = 6;
-    const position = pillPosition.value * tabWidth + pillPadding;
+    const barPadding = 15;
+    const position = pillPosition.value * tabWidth + barPadding;
 
     return {
       transform: [{ translateX: position }],
-      width: tabWidth - pillPadding * 2,
+      width: tabWidth,
     };
   });
 
@@ -397,12 +397,14 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   floatingBar: {
+    alignSelf: 'center',
     borderRadius: 28,
     borderWidth: 1,
     marginBottom: 12,
-    marginHorizontal: 16,
     overflow: 'hidden',
+    paddingHorizontal: 15,
     position: 'relative',
+    width: '70%',
     ...Platform.select({
       android: {
         elevation: 8,

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -797,7 +797,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
           <TouchableRipple onPress={() => openSubPanel('categories')} style={styles.settingsRow} testID="settings-categories-row">
             <View style={styles.settingsRowContent}>
               <View style={styles.settingsRowLeft}>
-                <Ionicons name="shape-outline" size={22} color={colors.text} />
+                <Ionicons name="shapes-outline" size={22} color={colors.text} />
                 <View style={styles.settingsRowText}>
                   <Text style={[styles.settingsRowLabel, { color: colors.text }]}>{t('categories') || 'Categories'}</Text>
                   <Text style={[styles.settingsRowValue, { color: colors.mutedText }]}>


### PR DESCRIPTION
## Summary
- Shrink floating tab bar to 70% width, centered, with 15px horizontal padding
- Fix pill indicator position/width to account for bar padding offset
- Fix invalid Ionicons name `shape-outline` → `shapes-outline` for Categories row in Settings

## Test plan
- [ ] Tab bar appears centered at ~70% screen width
- [ ] Active tab pill aligns correctly under each tab
- [ ] Categories icon renders in Settings