### PR TITLE
fix: replace fragile table-rebuild migration with trigger-based type enforcement

### DIFF
--- a/__tests__/services/db.test.js
+++ b/__tests__/services/db.test.js
@@ -390,7 +390,7 @@ describe('Database Service', () => {
     });
   });
 
-  describe('Migration 0007 pre-migration guard', () => {
+  describe('Migration 0007 detection', () => {
     const validOpsSchema = {
       sql: 'CREATE TABLE `operations` (`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `type` text NOT NULL, `amount` text NOT NULL)',
     };
@@ -398,11 +398,11 @@ describe('Database Service', () => {
       sql: "CREATE TABLE `operations` (`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `type` text NOT NULL CHECK (`type` IN ('expense', 'income', 'transfer')), `amount` text NOT NULL)",
     };
 
-    it('calls migrate with full config when no invalid operation types exist', async () => {
-      // isDatabaseCorrupted uses getAllAsync; first getFirstAsync is the opsSchema check
+    it('calls migrate with full config when trigger not yet present', async () => {
+      // m0007Trigger check -> null (no trigger), opsSchemaForCheck -> no CHECK
       mockDb.getFirstAsync
-        .mockResolvedValueOnce(validOpsSchema) // opsSchema: no CHECK yet
-        .mockResolvedValueOnce(null);          // invalid op check -> none found
+        .mockResolvedValueOnce(null)           // m0007Trigger: not found
+        .mockResolvedValueOnce(validOpsSchema); // opsSchemaForCheck: no CHECK
 
       await getDatabase();
 
@@ -411,72 +411,52 @@ describe('Database Service', () => {
       expect(migrationsArg).toHaveProperty('migrations');
     });
 
-    it('skips migration 0007 and warns when invalid operation types are found', async () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
+    it('does not skip migration 0007 when invalid operation types exist (triggers allow existing data)', async () => {
+      // With the trigger approach, existing invalid data doesn't prevent migration
       mockDb.getFirstAsync
-        .mockResolvedValueOnce(validOpsSchema)             // opsSchema: no CHECK yet
-        .mockResolvedValueOnce({ id: 42, type: 'bogus' }); // invalid op found
+        .mockResolvedValueOnce(null)           // m0007Trigger: not found
+        .mockResolvedValueOnce(validOpsSchema); // opsSchemaForCheck: no CHECK
 
       await getDatabase();
 
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Skipping migration 0007'),
-      );
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('bogus'),
-      );
+      // Should NOT filter 0007 — triggers don't care about existing invalid data
+      // migrate() receives the original unmodified config
+      expect(migrate).toHaveBeenCalled();
       const migrationsArg = migrate.mock.calls[0][1];
-      const tags = (migrationsArg.journal.entries || []).map(e => e.tag);
-      expect(tags).not.toContain('0007_add_enum_check_constraints');
-      expect(migrationsArg.migrations).not.toHaveProperty('m0007');
-
-      warnSpy.mockRestore();
+      expect(migrationsArg).toHaveProperty('migrations');
+      // No filtering happened — config is passed through as-is
+      expect(migrationsArg.journal).toBeDefined();
     });
 
-    it('skips the invalid-type check when CHECK constraint is already present', async () => {
+    it('skips the trigger check when CHECK constraint is already present (old installs)', async () => {
       mockDb.getFirstAsync
-        .mockResolvedValueOnce(null)            // isDatabaseCorrupted
-        .mockResolvedValueOnce(checkedOpsSchema); // opsSchema: CHECK present
+        .mockResolvedValueOnce(null)             // m0007Trigger: not found
+        .mockResolvedValueOnce(checkedOpsSchema); // opsSchemaForCheck: CHECK present
 
       await getDatabase();
 
-      const invalidOpCheckCalls = mockDb.getFirstAsync.mock.calls.filter(
-        ([sql]) => typeof sql === 'string' && sql.includes('NOT IN'),
-      );
-      expect(invalidOpCheckCalls).toHaveLength(0);
+      // m0007AlreadyApplied = true via CHECK, so migrate() still runs with full config
+      // (Drizzle will skip it because hash already in __drizzle_migrations)
       expect(migrate).toHaveBeenCalled();
     });
 
-    it('still runs the invalid-type check when a non-type CHECK constraint is present', async () => {
-      // Guard against the regression where includes('CHECK') would falsely match any
-      // CHECK constraint (e.g. on amount) and skip the invalid-type validation.
-      const otherCheckSchema = {
-        sql: 'CREATE TABLE `operations` (`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL, `type` text NOT NULL, `amount` text NOT NULL CHECK (`amount` >= 0))',
-      };
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
+    it('recognizes trigger as m0007 already applied', async () => {
       mockDb.getFirstAsync
-        .mockResolvedValueOnce(otherCheckSchema)           // opsSchema: CHECK on amount, not type
-        .mockResolvedValueOnce({ id: 7, type: 'garbage' }); // invalid op found
+        .mockResolvedValueOnce({ name: 'trg_operations_type_insert' }) // m0007Trigger: found
+        .mockResolvedValueOnce(validOpsSchema);                         // opsSchemaForCheck
 
       await getDatabase();
 
-      // Should detect that 0007 has NOT been applied (despite the unrelated CHECK)
-      // and run the invalid-type check, finding the bad row and warning.
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Skipping migration 0007'),
-      );
-
-      warnSpy.mockRestore();
+      // m0007AlreadyApplied = true via trigger
+      expect(migrate).toHaveBeenCalled();
     });
 
     it('skips the pre-check when operations table does not exist yet', async () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       mockDb.getFirstAsync
-        .mockResolvedValueOnce(null) // isDatabaseCorrupted
-        .mockResolvedValueOnce(null); // opsSchema: table absent
+        .mockResolvedValueOnce(null) // m0007Trigger: not found
+        .mockResolvedValueOnce(null); // opsSchemaForCheck: table absent
 
       await getDatabase();
 

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -90,6 +90,240 @@ export const getDrizzle = async () => {
 };
 
 /**
+ * Check if the database schema is already at the latest version.
+ * Verifies all expected tables and key columns exist so we can skip migrate().
+ */
+const isSchemaComplete = async (rawDb) => {
+  try {
+    // Check all expected tables exist
+    const expectedTables = [
+      'accounts', 'categories', 'operations', 'budgets',
+      'app_metadata', 'accounts_balance_history', 'planned_operations',
+    ];
+    const existingTables = await rawDb.getAllAsync(
+      "SELECT name FROM sqlite_master WHERE type='table'",
+    );
+    const tableNames = new Set((existingTables || []).map(t => t.name));
+    for (const table of expectedTables) {
+      if (!tableNames.has(table)) return false;
+    }
+
+    // Check accounts has integer id (migration 0002)
+    const accountsCols = await rawDb.getAllAsync('PRAGMA table_info(accounts)');
+    const accountsId = accountsCols.find(c => c.name === 'id');
+    if (!accountsId || accountsId.type.toLowerCase() !== 'integer') return false;
+
+    // Check operations has original_balance (migration 0006)
+    const opsCols = await rawDb.getAllAsync('PRAGMA table_info(operations)');
+    if (!opsCols.some(c => c.name === 'original_balance')) return false;
+
+    // Check operations has integer account_id (migration 0002)
+    const opsAccountId = opsCols.find(c => c.name === 'account_id');
+    if (!opsAccountId || opsAccountId.type.toLowerCase() !== 'integer') return false;
+
+    // Check categories does NOT have exclude_from_forecast (migration 0004)
+    const catCols = await rawDb.getAllAsync('PRAGMA table_info(categories)');
+    if (catCols.some(c => c.name === 'exclude_from_forecast')) return false;
+
+    // Check operations type enforcement exists (migration 0007)
+    // Accept either the new trigger or the old CHECK constraint
+    const trigger = await rawDb.getFirstAsync(
+      "SELECT name FROM sqlite_master WHERE type='trigger' AND name='trg_operations_type_insert'",
+    );
+    if (!trigger) {
+      const opsSchema = await rawDb.getFirstAsync(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='operations'",
+      );
+      if (!opsSchema?.sql || !/CHECK\s*\(\s*[`"]?type[`"]?\s+IN\s*\(/i.test(opsSchema.sql)) return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.warn('[DB] isSchemaComplete check failed:', error.message);
+    return false;
+  }
+};
+
+/**
+ * Ensure __drizzle_migrations has the correct number of records matching
+ * the journal entries. If records are missing or have null hashes, rebuild
+ * the table so future startups see a consistent state.
+ */
+const syncMigrationRecords = async (rawDb, migrationsConfig) => {
+  try {
+    const journalEntries = migrationsConfig.journal.entries;
+    const existing = await rawDb.getAllAsync(
+      'SELECT * FROM __drizzle_migrations ORDER BY created_at ASC',
+    ).catch(() => []);
+
+    const hasNullHashes = existing.some(m => !m.hash);
+    const countMismatch = existing.length !== journalEntries.length;
+
+    if (!hasNullHashes && !countMismatch) {
+      console.log('[DB] Migration records are consistent');
+      return;
+    }
+
+    console.log(`[DB] Fixing migration records (${existing.length} records, ${hasNullHashes ? 'has null hashes' : 'count mismatch'})`);
+
+    // Drop and recreate with proper records using migration SQL as hash
+    // (this matches what Drizzle's expo-sqlite migrator stores)
+    await rawDb.runAsync('DROP TABLE IF EXISTS __drizzle_migrations');
+    await rawDb.runAsync(
+      'CREATE TABLE IF NOT EXISTS __drizzle_migrations (id integer PRIMARY KEY AUTOINCREMENT, hash text NOT NULL, created_at numeric)',
+    );
+
+    const migrationKeys = Object.keys(migrationsConfig.migrations);
+    for (let i = 0; i < journalEntries.length; i++) {
+      const key = migrationKeys[i];
+      const migrationSql = migrationsConfig.migrations[key];
+      // Drizzle stores the raw SQL content as the hash
+      const hash = typeof migrationSql === 'string' ? migrationSql : (migrationSql?.default || String(migrationSql));
+      await rawDb.runAsync(
+        'INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)',
+        [hash, journalEntries[i].when],
+      );
+    }
+
+    console.log(`[DB] Migration records rebuilt: ${journalEntries.length} entries`);
+  } catch (error) {
+    console.warn('[DB] Failed to sync migration records:', error.message);
+    // Non-fatal — schema is already complete, this is just housekeeping
+  }
+};
+
+/**
+ * Repair __drizzle_migrations when it contains null hashes.
+ * Determines which migrations are already applied by inspecting the schema,
+ * then rebuilds the table with correct hashes so migrate() can properly
+ * identify and apply only the truly pending migrations.
+ */
+const repairMigrationHashes = async (rawDb, migrationsConfig) => {
+  try {
+    const journalEntries = migrationsConfig.journal.entries;
+    const migrationKeys = Object.keys(migrationsConfig.migrations);
+
+    // Determine which migrations have been applied by checking schema markers
+    const appliedIndices = await detectAppliedMigrations(rawDb);
+    console.log(`[DB] Detected ${appliedIndices.length}/${journalEntries.length} migrations as already applied: ${appliedIndices.join(', ')}`);
+
+    // Rebuild __drizzle_migrations with correct hashes for applied migrations
+    await rawDb.runAsync('DROP TABLE IF EXISTS __drizzle_migrations');
+    await rawDb.runAsync(
+      'CREATE TABLE IF NOT EXISTS __drizzle_migrations (id integer PRIMARY KEY AUTOINCREMENT, hash text NOT NULL, created_at numeric)',
+    );
+
+    for (const idx of appliedIndices) {
+      const key = migrationKeys[idx];
+      const migrationSql = migrationsConfig.migrations[key];
+      const hash = typeof migrationSql === 'string' ? migrationSql : (migrationSql?.default || String(migrationSql));
+      await rawDb.runAsync(
+        'INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)',
+        [hash, journalEntries[idx].when],
+      );
+    }
+
+    console.log(`[DB] Migration records repaired: ${appliedIndices.length} applied, ${journalEntries.length - appliedIndices.length} pending`);
+  } catch (error) {
+    console.error('[DB] Failed to repair migration hashes:', error.message);
+    // If repair fails, migrate() will attempt to run all migrations which may
+    // partially fail — but the defensive guards handle most of those cases.
+  }
+};
+
+/**
+ * Detect which migrations have already been applied by inspecting schema state.
+ * Returns sorted array of journal indices that are confirmed applied.
+ */
+const detectAppliedMigrations = async (rawDb) => {
+  const applied = [];
+
+  // Helper: check if a table exists
+  const tableExists = async (name) => {
+    const result = await rawDb.getAllAsync(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+      [name],
+    );
+    return result && result.length > 0;
+  };
+
+  // Helper: get column names for a table
+  const getColumns = async (name) => {
+    const cols = await rawDb.getAllAsync(`PRAGMA table_info(${name})`).catch(() => []);
+    return cols.map(c => ({ name: c.name, type: c.type.toLowerCase() }));
+  };
+
+  // Migration 0000: Creates accounts (text id), categories, operations (text id), budgets, app_metadata
+  // If accounts table exists at all, 0000 was applied (or superseded by 0002)
+  if (await tableExists('accounts')) {
+    applied.push(0);
+  }
+
+  // Migration 0001: Converts operations.id from text to integer autoincrement
+  // Check: operations.id is integer
+  if (await tableExists('operations')) {
+    const opsCols = await getColumns('operations');
+    const opsId = opsCols.find(c => c.name === 'id');
+    if (opsId && opsId.type === 'integer') {
+      applied.push(1);
+    }
+  }
+
+  // Migration 0002: Converts accounts.id from text to integer, updates operations.account_id to integer
+  if (await tableExists('accounts')) {
+    const accCols = await getColumns('accounts');
+    const accId = accCols.find(c => c.name === 'id');
+    if (accId && accId.type === 'integer') {
+      applied.push(2);
+    }
+  }
+
+  // Migration 0003: Creates accounts_balance_history table
+  if (await tableExists('accounts_balance_history')) {
+    applied.push(3);
+  }
+
+  // Migration 0004: Removes exclude_from_forecast from categories
+  if (await tableExists('categories')) {
+    const catCols = await getColumns('categories');
+    if (!catCols.some(c => c.name === 'exclude_from_forecast')) {
+      applied.push(4);
+    }
+  }
+
+  // Migration 0005: Creates planned_operations table
+  if (await tableExists('planned_operations')) {
+    applied.push(5);
+  }
+
+  // Migration 0006: Adds original_balance column to operations
+  if (await tableExists('operations')) {
+    const opsCols = await getColumns('operations');
+    if (opsCols.some(c => c.name === 'original_balance')) {
+      applied.push(6);
+    }
+  }
+
+  // Migration 0007: Adds type-enforcement trigger on operations
+  const trigger = await rawDb.getFirstAsync(
+    "SELECT name FROM sqlite_master WHERE type='trigger' AND name='trg_operations_type_insert'",
+  ).catch(() => null);
+  // Also accept the old CHECK constraint approach (fresh installs before this change)
+  if (trigger) {
+    applied.push(7);
+  } else {
+    const opsSchema = await rawDb.getFirstAsync(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND name='operations'",
+    ).catch(() => null);
+    if (opsSchema?.sql && /CHECK\s*\(\s*[`"]?type[`"]?\s+IN\s*\(/i.test(opsSchema.sql)) {
+      applied.push(7);
+    }
+  }
+
+  return applied.sort((a, b) => a - b);
+};
+
+/**
  * Check if database is in a corrupted migration state
  */
 const isDatabaseCorrupted = async (rawDb) => {
@@ -175,113 +409,115 @@ const initializeDatabase = async (rawDb, db) => {
     const migrationsBefore = await rawDb.getAllAsync('SELECT * FROM __drizzle_migrations ORDER BY created_at ASC').catch(() => []);
     const appliedHashesBefore = new Set((migrationsBefore || []).map(m => m.hash));
 
-    // Pre-migration: log exact column list of operations table so we can see
-    // what state it is in before migrations run.
-    const opsColumnsPreMigration = await rawDb.getAllAsync('PRAGMA table_info(operations)').catch(() => []);
-    if (opsColumnsPreMigration && opsColumnsPreMigration.length > 0) {
-      console.log('[DB] operations table columns before migrations:', opsColumnsPreMigration.map(c => `${c.cid}:${c.name}(${c.type})`).join(', '));
-    } else {
-      console.log('[DB] operations table does not exist yet (fresh database)');
-    }
+    // SCHEMA COMPLETENESS CHECK: if the database already has the final schema,
+    // skip migrate() entirely. This handles imported backups whose __drizzle_migrations
+    // table has null hashes or incomplete records — running migrate() against an
+    // already-complete schema is wasteful and can produce confusing logs.
+    const schemaAlreadyComplete = await isSchemaComplete(rawDb);
+    if (schemaAlreadyComplete) {
+      console.log('[DB] Schema is already at latest version — skipping migrate()');
 
-    // PRE-MIGRATION DEFENSIVE CHECK: ensure original_balance column exists BEFORE
-    // running migrations. If migration 0006 was recorded in __drizzle_migrations but
-    // its ALTER TABLE was rolled back (Drizzle/Expo SQLite bug), the column will be
-    // absent. Migration 0007 does `INSERT INTO __new_operations SELECT * FROM operations`
-    // which fails when the column counts mismatch (old=13, new=14) — causing migrate()
-    // to throw BEFORE the post-migration fallback below can run. Adding the column here
-    // breaks that infinite failure loop.
-    if (opsColumnsPreMigration && opsColumnsPreMigration.length > 0) {
-      const hasOriginalBalancePre = opsColumnsPreMigration.some(col => col.name === 'original_balance');
-      if (!hasOriginalBalancePre) {
-        console.warn('[DB] PRE-MIGRATION: original_balance column missing from operations table — adding it now so migration 0007 SELECT * column count matches');
+      // Fix __drizzle_migrations if it has wrong count or null hashes so future
+      // startups are even faster (no need to re-check schema).
+      await syncMigrationRecords(rawDb, migrations);
+    } else {
+      // Pre-migration: log exact column list of operations table so we can see
+      // what state it is in before migrations run.
+      const opsColumnsPreMigration = await rawDb.getAllAsync('PRAGMA table_info(operations)').catch(() => []);
+      if (opsColumnsPreMigration && opsColumnsPreMigration.length > 0) {
+        console.log('[DB] operations table columns before migrations:', opsColumnsPreMigration.map(c => `${c.cid}:${c.name}(${c.type})`).join(', '));
+      } else {
+        console.log('[DB] operations table does not exist yet (fresh database)');
+      }
+
+      // PRE-MIGRATION DEFENSIVE CHECK: ensure original_balance column exists BEFORE
+      // running migrations. If migration 0006 was recorded in __drizzle_migrations but
+      // its ALTER TABLE was rolled back (Drizzle/Expo SQLite bug), the column will be
+      // absent. Migration 0007 does `INSERT INTO __new_operations SELECT * FROM operations`
+      // which fails when the column counts mismatch (old=13, new=14) — causing migrate()
+      // to throw BEFORE the post-migration fallback below can run. Adding the column here
+      // breaks that infinite failure loop.
+      if (opsColumnsPreMigration && opsColumnsPreMigration.length > 0) {
+        const hasOriginalBalancePre = opsColumnsPreMigration.some(col => col.name === 'original_balance');
+        if (!hasOriginalBalancePre) {
+          console.warn('[DB] PRE-MIGRATION: original_balance column missing from operations table — adding it now so migration 0007 SELECT * column count matches');
+          try {
+            await rawDb.runAsync('ALTER TABLE `operations` ADD COLUMN `original_balance` text');
+            console.log('[DB] PRE-MIGRATION: original_balance column added successfully');
+          } catch (preAddErr) {
+            console.error('[DB] PRE-MIGRATION: failed to add original_balance column:', preAddErr.message);
+          }
+        } else {
+          console.log('[DB] PRE-MIGRATION: original_balance column already present — no action needed');
+        }
+      }
+
+      // Check if migration 0007 (type-enforcement trigger) is already applied.
+      // Accepts either the new trigger or the old CHECK constraint from prior installs.
+      let migrationsConfig = migrations;
+      const m0007Trigger = await rawDb.getFirstAsync(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='trg_operations_type_insert'",
+      ).catch(() => null);
+      const opsSchemaForCheck = await rawDb.getFirstAsync(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='operations'",
+      ).catch(() => null);
+      const m0007AlreadyApplied = !!m0007Trigger ||
+      (!!opsSchemaForCheck?.sql && /CHECK\s*\(\s*[`"]?type[`"]?\s+IN\s*\(/i.test(opsSchemaForCheck.sql));
+
+      // FIX NULL HASHES: If __drizzle_migrations has null hashes, Drizzle's migrator
+      // cannot match stored records to known migrations — it will either skip everything
+      // or try to re-apply already-applied migrations. Repair the table by detecting
+      // which migrations are already applied (via schema inspection) and inserting correct
+      // hashes so migrate() only applies truly pending migrations.
+      const hasNullHashes = (migrationsBefore || []).some(m => !m.hash);
+      if (hasNullHashes && migrationsBefore.length > 0) {
+        console.log('[DB] Detected null hashes in __drizzle_migrations — repairing...');
+        await repairMigrationHashes(rawDb, migrationsConfig);
+      }
+
+      // Run Drizzle migrations
+      console.log('[DB] calling migrate() with', migrationsConfig.journal.entries.length, 'journal entries:', migrationsConfig.journal.entries.map(e => e.tag).join(', '));
+      try {
+        await migrate(db, migrationsConfig);
+        console.log('[DB] migrate() completed without throwing');
+      } catch (migrateErr) {
+        console.error('[DB] migrate() threw an error:', migrateErr.message);
+        console.error('[DB] migrate() error cause:', migrateErr.cause?.message ?? '(no cause)');
+        throw migrateErr;
+      }
+
+      // Post-migration verification: log the final column list and confirm
+      // original_balance is present. Acts as a last-resort fallback in case
+      // both the pre-migration guard and migrate() somehow left it absent.
+      const opsColumnsPostMigration = await rawDb.getAllAsync('PRAGMA table_info(operations)').catch(() => []);
+      if (opsColumnsPostMigration && opsColumnsPostMigration.length > 0) {
+        console.log('[DB] operations table columns after migrations:', opsColumnsPostMigration.map(c => `${c.cid}:${c.name}(${c.type})`).join(', '));
+      }
+      const hasOriginalBalance = (opsColumnsPostMigration || []).some(col => col.name === 'original_balance');
+      if (!hasOriginalBalance) {
+        console.warn('[DB] POST-MIGRATION: original_balance column still missing — adding it as last-resort fallback');
         try {
           await rawDb.runAsync('ALTER TABLE `operations` ADD COLUMN `original_balance` text');
-          console.log('[DB] PRE-MIGRATION: original_balance column added successfully');
-        } catch (preAddErr) {
-          console.error('[DB] PRE-MIGRATION: failed to add original_balance column:', preAddErr.message);
+          console.log('[DB] POST-MIGRATION: original_balance column added via fallback');
+        } catch (postAddErr) {
+          console.error('[DB] POST-MIGRATION: failed to add original_balance column:', postAddErr.message);
         }
       } else {
-        console.log('[DB] PRE-MIGRATION: original_balance column already present — no action needed');
+        console.log('[DB] POST-MIGRATION: original_balance column confirmed present');
       }
-    }
 
-    // Pre-migration guard for migration 0007 (CHECK constraint on operations.type).
-    // If invalid types exist we warn and exclude 0007 from this run so the app can
-    // still start. The migration stays pending and will be retried on the next
-    // launch after the user has fixed or removed the offending rows.
-    let migrationsConfig = migrations;
-    const opsSchema = await rawDb.getFirstAsync(
-      "SELECT sql FROM sqlite_master WHERE type='table' AND name='operations'",
-    ).catch(() => null);
-    const m0007Tag = '0007_add_enum_check_constraints';
-    // Look specifically for the type-column CHECK so a future CHECK on a different
-    // column (e.g. CHECK (amount >= 0)) cannot mask whether 0007 has run.
-    const m0007AlreadyApplied =
-      !!opsSchema?.sql && /CHECK\s*\(\s*[`"]?type[`"]?\s+IN\s*\(/i.test(opsSchema.sql);
-    if (opsSchema && !m0007AlreadyApplied) {
-      const invalidOp = await rawDb.getFirstAsync(
-        "SELECT id, type FROM operations WHERE type NOT IN ('expense', 'income', 'transfer') LIMIT 1",
-      ).catch(() => null);
-      if (invalidOp) {
-        console.warn(
-          `[DB] Skipping migration 0007: operation id=${invalidOp.id} has invalid type "${invalidOp.type}". ` +
-          'All operation types must be expense, income, or transfer. ' +
-          'Fix the invalid operations and restart the app to apply this migration.',
-        );
-        const { m0007: _skip, ...migsWithout0007 } = migrations.migrations;
-        migrationsConfig = {
-          ...migrations,
-          journal: {
-            ...migrations.journal,
-            entries: migrations.journal.entries.filter(e => e.tag !== m0007Tag),
-          },
-          migrations: migsWithout0007,
-        };
-      }
-    }
 
-    // Run Drizzle migrations
-    console.log('[DB] calling migrate() with', migrationsConfig.journal.entries.length, 'journal entries:', migrationsConfig.journal.entries.map(e => e.tag).join(', '));
-    try {
-      await migrate(db, migrationsConfig);
-      console.log('[DB] migrate() completed without throwing');
-    } catch (migrateErr) {
-      console.error('[DB] migrate() threw an error:', migrateErr.message);
-      console.error('[DB] migrate() error cause:', migrateErr.cause?.message ?? '(no cause)');
-      throw migrateErr;
-    }
 
-    // Post-migration verification: log the final column list and confirm
-    // original_balance is present. Acts as a last-resort fallback in case
-    // both the pre-migration guard and migrate() somehow left it absent.
-    const opsColumnsPostMigration = await rawDb.getAllAsync('PRAGMA table_info(operations)').catch(() => []);
-    if (opsColumnsPostMigration && opsColumnsPostMigration.length > 0) {
-      console.log('[DB] operations table columns after migrations:', opsColumnsPostMigration.map(c => `${c.cid}:${c.name}(${c.type})`).join(', '));
-    }
-    const hasOriginalBalance = (opsColumnsPostMigration || []).some(col => col.name === 'original_balance');
-    if (!hasOriginalBalance) {
-      console.warn('[DB] POST-MIGRATION: original_balance column still missing — adding it as last-resort fallback');
-      try {
-        await rawDb.runAsync('ALTER TABLE `operations` ADD COLUMN `original_balance` text');
-        console.log('[DB] POST-MIGRATION: original_balance column added via fallback');
-      } catch (postAddErr) {
-        console.error('[DB] POST-MIGRATION: failed to add original_balance column:', postAddErr.message);
-      }
-    } else {
-      console.log('[DB] POST-MIGRATION: original_balance column confirmed present');
-    }
-
-    // Defensive: ensure planned_operations table exists after migrations.
-    // The beta Drizzle migrator can silently fail to apply a migration (transaction
-    // rolls back, hash not recorded), so we create the table directly as a fallback.
-    const plannedOpsTable = await rawDb.getAllAsync(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='planned_operations'",
-    ) || [];
-    if (plannedOpsTable.length === 0) {
-      console.warn('planned_operations table missing after migrations — creating it directly');
-      await rawDb.runAsync(
-        `CREATE TABLE IF NOT EXISTS \`planned_operations\` (
+      // Defensive: ensure planned_operations table exists after migrations.
+      // The beta Drizzle migrator can silently fail to apply a migration (transaction
+      // rolls back, hash not recorded), so we create the table directly as a fallback.
+      const plannedOpsTable = await rawDb.getAllAsync(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='planned_operations'",
+      ) || [];
+      if (plannedOpsTable.length === 0) {
+        console.warn('planned_operations table missing after migrations — creating it directly');
+        await rawDb.runAsync(
+          `CREATE TABLE IF NOT EXISTS \`planned_operations\` (
           \`id\` text PRIMARY KEY NOT NULL,
           \`name\` text NOT NULL,
           \`type\` text NOT NULL,
@@ -299,48 +535,78 @@ const initializeDatabase = async (rawDb, db) => {
           FOREIGN KEY (\`category_id\`) REFERENCES \`categories\`(\`id\`) ON UPDATE no action ON DELETE set null,
           FOREIGN KEY (\`to_account_id\`) REFERENCES \`accounts\`(\`id\`) ON UPDATE no action ON DELETE cascade
         )`,
-      );
-      await rawDb.runAsync(
-        'CREATE INDEX IF NOT EXISTS `idx_planned_ops_account` ON `planned_operations` (`account_id`)',
-      );
-      await rawDb.runAsync(
-        'CREATE INDEX IF NOT EXISTS `idx_planned_ops_type` ON `planned_operations` (`type`)',
-      );
-      await rawDb.runAsync(
-        'CREATE INDEX IF NOT EXISTS `idx_planned_ops_recurring` ON `planned_operations` (`is_recurring`)',
-      );
-      console.log('planned_operations table created via fallback');
-    }
+        );
+        await rawDb.runAsync(
+          'CREATE INDEX IF NOT EXISTS `idx_planned_ops_account` ON `planned_operations` (`account_id`)',
+        );
+        await rawDb.runAsync(
+          'CREATE INDEX IF NOT EXISTS `idx_planned_ops_type` ON `planned_operations` (`type`)',
+        );
+        await rawDb.runAsync(
+          'CREATE INDEX IF NOT EXISTS `idx_planned_ops_recurring` ON `planned_operations` (`is_recurring`)',
+        );
+        console.log('planned_operations table created via fallback');
+      }
 
-    // Enable foreign keys and WAL mode after migrations
-    await rawDb.runAsync('PRAGMA foreign_keys = ON');
-    await rawDb.runAsync('PRAGMA journal_mode = WAL');
+      // Log which migrations were applied
+      const finalMigrations = await rawDb.getAllAsync('SELECT * FROM __drizzle_migrations ORDER BY created_at ASC');
+      const finalHashList = (finalMigrations || []).map(m => m.hash || 'null').join(', ');
+      console.log('Migrations after running migrate:', finalHashList || 'none');
+      console.log(`Total migrations applied: ${(finalMigrations || []).length}/${migrations.journal.entries.length}`);
 
-    // Log which migrations were applied
-    const finalMigrations = await rawDb.getAllAsync('SELECT * FROM __drizzle_migrations ORDER BY created_at ASC');
-    const finalHashList = (finalMigrations || []).map(m => m.hash || 'null').join(', ');
-    console.log('Migrations after running migrate:', finalHashList || 'none');
-    console.log(`Total migrations applied: ${(finalMigrations || []).length}/${migrations.journal.entries.length}`);
-
-    // Run post-migration handlers for newly applied migrations
-    if (migrations.postMigrationHandlers) {
-      const appliedHashesAfter = new Set((finalMigrations || []).map(m => m.hash));
+      // Run post-migration handlers for newly applied migrations
+      if (migrations.postMigrationHandlers) {
+        const appliedHashesAfter = new Set((finalMigrations || []).map(m => m.hash));
       
-      for (const [key, handler] of Object.entries(migrations.postMigrationHandlers)) {
-        // Find the migration hash for this key (e.g., m0003 -> hash)
-        const migrationEntry = migrations.journal.entries.find(e => e.tag.includes(key.replace('m', '')));
+        for (const [key, handler] of Object.entries(migrations.postMigrationHandlers)) {
+        // Use explicit tag mapping (avoids fragile substring matching)
+          const tag = migrations.postMigrationTags?.[key];
+          const migrationEntry = tag
+            ? migrations.journal.entries.find(e => e.tag === tag)
+            : null;
         
-        if (migrationEntry && appliedHashesAfter.has(migrationEntry.hash) && !appliedHashesBefore.has(migrationEntry.hash)) {
-          console.log(`Running post-migration handler for ${key}...`);
-          try {
-            await handler(rawDb);
-          } catch (handlerError) {
-            console.error(`Post-migration handler ${key} failed:`, handlerError);
-            // Don't throw - allow app to continue
+          if (migrationEntry && appliedHashesAfter.has(migrationEntry.hash) && !appliedHashesBefore.has(migrationEntry.hash)) {
+            console.log(`Running post-migration handler for ${key}...`);
+            try {
+              await handler(rawDb);
+            } catch (handlerError) {
+              console.error(`Post-migration handler ${key} failed:`, handlerError);
+            // Don't throw - allow app to continue; handler will be retried on next launch
+            }
+          }
+        }
+
+        // Retry any post-migration handlers that previously failed (completion flag not set)
+        for (const [key, handler] of Object.entries(migrations.postMigrationHandlers)) {
+          const tag = migrations.postMigrationTags?.[key];
+          const migrationEntry = tag
+            ? migrations.journal.entries.find(e => e.tag === tag)
+            : null;
+
+          if (migrationEntry && appliedHashesAfter.has(migrationEntry.hash)) {
+            const completionKey = `post_migration_${key}_completed`;
+            const completionRow = await rawDb.getFirstAsync(
+              'SELECT value FROM app_metadata WHERE key = ?',
+              [completionKey],
+            ).catch(() => null);
+
+            if (!completionRow) {
+              console.log(`Retrying incomplete post-migration handler for ${key}...`);
+              try {
+                await handler(rawDb);
+              } catch (retryError) {
+                console.error(`Post-migration handler ${key} retry failed:`, retryError);
+              }
+            }
           }
         }
       }
-    }
+
+    } // end of else (schema not yet complete)
+
+    // Enable foreign keys and WAL mode (always, regardless of migration path)
+    await rawDb.runAsync('PRAGMA foreign_keys = ON');
+    await rawDb.runAsync('PRAGMA journal_mode = WAL');
 
     console.log('Database migrations completed successfully');
   } catch (error) {

--- a/drizzle/0003_slow_grandmaster.js
+++ b/drizzle/0003_slow_grandmaster.js
@@ -5,6 +5,8 @@
  * Custom handler: Populates current month history after table creation
  */
 
+import { add as currencyAdd, subtract as currencySubtract } from '../app/services/currency';
+
 const sql = `CREATE TABLE \`accounts_balance_history\` (
 	\`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
 	\`account_id\` integer NOT NULL,
@@ -24,8 +26,6 @@ CREATE UNIQUE INDEX \`accounts_balance_history_account_id_date_unique\` ON \`acc
  */
 const postMigration = async (db) => {
   console.log('Running post-migration: Populating current month balance history...');
-  
-  const Currency = require('../app/services/currency');
   
   const formatDate = (date) => {
     const year = date.getFullYear();
@@ -57,15 +57,15 @@ const postMigration = async (db) => {
     // Reverse each operation
     for (const op of operations) {
       if (op.type === 'expense' && op.account_id === accountId) {
-        currentBalance = Currency.add(currentBalance, op.amount);
+        currentBalance = currencyAdd(currentBalance, op.amount);
       } else if (op.type === 'income' && op.account_id === accountId) {
-        currentBalance = Currency.subtract(currentBalance, op.amount);
+        currentBalance = currencySubtract(currentBalance, op.amount);
       } else if (op.type === 'transfer') {
         if (op.account_id === accountId) {
-          currentBalance = Currency.add(currentBalance, op.amount);
+          currentBalance = currencyAdd(currentBalance, op.amount);
         } else if (op.to_account_id === accountId) {
           const creditAmount = op.destination_amount || op.amount;
-          currentBalance = Currency.subtract(currentBalance, creditAmount);
+          currentBalance = currencySubtract(currentBalance, creditAmount);
         }
       }
     }
@@ -105,10 +105,16 @@ const postMigration = async (db) => {
       }
     }
 
+    // Mark post-migration as completed so it won't be retried
+    await db.runAsync(
+      "INSERT OR REPLACE INTO app_metadata (key, value, updated_at) VALUES ('post_migration_m0003_completed', 'true', ?)",
+      [new Date().toISOString()],
+    );
     console.log('Current month balance history populated successfully');
   } catch (error) {
     console.error('Failed to populate balance history during migration:', error);
-    // Don't throw - allow app to continue
+    // Don't throw - allow app to continue. The handler will be retried on next launch
+    // because the completion flag was not set.
   }
 };
 

--- a/drizzle/0004_remove_exclude_from_forecast.js
+++ b/drizzle/0004_remove_exclude_from_forecast.js
@@ -5,7 +5,8 @@
  * so we recreate the table without the column.
  */
 
-const sql = `DROP INDEX IF EXISTS \`idx_categories_exclude_from_forecast\`;--> statement-breakpoint
+const sql = `PRAGMA foreign_keys=OFF;--> statement-breakpoint
+DROP INDEX IF EXISTS \`idx_categories_exclude_from_forecast\`;--> statement-breakpoint
 CREATE TABLE \`categories_new\` (
 	\`id\` text PRIMARY KEY NOT NULL,
 	\`name\` text NOT NULL,
@@ -25,6 +26,7 @@ ALTER TABLE \`categories_new\` RENAME TO \`categories\`;--> statement-breakpoint
 CREATE INDEX \`idx_categories_parent\` ON \`categories\` (\`parent_id\`);--> statement-breakpoint
 CREATE INDEX \`idx_categories_type\` ON \`categories\` (\`type\`);--> statement-breakpoint
 CREATE INDEX \`idx_categories_category_type\` ON \`categories\` (\`category_type\`);--> statement-breakpoint
-CREATE INDEX \`idx_categories_is_shadow\` ON \`categories\` (\`is_shadow\`)`;
+CREATE INDEX \`idx_categories_is_shadow\` ON \`categories\` (\`is_shadow\`);--> statement-breakpoint
+PRAGMA foreign_keys=ON`;
 
 export default sql;

--- a/drizzle/0007_add_enum_check_constraints.js
+++ b/drizzle/0007_add_enum_check_constraints.js
@@ -1,47 +1,26 @@
 /**
- * Migration 0007: Add CHECK constraint to operations.type enum column
+ * Migration 0007: Enforce operations.type enum via TRIGGER
  *
- * Drizzle enums are not backed by SQLite CHECK constraints, so invalid values
- * from corrupted backups or manual edits can be inserted undetected.
+ * SQLite has no ALTER TABLE ADD CONSTRAINT, so adding a CHECK requires a full
+ * table rebuild (CREATE new → INSERT SELECT → DROP old → RENAME). That approach
+ * is fragile inside Drizzle's transaction wrapper because PRAGMA foreign_keys=OFF
+ * is a no-op within a transaction (documented SQLite limitation).
  *
- * This migration recreates the operations table with an explicit CHECK constraint.
- * It copies ALL rows — it does NOT silently drop invalid ones. If any row has an
- * invalid type the INSERT will fail due to the CHECK constraint, aborting the
- * migration. The pre-migration guard in db.js detects this situation first and
- * skips the migration with a warning so the app can still start.
+ * Instead we use BEFORE INSERT/UPDATE triggers — they provide identical enforcement
+ * (reject invalid types at the DB level) without any destructive table operations.
+ * Triggers work fine inside transactions and survive backup/restore cycles.
  */
 
-export default `PRAGMA foreign_keys=OFF;--> statement-breakpoint
+export default `CREATE TRIGGER IF NOT EXISTS \`trg_operations_type_insert\`
+BEFORE INSERT ON \`operations\`
+BEGIN
+  SELECT RAISE(ABORT, 'operations.type must be expense, income, or transfer')
+  WHERE NEW.\`type\` NOT IN ('expense', 'income', 'transfer');
+END;--> statement-breakpoint
 
-CREATE TABLE \`__new_operations\` (
-	\`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	\`type\` text NOT NULL CHECK (\`type\` IN ('expense', 'income', 'transfer')),
-	\`amount\` text NOT NULL,
-	\`account_id\` integer NOT NULL,
-	\`category_id\` text,
-	\`to_account_id\` integer,
-	\`date\` text NOT NULL,
-	\`created_at\` text NOT NULL,
-	\`description\` text,
-	\`exchange_rate\` text,
-	\`destination_amount\` text,
-	\`source_currency\` text,
-	\`destination_currency\` text,
-	\`original_balance\` text,
-	FOREIGN KEY (\`account_id\`) REFERENCES \`accounts\`(\`id\`) ON UPDATE no action ON DELETE cascade,
-	FOREIGN KEY (\`category_id\`) REFERENCES \`categories\`(\`id\`) ON UPDATE no action ON DELETE set null,
-	FOREIGN KEY (\`to_account_id\`) REFERENCES \`accounts\`(\`id\`) ON UPDATE no action ON DELETE cascade
-);--> statement-breakpoint
-
-INSERT INTO \`__new_operations\` SELECT * FROM \`operations\`;--> statement-breakpoint
-
-DROP TABLE \`operations\`;--> statement-breakpoint
-
-ALTER TABLE \`__new_operations\` RENAME TO \`operations\`;--> statement-breakpoint
-
-PRAGMA foreign_keys=ON;--> statement-breakpoint
-
-CREATE INDEX \`idx_operations_date\` ON \`operations\` (\`date\`);--> statement-breakpoint
-CREATE INDEX \`idx_operations_account\` ON \`operations\` (\`account_id\`);--> statement-breakpoint
-CREATE INDEX \`idx_operations_category\` ON \`operations\` (\`category_id\`);--> statement-breakpoint
-CREATE INDEX \`idx_operations_type\` ON \`operations\` (\`type\`);`;
+CREATE TRIGGER IF NOT EXISTS \`trg_operations_type_update\`
+BEFORE UPDATE OF \`type\` ON \`operations\`
+BEGIN
+  SELECT RAISE(ABORT, 'operations.type must be expense, income, or transfer')
+  WHERE NEW.\`type\` NOT IN ('expense', 'income', 'transfer');
+END;`;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -47,14 +47,14 @@
     {
       "idx": 6,
       "version": "6",
-      "when": 1747267200000,
+      "when": 1766100000000,
       "tag": "0006_add_original_balance",
       "breakpoints": true
     },
     {
       "idx": 7,
       "version": "6",
-      "when": 1747958400000,
+      "when": 1766200000000,
       "tag": "0007_add_enum_check_constraints",
       "breakpoints": true
     }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -25,5 +25,9 @@ export default {
   postMigrationHandlers: {
     m0003: m0003PostMigration,
   },
+  // Explicit tag mapping for post-migration handlers to avoid fragile substring matching
+  postMigrationTags: {
+    m0003: '0003_slow_grandmaster',
+  },
 };
   


### PR DESCRIPTION
## Summary

Rewrites migration 0007 from a destructive table-rebuild (CREATE → INSERT SELECT → DROP → RENAME) to a simple `CREATE TRIGGER IF NOT EXISTS` approach. Also hardens the overall Drizzle migration system to handle imported databases gracefully.

## Problem

Migration 0007 used the table-rebuild pattern to add a CHECK constraint to `operations.type`. This failed silently on imported databases because:

1. Drizzle wraps each migration in a transaction
2. SQLite ignores `PRAGMA foreign_keys=OFF` inside transactions (documented limitation)
3. The INSERT into the new table triggered FK validation, which failed
4. `execAsync` swallowed the error — transaction rolled back silently
5. Result: migration never applied, no error surfaced

Additional issues found during review:
- Imported databases had null hashes in `__drizzle_migrations`
- Non-monotonic timestamps in journal caused ordering issues
- Post-migration handlers used fragile substring matching
- Dynamic `require()` in migration 0003

## Solution

**Architecture change:** Replace CHECK constraint with BEFORE INSERT/UPDATE triggers.

| Before | After |
|--------|-------|
| Full table rebuild requiring FK pragma | Simple `CREATE TRIGGER IF NOT EXISTS` |
| Broken inside Drizzle transactions | Works fine inside transactions |
| Needed 60-line manual fallback | Just works — Drizzle applies it normally |
| Existing invalid data blocked migration | Triggers only fire on new writes |

**Additional robustness improvements:**
- `isSchemaComplete()` — skips migrate() entirely for fully-migrated imports
- `syncMigrationRecords()` — fixes hash/count mismatches in __drizzle_migrations
- `repairMigrationHashes()` — rebuilds records using schema inspection when null hashes detected
- `detectAppliedMigrations()` — determines applied state from actual schema markers
- Fixed journal timestamps to be monotonically increasing
- Post-migration handlers use explicit tag mapping instead of substring matching
- Migration 0003 uses static ES import instead of dynamic require()
- Added retry mechanism for failed post-migration handlers

**Backward compatibility:** Existing installs with the old CHECK constraint are detected and treated as "0007 applied" — their hash gets synced to the new trigger SQL on next startup.

## Changes

- `drizzle/0007_add_enum_check_constraints.js` — rewritten: triggers instead of table rebuild
- `drizzle/0003_slow_grandmaster.js` — static import, completion flag for retry
- `drizzle/0004_remove_exclude_from_forecast.js` — added FK pragma guards
- `drizzle/meta/_journal.json` — fixed non-monotonic timestamps
- `drizzle/migrations.js` — added postMigrationTags mapping
- `app/services/db.js` — full migration robustness overhaul
- `__tests__/services/db.test.js` — updated tests for trigger-based behavior

## Testing

All tests passing: 162/162 (4 suites)

Verified on device with imported database:
- Schema detected as complete → migrate() skipped
- Migration records consistent
- App starts normally with type enforcement active