### PR TITLE
fix: show green success indicator for all export types

### DIFF
--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -565,6 +565,69 @@ describe('SettingsScreen', () => {
       expect(getByText('csv_description')).toBeTruthy();
       expect(getByText('sqlite_description')).toBeTruthy();
     });
+
+    it('shows success state after SQLite export completes', async () => {
+      mockExportBackup.mockResolvedValue();
+      const { getByText } = render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+
+      fireEvent.press(getByText('export'));
+
+      await act(async () => {
+        fireEvent.press(getByText('Save externally to SQLite'));
+      });
+
+      expect(mockExportBackup).toHaveBeenCalledWith('sqlite');
+      expect(getByText('export_success')).toBeTruthy();
+    });
+
+    it('shows success state after CSV export completes', async () => {
+      mockExportBackup.mockResolvedValue();
+      const { getByText } = render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+
+      fireEvent.press(getByText('export'));
+
+      await act(async () => {
+        fireEvent.press(getByText('Save externally to CSV'));
+      });
+
+      expect(mockExportBackup).toHaveBeenCalledWith('csv');
+      expect(getByText('export_success')).toBeTruthy();
+    });
+
+    it('shows success state after JSON export completes', async () => {
+      mockExportBackup.mockResolvedValue();
+      const { getByText } = render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+
+      fireEvent.press(getByText('export'));
+
+      await act(async () => {
+        fireEvent.press(getByText('Save externally to JSON'));
+      });
+
+      expect(mockExportBackup).toHaveBeenCalledWith('json');
+      expect(getByText('export_success')).toBeTruthy();
+    });
+
+    it('shows error dialog when an external export fails', async () => {
+      mockExportBackup.mockRejectedValue(new Error('Export failed'));
+      const { getByText } = render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+
+      fireEvent.press(getByText('export'));
+
+      await act(async () => {
+        fireEvent.press(getByText('Save externally to SQLite'));
+      });
+
+      expect(mockShowDialog).toHaveBeenCalled();
+    });
   });
 
   describe('Developer Section', () => {

--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -628,6 +628,63 @@ describe('SettingsScreen', () => {
 
       expect(mockShowDialog).toHaveBeenCalled();
     });
+
+    it('shows loading indicator while SQLite export is in progress', async () => {
+      let resolveExport;
+      mockExportBackup.mockReturnValue(new Promise(resolve => { resolveExport = resolve; }));
+
+      const { getByText } = render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+      fireEvent.press(getByText('export'));
+
+      act(() => {
+        fireEvent.press(getByText('Save externally to SQLite'));
+      });
+
+      await waitFor(() => expect(getByText('exporting')).toBeTruthy());
+
+      await act(async () => { resolveExport(); });
+      expect(getByText('export_success')).toBeTruthy();
+    });
+
+    it('shows loading indicator while CSV export is in progress', async () => {
+      let resolveExport;
+      mockExportBackup.mockReturnValue(new Promise(resolve => { resolveExport = resolve; }));
+
+      const { getByText } = render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+      fireEvent.press(getByText('export'));
+
+      act(() => {
+        fireEvent.press(getByText('Save externally to CSV'));
+      });
+
+      await waitFor(() => expect(getByText('exporting')).toBeTruthy());
+
+      await act(async () => { resolveExport(); });
+      expect(getByText('export_success')).toBeTruthy();
+    });
+
+    it('shows loading indicator while JSON export is in progress', async () => {
+      let resolveExport;
+      mockExportBackup.mockReturnValue(new Promise(resolve => { resolveExport = resolve; }));
+
+      const { getByText } = render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+      fireEvent.press(getByText('export'));
+
+      act(() => {
+        fireEvent.press(getByText('Save externally to JSON'));
+      });
+
+      await waitFor(() => expect(getByText('exporting')).toBeTruthy());
+
+      await act(async () => { resolveExport(); });
+      expect(getByText('export_success')).toBeTruthy();
+    });
   });
 
   describe('Developer Section', () => {

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -87,9 +87,20 @@ export default function SettingsScreen({ setSubPanelActive }) {
   const [importSelectedBackup, setImportSelectedBackup] = useState(null);
   const [saveLocalBackupLoading, setSaveLocalBackupLoading] = useState(false);
   const [saveLocalBackupSuccess, setSaveLocalBackupSuccess] = useState(false);
+  const [sheetsExportSuccess, setSheetsExportSuccess] = useState(false);
+  const [sqliteExportLoading, setSqliteExportLoading] = useState(false);
+  const [sqliteExportSuccess, setSqliteExportSuccess] = useState(false);
+  const [csvExportLoading, setCsvExportLoading] = useState(false);
+  const [csvExportSuccess, setCsvExportSuccess] = useState(false);
+  const [jsonExportLoading, setJsonExportLoading] = useState(false);
+  const [jsonExportSuccess, setJsonExportSuccess] = useState(false);
   const [expandedLogIds, setExpandedLogIds] = useState(new Set());
 
   const saveLocalBackupColor = saveLocalBackupSuccess ? '#4caf50' : colors.text;
+  const sheetsColor = sheetsExportSuccess ? '#4caf50' : colors.text;
+  const sqliteColor = sqliteExportSuccess ? '#4caf50' : colors.text;
+  const csvColor = csvExportSuccess ? '#4caf50' : colors.text;
+  const jsonColor = jsonExportSuccess ? '#4caf50' : colors.text;
 
   // Toggle animations using reanimated shared values
   const toggleProgress = useSharedValue(hideBalances ? 1 : 0);
@@ -240,8 +251,12 @@ export default function SettingsScreen({ setSubPanelActive }) {
   };
 
   const handleExportFormatSelect = useCallback(async (format) => {
+    const setLoading = format === 'sqlite' ? setSqliteExportLoading : format === 'csv' ? setCsvExportLoading : setJsonExportLoading;
+    const setSuccess = format === 'sqlite' ? setSqliteExportSuccess : format === 'csv' ? setCsvExportSuccess : setJsonExportSuccess;
+    setLoading(true);
     try {
       await exportBackup(format);
+      setSuccess(true);
     } catch (error) {
       console.error('Export backup error:', error);
       showDialog(
@@ -249,6 +264,8 @@ export default function SettingsScreen({ setSubPanelActive }) {
         t('backup_error') || 'Failed to create backup',
         [{ text: 'OK' }],
       );
+    } finally {
+      setLoading(false);
     }
   }, [t, showDialog]);
 
@@ -282,6 +299,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
       updateSheetsStep('complete', 'completed');
       setSheetsSuccessUrl(sheetUrl);
+      setSheetsExportSuccess(true);
     } catch (error) {
       if (error.message === 'sign_in_cancelled') {
         setExportStep('list');
@@ -851,60 +869,108 @@ export default function SettingsScreen({ setSubPanelActive }) {
               >
                 <View style={styles.listItemContent}>
                   <View style={styles.formatItemRow}>
-                    <Ionicons name="logo-google" size={24} color={colors.text} />
+                    <Ionicons name="logo-google" size={24} color={sheetsColor} />
                     <View style={styles.formatTextContainer}>
-                      <Text style={[styles.listItemText, { color: colors.text }]}>Google Sheets</Text>
+                      <Text style={[styles.listItemText, { color: sheetsColor }]}>Google Sheets</Text>
                       <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('google_sheets_description') || 'Export to a Google Sheets spreadsheet'}
+                        {sheetsExportSuccess
+                          ? (t('export_success') || 'Export complete')
+                          : (t('google_sheets_description') || 'Export to a Google Sheets spreadsheet')}
                       </Text>
                     </View>
                   </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  {sheetsExportSuccess ? (
+                    <Ionicons name="checkmark-circle" size={22} color="#4caf50" />
+                  ) : (
+                    <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  )}
                 </View>
               </TouchableRipple>
 
-              <TouchableRipple onPress={() => handleExportFormatSelect('sqlite')} style={styles.listItem}>
+              <TouchableRipple
+                onPress={sqliteExportLoading ? null : () => handleExportFormatSelect('sqlite')}
+                style={styles.listItem}
+                disabled={sqliteExportLoading}
+              >
                 <View style={styles.listItemContent}>
                   <View style={styles.formatItemRow}>
-                    <Ionicons name="server-outline" size={24} color={colors.text} />
+                    <Ionicons name="server-outline" size={24} color={sqliteColor} />
                     <View style={styles.formatTextContainer}>
-                      <Text style={[styles.listItemText, { color: colors.text }]}>Save externally to SQLite</Text>
+                      <Text style={[styles.listItemText, { color: sqliteColor }]}>Save externally to SQLite</Text>
                       <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('sqlite_description') || 'Raw database file, complete backup'}
+                        {sqliteExportLoading
+                          ? (t('exporting') || 'Exporting…')
+                          : sqliteExportSuccess
+                            ? (t('export_success') || 'Export complete')
+                            : (t('sqlite_description') || 'Raw database file, complete backup')}
                       </Text>
                     </View>
                   </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  {sqliteExportLoading ? (
+                    <ActivityIndicator size="small" color={colors.primary} />
+                  ) : sqliteExportSuccess ? (
+                    <Ionicons name="checkmark-circle" size={22} color="#4caf50" />
+                  ) : (
+                    <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  )}
                 </View>
               </TouchableRipple>
 
-              <TouchableRipple onPress={() => handleExportFormatSelect('csv')} style={styles.listItem}>
+              <TouchableRipple
+                onPress={csvExportLoading ? null : () => handleExportFormatSelect('csv')}
+                style={styles.listItem}
+                disabled={csvExportLoading}
+              >
                 <View style={styles.listItemContent}>
                   <View style={styles.formatItemRow}>
-                    <Ionicons name="document-text-outline" size={24} color={colors.text} />
+                    <Ionicons name="document-text-outline" size={24} color={csvColor} />
                     <View style={styles.formatTextContainer}>
-                      <Text style={[styles.listItemText, { color: colors.text }]}>Save externally to CSV</Text>
+                      <Text style={[styles.listItemText, { color: csvColor }]}>Save externally to CSV</Text>
                       <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('csv_description') || 'Plain text format, easy to edit'}
+                        {csvExportLoading
+                          ? (t('exporting') || 'Exporting…')
+                          : csvExportSuccess
+                            ? (t('export_success') || 'Export complete')
+                            : (t('csv_description') || 'Plain text format, easy to edit')}
                       </Text>
                     </View>
                   </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  {csvExportLoading ? (
+                    <ActivityIndicator size="small" color={colors.primary} />
+                  ) : csvExportSuccess ? (
+                    <Ionicons name="checkmark-circle" size={22} color="#4caf50" />
+                  ) : (
+                    <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  )}
                 </View>
               </TouchableRipple>
 
-              <TouchableRipple onPress={() => handleExportFormatSelect('json')} style={styles.listItem}>
+              <TouchableRipple
+                onPress={jsonExportLoading ? null : () => handleExportFormatSelect('json')}
+                style={styles.listItem}
+                disabled={jsonExportLoading}
+              >
                 <View style={styles.listItemContent}>
                   <View style={styles.formatItemRow}>
-                    <Ionicons name="code-outline" size={24} color={colors.text} />
+                    <Ionicons name="code-outline" size={24} color={jsonColor} />
                     <View style={styles.formatTextContainer}>
-                      <Text style={[styles.listItemText, { color: colors.text }]}>Save externally to JSON</Text>
+                      <Text style={[styles.listItemText, { color: jsonColor }]}>Save externally to JSON</Text>
                       <Text style={[styles.formatDescription, { color: colors.mutedText }]}>
-                        {t('json_description') || 'Standard format, compatible with all versions'}
+                        {jsonExportLoading
+                          ? (t('exporting') || 'Exporting…')
+                          : jsonExportSuccess
+                            ? (t('export_success') || 'Export complete')
+                            : (t('json_description') || 'Standard format, compatible with all versions')}
                       </Text>
                     </View>
                   </View>
-                  <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  {jsonExportLoading ? (
+                    <ActivityIndicator size="small" color={colors.primary} />
+                  ) : jsonExportSuccess ? (
+                    <Ionicons name="checkmark-circle" size={22} color="#4caf50" />
+                  ) : (
+                    <Ionicons name="chevron-forward" size={20} color={colors.mutedText} />
+                  )}
                 </View>
               </TouchableRipple>
             </ScrollView>


### PR DESCRIPTION
## Summary

- SQLite, CSV, and JSON export rows now show a loading spinner while preparing the export, then a green checkmark + "Export complete" description text after the share sheet is dismissed successfully
- Google Sheets row shows a green checkmark + "Export complete" when returning to the list after a successful export
- Matches the existing behaviour of the "Save local backup" row (green icon, green title text, success description, checkmark replacing chevron)

## Test plan

- [ ] Tap "Save externally to SQLite" → share sheet appears → dismiss → row turns green with checkmark
- [ ] Tap "Save externally to CSV" → same behaviour
- [ ] Tap "Save externally to JSON" → same behaviour
- [ ] Complete a Google Sheets export → go back to list → Google Sheets row shows green checkmark
- [ ] Verify "Save local backup" still works as before
- [ ] Verify loading spinner appears during export preparation for SQLite/CSV/JSON

https://claude.ai/code/session_01DLHb3XehafD6z22zTA41so

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLHb3XehafD6z22zTA41so)_