### PR TITLE
fix: add migration 0008 detection to schema completeness check

### DIFF
--- a/app/services/db.js
+++ b/app/services/db.js
@@ -137,6 +137,9 @@ const isSchemaComplete = async (rawDb) => {
       if (!opsSchema?.sql || !/CHECK\s*\(\s*[`"]?type[`"]?\s+IN\s*\(/i.test(opsSchema.sql)) return false;
     }
 
+    // Check accounts has deleted_at column (migration 0008)
+    if (!accountsCols.some(c => c.name === 'deleted_at')) return false;
+
     return true;
   } catch (error) {
     console.warn('[DB] isSchemaComplete check failed:', error.message);
@@ -317,6 +320,14 @@ const detectAppliedMigrations = async (rawDb) => {
     ).catch(() => null);
     if (opsSchema?.sql && /CHECK\s*\(\s*[`"]?type[`"]?\s+IN\s*\(/i.test(opsSchema.sql)) {
       applied.push(7);
+    }
+  }
+
+  // Migration 0008: Adds deleted_at column to accounts (soft-delete)
+  if (await tableExists('accounts')) {
+    const accCols = await getColumns('accounts');
+    if (accCols.some(c => c.name === 'deleted_at')) {
+      applied.push(8);
     }
   }
 


### PR DESCRIPTION
## Problem

After merging PR #876 (soft-delete accounts), existing devices that had migrations 0000–0007 applied would hit:

```
Error: no such column: accounts.deleted_at
```

`isSchemaComplete()` only checked for migrations 0–7, so it returned `true` → `migrate()` was skipped → the `ALTER TABLE accounts ADD COLUMN deleted_at` from migration 0008 never ran.

## Fix

Added migration 0008 detection to:
- `isSchemaComplete()` — checks `accounts.deleted_at` column exists
- `detectAppliedMigrations()` — includes index 8 when column is present (for null-hash repair)

## Testing

162/162 tests pass.