### PR TITLE
fix: soft-delete accounts to preserve balance history (#872)

### DIFF
--- a/__tests__/services/AccountsDB.test.js
+++ b/__tests__/services/AccountsDB.test.js
@@ -281,8 +281,8 @@ describe('AccountsDB', () => {
 
       expect(db.executeTransaction).toHaveBeenCalled();
       expect(mockTxDb.runAsync).toHaveBeenCalledWith(
-        'DELETE FROM accounts WHERE id = ?',
-        ['1'],
+        'UPDATE accounts SET deleted_at = ?, updated_at = ? WHERE id = ?',
+        expect.arrayContaining(['1']),
       );
     });
 
@@ -657,8 +657,8 @@ describe('AccountsDB', () => {
         ['transfer-to', 'to-delete'],
       );
       expect(mockTxDb.runAsync).toHaveBeenCalledWith(
-        'DELETE FROM accounts WHERE id = ?',
-        ['to-delete'],
+        'UPDATE accounts SET deleted_at = ?, updated_at = ? WHERE id = ?',
+        expect.arrayContaining(['to-delete']),
       );
     });
   });

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -22,6 +22,7 @@ export const accounts = sqliteTable('accounts', {
   monthlyTarget: text('monthly_target'),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
+  deletedAt: text('deleted_at'),
 }, (table) => ({
   orderIdx: index('idx_accounts_order').on(table.displayOrder),
   hiddenIdx: index('idx_accounts_hidden').on(table.hidden),

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -1,6 +1,6 @@
 import { executeQuery, queryAll, queryFirst, executeTransaction, getDrizzle } from './db';
 import * as Currency from './currency';
-import { eq, sql, desc, asc } from 'drizzle-orm';
+import { eq, sql, desc, asc, isNull, and } from 'drizzle-orm';
 import { accounts } from '../db/schema';
 import * as BalanceHistoryDB from './BalanceHistoryDB';
 
@@ -13,6 +13,7 @@ export const getAllAccounts = async () => {
     const db = await getDrizzle();
     const results = await db.select()
       .from(accounts)
+      .where(isNull(accounts.deletedAt))
       .orderBy(asc(accounts.displayOrder), desc(accounts.createdAt));
     return results || [];
   } catch (error) {
@@ -253,7 +254,10 @@ export const deleteAccount = async (id, transferToAccountId = null) => {
         );
       }
 
-      await db.runAsync('DELETE FROM accounts WHERE id = ?', [id]);
+      await db.runAsync(
+        'UPDATE accounts SET deleted_at = ?, updated_at = ? WHERE id = ?',
+        [new Date().toISOString(), new Date().toISOString(), id],
+      );
     });
   } catch (error) {
     console.error('Failed to delete account:', error);
@@ -374,7 +378,7 @@ export const accountExists = async (id) => {
     const db = await getDrizzle();
     const results = await db.select({ id: accounts.id })
       .from(accounts)
-      .where(eq(accounts.id, id))
+      .where(and(eq(accounts.id, id), isNull(accounts.deletedAt)))
       .limit(1);
     return results.length > 0;
   } catch (error) {

--- a/drizzle/0008_soft_delete_accounts.js
+++ b/drizzle/0008_soft_delete_accounts.js
@@ -1,0 +1,12 @@
+/**
+ * Migration 0008: Add deleted_at column to accounts table (soft-delete)
+ *
+ * Instead of hard-deleting accounts (which CASCADE-deletes all balance history),
+ * accounts are now soft-deleted by setting deleted_at to a timestamp.
+ * Soft-deleted accounts are hidden from all normal queries but their balance
+ * history and linked operations are preserved.
+ */
+
+const sql = `ALTER TABLE \`accounts\` ADD COLUMN \`deleted_at\` text;`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1747958400000,
       "tag": "0007_add_enum_check_constraints",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1748736000000,
+      "tag": "0008_soft_delete_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -9,6 +9,7 @@ import m0004 from './0004_remove_exclude_from_forecast.js';
 import m0005 from './0005_planned_operations.js';
 import m0006 from './0006_add_original_balance.js';
 import m0007 from './0007_add_enum_check_constraints.js';
+import m0008 from './0008_soft_delete_accounts.js';
 
 export default {
   journal,
@@ -21,6 +22,7 @@ export default {
     m0005,
     m0006,
     m0007,
+    m0008,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -110,6 +110,7 @@ jest.mock('drizzle-orm', () => {
   return {
     eq: jest.fn((field, value) => ({ field, value, op: 'eq' })),
     and: jest.fn((...conditions) => ({ conditions, op: 'and' })),
+    isNull: jest.fn((field) => ({ field, op: 'isNull' })),
     desc: jest.fn((field) => ({ field, direction: 'desc' })),
     asc: jest.fn((field) => ({ field, direction: 'asc' })),
     sql: sqlMock,


### PR DESCRIPTION
## Summary

Fixes #872 — implements option 4 (soft-delete) to prevent the CASCADE foreign key from destroying balance history when an account is deleted.

- Replaces `DELETE FROM accounts WHERE id = ?` with setting a `deleted_at` timestamp; the account row and all its referenced balance history remain intact in the database
- All normal queries filter `WHERE deleted_at IS NULL` so soft-deleted accounts are invisible to users
- Operations transferred to another account before deletion continue to display correctly

## Changes

| File | Change |
|------|--------|
| `drizzle/0008_soft_delete_accounts.js` | New migration: adds `deleted_at TEXT` column to accounts |
| `drizzle/meta/_journal.json` | Registers migration 0008 |
| `drizzle/migrations.js` | Imports and exports m0008 |
| `app/db/schema.js` | Adds `deletedAt` field to accounts schema |
| `app/services/AccountsDB.js` | `deleteAccount` → soft-delete; `getAllAccounts` / `accountExists` → filter deleted rows |

## Test plan

- [ ] Delete an account (with "transfer operations" option) — account disappears from list
- [ ] Verify balance history entries for the deleted account still exist in the DB
- [ ] Verify transferred operations now show under the destination account
- [ ] Verify Graphs screen balance history still reflects historical data from deleted account
- [ ] Fresh install: migration 0008 runs cleanly, existing accounts unaffected (`deleted_at` defaults to NULL)

https://claude.ai/code/session_01CE2RwCt6LsjEnCuo2qFByC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CE2RwCt6LsjEnCuo2qFByC)_