### PR TITLE
fix: handle Android back gesture in search/filter UI

### DIFF
--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet, Animated, Easing } from 'react-native';
+import { View, Text, StyleSheet, Animated, Easing, BackHandler } from 'react-native';
 import { useEffect, useCallback, useRef } from 'react';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import SearchBar from './search/SearchBar';
@@ -88,6 +88,19 @@ export default function Header({ rightContent, activeScreen, operationsData }) {
 
   const isSearchOpen = searchMode === 'open' && activeScreen === 'Operations';
   const showSearchBar = activeScreen === 'Operations';
+
+  useEffect(() => {
+    if (!isSearchOpen) return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (filtersExpanded) {
+        toggleFilters();
+      } else {
+        handleCloseSearch();
+      }
+      return true;
+    });
+    return () => sub.remove();
+  }, [isSearchOpen, filtersExpanded, toggleFilters, handleCloseSearch]);
 
   return (
     <View


### PR DESCRIPTION
## Summary

- Back gesture while search is open and filters are expanded → closes the filter panel
- Back gesture while search is open and filters are not expanded → closes the search bar
- No change to back gesture behavior when search is closed

## Implementation

Added a `BackHandler` effect in `Header.js`, which already has all the needed state (`isSearchOpen`, `filtersExpanded`) and callbacks (`toggleFilters`, `handleCloseSearch`). The handler is registered only when search is open and automatically removed when it closes.

## Test plan

- [ ] Open search on Operations screen, open filters → press back → filters collapse, search stays open
- [ ] Open search on Operations screen, no filters open → press back → search closes
- [ ] Back gesture on other tabs (Accounts, Categories, etc.) behaves normally (no regression)
- [ ] Back gesture when search is closed behaves normally

https://claude.ai/code/session_01SCoFLq5sTH6v3PDxFoRj2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCoFLq5sTH6v3PDxFoRj2f)_