### PR TITLE
fix: save/Cancel buttons hidden behind floating tab bar in Edit Account

### DIFF
--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -784,7 +784,7 @@ describe('AppUpdateService', () => {
       expect(onPhaseChange).toHaveBeenCalledWith('verifying');
     });
 
-    it('does not call onPhaseChange with verifying when no checksumUrl is provided', async () => {
+    it('calls onPhaseChange("backing_up") but not "verifying" when no checksumUrl is provided', async () => {
       FileSystem.createDownloadResumable.mockReturnValue({
         downloadAsync: jest.fn().mockResolvedValue({ uri: 'file:///cache/penny-v1.0.0.apk' }),
       });
@@ -797,6 +797,7 @@ describe('AppUpdateService', () => {
         { onPhaseChange },
       );
 
+      expect(onPhaseChange).toHaveBeenCalledWith('backing_up');
       expect(onPhaseChange).not.toHaveBeenCalledWith('verifying');
     });
   });

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -12,7 +12,7 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeConfig } from '../contexts/ThemeConfigContext';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
-import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS, HEIGHTS } from '../styles/layout';
 import { useAccountsData } from '../contexts/AccountsDataContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useOperationsData } from '../contexts/OperationsDataContext';
@@ -1240,7 +1240,9 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     gap: 8,
-    padding: 12,
+    paddingBottom: HEIGHTS.tabBar,
+    paddingHorizontal: 12,
+    paddingTop: 12,
   },
   formPanelHeader: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary

- The Save/Cancel buttons in the Edit Account form panel were positioned at the very bottom of the screen, directly behind the floating tab bar
- Added `paddingBottom: HEIGHTS.tabBar` (80px) to `formPanelFooter` so buttons sit above the floating navigation bar
- Also imported the existing `HEIGHTS` token from `designTokens.js` — no new constants needed

## Test plan

- [ ] Open the Accounts tab and tap any account to open Edit Account
- [ ] Verify Cancel and Save buttons are fully visible above the floating tab bar
- [ ] Verify tapping Save saves the account correctly
- [ ] Verify tapping Cancel dismisses the form without saving
- [ ] Verify the same layout works for the Add Account form (new account)

https://claude.ai/code/session_01Dqi7rfXi7WJNdMjs4oAxMr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dqi7rfXi7WJNdMjs4oAxMr)_