### PR TITLE
fix: move update indicator from header to Settings tab icon

### DIFF
--- a/__tests__/components/Header.test.js
+++ b/__tests__/components/Header.test.js
@@ -41,19 +41,6 @@ jest.mock('../../app/styles/layout', () => ({
   HORIZONTAL_PADDING: 16,
 }));
 
-// Mock UpdateDownloadContext
-let mockIsDownloading = false;
-let mockDownloadProgress = null;
-let mockDownloadPhase = null;
-jest.mock('../../app/contexts/UpdateDownloadContext', () => ({
-  useUpdateDownload: () => ({
-    isDownloading: mockIsDownloading,
-    downloadProgress: mockDownloadProgress,
-    downloadPhase: mockDownloadPhase,
-    startDownload: jest.fn(),
-  }),
-}));
-
 // Mock SearchContext
 jest.mock('../../app/contexts/SearchContext', () => ({
   useSearch: () => ({
@@ -65,9 +52,6 @@ jest.mock('../../app/contexts/SearchContext', () => ({
 describe('Header', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsDownloading = false;
-    mockDownloadProgress = null;
-    mockDownloadPhase = null;
   });
 
   describe('Rendering', () => {
@@ -89,46 +73,9 @@ describe('Header', () => {
   });
 
   describe('Download indicator', () => {
-    it('does not show download indicator when not downloading', () => {
-      mockIsDownloading = false;
+    it('never shows a download indicator in the header (indicator lives on the tab bar)', () => {
       const { queryByTestId } = render(<Header />);
       expect(queryByTestId('download-indicator')).toBeNull();
-    });
-
-    it('shows download indicator when downloading', () => {
-      mockIsDownloading = true;
-      mockDownloadProgress = 0.42;
-      const { getByTestId } = render(<Header />);
-      expect(getByTestId('download-indicator')).toBeTruthy();
-    });
-
-    it('shows correct percentage when downloading', () => {
-      mockIsDownloading = true;
-      mockDownloadProgress = 0.75;
-      const { getByText } = render(<Header />);
-      expect(getByText('75%')).toBeTruthy();
-    });
-
-    it('shows sync icon and "verifying_update" text when phase is verifying', () => {
-      mockIsDownloading = true;
-      mockDownloadProgress = 0;
-      mockDownloadPhase = 'verifying';
-      const { getByTestId, getByText, queryByText } = render(<Header />);
-
-      expect(getByTestId('icon-sync')).toBeTruthy();
-      expect(getByText('verifying_update')).toBeTruthy();
-      expect(queryByText('%')).toBeNull();
-    });
-
-    it('shows arrow-down icon and percentage when phase is downloading', () => {
-      mockIsDownloading = true;
-      mockDownloadProgress = 0.6;
-      mockDownloadPhase = 'downloading';
-      const { getByTestId, getByText, queryByTestId } = render(<Header />);
-
-      expect(getByTestId('icon-arrow-down')).toBeTruthy();
-      expect(getByText('60%')).toBeTruthy();
-      expect(queryByTestId('icon-sync')).toBeNull();
     });
   });
 

--- a/__tests__/navigation/SimpleTabs.test.js
+++ b/__tests__/navigation/SimpleTabs.test.js
@@ -268,6 +268,8 @@ jest.mock('react-native-reanimated', () => {
       if (callback) callback(true);
       return toValue;
     },
+    withRepeat: (animation) => animation,
+    cancelAnimation: jest.fn(),
     runOnJS: (fn) => fn,
     runOnUI: (fn) => fn,
     Easing: {
@@ -282,6 +284,30 @@ jest.mock('react-native-reanimated', () => {
     },
   };
 });
+
+// Mock react-native-svg
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const PropTypes = require('prop-types');
+  function Svg({ children, width, height }) {
+    return React.createElement(View, { testID: 'svg', width, height }, children);
+  }
+  Svg.propTypes = { children: PropTypes.node, width: PropTypes.number, height: PropTypes.number, viewBox: PropTypes.string };
+  function Circle() { return null; }
+  Circle.propTypes = { cx: PropTypes.number, cy: PropTypes.number, r: PropTypes.number, stroke: PropTypes.string, strokeWidth: PropTypes.number, fill: PropTypes.string, opacity: PropTypes.number, strokeDasharray: PropTypes.any, strokeDashoffset: PropTypes.number, strokeLinecap: PropTypes.string };
+  return { Svg, Circle };
+});
+
+// Mock UpdateDownloadContext
+jest.mock('../../app/contexts/UpdateDownloadContext', () => ({
+  useUpdateDownload: () => ({
+    isDownloading: false,
+    downloadProgress: null,
+    downloadPhase: null,
+    startDownload: jest.fn(),
+  }),
+}));
 
 describe('SimpleTabs Component Rendering', () => {
   beforeEach(() => {

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -1,12 +1,11 @@
-import { View, Text, StyleSheet, Animated, Easing, BackHandler } from 'react-native';
-import { useEffect, useCallback, useRef } from 'react';
+import { View, Text, StyleSheet, BackHandler } from 'react-native';
+import { useEffect, useCallback } from 'react';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import SearchBar from './search/SearchBar';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import { useLocalization } from '../contexts/LocalizationContext';
-import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
 import { useSearch } from '../contexts/SearchContext';
 import FilterChipStrip from './search/FilterChipStrip';
 import { useOperationsData } from '../contexts/OperationsDataContext';
@@ -15,35 +14,7 @@ import { useOperationsActions } from '../contexts/OperationsActionsContext';
 export default function Header({ rightContent, activeScreen, operationsData }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
-  const { isDownloading, downloadProgress, downloadPhase } = useUpdateDownload();
   const { openSearch, searchMode, closeSearch, reopenSearch, toggleFilters, filtersExpanded } = useSearch();
-  const downloadArrowAnim = useRef(new Animated.Value(0)).current;
-  const rotateAnim = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    if (!isDownloading) {
-      downloadArrowAnim.setValue(0);
-      rotateAnim.setValue(0);
-      return;
-    }
-    if (downloadPhase === 'verifying') {
-      downloadArrowAnim.setValue(0);
-      const loop = Animated.loop(
-        Animated.timing(rotateAnim, { toValue: 1, duration: 1000, easing: Easing.linear, useNativeDriver: true }),
-      );
-      loop.start();
-      return () => loop.stop();
-    }
-    rotateAnim.setValue(0);
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(downloadArrowAnim, { toValue: 5, duration: 400, useNativeDriver: true }),
-        Animated.timing(downloadArrowAnim, { toValue: 0, duration: 400, useNativeDriver: true }),
-      ]),
-    );
-    loop.start();
-    return () => loop.stop();
-  }, [isDownloading, downloadPhase, downloadArrowAnim, rotateAnim]);
 
   const { searchState, hasActiveSearch, getSearchFilterCount } = useOperationsData();
   const { setSearchText, updateSearchFilters } = useOperationsActions();
@@ -113,35 +84,6 @@ export default function Header({ rightContent, activeScreen, operationsData }) {
       {rightContent && !showSearchBar && (
         <View style={styles.buttonContainer}>{rightContent}</View>
       )}
-      {isDownloading && !showSearchBar && (
-        <View
-          style={styles.downloadIndicator}
-          accessibilityLabel={
-            downloadPhase === 'verifying'
-              ? (t('verifying_update') || 'Checking…')
-              : `${t('downloading_update') || 'Downloading update'} ${Math.round((downloadProgress ?? 0) * 100)}%`
-          }
-          accessibilityRole="progressbar"
-          testID="download-indicator"
-        >
-          {downloadPhase === 'verifying' ? (
-            <Animated.View style={{
-              transform: [{ rotate: rotateAnim.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '360deg'] }) }],
-            }}>
-              <Icon name="sync" size={20} color={colors.primary} />
-            </Animated.View>
-          ) : (
-            <Animated.View style={{ transform: [{ translateY: downloadArrowAnim }] }}>
-              <Icon name="arrow-down" size={20} color={colors.primary} />
-            </Animated.View>
-          )}
-          <Text style={[styles.downloadPercent, { color: colors.mutedText }]}>
-            {downloadPhase === 'verifying'
-              ? (t('verifying_update') || 'Checking…')
-              : `${Math.round((downloadProgress ?? 0) * 100)}%`}
-          </Text>
-        </View>
-      )}
       {showSearchBar && (
         <>
           <SearchBar
@@ -198,13 +140,5 @@ const styles = StyleSheet.create({
     alignItems: 'stretch',
     flexDirection: 'column',
     paddingHorizontal: 0,
-  },
-  downloadIndicator: {
-    alignItems: 'center',
-    gap: 2,
-  },
-  downloadPercent: {
-    fontSize: 9,
-    fontVariant: ['tabular-nums'],
   },
 });

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, memo } from 'react';
+import React, { useMemo, useCallback, useRef, useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, Dimensions, Platform, BackHandler } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -8,9 +8,12 @@ import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
+  withRepeat,
+  cancelAnimation,
   Easing,
   runOnJS,
 } from 'react-native-reanimated';
+import { Svg, Circle } from 'react-native-svg';
 
 const SCREEN_TIMING = { duration: 300, easing: Easing.out(Easing.cubic) };
 const PILL_TIMING = { duration: 200, easing: Easing.out(Easing.quad) };
@@ -21,6 +24,7 @@ import PlannedOperationsScreen from '../screens/PlannedOperationsScreen';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useOperationsData } from '../contexts/OperationsDataContext';
+import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
 import Header from '../components/Header';
 import SettingsScreen from '../screens/SettingsScreen';
 
@@ -39,11 +43,91 @@ const TAB_ICONS = {
   Settings: 'cog-outline',
 };
 
+const PROGRESS_RADIUS = 9;
+const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
+
+// Circular material progress indicator that replaces the Settings cog icon
+// while an update is downloading or being verified.
+const UpdateProgressIcon = memo(({ phase, progress, color }) => {
+  const spinValue = useSharedValue(0);
+
+  useEffect(() => {
+    if (phase === 'verifying') {
+      spinValue.value = withRepeat(
+        withTiming(1, { duration: 1000, easing: Easing.linear }),
+        -1,
+        false,
+      );
+    } else {
+      cancelAnimation(spinValue);
+      spinValue.value = 0;
+    }
+    return () => cancelAnimation(spinValue);
+  }, [phase, spinValue]);
+
+  const spinStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${spinValue.value * 360 - 90}deg` }],
+  }));
+
+  const strokeOffset = PROGRESS_CIRCUMFERENCE * (1 - (progress ?? 0));
+
+  if (phase === 'verifying') {
+    return (
+      <Animated.View style={spinStyle}>
+        <Svg width={22} height={22} viewBox="0 0 22 22">
+          <Circle
+            cx={11}
+            cy={11}
+            r={PROGRESS_RADIUS}
+            stroke={color}
+            strokeWidth={2.5}
+            fill="none"
+            strokeDasharray={`${PROGRESS_CIRCUMFERENCE * 0.75} ${PROGRESS_CIRCUMFERENCE * 0.25}`}
+            strokeLinecap="round"
+          />
+        </Svg>
+      </Animated.View>
+    );
+  }
+
+  // Determinate circle: track + progress arc, rotated so fill starts at 12 o'clock
+  return (
+    <View style={{ transform: [{ rotate: '-90deg' }] }}>
+      <Svg width={22} height={22} viewBox="0 0 22 22">
+        <Circle
+          cx={11}
+          cy={11}
+          r={PROGRESS_RADIUS}
+          stroke={color}
+          strokeWidth={2}
+          fill="none"
+          opacity={0.25}
+        />
+        <Circle
+          cx={11}
+          cy={11}
+          r={PROGRESS_RADIUS}
+          stroke={color}
+          strokeWidth={2.5}
+          fill="none"
+          strokeDasharray={PROGRESS_CIRCUMFERENCE}
+          strokeDashoffset={strokeOffset}
+          strokeLinecap="round"
+        />
+      </Svg>
+    </View>
+  );
+});
+
+UpdateProgressIcon.displayName = 'UpdateProgressIcon';
+
 // Memoized tab button with icon + label, pill active state
-const TabButton = memo(({ tab, isActive, colors, onPress }) => {
+const TabButton = memo(({ tab, isActive, colors, onPress, isUpdating, updatePhase, updateProgress }) => {
   const handlePress = useCallback(() => {
     onPress(tab.key);
   }, [onPress, tab.key]);
+
+  const iconColor = isActive ? colors.primary : colors.mutedText;
 
   const labelStyle = useMemo(() => [
     styles.tabLabel,
@@ -64,11 +148,15 @@ const TabButton = memo(({ tab, isActive, colors, onPress }) => {
       accessibilityLabel={tab.label}
     >
       <View style={styles.tabContent}>
-        <MaterialCommunityIcons
-          name={TAB_ICONS[tab.key] || 'circle-outline'}
-          size={22}
-          color={isActive ? colors.primary : colors.mutedText}
-        />
+        {isUpdating ? (
+          <UpdateProgressIcon phase={updatePhase} progress={updateProgress} color={iconColor} />
+        ) : (
+          <MaterialCommunityIcons
+            name={TAB_ICONS[tab.key] || 'circle-outline'}
+            size={22}
+            color={iconColor}
+          />
+        )}
         <Text
           variant="labelSmall"
           style={labelStyle}
@@ -95,17 +183,24 @@ TabButton.propTypes = {
     mutedText: PropTypes.string,
   }).isRequired,
   onPress: PropTypes.func,
+  isUpdating: PropTypes.bool,
+  updatePhase: PropTypes.string,
+  updateProgress: PropTypes.number,
 };
 
 TabButton.defaultProps = {
   isActive: false,
   onPress: () => {},
+  isUpdating: false,
+  updatePhase: null,
+  updateProgress: null,
 };
 
 export default function SimpleTabs() {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const operationsData = useOperationsData();
+  const { isDownloading, downloadProgress, downloadPhase } = useUpdateDownload();
   const [active, setActive] = React.useState('Operations');
   const [subPanelActive, setSubPanelActive] = React.useState(false);
   const [tabBarWidth, setTabBarWidth] = React.useState(SCREEN_WIDTH);
@@ -363,6 +458,9 @@ export default function SimpleTabs() {
                   isActive={displayedTab === tab.key}
                   colors={colors}
                   onPress={handleTabPress}
+                  isUpdating={tab.key === 'Settings' && isDownloading}
+                  updatePhase={downloadPhase}
+                  updateProgress={downloadProgress}
                 />
               ))}
             </View>

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -121,6 +121,12 @@ const UpdateProgressIcon = memo(({ phase, progress, color }) => {
 
 UpdateProgressIcon.displayName = 'UpdateProgressIcon';
 
+UpdateProgressIcon.propTypes = {
+  phase: PropTypes.string,
+  progress: PropTypes.number,
+  color: PropTypes.string.isRequired,
+};
+
 // Memoized tab button with icon + label, pill active state
 const TabButton = memo(({ tab, isActive, colors, onPress, isUpdating, updatePhase, updateProgress }) => {
   const handlePress = useCallback(() => {


### PR DESCRIPTION
## Summary

- Removes the download/verify indicator from the top `Header` component entirely
- Replaces the Settings tab cog icon with a material circular progress indicator while an update is active
- **Downloading phase**: determinate SVG ring that fills clockwise (0→100%) as `downloadProgress` advances; track ring shown at 25% opacity behind it
- **Verifying phase**: indeterminate spinning 3/4-arc using Reanimated `withRepeat` — the standard Material Design indeterminate circular indicator pattern

## Details

**`app/components/Header.js`** — stripped of all update-download state, animation refs, and the indicator JSX block. `Animated`, `Easing`, `useRef`, and `useUpdateDownload` imports removed.

**`app/navigation/SimpleTabs.js`** — added `UpdateProgressIcon` component (SVG-based, Reanimated-animated) and wires `useUpdateDownload` state into the Settings `TabButton`. No other tabs are affected.

## Test plan

- [ ] All 3544 existing tests pass (verified locally)
- [ ] `Header.test.js` updated: obsolete download-indicator assertions removed; confirms header never renders the indicator
- [ ] `SimpleTabs.test.js` updated: mocks added for `UpdateDownloadContext`, `react-native-svg`, and new Reanimated exports (`withRepeat`, `cancelAnimation`)

https://claude.ai/code/session_017UhiKadBadnf2Usqn3VkZe

---
_Generated by [Claude Code](https://claude.ai/code/session_017UhiKadBadnf2Usqn3VkZe)_