### PR TITLE
fix: scrollToOffset TypeError on search close

### DIFF
--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, forwardRef } from 'react';
+import React, { useMemo, useCallback, forwardRef, useRef, useImperativeHandle } from 'react';
 import { View, Text, StyleSheet, SectionList, ActivityIndicator } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
@@ -219,9 +219,29 @@ const OperationsList = forwardRef(({
 
   const keyExtractor = useCallback((item) => item.id, []);
 
+  const sectionListRef = useRef(null);
+
+  // Expose FlatList-compatible scroll methods so OperationsScreen can call
+  // scrollToOffset/scrollToIndex without knowing the underlying list type.
+  useImperativeHandle(ref, () => ({
+    scrollToOffset: ({ offset, animated }) => {
+      sectionListRef.current?.getScrollResponder()?.scrollTo({ y: offset, animated });
+    },
+    scrollToIndex: ({ index, animated, viewPosition }) => {
+      if (!sectionListRef.current || index < 0 || index >= sections.length) return;
+      if (!sections[index] || sections[index].data.length === 0) return;
+      sectionListRef.current.scrollToLocation({
+        sectionIndex: index,
+        itemIndex: 0,
+        animated: animated ?? false,
+        viewPosition: viewPosition ?? 0,
+      });
+    },
+  }), [sections]);
+
   return (
     <SectionList
-      ref={ref}
+      ref={sectionListRef}
       contentInsetAdjustmentBehavior="automatic"
       sections={sections}
       renderItem={renderItem}


### PR DESCRIPTION
## Summary

- `OperationsList` uses `SectionList` but forwarded the raw ref to `OperationsScreen`, which called FlatList-only methods (`scrollToOffset`, `scrollToIndex`) on it
- `SectionList` has no `scrollToOffset`, so optional-chaining resolved to `undefined` and the subsequent call threw `TypeError: flatListRef.current?.scrollToOffset is not a function (it is undefined)` whenever search was closed
- Added `useImperativeHandle` in `OperationsList` to expose FlatList-compatible scroll methods that delegate to `SectionList` equivalents:
  - `scrollToOffset` → `getScrollResponder().scrollTo()`
  - `scrollToIndex` → `scrollToLocation()` (since `groupedOperations` maps 1:1 to sections, the flat index equals the section index)

## Test plan

- [ ] Open the app and trigger a search (tap search icon)
- [ ] Close the search — confirm no TypeError in logs and the list scrolls to top smoothly
- [ ] Use the date picker to jump to a date — confirm it scrolls to that date's section without crashing
- [ ] All 3510 Jest tests pass

https://claude.ai/code/session_01VieWoyPkMujqRYfxLmEgdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VieWoyPkMujqRYfxLmEgdu)_