### PR TITLE
fix(tabs): smooth non-adjacent tab transitions and settings subpanel touch

### DIFF
--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, useLayoutEffect, memo } from 'react';
+import React, { useMemo, useCallback, useRef, memo } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, Dimensions, Platform, BackHandler } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -102,27 +102,6 @@ TabButton.defaultProps = {
   onPress: () => {},
 };
 
-/**
- * Renders the correct screen for a given tab key.
- * Used by the overlay during non-adjacent tab transitions.
- */
-const ScreenContent = memo(({ tabKey, setSubPanelActive }) => {
-  switch (tabKey) {
-  case 'Operations': return <OperationsScreen />;
-  case 'Graphs': return <GraphsScreen />;
-  case 'Planned': return <PlannedOperationsScreen />;
-  case 'Settings': return <SettingsScreen setSubPanelActive={setSubPanelActive} />;
-  default: return null;
-  }
-});
-
-ScreenContent.displayName = 'ScreenContent';
-
-ScreenContent.propTypes = {
-  tabKey: PropTypes.string.isRequired,
-  setSubPanelActive: PropTypes.func.isRequired,
-};
-
 export default function SimpleTabs() {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
@@ -131,24 +110,12 @@ export default function SimpleTabs() {
   const [subPanelActive, setSubPanelActive] = React.useState(false);
   const [tabBarWidth, setTabBarWidth] = React.useState(SCREEN_WIDTH);
 
-  // overlayContent: which screen to render inside the always-mounted overlay View.
-  // The overlay View itself is always in the tree so its position can be driven
-  // by overlayTranslateX (a shared value) immediately on the worklet thread —
-  // no React render cycle needed before animations can start.
-  const [overlayContent, setOverlayContent] = React.useState(null); // string | null
   // Guard ref — updated synchronously so handleTabPress never reads stale state.
   const isTransitioningRef = useRef(false);
-  // Shared value mirror of isTransitioningRef — readable on the worklet thread
-  // inside panGesture callbacks without making overlayContent a useMemo dep
-  // (which would reinstall the native gesture recognizer mid-animation).
+  // Shared value mirror — readable on the worklet thread inside panGesture
+  // callbacks without making any React state a useMemo dep (which would
+  // reinstall the native gesture recognizer mid-animation and cause jitter).
   const isTransitioningShared = useSharedValue(false);
-  // Stores animation params for the pending non-adjacent transition.
-  // handleTabPress writes here; useLayoutEffect reads and fires the actual
-  // slide AFTER ScreenContent has been committed to the native layer — so the
-  // overlay is never blank when it enters the viewport.
-  const pendingTransitionRef = useRef(null);
-  // Start far offscreen so the always-mounted empty View is never visible at rest.
-  const overlayTranslateX = useSharedValue(2 * SCREEN_WIDTH);
 
   const TABS = useMemo(() => [
     { key: 'Operations', label: t('operations') || 'Operations' },
@@ -163,86 +130,74 @@ export default function SimpleTabs() {
   const startTranslateX = useSharedValue(0);
   const tabBarWidthShared = useSharedValue(SCREEN_WIDTH);
   // Dedicated pill position — animated independently so it works for swipe,
-  // adjacent spring, and overlay timing transitions.
+  // adjacent, and non-adjacent transitions.
   const pillPosition = useSharedValue(0);
 
-  // NOTE: there is intentionally NO useEffect driving translateX from `active`.
-  // That pattern caused the useEffect to clobber ongoing spring animations.
-  // translateX is set exclusively by: handleTabPress, swipe onEnd, and
-  // completeOverlayTransition.
+  // Per-screen horizontal offset for non-adjacent transitions.
+  // During a non-adjacent tap A→D we instantly reposition the target screen to
+  // be adjacent to the source (worklet thread, no React render), animate the
+  // strip exactly 1 screen width (same as adjacent), then snap strip to the
+  // real resting position and zero the offset — both on the worklet thread so
+  // there is no visible jump. All 4 screens stay pre-mounted; no overlay needed.
+  const screenAdjust0 = useSharedValue(0);
+  const screenAdjust1 = useSharedValue(0);
+  const screenAdjust2 = useSharedValue(0);
+  const screenAdjust3 = useSharedValue(0);
 
-  // Finalize an overlay transition: snap strip to new position, update React
-  // state, and remove the overlay in the same render cycle.
-  // NOTE: translateX is already snapped on the worklet thread before this
-  // runs, so there is no visual flash from removing the overlay synchronously.
-  // The previous requestAnimationFrame deferral created a 1-2 frame window
-  // where active had updated but overlay was still set, causing handleTabPress
-  // to ignore taps during that window.
-  // Snap strip to final position and hide overlay when slide-in completes.
-  const completeOverlayTransition = useCallback((tabKey) => {
-    console.log(`[DBG:tabs] completeOverlayTransition tabKey=${tabKey} ts=${Date.now()}`);
-    const newIndex = TABS.findIndex(tab => tab.key === tabKey);
-    translateX.value = -newIndex * SCREEN_WIDTH; // snap strip to resting position
-    overlayTranslateX.value = 2 * SCREEN_WIDTH;  // hide overlay instantly
-    isTransitioningShared.value = false;
+  const screenAdjustedStyle0 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust0.value }] }));
+  const screenAdjustedStyle1 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust1.value }] }));
+  const screenAdjustedStyle2 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust2.value }] }));
+  const screenAdjustedStyle3 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust3.value }] }));
+
+  // Called on JS thread when a non-adjacent transition finishes.
+  const clearTransitioningRef = useCallback(() => {
     isTransitioningRef.current = false;
-    setOverlayContent(null);
-  }, [TABS, translateX, overlayTranslateX, isTransitioningShared]);
-
-  // Fire the slide animation only after ScreenContent has been committed to the
-  // native layer — useLayoutEffect runs synchronously after React commit, so by
-  // the time this executes the overlay's views exist and the first animation
-  // frame will show content, not a blank background.
-  useLayoutEffect(() => {
-    if (!overlayContent || !pendingTransitionRef.current) return;
-    const { stripExit, direction, tabKey } = pendingTransitionRef.current;
-    pendingTransitionRef.current = null;
-    overlayTranslateX.value = direction * SCREEN_WIDTH; // snap to starting edge
-    translateX.value = withTiming(stripExit, SCREEN_TIMING);
-    overlayTranslateX.value = withTiming(0, SCREEN_TIMING, () => {
-      'worklet';
-      runOnJS(completeOverlayTransition)(tabKey);
-    });
-  }, [overlayContent, overlayTranslateX, translateX, completeOverlayTransition]);
+  }, []);
 
   const handleTabPress = useCallback((tabKey) => {
-    console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} transitioning=${isTransitioningRef.current} ts=${Date.now()}`);
-    if (isTransitioningRef.current) {
-      console.log('[DBG:tabs] handleTabPress IGNORED — transition in progress');
-      return;
-    }
+    if (isTransitioningRef.current) return;
     const newIndex = TABS.findIndex(tab => tab.key === tabKey);
     const oldIndex = TABS.findIndex(tab => tab.key === active);
     if (newIndex === -1 || newIndex === oldIndex) return;
 
     const distance = Math.abs(newIndex - oldIndex);
 
+    setActive(tabKey);
+    activeIndex.value = newIndex;
+    pillPosition.value = withTiming(newIndex, PILL_TIMING);
+
     if (distance === 1) {
-      setActive(tabKey);
-      activeIndex.value = newIndex;
-      pillPosition.value = withTiming(newIndex, PILL_TIMING);
       translateX.value = withTiming(-newIndex * SCREEN_WIDTH, SCREEN_TIMING);
       return;
     }
 
     // ---- Non-adjacent tab ----
-    // Mount target content in the overlay while it is still parked far offscreen
-    // (overlayTranslateX = 2*SCREEN_WIDTH). useLayoutEffect fires synchronously
-    // after React commits ScreenContent to the native layer, then starts the
-    // slide — so the overlay is never blank when it enters the viewport.
+    // Reposition the target screen to sit immediately adjacent to the source
+    // on the worklet thread (zero React overhead). The strip then animates
+    // exactly 1 screen width — identical feel to adjacent. On completion the
+    // strip snaps to the real resting position and the per-screen offset is
+    // zeroed simultaneously, both on the worklet thread — no visual jump.
     const direction = newIndex > oldIndex ? 1 : -1;
-    const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
+    // How far to shift the target so it appears one screen width past the source.
+    const adjacentOffset = (oldIndex + direction - newIndex) * SCREEN_WIDTH;
+    const adjSharedValues = [screenAdjust0, screenAdjust1, screenAdjust2, screenAdjust3];
+    const targetAdjust = adjSharedValues[newIndex];
 
     isTransitioningShared.value = true;
     isTransitioningRef.current = true;
-    setActive(tabKey);
-    activeIndex.value = newIndex;
-    pillPosition.value = withTiming(newIndex, PILL_TIMING);
 
-    // Store params for useLayoutEffect to consume after mount.
-    pendingTransitionRef.current = { stripExit, direction, tabKey };
-    setOverlayContent(tabKey);
-  }, [TABS, active, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition, isTransitioningShared]);
+    targetAdjust.value = adjacentOffset; // instant reposition on worklet thread
+    translateX.value = withTiming(-(oldIndex + direction) * SCREEN_WIDTH, SCREEN_TIMING, (finished) => {
+      'worklet';
+      if (!finished) return;
+      // Snap strip and zero offset simultaneously — no React render, no flash.
+      translateX.value = -newIndex * SCREEN_WIDTH;
+      targetAdjust.value = 0;
+      isTransitioningShared.value = false;
+      runOnJS(clearTransitioningRef)();
+    });
+  }, [TABS, active, activeIndex, translateX, pillPosition, isTransitioningShared,
+    screenAdjust0, screenAdjust1, screenAdjust2, screenAdjust3, clearTransitioningRef]);
 
   // Android hardware back button navigates to Operations from any other tab
   React.useEffect(() => {
@@ -257,9 +212,9 @@ export default function SimpleTabs() {
   }, [active, handleTabPress]);
 
   // Pan gesture for swipe navigation with real-time feedback.
-  // isTransitioningShared (not overlayContent) guards against swipe during overlay
-  // transitions — avoids making overlayContent a dep which would reinstall the
-  // native gesture recognizer mid-animation and cause jitter.
+  // isTransitioningShared guards against swipe during non-adjacent transitions
+  // without being a useMemo dep — avoids reinstalling the native gesture
+  // recognizer mid-animation which causes jitter.
   const panGesture = useMemo(() => {
     return Gesture.Pan()
       .enabled(!subPanelActive)
@@ -277,7 +232,6 @@ export default function SimpleTabs() {
         const maxTranslateX = 0;
         const minTranslateX = -(TABS.length - 1) * SCREEN_WIDTH;
         translateX.value = Math.max(minTranslateX, Math.min(maxTranslateX, newTranslateX));
-        // Keep pill tracking the drag
         pillPosition.value = -translateX.value / SCREEN_WIDTH;
       })
       .onEnd((event) => {
@@ -298,9 +252,8 @@ export default function SimpleTabs() {
 
         if (newIndex !== currentIndex) {
           activeIndex.value = newIndex;
-          const target = -newIndex * SCREEN_WIDTH;
           pillPosition.value = withTiming(newIndex, PILL_TIMING);
-          translateX.value = withTiming(target, SCREEN_TIMING, (isFinished) => {
+          translateX.value = withTiming(-newIndex * SCREEN_WIDTH, SCREEN_TIMING, (isFinished) => {
             if (isFinished) {
               runOnJS(setActive)(TABS[newIndex].key);
             }
@@ -316,23 +269,16 @@ export default function SimpleTabs() {
     transform: [{ translateX: translateX.value }],
   }));
 
-  const overlayAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: overlayTranslateX.value }],
-  }));
-
   const handleTabBarLayout = useCallback((event) => {
     const { width } = event.nativeEvent.layout;
     setTabBarWidth(width);
     tabBarWidthShared.value = width;
   }, [tabBarWidthShared]);
 
-  // Pill indicator — driven by pillPosition which is animated for every
-  // transition type (swipe drag, adjacent spring, non-adjacent timing).
   const pillAnimatedStyle = useAnimatedStyle(() => {
     const tabWidth = tabBarWidthShared.value / TABS.length;
     const barPadding = 15;
     const position = pillPosition.value * tabWidth + barPadding;
-
     return {
       transform: [{ translateX: position }],
       width: tabWidth,
@@ -342,23 +288,22 @@ export default function SimpleTabs() {
   const renderScreens = useCallback(() => {
     return (
       <>
-        <View style={styles.screen}>
+        <Animated.View style={[styles.screen, screenAdjustedStyle0]}>
           <OperationsScreen />
-        </View>
-        <View style={styles.screen}>
+        </Animated.View>
+        <Animated.View style={[styles.screen, screenAdjustedStyle1]}>
           <GraphsScreen />
-        </View>
-        <View style={styles.screen}>
+        </Animated.View>
+        <Animated.View style={[styles.screen, screenAdjustedStyle2]}>
           <PlannedOperationsScreen />
-        </View>
-        <View style={styles.screen}>
+        </Animated.View>
+        <Animated.View style={[styles.screen, screenAdjustedStyle3]}>
           <SettingsScreen setSubPanelActive={setSubPanelActive} />
-        </View>
+        </Animated.View>
       </>
     );
-  }, [setSubPanelActive]);
+  }, [setSubPanelActive, screenAdjustedStyle0, screenAdjustedStyle1, screenAdjustedStyle2, screenAdjustedStyle3]);
 
-  // active is set immediately on tap so it's always the correct displayed tab.
   const displayedTab = active;
 
   return (
@@ -370,19 +315,6 @@ export default function SimpleTabs() {
             {renderScreens()}
           </Animated.View>
         </GestureDetector>
-
-        {/* Overlay for non-adjacent tab transitions — always mounted so its
-            position can be driven by overlayTranslateX immediately on the
-            worklet thread (no React render delay before animation starts).
-            Content loads asynchronously inside the already-moving view. */}
-        <Animated.View
-          style={[styles.overlayScreen, { backgroundColor: colors.background }, overlayAnimatedStyle]}
-          pointerEvents={overlayContent ? 'auto' : 'none'}
-        >
-          {overlayContent && (
-            <ScreenContent tabKey={overlayContent} setSubPanelActive={setSubPanelActive} />
-          )}
-        </Animated.View>
       </View>
       {/* Floating bar overlays content so screen shows through behind it */}
       <SafeAreaView edges={['bottom']} style={styles.floatingBarWrapper} pointerEvents="box-none">
@@ -465,13 +397,6 @@ const styles = StyleSheet.create({
     left: 0,
     position: 'absolute',
     right: 0,
-  },
-  overlayScreen: {
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
   },
   screen: {
     height: '100%',

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -137,6 +137,11 @@ export default function SimpleTabs() {
   // opposite direction — like two adjacent screens. No intermediate screens
   // are ever visible because the overlay fully covers them.
   const [overlay, setOverlay] = React.useState(null); // { key: string } | null
+  // Ref mirror of overlay — always current, avoids stale closure in handleTabPress.
+  // React state updates are async; reading overlay inside a useCallback reads
+  // the value captured at creation time. The ref is updated synchronously
+  // alongside every setOverlay call so handleTabPress never sees stale state.
+  const overlayRef = useRef(null);
   const overlayTranslateX = useSharedValue(SCREEN_WIDTH);
 
   const TABS = useMemo(() => [
@@ -172,15 +177,16 @@ export default function SimpleTabs() {
     const newIndex = TABS.findIndex(tab => tab.key === tabKey);
     translateX.value = -newIndex * SCREEN_WIDTH;
     activeIndex.value = newIndex;
+    overlayRef.current = null; // clear ref immediately — handleTabPress reads this
     setActive(tabKey);
-    console.log(`[DBG:tabs] overlay clearing synchronously (no RAF) ts=${Date.now()}`);
+    console.log(`[DBG:tabs] overlay clearing synchronously ts=${Date.now()}`);
     setOverlay(null);
   }, [TABS, translateX, activeIndex]);
 
   const handleTabPress = useCallback((tabKey) => {
-    console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} overlay=${overlay ? overlay.key : 'null'} ts=${Date.now()}`);
-    if (overlay) {
-      console.log(`[DBG:tabs] handleTabPress IGNORED — overlay still active (${overlay.key})`);
+    console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} overlayRef=${overlayRef.current ? overlayRef.current.key : 'null'} ts=${Date.now()}`);
+    if (overlayRef.current) {
+      console.log(`[DBG:tabs] handleTabPress IGNORED — overlayRef active (${overlayRef.current.key})`);
       return; // ignore during an active overlay transition
     }
     const newIndex = TABS.findIndex(tab => tab.key === tabKey);
@@ -210,8 +216,9 @@ export default function SimpleTabs() {
     //    useLayoutEffect fires after React commits the overlay View.
     overlayTranslateX.value = direction * SCREEN_WIDTH;
     pendingOverlayRef.current = { oldIndex, newIndex, direction, tabKey };
+    overlayRef.current = { key: tabKey }; // set ref immediately alongside state
     setOverlay({ key: tabKey });
-  }, [TABS, active, overlay, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition]);
+  }, [TABS, active, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition]);
 
   // Start overlay animations after React has committed the overlay mount.
   useLayoutEffect(() => {

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -163,17 +163,23 @@ export default function SimpleTabs() {
   // Finalize an overlay transition: snap strip to new position, update React
   // state, then remove the overlay on the next frame so the strip takes over.
   const completeOverlayTransition = useCallback((tabKey) => {
+    console.log(`[DBG:tabs] completeOverlayTransition tabKey=${tabKey} ts=${Date.now()}`);
     const newIndex = TABS.findIndex(tab => tab.key === tabKey);
     translateX.value = -newIndex * SCREEN_WIDTH;
     activeIndex.value = newIndex;
     setActive(tabKey);
     requestAnimationFrame(() => {
+      console.log(`[DBG:tabs] overlay RAF clearing overlay ts=${Date.now()}`);
       setOverlay(null);
     });
   }, [TABS, translateX, activeIndex]);
 
   const handleTabPress = useCallback((tabKey) => {
-    if (overlay) return; // ignore during an active overlay transition
+    console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} overlay=${overlay ? overlay.key : 'null'} ts=${Date.now()}`);
+    if (overlay) {
+      console.log(`[DBG:tabs] handleTabPress IGNORED — overlay still active (${overlay.key})`);
+      return; // ignore during an active overlay transition
+    }
     const newIndex = TABS.findIndex(tab => tab.key === tabKey);
     const oldIndex = TABS.findIndex(tab => tab.key === active);
     if (newIndex === -1 || newIndex === oldIndex) return;
@@ -210,11 +216,14 @@ export default function SimpleTabs() {
     const { oldIndex, newIndex, direction, tabKey } = pendingOverlayRef.current;
     pendingOverlayRef.current = null;
 
+    console.log(`[DBG:tabs] useLayoutEffect starting overlay anim tabKey=${tabKey} oldIndex=${oldIndex} newIndex=${newIndex} direction=${direction} ts=${Date.now()}`);
+
     const springConfig = { damping: 40, stiffness: 150 };
     const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
 
     translateX.value = withSpring(stripExit, springConfig);
     overlayTranslateX.value = withSpring(0, springConfig, () => {
+      'worklet';
       runOnJS(completeOverlayTransition)(tabKey);
     });
     pillPosition.value = withSpring(newIndex, springConfig);

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -226,10 +226,8 @@ export default function SimpleTabs() {
       runOnJS(completeOverlayTransition)(tabKey);
     });
 
-    // Render content inside the overlay. startTransition marks this as low-priority
-    // so React spreads the mount work across frames instead of blocking the UI thread
-    // in one synchronous chunk — keeps the animation smooth on Fabric/new arch.
-    React.startTransition(() => { setOverlayContent(tabKey); });
+    // Render content inside the overlay (React async — already animating by now).
+    setOverlayContent(tabKey);
   }, [TABS, active, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition, isTransitioningShared]);
 
   // Android hardware back button navigates to Operations from any other tab

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, memo } from 'react';
+import React, { useMemo, useCallback, useRef, useLayoutEffect, memo } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, Dimensions, Platform, BackHandler } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -142,6 +142,11 @@ export default function SimpleTabs() {
   // inside panGesture callbacks without making overlayContent a useMemo dep
   // (which would reinstall the native gesture recognizer mid-animation).
   const isTransitioningShared = useSharedValue(false);
+  // Stores animation params for the pending non-adjacent transition.
+  // handleTabPress writes here; useLayoutEffect reads and fires the actual
+  // slide AFTER ScreenContent has been committed to the native layer — so the
+  // overlay is never blank when it enters the viewport.
+  const pendingTransitionRef = useRef(null);
   // Start far offscreen so the always-mounted empty View is never visible at rest.
   const overlayTranslateX = useSharedValue(2 * SCREEN_WIDTH);
 
@@ -184,6 +189,22 @@ export default function SimpleTabs() {
     setOverlayContent(null);
   }, [TABS, translateX, overlayTranslateX, isTransitioningShared]);
 
+  // Fire the slide animation only after ScreenContent has been committed to the
+  // native layer — useLayoutEffect runs synchronously after React commit, so by
+  // the time this executes the overlay's views exist and the first animation
+  // frame will show content, not a blank background.
+  useLayoutEffect(() => {
+    if (!overlayContent || !pendingTransitionRef.current) return;
+    const { stripExit, direction, tabKey } = pendingTransitionRef.current;
+    pendingTransitionRef.current = null;
+    overlayTranslateX.value = direction * SCREEN_WIDTH; // snap to starting edge
+    translateX.value = withTiming(stripExit, SCREEN_TIMING);
+    overlayTranslateX.value = withTiming(0, SCREEN_TIMING, () => {
+      'worklet';
+      runOnJS(completeOverlayTransition)(tabKey);
+    });
+  }, [overlayContent, overlayTranslateX, translateX, completeOverlayTransition]);
+
   const handleTabPress = useCallback((tabKey) => {
     console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} transitioning=${isTransitioningRef.current} ts=${Date.now()}`);
     if (isTransitioningRef.current) {
@@ -205,10 +226,10 @@ export default function SimpleTabs() {
     }
 
     // ---- Non-adjacent tab ----
-    // Strip slides out (1 screen width). Overlay (target screen) slides in from
-    // the opposite side. Both start immediately on the worklet thread — no React
-    // render cycle delay. ScreenContent mounts inside the already-moving overlay
-    // a frame or two later; the overlay's background covers the strip until then.
+    // Mount target content in the overlay while it is still parked far offscreen
+    // (overlayTranslateX = 2*SCREEN_WIDTH). useLayoutEffect fires synchronously
+    // after React commits ScreenContent to the native layer, then starts the
+    // slide — so the overlay is never blank when it enters the viewport.
     const direction = newIndex > oldIndex ? 1 : -1;
     const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
 
@@ -218,15 +239,8 @@ export default function SimpleTabs() {
     activeIndex.value = newIndex;
     pillPosition.value = withTiming(newIndex, PILL_TIMING);
 
-    // Snap overlay to starting edge, then animate both simultaneously.
-    overlayTranslateX.value = direction * SCREEN_WIDTH;
-    translateX.value = withTiming(stripExit, SCREEN_TIMING);
-    overlayTranslateX.value = withTiming(0, SCREEN_TIMING, () => {
-      'worklet';
-      runOnJS(completeOverlayTransition)(tabKey);
-    });
-
-    // Render content inside the overlay (React async — already animating by now).
+    // Store params for useLayoutEffect to consume after mount.
+    pendingTransitionRef.current = { stripExit, direction, tabKey };
     setOverlayContent(tabKey);
   }, [TABS, active, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition, isTransitioningShared]);
 

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -7,9 +7,13 @@ import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
-  withSpring,
+  withTiming,
+  Easing,
   runOnJS,
 } from 'react-native-reanimated';
+
+const SCREEN_TIMING = { duration: 300, easing: Easing.out(Easing.cubic) };
+const PILL_TIMING = { duration: 200, easing: Easing.out(Easing.quad) };
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import OperationsScreen from '../screens/OperationsScreen';
 import GraphsScreen from '../screens/GraphsScreen';
@@ -199,11 +203,8 @@ export default function SimpleTabs() {
       // Adjacent tab — animate the strip with a spring (no intermediates possible)
       setActive(tabKey);
       activeIndex.value = newIndex;
-      pillPosition.value = withSpring(newIndex, { damping: 40, stiffness: 150 });
-      translateX.value = withSpring(-newIndex * SCREEN_WIDTH, {
-        damping: 40,
-        stiffness: 150,
-      });
+      pillPosition.value = withTiming(newIndex, PILL_TIMING);
+      translateX.value = withTiming(-newIndex * SCREEN_WIDTH, SCREEN_TIMING);
       return;
     }
 
@@ -228,15 +229,14 @@ export default function SimpleTabs() {
 
     console.log(`[DBG:tabs] useLayoutEffect starting overlay anim tabKey=${tabKey} oldIndex=${oldIndex} newIndex=${newIndex} direction=${direction} ts=${Date.now()}`);
 
-    const springConfig = { damping: 40, stiffness: 150 };
     const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
 
-    translateX.value = withSpring(stripExit, springConfig);
-    overlayTranslateX.value = withSpring(0, springConfig, () => {
+    translateX.value = withTiming(stripExit, SCREEN_TIMING);
+    overlayTranslateX.value = withTiming(0, SCREEN_TIMING, () => {
       'worklet';
       runOnJS(completeOverlayTransition)(tabKey);
     });
-    pillPosition.value = withSpring(newIndex, springConfig);
+    pillPosition.value = withTiming(newIndex, PILL_TIMING);
   }, [overlay, translateX, overlayTranslateX, pillPosition, completeOverlayTransition]);
 
   // Android hardware back button navigates to Operations from any other tab
@@ -288,21 +288,15 @@ export default function SimpleTabs() {
         if (newIndex !== currentIndex) {
           activeIndex.value = newIndex;
           const target = -newIndex * SCREEN_WIDTH;
-          pillPosition.value = withSpring(newIndex, { damping: 40, stiffness: 150 });
-          translateX.value = withSpring(target, {
-            damping: 40,
-            stiffness: 150,
-          }, (isFinished) => {
+          pillPosition.value = withTiming(newIndex, PILL_TIMING);
+          translateX.value = withTiming(target, SCREEN_TIMING, (isFinished) => {
             if (isFinished) {
               runOnJS(setActive)(TABS[newIndex].key);
             }
           });
         } else {
-          pillPosition.value = withSpring(currentIndex, { damping: 40, stiffness: 150 });
-          translateX.value = withSpring(-currentIndex * SCREEN_WIDTH, {
-            damping: 40,
-            stiffness: 150,
-          });
+          pillPosition.value = withTiming(currentIndex, PILL_TIMING);
+          translateX.value = withTiming(-currentIndex * SCREEN_WIDTH, SCREEN_TIMING);
         }
       });
   }, [translateX, activeIndex, startTranslateX, TABS, setActive, subPanelActive, overlay, pillPosition]);

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -161,17 +161,20 @@ export default function SimpleTabs() {
   // completeOverlayTransition.
 
   // Finalize an overlay transition: snap strip to new position, update React
-  // state, then remove the overlay on the next frame so the strip takes over.
+  // state, and remove the overlay in the same render cycle.
+  // NOTE: translateX is already snapped on the worklet thread before this
+  // runs, so there is no visual flash from removing the overlay synchronously.
+  // The previous requestAnimationFrame deferral created a 1-2 frame window
+  // where active had updated but overlay was still set, causing handleTabPress
+  // to ignore taps during that window.
   const completeOverlayTransition = useCallback((tabKey) => {
     console.log(`[DBG:tabs] completeOverlayTransition tabKey=${tabKey} ts=${Date.now()}`);
     const newIndex = TABS.findIndex(tab => tab.key === tabKey);
     translateX.value = -newIndex * SCREEN_WIDTH;
     activeIndex.value = newIndex;
     setActive(tabKey);
-    requestAnimationFrame(() => {
-      console.log(`[DBG:tabs] overlay RAF clearing overlay ts=${Date.now()}`);
-      setOverlay(null);
-    });
+    console.log(`[DBG:tabs] overlay clearing synchronously (no RAF) ts=${Date.now()}`);
+    setOverlay(null);
   }, [TABS, translateX, activeIndex]);
 
   const handleTabPress = useCallback((tabKey) => {

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -209,35 +209,39 @@ export default function SimpleTabs() {
     }
 
     // ---- Non-adjacent tab ----
-    // Telegram-style: current screen slides out, target screen slides in,
-    // both moving at the same speed like two adjacent screens.
+    // Telegram-style: current screen slides out, target screen slides in.
+    // Strip animation starts immediately (worklet thread — zero React delay).
+    // Overlay mounts async; its slide-in starts in useLayoutEffect once
+    // React has committed the View. The strip is already moving by then so
+    // the user perceives no freeze.
     const direction = newIndex > oldIndex ? 1 : -1; // +1 = target is to the right
+    const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
 
-    // 1) Position overlay offscreen, store animation params, and mount.
-    //    useLayoutEffect fires after React commits the overlay View.
+    // Start strip and pill animations immediately — no React render involved.
+    translateX.value = withTiming(stripExit, SCREEN_TIMING);
+    pillPosition.value = withTiming(newIndex, PILL_TIMING);
+
+    // Mount overlay offscreen; useLayoutEffect slides it in.
     overlayTranslateX.value = direction * SCREEN_WIDTH;
-    pendingOverlayRef.current = { oldIndex, newIndex, direction, tabKey };
-    overlayRef.current = { key: tabKey }; // set ref immediately alongside state
+    pendingOverlayRef.current = { tabKey };
+    overlayRef.current = { key: tabKey };
     setOverlay({ key: tabKey });
   }, [TABS, active, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition]);
 
-  // Start overlay animations after React has committed the overlay mount.
+  // Slide the overlay in after React has committed its mount.
+  // Strip is already animating by the time this fires.
   useLayoutEffect(() => {
     if (!overlay || !pendingOverlayRef.current) return;
-    const { oldIndex, newIndex, direction, tabKey } = pendingOverlayRef.current;
+    const { tabKey } = pendingOverlayRef.current;
     pendingOverlayRef.current = null;
 
-    console.log(`[DBG:tabs] useLayoutEffect starting overlay anim tabKey=${tabKey} oldIndex=${oldIndex} newIndex=${newIndex} direction=${direction} ts=${Date.now()}`);
+    console.log(`[DBG:tabs] useLayoutEffect sliding overlay in tabKey=${tabKey} ts=${Date.now()}`);
 
-    const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
-
-    translateX.value = withTiming(stripExit, SCREEN_TIMING);
     overlayTranslateX.value = withTiming(0, SCREEN_TIMING, () => {
       'worklet';
       runOnJS(completeOverlayTransition)(tabKey);
     });
-    pillPosition.value = withTiming(newIndex, PILL_TIMING);
-  }, [overlay, translateX, overlayTranslateX, pillPosition, completeOverlayTransition]);
+  }, [overlay, overlayTranslateX, completeOverlayTransition]);
 
   // Android hardware back button navigates to Operations from any other tab
   React.useEffect(() => {

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -178,14 +178,11 @@ export default function SimpleTabs() {
   // to ignore taps during that window.
   const completeOverlayTransition = useCallback((tabKey) => {
     console.log(`[DBG:tabs] completeOverlayTransition tabKey=${tabKey} ts=${Date.now()}`);
-    const newIndex = TABS.findIndex(tab => tab.key === tabKey);
-    translateX.value = -newIndex * SCREEN_WIDTH;
-    activeIndex.value = newIndex;
-    overlayRef.current = null; // clear ref immediately — handleTabPress reads this
-    setActive(tabKey);
-    console.log(`[DBG:tabs] overlay clearing synchronously ts=${Date.now()}`);
+    // translateX and setActive were set instantly in handleTabPress —
+    // nothing to snap or update here, just tear down the overlay.
+    overlayRef.current = null;
     setOverlay(null);
-  }, [TABS, translateX, activeIndex]);
+  }, []);
 
   const handleTabPress = useCallback((tabKey) => {
     console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} overlayRef=${overlayRef.current ? overlayRef.current.key : 'null'} ts=${Date.now()}`);
@@ -209,16 +206,14 @@ export default function SimpleTabs() {
     }
 
     // ---- Non-adjacent tab ----
-    // Telegram-style: current screen slides out, target screen slides in.
-    // Strip animation starts immediately (worklet thread — zero React delay).
-    // Overlay mounts async; its slide-in starts in useLayoutEffect once
-    // React has committed the View. The strip is already moving by then so
-    // the user perceives no freeze.
+    // Snap strip to target instantly so intermediate screens are never visible.
+    // The overlay (target screen) starts offscreen and slides in to give the
+    // transition its animation — the strip behind it is already in position.
     const direction = newIndex > oldIndex ? 1 : -1; // +1 = target is to the right
-    const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
 
-    // Start strip and pill animations immediately — no React render involved.
-    translateX.value = withTiming(stripExit, SCREEN_TIMING);
+    translateX.value = -newIndex * SCREEN_WIDTH; // instant snap — no intermediate screens
+    activeIndex.value = newIndex;
+    setActive(tabKey);
     pillPosition.value = withTiming(newIndex, PILL_TIMING);
 
     // Mount overlay offscreen; useLayoutEffect slides it in.

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, useLayoutEffect, memo } from 'react';
+import React, { useMemo, useCallback, useRef, memo } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, Dimensions, Platform, BackHandler } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -131,22 +131,19 @@ export default function SimpleTabs() {
   const [subPanelActive, setSubPanelActive] = React.useState(false);
   const [tabBarWidth, setTabBarWidth] = React.useState(SCREEN_WIDTH);
 
-  // Ref holding pending overlay animation params — consumed by useLayoutEffect
-  // after React commits the overlay mount, guaranteeing the View exists.
-  const pendingOverlayRef = useRef(null);
-
-  // Overlay state for non-adjacent tab press transitions.
-  // An overlay renders the target screen on top of the strip and slides in
-  // while the strip simultaneously slides the current screen out in the
-  // opposite direction — like two adjacent screens. No intermediate screens
-  // are ever visible because the overlay fully covers them.
-  const [overlay, setOverlay] = React.useState(null); // { key: string } | null
-  // Ref mirror of overlay — always current, avoids stale closure in handleTabPress.
-  // React state updates are async; reading overlay inside a useCallback reads
-  // the value captured at creation time. The ref is updated synchronously
-  // alongside every setOverlay call so handleTabPress never sees stale state.
-  const overlayRef = useRef(null);
-  const overlayTranslateX = useSharedValue(SCREEN_WIDTH);
+  // overlayContent: which screen to render inside the always-mounted overlay View.
+  // The overlay View itself is always in the tree so its position can be driven
+  // by overlayTranslateX (a shared value) immediately on the worklet thread —
+  // no React render cycle needed before animations can start.
+  const [overlayContent, setOverlayContent] = React.useState(null); // string | null
+  // Guard ref — updated synchronously so handleTabPress never reads stale state.
+  const isTransitioningRef = useRef(false);
+  // Shared value mirror of isTransitioningRef — readable on the worklet thread
+  // inside panGesture callbacks without making overlayContent a useMemo dep
+  // (which would reinstall the native gesture recognizer mid-animation).
+  const isTransitioningShared = useSharedValue(false);
+  // Start far offscreen so the always-mounted empty View is never visible at rest.
+  const overlayTranslateX = useSharedValue(2 * SCREEN_WIDTH);
 
   const TABS = useMemo(() => [
     { key: 'Operations', label: t('operations') || 'Operations' },
@@ -176,19 +173,22 @@ export default function SimpleTabs() {
   // The previous requestAnimationFrame deferral created a 1-2 frame window
   // where active had updated but overlay was still set, causing handleTabPress
   // to ignore taps during that window.
+  // Snap strip to final position and hide overlay when slide-in completes.
   const completeOverlayTransition = useCallback((tabKey) => {
     console.log(`[DBG:tabs] completeOverlayTransition tabKey=${tabKey} ts=${Date.now()}`);
-    // translateX and setActive were set instantly in handleTabPress —
-    // nothing to snap or update here, just tear down the overlay.
-    overlayRef.current = null;
-    setOverlay(null);
-  }, []);
+    const newIndex = TABS.findIndex(tab => tab.key === tabKey);
+    translateX.value = -newIndex * SCREEN_WIDTH; // snap strip to resting position
+    overlayTranslateX.value = 2 * SCREEN_WIDTH;  // hide overlay instantly
+    isTransitioningShared.value = false;
+    isTransitioningRef.current = false;
+    setOverlayContent(null);
+  }, [TABS, translateX, overlayTranslateX, isTransitioningShared]);
 
   const handleTabPress = useCallback((tabKey) => {
-    console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} overlayRef=${overlayRef.current ? overlayRef.current.key : 'null'} ts=${Date.now()}`);
-    if (overlayRef.current) {
-      console.log(`[DBG:tabs] handleTabPress IGNORED — overlayRef active (${overlayRef.current.key})`);
-      return; // ignore during an active overlay transition
+    console.log(`[DBG:tabs] handleTabPress tabKey=${tabKey} active=${active} transitioning=${isTransitioningRef.current} ts=${Date.now()}`);
+    if (isTransitioningRef.current) {
+      console.log('[DBG:tabs] handleTabPress IGNORED — transition in progress');
+      return;
     }
     const newIndex = TABS.findIndex(tab => tab.key === tabKey);
     const oldIndex = TABS.findIndex(tab => tab.key === active);
@@ -197,7 +197,6 @@ export default function SimpleTabs() {
     const distance = Math.abs(newIndex - oldIndex);
 
     if (distance === 1) {
-      // Adjacent tab — animate the strip with a spring (no intermediates possible)
       setActive(tabKey);
       activeIndex.value = newIndex;
       pillPosition.value = withTiming(newIndex, PILL_TIMING);
@@ -206,62 +205,62 @@ export default function SimpleTabs() {
     }
 
     // ---- Non-adjacent tab ----
-    // Snap strip to target instantly so intermediate screens are never visible.
-    // The overlay (target screen) starts offscreen and slides in to give the
-    // transition its animation — the strip behind it is already in position.
-    const direction = newIndex > oldIndex ? 1 : -1; // +1 = target is to the right
+    // Strip slides out (1 screen width). Overlay (target screen) slides in from
+    // the opposite side. Both start immediately on the worklet thread — no React
+    // render cycle delay. ScreenContent mounts inside the already-moving overlay
+    // a frame or two later; the overlay's background covers the strip until then.
+    const direction = newIndex > oldIndex ? 1 : -1;
+    const stripExit = (-oldIndex * SCREEN_WIDTH) - direction * SCREEN_WIDTH;
 
-    translateX.value = -newIndex * SCREEN_WIDTH; // instant snap — no intermediate screens
-    activeIndex.value = newIndex;
+    isTransitioningShared.value = true;
+    isTransitioningRef.current = true;
     setActive(tabKey);
+    activeIndex.value = newIndex;
     pillPosition.value = withTiming(newIndex, PILL_TIMING);
 
-    // Mount overlay offscreen; useLayoutEffect slides it in.
+    // Snap overlay to starting edge, then animate both simultaneously.
     overlayTranslateX.value = direction * SCREEN_WIDTH;
-    pendingOverlayRef.current = { tabKey };
-    overlayRef.current = { key: tabKey };
-    setOverlay({ key: tabKey });
-  }, [TABS, active, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition]);
-
-  // Slide the overlay in after React has committed its mount.
-  // Strip is already animating by the time this fires.
-  useLayoutEffect(() => {
-    if (!overlay || !pendingOverlayRef.current) return;
-    const { tabKey } = pendingOverlayRef.current;
-    pendingOverlayRef.current = null;
-
-    console.log(`[DBG:tabs] useLayoutEffect sliding overlay in tabKey=${tabKey} ts=${Date.now()}`);
-
+    translateX.value = withTiming(stripExit, SCREEN_TIMING);
     overlayTranslateX.value = withTiming(0, SCREEN_TIMING, () => {
       'worklet';
       runOnJS(completeOverlayTransition)(tabKey);
     });
-  }, [overlay, overlayTranslateX, completeOverlayTransition]);
+
+    // Render content inside the overlay. startTransition marks this as low-priority
+    // so React spreads the mount work across frames instead of blocking the UI thread
+    // in one synchronous chunk — keeps the animation smooth on Fabric/new arch.
+    React.startTransition(() => { setOverlayContent(tabKey); });
+  }, [TABS, active, activeIndex, translateX, overlayTranslateX, pillPosition, completeOverlayTransition, isTransitioningShared]);
 
   // Android hardware back button navigates to Operations from any other tab
   React.useEffect(() => {
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
-      if (active !== 'Operations' && !overlay) {
+      if (active !== 'Operations' && !isTransitioningRef.current) {
         handleTabPress('Operations');
         return true;
       }
       return false;
     });
     return () => subscription.remove();
-  }, [active, overlay, handleTabPress]);
+  }, [active, handleTabPress]);
 
-  // Pan gesture for swipe navigation with real-time feedback
+  // Pan gesture for swipe navigation with real-time feedback.
+  // isTransitioningShared (not overlayContent) guards against swipe during overlay
+  // transitions — avoids making overlayContent a dep which would reinstall the
+  // native gesture recognizer mid-animation and cause jitter.
   const panGesture = useMemo(() => {
     return Gesture.Pan()
-      .enabled(!subPanelActive && !overlay)
+      .enabled(!subPanelActive)
       .activeOffsetX([-10, 10])
       .failOffsetY([-10, 10])
       .onStart(() => {
         'worklet';
+        if (isTransitioningShared.value) return;
         startTranslateX.value = translateX.value;
       })
       .onUpdate((event) => {
         'worklet';
+        if (isTransitioningShared.value) return;
         const newTranslateX = startTranslateX.value + event.translationX;
         const maxTranslateX = 0;
         const minTranslateX = -(TABS.length - 1) * SCREEN_WIDTH;
@@ -271,6 +270,7 @@ export default function SimpleTabs() {
       })
       .onEnd((event) => {
         'worklet';
+        if (isTransitioningShared.value) return;
         const { translationX: gestureTranslationX, velocityX } = event;
         const SWIPE_THRESHOLD = 50;
         const VELOCITY_THRESHOLD = 500;
@@ -298,7 +298,7 @@ export default function SimpleTabs() {
           translateX.value = withTiming(-currentIndex * SCREEN_WIDTH, SCREEN_TIMING);
         }
       });
-  }, [translateX, activeIndex, startTranslateX, TABS, setActive, subPanelActive, overlay, pillPosition]);
+  }, [translateX, activeIndex, startTranslateX, TABS, setActive, subPanelActive, pillPosition, isTransitioningShared]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],
@@ -346,8 +346,8 @@ export default function SimpleTabs() {
     );
   }, [setSubPanelActive]);
 
-  // Determine which tab key is visually active (for header + tab highlight)
-  const displayedTab = overlay ? overlay.key : active;
+  // active is set immediately on tap so it's always the correct displayed tab.
+  const displayedTab = active;
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={['top', 'left', 'right']}>
@@ -359,15 +359,18 @@ export default function SimpleTabs() {
           </Animated.View>
         </GestureDetector>
 
-        {/* Overlay for non-adjacent tab press — slides the target screen in
-            on top of the strip while the strip slides the current screen out
-            in the opposite direction. The overlay fully covers any
-            intermediate screens that would otherwise flash through. */}
-        {overlay && (
-          <Animated.View style={[styles.overlayScreen, { backgroundColor: colors.background }, overlayAnimatedStyle]}>
-            <ScreenContent tabKey={overlay.key} setSubPanelActive={setSubPanelActive} />
-          </Animated.View>
-        )}
+        {/* Overlay for non-adjacent tab transitions — always mounted so its
+            position can be driven by overlayTranslateX immediately on the
+            worklet thread (no React render delay before animation starts).
+            Content loads asynchronously inside the already-moving view. */}
+        <Animated.View
+          style={[styles.overlayScreen, { backgroundColor: colors.background }, overlayAnimatedStyle]}
+          pointerEvents={overlayContent ? 'auto' : 'none'}
+        >
+          {overlayContent && (
+            <ScreenContent tabKey={overlayContent} setSubPanelActive={setSubPanelActive} />
+          )}
+        </Animated.View>
       </View>
       {/* Floating bar overlays content so screen shows through behind it */}
       <SafeAreaView edges={['bottom']} style={styles.floatingBarWrapper} pointerEvents="box-none">

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -143,11 +143,17 @@ export default function SimpleTabs() {
   const screenAdjust1 = useSharedValue(0);
   const screenAdjust2 = useSharedValue(0);
   const screenAdjust3 = useSharedValue(0);
+  // Opacity per screen — intermediates are zeroed during non-adjacent transitions
+  // so they don't bleed through when the target overlaps their strip position.
+  const screenOpacity0 = useSharedValue(1);
+  const screenOpacity1 = useSharedValue(1);
+  const screenOpacity2 = useSharedValue(1);
+  const screenOpacity3 = useSharedValue(1);
 
-  const screenAdjustedStyle0 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust0.value }] }));
-  const screenAdjustedStyle1 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust1.value }] }));
-  const screenAdjustedStyle2 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust2.value }] }));
-  const screenAdjustedStyle3 = useAnimatedStyle(() => ({ transform: [{ translateX: screenAdjust3.value }] }));
+  const screenAdjustedStyle0 = useAnimatedStyle(() => ({ opacity: screenOpacity0.value, transform: [{ translateX: screenAdjust0.value }] }));
+  const screenAdjustedStyle1 = useAnimatedStyle(() => ({ opacity: screenOpacity1.value, transform: [{ translateX: screenAdjust1.value }] }));
+  const screenAdjustedStyle2 = useAnimatedStyle(() => ({ opacity: screenOpacity2.value, transform: [{ translateX: screenAdjust2.value }] }));
+  const screenAdjustedStyle3 = useAnimatedStyle(() => ({ opacity: screenOpacity3.value, transform: [{ translateX: screenAdjust3.value }] }));
 
   // Called on JS thread when a non-adjacent transition finishes.
   const clearTransitioningRef = useCallback(() => {
@@ -181,23 +187,36 @@ export default function SimpleTabs() {
     // How far to shift the target so it appears one screen width past the source.
     const adjacentOffset = (oldIndex + direction - newIndex) * SCREEN_WIDTH;
     const adjSharedValues = [screenAdjust0, screenAdjust1, screenAdjust2, screenAdjust3];
+    const opacityValues = [screenOpacity0, screenOpacity1, screenOpacity2, screenOpacity3];
     const targetAdjust = adjSharedValues[newIndex];
 
     isTransitioningShared.value = true;
     isTransitioningRef.current = true;
 
+    // Hide intermediate screens so they don't bleed through when the repositioned
+    // target overlaps their strip position (all worklet-thread, no React render).
+    for (let i = 0; i < 4; i++) {
+      if (i !== oldIndex && i !== newIndex) opacityValues[i].value = 0;
+    }
+
     targetAdjust.value = adjacentOffset; // instant reposition on worklet thread
     translateX.value = withTiming(-(oldIndex + direction) * SCREEN_WIDTH, SCREEN_TIMING, (finished) => {
       'worklet';
       if (!finished) return;
-      // Snap strip and zero offset simultaneously — no React render, no flash.
+      // Snap strip, zero offset, restore opacities — all on worklet thread, no flash.
       translateX.value = -newIndex * SCREEN_WIDTH;
       targetAdjust.value = 0;
+      opacityValues[0].value = 1;
+      opacityValues[1].value = 1;
+      opacityValues[2].value = 1;
+      opacityValues[3].value = 1;
       isTransitioningShared.value = false;
       runOnJS(clearTransitioningRef)();
     });
   }, [TABS, active, activeIndex, translateX, pillPosition, isTransitioningShared,
-    screenAdjust0, screenAdjust1, screenAdjust2, screenAdjust3, clearTransitioningRef]);
+    screenAdjust0, screenAdjust1, screenAdjust2, screenAdjust3,
+    screenOpacity0, screenOpacity1, screenOpacity2, screenOpacity3,
+    clearTransitioningRef]);
 
   // Android hardware back button navigates to Operations from any other tab
   React.useEffect(() => {

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -128,6 +128,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
   }, [hideBalances, setHideBalances, t, showDialog]);
 
   const openSubPanel = useCallback((panel) => {
+    console.log(`[DBG:settings] openSubPanel panel=${panel} ts=${Date.now()}`);
     if (panel === 'import') {
       setImportStep('source');
       setImportSelectedBackup(null);
@@ -140,14 +141,18 @@ export default function SettingsScreen({ setSubPanelActive }) {
     Animated.parallel([
       Animated.timing(settingsAnim, { toValue: 1, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true }),
       Animated.timing(subPanelAnim, { toValue: 1, duration: 260, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
-    ]).start();
+    ]).start(() => {
+      console.log(`[DBG:settings] openSubPanel anim complete panel=${panel} ts=${Date.now()}`);
+    });
   }, [settingsAnim, subPanelAnim, loadStoredBackups]);
 
   const closeSubPanel = useCallback(() => {
+    console.log(`[DBG:settings] closeSubPanel called ts=${Date.now()}`);
     Animated.parallel([
       Animated.timing(subPanelAnim, { toValue: 0, duration: 180, easing: Easing.in(Easing.quad), useNativeDriver: true }),
       Animated.timing(settingsAnim, { toValue: 0, duration: 240, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
     ]).start(() => {
+      console.log(`[DBG:settings] closeSubPanel anim complete ts=${Date.now()}`);
       setActiveSubPanel(null);
       setUpdateResult(null);
       setImportStep('source');
@@ -166,8 +171,14 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
   // Signal parent SimpleTabs when a subpanel is open so it can disable tab swiping
   useEffect(() => {
+    console.log(`[DBG:settings] activeSubPanel changed → ${activeSubPanel} ts=${Date.now()}`);
     setSubPanelActive(activeSubPanel !== null);
   }, [activeSubPanel, setSubPanelActive]);
+
+  // Debug helper called from the swipe worklet via runOnJS
+  const logSwipeGesture = useCallback((tx, vx, triggered) => {
+    console.log(`[DBG:settings] swipeBack onEnd tx=${tx.toFixed(1)} vx=${vx.toFixed(1)} triggered=${triggered} panel=${activeSubPanel} ts=${Date.now()}`);
+  }, [activeSubPanel]);
 
   // Swipe right to close the active subpanel (mirrors Android back gesture)
   const swipeBackGesture = useMemo(() =>
@@ -177,11 +188,13 @@ export default function SettingsScreen({ setSubPanelActive }) {
       .failOffsetY([-15, 15])
       .onEnd((event) => {
         'worklet';
-        if (event.translationX > 50 || event.velocityX > 500) {
+        const triggered = event.translationX > 50 || event.velocityX > 500;
+        runOnJS(logSwipeGesture)(event.translationX, event.velocityX, triggered);
+        if (triggered) {
           runOnJS(closeSubPanel)();
         }
       }),
-  [activeSubPanel, closeSubPanel],
+  [activeSubPanel, closeSubPanel, logSwipeGesture],
   );
 
   // Android hardware back button closes the active subpanel


### PR DESCRIPTION
## Summary

- Fixed settings subpanel unresponsiveness on real device (Pixel 7 Pro) — opacity:0 doesn't disable Android touch hitboxes; added `pointerEvents='none'` on the dimmed main list
- Fixed first-tap-ignored bug on tab navigation using an `overlayRef` mirror of state to avoid stale closures
- Replaced `withSpring` with `withTiming` on all tab transitions (no more swing)
- Fixed non-adjacent tab transitions: replaced overlay approach with per-screen offset repositioning — target screen is instantly moved adjacent to source on the worklet thread, strip animates 1 screen width (same feel as adjacent), intermediate screens are opacity-zeroed to prevent bleed-through, everything snaps back on worklet thread with no React render during animation

## Problem

Non-adjacent tab transitions (e.g. Operations → Settings) had multiple issues:
- Stutter from RNGH reinstalling the native gesture recognizer mid-animation (overlayContent was a useMemo dep)
- Blank frame as overlay slid in before screen content mounted
- Visible intermediate screens when using the per-screen offset approach (JSX z-order bleed-through)
- useLayoutEffect delay causing desync between tab label/pill and screen slide

## Solution

All-worklet-thread approach with no overlay:
1. Intermediate screen opacities zeroed instantly (worklet thread)
2. Target screen repositioned to be adjacent to source via shared value offset (worklet thread)
3. Strip animates exactly 1 screen width — identical to adjacent transition
4. On complete: strip snaps, offset zeroes, opacities restore — all worklet, no React render

## Changes

- `app/navigation/SimpleTabs.js` — complete rewrite of non-adjacent transition logic; removed overlay, ScreenContent component, useLayoutEffect; added per-screen adjust + opacity shared values
- `app/screens/SettingsScreen.js` — pointerEvents fix, debug logs for swipe gesture diagnostics

## Test plan

- [ ] Adjacent tab transitions feel identical to before (smooth, 300ms)
- [ ] Non-adjacent tab transitions (Operations ↔ Settings, Operations ↔ Planned) feel identical to adjacent — no blank, no bleed-through, no stutter
- [ ] Settings subpanel rows are tappable on real device
- [ ] Swipe gesture between tabs works correctly
- [ ] Hardware back button returns to Operations