### PR TITLE
fix: Move dark/light theme switch to settings screen

### DIFF
--- a/__tests__/components/Header-rightContent.test.js
+++ b/__tests__/components/Header-rightContent.test.js
@@ -4,10 +4,6 @@ import { Text } from 'react-native';
 import Header from '../../app/components/Header';
 
 // Mock contexts
-jest.mock('../../app/contexts/ThemeConfigContext', () => ({
-  useThemeConfig: () => ({ colorScheme: 'light', setTheme: jest.fn() }),
-}));
-
 jest.mock('../../app/contexts/ThemeColorsContext', () => ({
   useThemeColors: () => ({
     colors: {
@@ -37,19 +33,17 @@ jest.mock('../../app/services/db', () => ({
 }));
 
 describe('Header - rightContent prop', () => {
-  it('renders default buttons when rightContent not provided', () => {
-    const { getByTestId } = render(<Header />);
-
-    expect(getByTestId('theme-toggle-button')).toBeTruthy();
+  it('renders without crashing when rightContent not provided', () => {
+    const { toJSON } = render(<Header />);
+    expect(toJSON()).toBeTruthy();
   });
 
-  it('renders rightContent instead of default buttons when provided', () => {
+  it('renders rightContent when provided', () => {
     const customContent = <Text testID="custom-content">Custom</Text>;
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId } = render(
       <Header rightContent={customContent} />,
     );
 
     expect(getByTestId('custom-content')).toBeTruthy();
-    expect(queryByTestId('theme-toggle-button')).toBeNull();
   });
 });

--- a/__tests__/components/Header.test.js
+++ b/__tests__/components/Header.test.js
@@ -7,16 +7,6 @@ import { render, fireEvent } from '@testing-library/react-native';
 import Header from '../../app/components/Header';
 
 // Mock contexts
-const mockSetTheme = jest.fn();
-let mockColorScheme = 'light';
-
-jest.mock('../../app/contexts/ThemeConfigContext', () => ({
-  useThemeConfig: () => ({
-    colorScheme: mockColorScheme,
-    setTheme: mockSetTheme,
-  }),
-}));
-
 jest.mock('../../app/contexts/ThemeColorsContext', () => ({
   useThemeColors: () => ({
     colors: {
@@ -92,28 +82,9 @@ describe('Header', () => {
       expect(queryByText(/DB v/)).toBeNull();
     });
 
-    it('renders theme toggle icon (sunny for light mode)', () => {
-      const { getByTestId } = render(<Header />);
-      expect(getByTestId('icon-sunny')).toBeTruthy();
-    });
-  });
-
-  describe('Theme toggle', () => {
-    it('calls setTheme with dark when in light mode', () => {
-      const { getByLabelText } = render(<Header />);
-
-      const themeButton = getByLabelText('Switch to dark theme');
-      fireEvent.press(themeButton);
-
-      expect(mockSetTheme).toHaveBeenCalledWith('dark');
-    });
-
-    it('has correct accessibility properties for light mode', () => {
-      const { getByLabelText } = render(<Header />);
-
-      const themeButton = getByLabelText('Switch to dark theme');
-      expect(themeButton.props.accessibilityRole).toBe('button');
-      expect(themeButton.props.accessibilityHint).toBe('Toggles between light and dark theme');
+    it('does not render theme toggle button in header', () => {
+      const { queryByTestId } = render(<Header />);
+      expect(queryByTestId('theme-toggle-button')).toBeNull();
     });
   });
 
@@ -161,33 +132,4 @@ describe('Header', () => {
     });
   });
 
-  describe('Dark theme mode', () => {
-    beforeEach(() => {
-      mockColorScheme = 'dark';
-    });
-
-    afterEach(() => {
-      mockColorScheme = 'light';
-    });
-
-    it('shows moon icon in dark mode', () => {
-      const { getByTestId } = render(<Header />);
-      expect(getByTestId('icon-moon')).toBeTruthy();
-    });
-
-    it('has correct accessibility label for dark mode', () => {
-      const { getByLabelText } = render(<Header />);
-      const themeButton = getByLabelText('Switch to light theme');
-      expect(themeButton).toBeTruthy();
-    });
-
-    it('calls setTheme with light when in dark mode', () => {
-      const { getByLabelText } = render(<Header />);
-
-      const themeButton = getByLabelText('Switch to light theme');
-      fireEvent.press(themeButton);
-
-      expect(mockSetTheme).toHaveBeenCalledWith('light');
-    });
-  });
 });

--- a/__tests__/integration/HeaderSearchIntegration.test.js
+++ b/__tests__/integration/HeaderSearchIntegration.test.js
@@ -12,13 +12,6 @@ jest.mock('../../app/contexts/SearchContext', () => ({
 jest.mock('../../app/contexts/OperationsDataContext');
 jest.mock('../../app/contexts/OperationsActionsContext');
 
-jest.mock('../../app/contexts/ThemeConfigContext', () => ({
-  useThemeConfig: () => ({
-    colorScheme: 'light',
-    setTheme: jest.fn(),
-  }),
-}));
-
 jest.mock('../../app/contexts/ThemeColorsContext', () => ({
   useThemeColors: () => ({
     colors: {
@@ -313,21 +306,19 @@ describe('Header Search Integration', () => {
   });
 
   describe('Integration with Other Header Buttons', () => {
-    it('shows search button alongside theme toggle button', () => {
+    it('shows search button in operations header', () => {
       const { getByTestId } = render(
         <Header activeScreen="Operations" />,
       );
       expect(getByTestId('search-button')).toBeTruthy();
-      expect(getByTestId('theme-toggle-button')).toBeTruthy();
     });
 
-    it('search button remains functional alongside theme toggle', () => {
+    it('search button is functional', () => {
       const { getByTestId } = render(
         <Header activeScreen="Operations" />,
       );
 
       fireEvent.press(getByTestId('search-button'));
-      fireEvent.press(getByTestId('theme-toggle-button'));
 
       expect(mockOpenSearch).toHaveBeenCalledTimes(1);
     });

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -3,7 +3,6 @@ import { useEffect, useCallback, useRef } from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import SearchBar from './search/SearchBar';
 import PropTypes from 'prop-types';
-import { useThemeConfig } from '../contexts/ThemeConfigContext';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -16,7 +15,6 @@ import { useOperationsActions } from '../contexts/OperationsActionsContext';
 
 export default function Header({ rightContent, activeScreen, operationsData }) {
   console.debug('[Header] Rendering - activeScreen:', activeScreen, ', operationsData exists:', !!operationsData);
-  const { colorScheme, setTheme } = useThemeConfig();
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { isDownloading, downloadProgress, downloadPhase } = useUpdateDownload();
@@ -73,11 +71,6 @@ export default function Header({ rightContent, activeScreen, operationsData }) {
     };
     updateSearchFilters(clearValues[groupKey]);
   }, [updateSearchFilters]);
-
-  const toggleTheme = () => {
-    const newTheme = colorScheme === 'dark' ? 'light' : 'dark';
-    setTheme(newTheme);
-  };
 
   return (
     <View
@@ -187,21 +180,6 @@ export default function Header({ rightContent, activeScreen, operationsData }) {
                   )}
                 </View>
               )}
-              <TouchableOpacity
-                onPress={toggleTheme}
-                testID="theme-toggle-button"
-                accessibilityLabel={colorScheme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-                accessibilityRole="button"
-                accessibilityHint="Toggles between light and dark theme"
-                style={styles.themeButton}
-                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              >
-                <Ionicons
-                  name={colorScheme === 'dark' ? 'moon' : 'sunny'}
-                  size={24}
-                  color={colors.text}
-                />
-              </TouchableOpacity>
             </>
           )}
         </View>
@@ -253,8 +231,5 @@ const styles = StyleSheet.create({
   },
   searchButtonContainer: {
     position: 'relative',
-  },
-  themeButton: {
-    padding: 8,
   },
 });

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -9,6 +9,7 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { runOnJS } from 'react-native-reanimated';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { useThemeConfig } from '../contexts/ThemeConfigContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
@@ -56,6 +57,7 @@ const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 export default function SettingsScreen({ setSubPanelActive }) {
   const insets = useSafeAreaInsets();
   const { colors } = useThemeColors();
+  const { colorScheme, setTheme } = useThemeConfig();
   const { t, language, setLanguage, availableLanguages } = useLocalization();
   const { hideBalances, setHideBalances } = useDisplaySettings();
   const { showDialog } = useDialog();
@@ -98,6 +100,20 @@ export default function SettingsScreen({ setSubPanelActive }) {
       bounciness: 4,
     }).start();
   }, [hideBalances, toggleAnim]);
+
+  const themeToggleAnim = useRef(new Animated.Value(colorScheme === 'dark' ? 1 : 0)).current;
+  useEffect(() => {
+    Animated.spring(themeToggleAnim, {
+      toValue: colorScheme === 'dark' ? 1 : 0,
+      useNativeDriver: true,
+      speed: 20,
+      bounciness: 4,
+    }).start();
+  }, [colorScheme, themeToggleAnim]);
+
+  const handleToggleDarkMode = useCallback(() => {
+    setTheme(colorScheme === 'dark' ? 'light' : 'dark');
+  }, [colorScheme, setTheme]);
 
   const { entries, clearLogs, getExportText } = useLogEntries(logFilter);
 
@@ -787,6 +803,25 @@ export default function SettingsScreen({ setSubPanelActive }) {
               <View style={[styles.switchTrack, { backgroundColor: hideBalances ? colors.primary : colors.border }]}>
                 <Animated.View style={[styles.switchThumb, {
                   transform: [{ translateX: toggleAnim.interpolate({ inputRange: [0, 1], outputRange: [2, 22] }) }],
+                }]} />
+              </View>
+            </View>
+          </TouchableRipple>
+
+          <TouchableRipple onPress={handleToggleDarkMode} style={styles.settingsRow} testID="settings-theme-row">
+            <View style={styles.settingsRowContent}>
+              <View style={styles.settingsRowLeft}>
+                <Ionicons name={colorScheme === 'dark' ? 'moon-outline' : 'sunny-outline'} size={22} color={colors.text} />
+                <View style={styles.settingsRowText}>
+                  <Text style={[styles.settingsRowLabel, { color: colors.text }]}>{t('theme') || 'Theme'}</Text>
+                  <Text style={[styles.settingsRowValue, { color: colors.mutedText }]}>
+                    {colorScheme === 'dark' ? 'Dark' : 'Light'}
+                  </Text>
+                </View>
+              </View>
+              <View style={[styles.switchTrack, { backgroundColor: colorScheme === 'dark' ? colors.primary : colors.border }]}>
+                <Animated.View style={[styles.switchThumb, {
+                  transform: [{ translateX: themeToggleAnim.interpolate({ inputRange: [0, 1], outputRange: [2, 22] }) }],
                 }]} />
               </View>
             </View>


### PR DESCRIPTION
## Summary

- Removes the theme toggle button (moon/sunny icon) from the Header component
- Adds a "Theme" toggle row to SettingsScreen, grouped with Hide Balances under display settings
- Uses the same animated switch style as the existing Hide Balances toggle
- Icon updates dynamically (moon-outline for dark, sunny-outline for light)

## Test plan

- [ ] Open settings and verify a "Theme" row appears below "Hide balances"
- [ ] Tap the toggle — app switches between light and dark mode
- [ ] Verify the switch animates and the icon updates to match the current mode
- [ ] Verify the theme toggle button is no longer visible in the header

https://claude.ai/code/session_01CXUBuM4v6bkemvTQHPNBKu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXUBuM4v6bkemvTQHPNBKu)_