### PR TITLE
feat(import): add cancel button and safety backup step to all import flows

### DIFF
--- a/__tests__/contexts/ImportProgressContext.test.js
+++ b/__tests__/contexts/ImportProgressContext.test.js
@@ -88,14 +88,14 @@ describe('ImportProgressContext', () => {
         result.current.startImport();
       });
 
-      expect(result.current.steps).toHaveLength(12);
+      expect(result.current.steps).toHaveLength(13);
       expect(result.current.steps[0]).toEqual({
         id: 'format',
         label: 'Detecting format',
         status: 'pending',
         data: null,
       });
-      expect(result.current.steps[11]).toEqual({
+      expect(result.current.steps[12]).toEqual({
         id: 'complete',
         label: 'Database restored successfully',
         status: 'pending',
@@ -124,6 +124,7 @@ describe('ImportProgressContext', () => {
       expect(stepIds).toEqual([
         'format',
         'import',
+        'backup',
         'restore',
         'clear',
         'accounts',
@@ -216,7 +217,7 @@ describe('ImportProgressContext', () => {
       });
 
       // Steps should remain unchanged
-      expect(result.current.steps).toHaveLength(12);
+      expect(result.current.steps).toHaveLength(13);
     });
   });
 
@@ -502,7 +503,7 @@ describe('ImportProgressContext', () => {
       });
 
       expect(result.current.isImporting).toBe(true);
-      expect(result.current.steps).toHaveLength(12);
+      expect(result.current.steps).toHaveLength(13);
       expect(result.current.currentStep).toBe('format');
     });
 
@@ -528,7 +529,7 @@ describe('ImportProgressContext', () => {
       });
 
       expect(result.current.isImporting).toBe(true);
-      expect(result.current.steps).toHaveLength(12);
+      expect(result.current.steps).toHaveLength(13);
       expect(result.current.currentStep).toBe('format');
     });
   });

--- a/__tests__/contexts/ImportProgressContext.test.js
+++ b/__tests__/contexts/ImportProgressContext.test.js
@@ -610,4 +610,121 @@ describe('ImportProgressContext', () => {
       expect(result.current.currentStep).toBe('restore');
     });
   });
+
+  describe('requestCancel', () => {
+    it('sets isCancelling to true', () => {
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+
+      expect(result.current.isCancelling).toBe(false);
+
+      act(() => { result.current.requestCancel(); });
+
+      expect(result.current.isCancelling).toBe(true);
+    });
+
+    it('marks the cancel token as cancelled', () => {
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+
+      const token = result.current.getCancelToken();
+      expect(token.cancelled).toBe(false);
+
+      act(() => { result.current.requestCancel(); });
+
+      expect(token.cancelled).toBe(true);
+    });
+
+    it('isCancelling resets to false after cancelImport', () => {
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+      act(() => { result.current.requestCancel(); });
+
+      expect(result.current.isCancelling).toBe(true);
+
+      act(() => { result.current.cancelImport(); });
+
+      expect(result.current.isCancelling).toBe(false);
+    });
+
+    it('isCancelling resets to false after finishImport', () => {
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+      act(() => { result.current.requestCancel(); });
+      act(() => { result.current.finishImport(); });
+
+      expect(result.current.isCancelling).toBe(false);
+    });
+  });
+
+  describe('getCancelToken', () => {
+    it('returns a fresh non-cancelled token after startImport', () => {
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+
+      const token = result.current.getCancelToken();
+      expect(token).toBeDefined();
+      expect(token.cancelled).toBe(false);
+    });
+
+    it('returns a new token on each startImport call', () => {
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+      const firstToken = result.current.getCancelToken();
+
+      act(() => { result.current.cancelImport(); });
+      act(() => { result.current.startImport(); });
+      const secondToken = result.current.getCancelToken();
+
+      expect(secondToken.cancelled).toBe(false);
+      // After second startImport, the old token ref is replaced
+      expect(secondToken).not.toBe(firstToken);
+    });
+  });
+
+  describe('Event listener complete branch', () => {
+    it('sets currentStep to complete when complete event fires with completed status', () => {
+      let eventHandler;
+      appEvents.on.mockImplementation((event, handler) => {
+        eventHandler = handler;
+        return jest.fn();
+      });
+
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+
+      act(() => {
+        eventHandler({ stepId: 'complete', status: 'completed', data: null });
+      });
+
+      expect(result.current.currentStep).toBe('complete');
+    });
+
+    it('does not set currentStep to complete when complete event fires with non-completed status', () => {
+      let eventHandler;
+      appEvents.on.mockImplementation((event, handler) => {
+        eventHandler = handler;
+        return jest.fn();
+      });
+
+      const { result } = renderHook(() => useImportProgress(), { wrapper });
+
+      act(() => { result.current.startImport(); });
+
+      act(() => {
+        eventHandler({ stepId: 'complete', status: 'in_progress', data: null });
+      });
+
+      // currentStep should be 'complete' because updateStep sets it for in_progress too
+      // but that's handled by the in_progress branch, not the explicit setCurrentStep
+      expect(result.current.currentStep).toBe('complete');
+    });
+  });
 });

--- a/__tests__/integration/GoogleSheetsExport.test.js
+++ b/__tests__/integration/GoogleSheetsExport.test.js
@@ -35,6 +35,7 @@ jest.mock('../../app/contexts/ImportProgressContext', () => ({
     startImport: jest.fn(),
     cancelImport: jest.fn(),
     completeImport: jest.fn(),
+    getCancelToken: jest.fn(() => ({ cancelled: false })),
   }),
 }));
 

--- a/__tests__/modals/ImportProgressModal.test.js
+++ b/__tests__/modals/ImportProgressModal.test.js
@@ -294,6 +294,164 @@ describe('ImportProgressModal', () => {
     });
   });
 
+  describe('Cancel Button', () => {
+    it('shows cancel button while import is in progress', () => {
+      const { getByText } = render(<ImportProgressModal />);
+      expect(getByText('Cancel')).toBeTruthy();
+    });
+
+    it('calls requestCancel when cancel button is pressed', () => {
+      const { getByText } = render(<ImportProgressModal />);
+      fireEvent.press(getByText('Cancel'));
+      expect(mockRequestCancel).toHaveBeenCalled();
+    });
+
+    it('shows Cancelling... text when isCancelling is true', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [],
+        currentStep: 'accounts',
+        isCancelling: true,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText, queryByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Cancelling...')).toBeTruthy();
+      expect(queryByText('Cancel')).toBeNull();
+    });
+
+    it('hides both cancel button and cancelling text when complete', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [{ id: 'complete', label: 'Done', status: 'completed', data: null }],
+        currentStep: 'complete',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { queryByText } = render(<ImportProgressModal />);
+
+      expect(queryByText('Cancel')).toBeNull();
+      expect(queryByText('Cancelling...')).toBeNull();
+    });
+  });
+
+  describe('Extended Step Labels', () => {
+    it('shows in-progress labels for operations, budgets, metadata', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'operations', label: 'Restoring operations', status: 'in_progress', data: 42 },
+          { id: 'budgets', label: 'Restoring budgets', status: 'in_progress', data: 5 },
+          { id: 'metadata', label: 'Restoring metadata', status: 'in_progress', data: 3 },
+        ],
+        currentStep: 'operations',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Restoring 42 operations...')).toBeTruthy();
+      expect(getByText('Restoring 5 budgets...')).toBeTruthy();
+      expect(getByText('Restoring 3 metadata entries...')).toBeTruthy();
+    });
+
+    it('shows completed labels for operations, budgets, metadata', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'operations', label: 'Restoring operations', status: 'completed', data: 42 },
+          { id: 'budgets', label: 'Restoring budgets', status: 'completed', data: 5 },
+          { id: 'metadata', label: 'Restoring metadata', status: 'completed', data: 3 },
+        ],
+        currentStep: 'metadata',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Restored 42 operations')).toBeTruthy();
+      expect(getByText('Restored 5 budgets')).toBeTruthy();
+      expect(getByText('Restored 3 metadata entries')).toBeTruthy();
+    });
+
+    it('shows complete step label with multiple skipped operations', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'complete', label: 'Database restored successfully', status: 'completed', data: { skippedOperations: 3 } },
+        ],
+        currentStep: 'complete',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Database restored successfully (3 operations skipped — see logs)')).toBeTruthy();
+    });
+
+    it('shows complete step label with 1 skipped operation (singular)', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'complete', label: 'Database restored successfully', status: 'completed', data: { skippedOperations: 1 } },
+        ],
+        currentStep: 'complete',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Database restored successfully (1 operation skipped — see logs)')).toBeTruthy();
+    });
+
+    it('shows default complete label when no operations were skipped', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'complete', label: 'Database restored successfully', status: 'completed', data: { skippedOperations: 0 } },
+        ],
+        currentStep: 'complete',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Database restored successfully')).toBeTruthy();
+    });
+  });
+
+  describe('Step Layout', () => {
+    it('records step y-position when layout event fires', () => {
+      const { UNSAFE_getAllByType } = render(<ImportProgressModal />);
+
+      const { View } = require('react-native');
+      const viewsWithLayout = UNSAFE_getAllByType(View).filter(v => v.props.onLayout);
+
+      expect(viewsWithLayout.length).toBeGreaterThan(0);
+
+      // Firing a layout event should not throw
+      expect(() => {
+        fireEvent(viewsWithLayout[0], 'layout', {
+          nativeEvent: { layout: { y: 100 } },
+        });
+      }).not.toThrow();
+    });
+  });
+
   describe('Edge Cases', () => {
     it('handles empty steps array', () => {
       mockUseImportProgress.mockReturnValue({

--- a/__tests__/modals/ImportProgressModal.test.js
+++ b/__tests__/modals/ImportProgressModal.test.js
@@ -30,6 +30,7 @@ jest.mock('../../app/contexts/ThemeColorsContext', () => ({
 }));
 
 const mockFinishImport = jest.fn();
+const mockRequestCancel = jest.fn();
 const mockUseImportProgress = jest.fn();
 
 jest.mock('../../app/contexts/ImportProgressContext', () => ({
@@ -64,7 +65,9 @@ describe('ImportProgressModal', () => {
         { id: 'complete', label: 'Import complete', status: 'pending', data: null },
       ],
       currentStep: 'accounts',
+      isCancelling: false,
       finishImport: mockFinishImport,
+      requestCancel: mockRequestCancel,
     });
   });
 
@@ -161,10 +164,12 @@ describe('ImportProgressModal', () => {
 
   describe('OK Button', () => {
     it('disables OK button while import is in progress', () => {
-      const { UNSAFE_getByType } = render(<ImportProgressModal />);
+      const { UNSAFE_getAllByType } = render(<ImportProgressModal />);
 
       const Button = require('react-native-paper').Button;
-      const okButton = UNSAFE_getByType(Button);
+      const buttons = UNSAFE_getAllByType(Button);
+      // When not complete, both Cancel and OK buttons are rendered; OK is last
+      const okButton = buttons[buttons.length - 1];
 
       expect(okButton.props.disabled).toBe(true);
     });

--- a/__tests__/modals/ImportProgressModal.test.js
+++ b/__tests__/modals/ImportProgressModal.test.js
@@ -416,6 +416,40 @@ describe('ImportProgressModal', () => {
       expect(getByText('Database restored successfully (1 operation skipped — see logs)')).toBeTruthy();
     });
 
+    it('returns step label for in-progress step with data but unrecognised id', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'restore', label: 'Restoring database', status: 'in_progress', data: 'some-data' },
+        ],
+        currentStep: 'restore',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Restoring database')).toBeTruthy();
+    });
+
+    it('returns step label for completed step with data but unrecognised id', () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'clear', label: 'Clearing existing data', status: 'completed', data: 'some-data' },
+        ],
+        currentStep: 'clear',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { getByText } = render(<ImportProgressModal />);
+
+      expect(getByText('Clearing existing data')).toBeTruthy();
+    });
+
     it('shows default complete label when no operations were skipped', () => {
       mockUseImportProgress.mockReturnValue({
         isImporting: true,

--- a/__tests__/modals/ImportProgressModal.test.js
+++ b/__tests__/modals/ImportProgressModal.test.js
@@ -486,6 +486,90 @@ describe('ImportProgressModal', () => {
     });
   });
 
+  describe('Auto-scroll Effect', () => {
+    it('scrolls to current step when its position is populated from a layout event', async () => {
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'accounts', label: 'Accounts', status: 'in_progress', data: null },
+          { id: 'categories', label: 'Categories', status: 'pending', data: null },
+        ],
+        currentStep: 'accounts',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      const { UNSAFE_getAllByType, rerender } = render(<ImportProgressModal />);
+
+      const { View } = require('react-native');
+      // Populate stepPositions.current for all rendered step rows
+      const layoutViews = UNSAFE_getAllByType(View).filter(v => v.props.onLayout);
+      layoutViews.forEach((v, i) =>
+        fireEvent(v, 'layout', { nativeEvent: { layout: { y: i * 60 } } }),
+      );
+
+      // Re-render with a new currentStep that has a known position (categories at y=60)
+      mockUseImportProgress.mockReturnValue({
+        isImporting: true,
+        steps: [
+          { id: 'accounts', label: 'Accounts', status: 'completed', data: null },
+          { id: 'categories', label: 'Categories', status: 'in_progress', data: null },
+        ],
+        currentStep: 'categories',
+        isCancelling: false,
+        finishImport: mockFinishImport,
+        requestCancel: mockRequestCancel,
+      });
+
+      rerender(<ImportProgressModal />);
+
+      // The useEffect fires for the new currentStep with a known position; no errors expected
+      await waitFor(() => {
+        expect(UNSAFE_getAllByType(View).length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('Web Platform Reload', () => {
+    it('calls window.location.reload when Platform.OS is web', async () => {
+      const Platform = require('react-native').Platform;
+      const originalOS = Platform.OS;
+      Platform.OS = 'web';
+
+      const mockReload = jest.fn();
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        writable: true,
+        value: { reload: mockReload },
+      });
+
+      try {
+        mockUseImportProgress.mockReturnValue({
+          isImporting: true,
+          steps: [{ id: 'complete', label: 'Done', status: 'completed', data: null }],
+          currentStep: 'complete',
+          isCancelling: false,
+          finishImport: mockFinishImport,
+          requestCancel: mockRequestCancel,
+        });
+
+        const { UNSAFE_getByType } = render(<ImportProgressModal />);
+        const Button = require('react-native-paper').Button;
+        const okButton = UNSAFE_getByType(Button);
+
+        fireEvent.press(okButton);
+
+        await waitFor(() => {
+          expect(mockFinishImport).toHaveBeenCalled();
+          expect(mockReload).toHaveBeenCalled();
+        });
+      } finally {
+        Platform.OS = originalOS;
+      }
+    });
+  });
+
   describe('Edge Cases', () => {
     it('handles empty steps array', () => {
       mockUseImportProgress.mockReturnValue({

--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -60,6 +60,7 @@ jest.mock('../../app/contexts/ImportProgressContext', () => ({
     startImport: mockStartImport,
     cancelImport: mockCancelImport,
     completeImport: mockCompleteImport,
+    getCancelToken: jest.fn(() => ({ cancelled: false })),
   }),
 }));
 
@@ -506,7 +507,7 @@ describe('SettingsScreen', () => {
       expect(mockCancelImport).not.toHaveBeenCalled();
 
       await waitFor(() => {
-        expect(mockImportBackupFromFile).toHaveBeenCalledWith({ fileUri: '/mock/file.json', filename: 'backup.json' });
+        expect(mockImportBackupFromFile).toHaveBeenCalledWith({ fileUri: '/mock/file.json', filename: 'backup.json' }, expect.any(Object));
         expect(mockStartImport).toHaveBeenCalled();
       });
     });

--- a/app/contexts/ImportProgressContext.js
+++ b/app/contexts/ImportProgressContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { appEvents } from '../services/eventEmitter';
 import { IMPORT_PROGRESS_EVENT } from '../services/BackupRestore';
@@ -17,12 +17,17 @@ export const ImportProgressProvider = ({ children }) => {
   const [isImporting, setIsImporting] = useState(false);
   const [steps, setSteps] = useState([]);
   const [currentStep, setCurrentStep] = useState(null);
+  const [isCancelling, setIsCancelling] = useState(false);
+  const cancelTokenRef = useRef({ cancelled: false });
 
   const startImport = useCallback(() => {
+    cancelTokenRef.current = { cancelled: false };
+    setIsCancelling(false);
     setIsImporting(true);
     setSteps([
       { id: 'format', label: 'Detecting format', status: 'pending', data: null },
       { id: 'import', label: 'Importing backup', status: 'pending', data: null },
+      { id: 'backup', label: 'Creating safety backup', status: 'pending', data: null },
       { id: 'restore', label: 'Restoring database', status: 'pending', data: null },
       { id: 'clear', label: 'Clearing existing data', status: 'pending', data: null },
       { id: 'accounts', label: 'Restoring accounts', status: 'pending', data: null },
@@ -36,6 +41,13 @@ export const ImportProgressProvider = ({ children }) => {
     ]);
     setCurrentStep('format');
   }, []);
+
+  const requestCancel = useCallback(() => {
+    cancelTokenRef.current.cancelled = true;
+    setIsCancelling(true);
+  }, []);
+
+  const getCancelToken = useCallback(() => cancelTokenRef.current, []);
 
   const updateStep = useCallback((stepId, status, data = null) => {
     setSteps(prevSteps =>
@@ -58,6 +70,8 @@ export const ImportProgressProvider = ({ children }) => {
     setIsImporting(false);
     setSteps([]);
     setCurrentStep(null);
+    setIsCancelling(false);
+    cancelTokenRef.current = { cancelled: false };
   }, []);
 
   // Listen for import progress events
@@ -76,18 +90,23 @@ export const ImportProgressProvider = ({ children }) => {
     setIsImporting(false);
     setSteps([]);
     setCurrentStep(null);
+    setIsCancelling(false);
+    cancelTokenRef.current = { cancelled: false };
   }, []);
 
   const value = useMemo(() => ({
     isImporting,
     steps,
     currentStep,
+    isCancelling,
     startImport,
     updateStep,
     completeImport,
     cancelImport,
     finishImport,
-  }), [isImporting, steps, currentStep, startImport, updateStep, completeImport, cancelImport, finishImport]);
+    requestCancel,
+    getCancelToken,
+  }), [isImporting, steps, currentStep, isCancelling, startImport, updateStep, completeImport, cancelImport, finishImport, requestCancel, getCancelToken]);
 
   return (
     <ImportProgressContext.Provider value={value}>

--- a/app/modals/ImportProgressModal.js
+++ b/app/modals/ImportProgressModal.js
@@ -8,7 +8,7 @@ import { useImportProgress } from '../contexts/ImportProgressContext';
 
 export default function ImportProgressModal() {
   const { colors } = useThemeColors();
-  const { isImporting, steps, currentStep, finishImport } = useImportProgress();
+  const { isImporting, steps, currentStep, isCancelling, finishImport, requestCancel } = useImportProgress();
   const scrollViewRef = useRef(null);
   const stepPositions = useRef({});
 
@@ -187,6 +187,24 @@ export default function ImportProgressModal() {
         </ScrollView>
 
         <View style={styles.footer}>
+          {!isComplete && (
+            isCancelling ? (
+              <Text
+                variant="bodyMedium"
+                style={[styles.cancellingText, { color: colors.mutedText }]}
+              >
+                Cancelling...
+              </Text>
+            ) : (
+              <Button
+                mode="outlined"
+                onPress={requestCancel}
+                style={styles.cancelButton}
+              >
+                <Text>Cancel</Text>
+              </Button>
+            )
+          )}
           <Button
             mode="contained"
             onPress={handleOkPress}
@@ -202,6 +220,14 @@ export default function ImportProgressModal() {
 }
 
 const styles = StyleSheet.create({
+  cancelButton: {
+    marginBottom: 8,
+    minWidth: 120,
+  },
+  cancellingText: {
+    marginBottom: 12,
+    textAlign: 'center',
+  },
   footer: {
     alignItems: 'center',
     marginTop: 16,

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -17,7 +17,7 @@ import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useImportProgress } from '../contexts/ImportProgressContext';
-import { exportBackup, pickImportFile, importBackupFromFile, restoreBackup, createBackup, getPreRestoreSnapshots } from '../services/BackupRestore';
+import { exportBackup, pickImportFile, importBackupFromFile, restoreBackup, createBackup, getPreRestoreSnapshots, CancelledImportError } from '../services/BackupRestore';
 import { getStoredBackups, DAILY_BACKUP_DIR } from '../services/DailyBackupService';
 import { useLogEntries } from '../hooks/useLogEntries';
 import { File, Paths } from 'expo-file-system';
@@ -67,7 +67,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
   const { hideBalances, setHideBalances } = useDisplaySettings();
   const { showDialog } = useDialog();
   const { resetDatabase } = useAccountsActions();
-  const { startImport, cancelImport, completeImport } = useImportProgress();
+  const { startImport, cancelImport, completeImport, getCancelToken } = useImportProgress();
   const { startDownload } = useUpdateDownload();
   const [activeSubPanel, setActiveSubPanel] = useState(null);
   const [logFilter, setLogFilter] = useState('all');
@@ -347,15 +347,17 @@ export default function SettingsScreen({ setSubPanelActive }) {
     importPickInProgress.current = false;
     closeSubPanel();
     startImport();
+    const cancelToken = getCancelToken();
     try {
-      await importBackupFromFile(fileInfo);
+      await importBackupFromFile(fileInfo, cancelToken);
       completeImport();
     } catch (error) {
       cancelImport();
+      if (error instanceof CancelledImportError) return;
       console.error('Import backup error:', error);
       showDialog(t('error') || 'Error', error.message || t('restore_error') || 'Failed to restore backup', [{ text: 'OK' }]);
     }
-  }, [closeSubPanel, startImport, completeImport, cancelImport, t, showDialog]);
+  }, [closeSubPanel, startImport, completeImport, cancelImport, getCancelToken, t, showDialog]);
 
   const handleShareLogs = useCallback(async () => {
     try {
@@ -427,14 +429,17 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
     closeSubPanel();
     startImport();
+    const cancelToken = getCancelToken();
     try {
-      await restoreBackup(backup);
+      await restoreBackup(backup, cancelToken);
       completeImport();
     } catch (restoreError) {
       cancelImport();
-      console.error('[SheetsImport] restore error:', restoreError);
+      if (!(restoreError instanceof CancelledImportError)) {
+        console.error('[SheetsImport] restore error:', restoreError);
+      }
     }
-  }, [t, closeSubPanel, startImport, completeImport, cancelImport]);
+  }, [t, closeSubPanel, startImport, completeImport, cancelImport, getCancelToken]);
 
   const handleImportLocalBackupSelect = useCallback((item) => {
     setImportSelectedBackup(item);
@@ -461,21 +466,23 @@ export default function SettingsScreen({ setSubPanelActive }) {
     if (!importSelectedBackup) return;
     closeSubPanel();
     startImport();
+    const cancelToken = getCancelToken();
     try {
       const content = await LegacyFileSystem.readAsStringAsync(importSelectedBackup.uri);
       const backup = JSON.parse(content);
-      await restoreBackup(backup);
+      await restoreBackup(backup, cancelToken);
       completeImport();
     } catch (error) {
-      console.error('Local backup restore error:', error);
       cancelImport();
+      if (error instanceof CancelledImportError) return;
+      console.error('Local backup restore error:', error);
       showDialog(
         t('error') || 'Error',
         error.message || t('restore_error') || 'Failed to restore backup',
         [{ text: 'OK' }],
       );
     }
-  }, [importSelectedBackup, closeSubPanel, startImport, completeImport, cancelImport, t, showDialog]);
+  }, [importSelectedBackup, closeSubPanel, startImport, completeImport, cancelImport, getCancelToken, t, showDialog]);
 
   const handleSaveLocalBackup = useCallback(async () => {
     setSaveLocalBackupLoading(true);

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -13,6 +13,13 @@ const BACKUP_VERSION = 1;
 // Event for import progress
 export const IMPORT_PROGRESS_EVENT = 'import:progress';
 
+export class CancelledImportError extends Error {
+  constructor() {
+    super('Import cancelled by user');
+    this.name = 'CancelledImportError';
+  }
+}
+
 /**
  * Create a backup of the entire database
  * @returns {Promise<Object>} Backup data object
@@ -368,9 +375,10 @@ const validateBackup = (backup) => {
 /**
  * Restore database from backup data
  * @param {Object} backup - Backup object
+ * @param {{ cancelled: boolean }} [cancelToken] - Optional token; set cancelled=true to abort
  * @returns {Promise<void>}
  */
-export const restoreBackup = async (backup) => {
+export const restoreBackup = async (backup, cancelToken) => {
   try {
     console.log('Restoring database from backup...');
     appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'restore', status: 'in_progress' });
@@ -403,8 +411,11 @@ export const restoreBackup = async (backup) => {
       );
     }
 
+    if (cancelToken?.cancelled) throw new CancelledImportError();
+
     // Create a pre-restore snapshot so the user can recover if something goes wrong.
     let snapshotUri = null;
+    appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'backup', status: 'in_progress' });
     try {
       const snapshot = await createBackup();
       const snapshotTimestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
@@ -427,8 +438,12 @@ export const restoreBackup = async (backup) => {
         console.warn('Failed to clean up old pre-restore snapshots:', cleanupError);
       }
     } catch (snapshotError) {
+      if (snapshotError instanceof CancelledImportError) throw snapshotError;
       console.warn('Failed to create pre-restore snapshot:', snapshotError);
     }
+    appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'backup', status: 'completed' });
+
+    if (cancelToken?.cancelled) throw new CancelledImportError();
 
     let skippedOperations = 0;
 
@@ -450,6 +465,8 @@ export const restoreBackup = async (backup) => {
 
       console.log('Existing data cleared and auto-increment counters reset');
       appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'clear', status: 'completed' });
+
+      if (cancelToken?.cancelled) throw new CancelledImportError();
 
       // Restore accounts - preserve integer IDs, map UUID IDs to new integers
       appEvents.emit(IMPORT_PROGRESS_EVENT, {
@@ -520,6 +537,8 @@ export const restoreBackup = async (backup) => {
         data: backup.data.accounts.length,
       });
 
+      if (cancelToken?.cancelled) throw new CancelledImportError();
+
       // Restore categories
       appEvents.emit(IMPORT_PROGRESS_EVENT, {
         stepId: 'categories',
@@ -557,6 +576,8 @@ export const restoreBackup = async (backup) => {
         status: 'completed',
         data: backup.data.categories.length,
       });
+
+      if (cancelToken?.cancelled) throw new CancelledImportError();
 
       // Restore operations - map account IDs from UUID to integer
       appEvents.emit(IMPORT_PROGRESS_EVENT, {
@@ -613,6 +634,8 @@ export const restoreBackup = async (backup) => {
         status: 'completed',
         data: backup.data.operations.length,
       });
+
+      if (cancelToken?.cancelled) throw new CancelledImportError();
 
       // Restore balance history
       if (backup.data.balance_history) {
@@ -956,9 +979,10 @@ const parseCSV = (csvContent) => {
 /**
  * Import backup from CSV file
  * @param {string} fileUri - File URI
+ * @param {{ cancelled: boolean }} [cancelToken]
  * @returns {Promise<Object>} Imported backup object
  */
-const importBackupCSV = async (fileUri) => {
+const importBackupCSV = async (fileUri, cancelToken) => {
   console.log('Importing CSV backup...');
   appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'import', status: 'in_progress' });
   const fileContent = await FileSystem.readAsStringAsync(fileUri);
@@ -1004,7 +1028,7 @@ const importBackupCSV = async (fileUri) => {
   };
 
   appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'import', status: 'completed' });
-  await restoreBackup(backup);
+  await restoreBackup(backup, cancelToken);
   return backup;
 };
 
@@ -1013,9 +1037,10 @@ const importBackupCSV = async (fileUri) => {
 /**
  * Import backup from SQLite database file
  * @param {string} fileUri - File URI
+ * @param {{ cancelled: boolean }} [cancelToken]
  * @returns {Promise<Object>} Imported backup info
  */
-const importBackupSQLite = async (fileUri) => {
+const importBackupSQLite = async (fileUri, cancelToken) => {
   console.log('Importing SQLite backup...');
   appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'import', status: 'in_progress' });
 
@@ -1134,7 +1159,7 @@ const importBackupSQLite = async (fileUri) => {
     appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'import', status: 'completed' });
 
     // Use the standard restore process
-    await restoreBackup(backup);
+    await restoreBackup(backup, cancelToken);
 
     return backup;
   } catch (error) {
@@ -1197,7 +1222,7 @@ export const pickImportFile = async () => {
   };
 };
 
-export const importBackupFromFile = async ({ fileUri, filename }) => {
+export const importBackupFromFile = async ({ fileUri, filename }, cancelToken) => {
   try {
     console.log('Reading backup file:', fileUri, 'Name:', filename);
 
@@ -1214,10 +1239,10 @@ export const importBackupFromFile = async ({ fileUri, filename }) => {
     let backup;
     switch (format) {
     case 'csv':
-      backup = await importBackupCSV(fileUri);
+      backup = await importBackupCSV(fileUri, cancelToken);
       break;
     case 'sqlite':
-      backup = await importBackupSQLite(fileUri);
+      backup = await importBackupSQLite(fileUri, cancelToken);
       break;
     case 'json':
     default: {
@@ -1229,7 +1254,7 @@ export const importBackupFromFile = async ({ fileUri, filename }) => {
         throw new Error('Invalid backup file: not valid JSON');
       }
       appEvents.emit(IMPORT_PROGRESS_EVENT, { stepId: 'import', status: 'completed' });
-      await restoreBackup(backup);
+      await restoreBackup(backup, cancelToken);
       break;
     }
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a **Cancel** button to the import progress modal, visible while import is in progress. Once pressed, it changes to "Cancelling..." and sets a cancel token that the import pipeline checks at each major step.
- Adds **"Creating safety backup"** as an explicit visible step in the import progress UI (the backup was already being created silently; now users can see it happening).
- Introduces `CancelledImportError` to distinguish user cancellation from real failures — no error dialog is shown when the user cancels.
- Threads a `cancelToken` object through `importBackupFromFile` → `importBackupCSV` / `importBackupSQLite` → `restoreBackup`, with checks at each major step (after clear, accounts, categories, operations). When cancelled inside the SQLite transaction, throwing `CancelledImportError` causes an automatic rollback, preserving the original data atomically.
- Wires the cancel token into all three import entry points in `SettingsScreen`: file import, local backup restore, and Google Sheets import.

## Test plan

- [ ] Start a file import (JSON/CSV/SQLite) and press Cancel before it completes — modal closes, no error dialog, original data is intact
- [ ] Start a local backup restore and press Cancel — same behaviour
- [ ] Start a Google Sheets import and press Cancel — same behaviour
- [ ] Let an import complete normally — Cancel button is gone, OK button is enabled, safety backup step shows as completed
- [ ] Confirm that the "Creating safety backup" step appears and completes before data is cleared

https://claude.ai/code/session_01EvhNFogJ7Z5wEDX5Mz65Ei
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvhNFogJ7Z5wEDX5Mz65Ei)_