### PR TITLE
Telegram-style predictive back shrink for panels

### DIFF
--- a/__tests__/hooks/useBackShrink.test.js
+++ b/__tests__/hooks/useBackShrink.test.js
@@ -1,0 +1,74 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useBackShrink } from '../../app/hooks/useBackShrink';
+
+// react-native-reanimated is mocked globally in jest.setup.js:
+//  - useSharedValue(v) -> { value: v }
+//  - useAnimatedStyle(fn) -> {}
+//  - withTiming(value, cfg, cb) -> value (callback is not invoked under the mock)
+
+describe('useBackShrink', () => {
+  describe('Shape', () => {
+    it('exposes the documented API', () => {
+      const { result } = renderHook(() => useBackShrink());
+
+      expect(result.current.progress).toBeDefined();
+      expect(result.current.animatedStyle).toBeDefined();
+      expect(result.current.originStyle).toBeDefined();
+      expect(typeof result.current.reset).toBe('function');
+      expect(typeof result.current.setProgress).toBe('function');
+      expect(typeof result.current.cancel).toBe('function');
+      expect(typeof result.current.commit).toBe('function');
+    });
+
+    it('starts at rest (progress 0)', () => {
+      const { result } = renderHook(() => useBackShrink());
+      expect(result.current.progress.value).toBe(0);
+    });
+  });
+
+  describe('originStyle', () => {
+    it('anchors the shrink to the bottom-right by default', () => {
+      const { result } = renderHook(() => useBackShrink());
+      expect(result.current.originStyle.transformOrigin).toBe('right bottom');
+    });
+
+    it('honors a custom origin', () => {
+      const { result } = renderHook(() => useBackShrink({ origin: 'left top' }));
+      expect(result.current.originStyle.transformOrigin).toBe('left top');
+    });
+  });
+
+  describe('Controls', () => {
+    it('setProgress drives the progress value directly', () => {
+      const { result } = renderHook(() => useBackShrink());
+      act(() => result.current.setProgress(0.5));
+      expect(result.current.progress.value).toBe(0.5);
+    });
+
+    it('reset snaps progress back to 0', () => {
+      const { result } = renderHook(() => useBackShrink());
+      act(() => result.current.setProgress(0.8));
+      act(() => result.current.reset());
+      expect(result.current.progress.value).toBe(0);
+    });
+
+    it('commit animates progress toward 1 (fully shrunk)', () => {
+      const { result } = renderHook(() => useBackShrink());
+      act(() => result.current.commit());
+      expect(result.current.progress.value).toBe(1);
+    });
+
+    it('commit accepts an onDone callback without throwing', () => {
+      const onDone = jest.fn();
+      const { result } = renderHook(() => useBackShrink());
+      expect(() => act(() => result.current.commit(onDone))).not.toThrow();
+    });
+
+    it('cancel animates progress back toward 0', () => {
+      const { result } = renderHook(() => useBackShrink());
+      act(() => result.current.setProgress(0.6));
+      act(() => result.current.cancel());
+      expect(result.current.progress.value).toBe(0);
+    });
+  });
+});

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -11,6 +11,7 @@ import {
   Animated,
   Dimensions,
 } from 'react-native';
+import Reanimated from 'react-native-reanimated';
 import { Text, TouchableRipple } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
@@ -18,6 +19,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import { useBackShrink } from '../hooks/useBackShrink';
 import ModalBlurOverlay from './ModalBlurOverlay';
 
 /**
@@ -58,9 +60,19 @@ export default function ModalShell({
   const onDismissRef = useRef(onDismiss);
   useEffect(() => { onDismissRef.current = onDismiss; }, [onDismiss]);
 
+  // Telegram-style predictive "back" shrink — played when the Android back
+  // button/gesture closes the sheet (onRequestClose). The card keeps its
+  // rounded top, so start from the existing 24px radius rather than square.
+  const { animatedStyle: shrinkStyle, originStyle, reset: resetShrink, commit: commitShrink } =
+    useBackShrink({ baseBorderRadius: 24, borderRadius: 24 });
+
   // Slide in from bottom when modal opens
   useEffect(() => {
     if (visible) {
+      // Always start offscreen and un-shrunk so the open animation is correct
+      // no matter how the sheet was previously dismissed (slide or shrink).
+      translateY.setValue(screenHeight);
+      resetShrink();
       Animated.spring(translateY, {
         toValue: 0,
         useNativeDriver: true,
@@ -68,7 +80,12 @@ export default function ModalShell({
         speed: 14,
       }).start();
     }
-  }, [visible, translateY]);
+  }, [visible, translateY, screenHeight, resetShrink]);
+
+  // Back button / gesture: play the shrink, then dismiss.
+  const handleBackDismiss = useCallback(() => {
+    commitShrink(() => onDismissRef.current?.());
+  }, [commitShrink]);
 
   // Animate out then call callback — used for overlay tap and cancel button
   const animateOut = useCallback((callback) => {
@@ -125,101 +142,103 @@ export default function ModalShell({
         visible={visible}
         animationType="none"
         transparent={true}
-        onRequestClose={() => animateOut(onDismiss)}
+        onRequestClose={handleBackDismiss}
       >
         <KeyboardAvoidingView behavior="padding" style={styles.flex1}>
           <Pressable style={styles.overlay} onPress={() => animateOut(onDismiss)}>
             <Animated.View style={{ transform: [{ translateY }] }}>
-              <Pressable
-                style={[styles.card, { backgroundColor: colors.card, maxHeight: Dimensions.get('window').height * 0.88 }]}
-                onPress={() => {}}
-              >
-                {/* Drag zone: handle + header — touch here to dismiss by dragging down */}
-                <View {...panResponder.panHandlers}>
-                  <View style={[styles.dragHandle, { backgroundColor: colors.border }]} />
-
-                  {/* Header */}
-                  <View style={styles.header}>
-                    <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
-                    {subtitle ? (
-                      <Text style={[styles.subtitle, { color: colors.mutedText }]}>
-                        {subtitle}
-                      </Text>
-                    ) : null}
-                  </View>
-                </View>
-
-                {/* Scrollable form content */}
-                <ScrollView
-                  ref={scrollRef}
-                  style={styles.scroll}
-                  contentContainerStyle={styles.scrollContent}
-                  keyboardShouldPersistTaps="handled"
-                  showsVerticalScrollIndicator={false}
+              <Reanimated.View style={[originStyle, shrinkStyle]}>
+                <Pressable
+                  style={[styles.card, { backgroundColor: colors.card, maxHeight: Dimensions.get('window').height * 0.88 }]}
+                  onPress={() => {}}
                 >
-                  {children}
-                </ScrollView>
+                  {/* Drag zone: handle + header — touch here to dismiss by dragging down */}
+                  <View {...panResponder.panHandlers}>
+                    <View style={[styles.dragHandle, { backgroundColor: colors.border }]} />
 
-                {/* Secondary actions: delete + extra actions in one compact row */}
-                {(onDelete || extraActions) ? (
-                  <View style={styles.deleteWrapper}>
-                    {onDelete ? (
-                      <TouchableRipple
-                        onPress={deleteDisabled ? undefined : onDelete}
-                        disabled={deleteDisabled}
-                        rippleColor={colors.delete + '18'}
-                        style={[
-                          styles.btn,
-                          styles.deleteRow,
-                          { borderColor: colors.delete + '40' },
-                          deleteDisabled && styles.disabled,
-                        ]}
-                        borderless={false}
-                      >
-                        <View style={styles.deleteRowContent}>
-                          <Icon name="delete-outline" size={18} color={colors.delete} />
-                          <Text style={[styles.deleteRowText, { color: colors.delete }]}>
-                            {deleteLabel || t('delete')}
-                          </Text>
-                        </View>
-                      </TouchableRipple>
-                    ) : null}
-                    {extraActions || null}
+                    {/* Header */}
+                    <View style={styles.header}>
+                      <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+                      {subtitle ? (
+                        <Text style={[styles.subtitle, { color: colors.mutedText }]}>
+                          {subtitle}
+                        </Text>
+                      ) : null}
+                    </View>
                   </View>
-                ) : null}
 
-                {/* Cancel / Save (or full-width Cancel when onSave is absent) */}
-                <View style={[styles.actions, { borderTopColor: colors.border, paddingBottom: SPACING.md + insets.bottom }]}>
-                  <TouchableRipple
-                    onPress={() => animateOut(onCancel)}
-                    style={[
-                      styles.btn,
-                      styles.cancelBtn,
-                      { borderColor: colors.border },
-                      !onSave && styles.fullWidthBtn,
-                    ]}
-                    rippleColor="rgba(0,0,0,0.05)"
-                    borderless={false}
+                  {/* Scrollable form content */}
+                  <ScrollView
+                    ref={scrollRef}
+                    style={styles.scroll}
+                    contentContainerStyle={styles.scrollContent}
+                    keyboardShouldPersistTaps="handled"
+                    showsVerticalScrollIndicator={false}
                   >
-                    <Text style={[styles.btnText, { color: colors.text }]}>
-                      {cancelLabel || t('cancel')}
-                    </Text>
-                  </TouchableRipple>
+                    {children}
+                  </ScrollView>
 
-                  {onSave ? (
+                  {/* Secondary actions: delete + extra actions in one compact row */}
+                  {(onDelete || extraActions) ? (
+                    <View style={styles.deleteWrapper}>
+                      {onDelete ? (
+                        <TouchableRipple
+                          onPress={deleteDisabled ? undefined : onDelete}
+                          disabled={deleteDisabled}
+                          rippleColor={colors.delete + '18'}
+                          style={[
+                            styles.btn,
+                            styles.deleteRow,
+                            { borderColor: colors.delete + '40' },
+                            deleteDisabled && styles.disabled,
+                          ]}
+                          borderless={false}
+                        >
+                          <View style={styles.deleteRowContent}>
+                            <Icon name="delete-outline" size={18} color={colors.delete} />
+                            <Text style={[styles.deleteRowText, { color: colors.delete }]}>
+                              {deleteLabel || t('delete')}
+                            </Text>
+                          </View>
+                        </TouchableRipple>
+                      ) : null}
+                      {extraActions || null}
+                    </View>
+                  ) : null}
+
+                  {/* Cancel / Save (or full-width Cancel when onSave is absent) */}
+                  <View style={[styles.actions, { borderTopColor: colors.border, paddingBottom: SPACING.md + insets.bottom }]}>
                     <TouchableRipple
-                      onPress={onSave}
-                      style={[styles.btn, { backgroundColor: colors.primary }]}
-                      rippleColor="rgba(255,255,255,0.2)"
+                      onPress={() => animateOut(onCancel)}
+                      style={[
+                        styles.btn,
+                        styles.cancelBtn,
+                        { borderColor: colors.border },
+                        !onSave && styles.fullWidthBtn,
+                      ]}
+                      rippleColor="rgba(0,0,0,0.05)"
                       borderless={false}
                     >
-                      <Text style={[styles.btnText, styles.saveBtnText]}>
-                        {saveLabel || t('save')}
+                      <Text style={[styles.btnText, { color: colors.text }]}>
+                        {cancelLabel || t('cancel')}
                       </Text>
                     </TouchableRipple>
-                  ) : null}
-                </View>
-              </Pressable>
+
+                    {onSave ? (
+                      <TouchableRipple
+                        onPress={onSave}
+                        style={[styles.btn, { backgroundColor: colors.primary }]}
+                        rippleColor="rgba(255,255,255,0.2)"
+                        borderless={false}
+                      >
+                        <Text style={[styles.btnText, styles.saveBtnText]}>
+                          {saveLabel || t('save')}
+                        </Text>
+                      </TouchableRipple>
+                    ) : null}
+                  </View>
+                </Pressable>
+              </Reanimated.View>
             </Animated.View>
           </Pressable>
         </KeyboardAvoidingView>

--- a/app/hooks/useBackShrink.js
+++ b/app/hooks/useBackShrink.js
@@ -1,0 +1,132 @@
+import { useCallback } from 'react';
+import {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  interpolate,
+  Extrapolation,
+  runOnJS,
+  Easing,
+} from 'react-native-reanimated';
+
+/**
+ * useBackShrink — Telegram-style predictive "back" shrink for panels.
+ *
+ * Reproduces the animation Telegram plays when you start the Android back
+ * gesture: the current panel scales down, anchored to its BOTTOM-RIGHT corner,
+ * is pulled slightly inward, and its corners round off — revealing whatever
+ * sits behind it.
+ *
+ * The hook exposes a single `progress` shared value (0 = panel at rest, 1 =
+ * fully shrunk away) plus an `animatedStyle` that maps that progress onto the
+ * shrink transform. How `progress` is driven is up to the caller:
+ *
+ *   • Today (RN 0.81) the Android system back only reports on RELEASE via
+ *     `BackHandler` / `Modal.onRequestClose`, so panels call `commit(onClose)`
+ *     to play the shrink as a close animation and then dismiss.
+ *
+ *   • Later, a native predictive-back source (an `OnBackAnimationCallback`
+ *     bridged to JS) can drive the gesture LIVE by calling `setProgress(p)` as
+ *     the finger moves, then `commit(onClose)` on release or `cancel()` if the
+ *     gesture is abandoned. No panel code has to change when that lands.
+ *
+ * Usage:
+ *
+ *   const { animatedStyle, originStyle, commit, reset } = useBackShrink();
+ *   // when (re)opening the panel:        reset();
+ *   // on back press/gesture release:     commit(closePanel);
+ *   // wrap the panel container:
+ *   <Animated.View style={[styles.panel, originStyle, animatedStyle]}>…</Animated.View>
+ *
+ * `Animated` must be the component from `react-native-reanimated`.
+ *
+ * @param {object}  [options]
+ * @param {number}  [options.minScale=0.92]        Scale at full progress.
+ * @param {number}  [options.translateX=22]        Inward pull (px) at full progress.
+ * @param {number}  [options.translateY=0]         Vertical pull (px) at full progress.
+ * @param {number}  [options.borderRadius=28]      Corner radius at full progress.
+ * @param {number}  [options.baseBorderRadius=0]   Corner radius at rest.
+ * @param {number}  [options.fade=0.12]            Opacity reduction at full progress (0..1).
+ * @param {number}  [options.commitDuration=240]   ms for the close (progress→1) animation.
+ * @param {number}  [options.cancelDuration=180]   ms for the cancel (progress→0) animation.
+ * @param {string}  [options.origin='right bottom'] transform-origin anchor.
+ * @returns {{
+ *   progress: object,
+ *   animatedStyle: object,
+ *   originStyle: object,
+ *   reset: () => void,
+ *   setProgress: (value: number) => void,
+ *   cancel: () => void,
+ *   commit: (onDone?: () => void) => void,
+ * }}
+ */
+export function useBackShrink(options = {}) {
+  const {
+    minScale = 0.92,
+    translateX = 22,
+    translateY = 0,
+    borderRadius = 28,
+    baseBorderRadius = 0,
+    fade = 0.12,
+    commitDuration = 240,
+    cancelDuration = 180,
+    origin = 'right bottom',
+  } = options;
+
+  // 0 = panel at rest, 1 = fully shrunk (dismissing).
+  const progress = useSharedValue(0);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const p = progress.value;
+    return {
+      opacity: interpolate(p, [0, 1], [1, 1 - fade], Extrapolation.CLAMP),
+      borderRadius: interpolate(p, [0, 1], [baseBorderRadius, borderRadius], Extrapolation.CLAMP),
+      transform: [
+        { translateX: interpolate(p, [0, 1], [0, translateX], Extrapolation.CLAMP) },
+        { translateY: interpolate(p, [0, 1], [0, translateY], Extrapolation.CLAMP) },
+        { scale: interpolate(p, [0, 1], [1, minScale], Extrapolation.CLAMP) },
+      ],
+    };
+  });
+
+  // transform-origin is constant, so it lives in a plain (non-animated) style
+  // the caller merges into the same view as `animatedStyle`.
+  const originStyle = { transformOrigin: origin };
+
+  // Snap back to rest with no animation — call when (re)opening a panel so a
+  // previous commit doesn't leave it shrunk.
+  const reset = useCallback(() => {
+    progress.value = 0;
+  }, [progress]);
+
+  // Drive progress directly (0..1). Intended for a native predictive-back
+  // progress source feeding the live gesture.
+  const setProgress = useCallback((value) => {
+    progress.value = value;
+  }, [progress]);
+
+  // Ease back to rest — the back gesture was cancelled.
+  const cancel = useCallback(() => {
+    progress.value = withTiming(0, {
+      duration: cancelDuration,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [progress, cancelDuration]);
+
+  // Play the shrink to completion, then run `onDone` (typically the real close).
+  const commit = useCallback((onDone) => {
+    progress.value = withTiming(
+      1,
+      { duration: commitDuration, easing: Easing.in(Easing.cubic) },
+      (finished) => {
+        if (finished && onDone) {
+          runOnJS(onDone)();
+        }
+      },
+    );
+  }, [progress, commitDuration]);
+
+  return { progress, animatedStyle, originStyle, reset, setProgress, cancel, commit };
+}
+
+export default useBackShrink;

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -11,6 +11,7 @@ import Animated, {
   useAnimatedStyle,
   withSpring,
 } from 'react-native-reanimated';
+import { useBackShrink } from '../hooks/useBackShrink';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useThemeConfig } from '../contexts/ThemeConfigContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -173,6 +174,14 @@ export default function SettingsScreen({ setSubPanelActive }) {
     }
   }, []);
 
+  // Telegram-style predictive "back" shrink for the active subpanel.
+  const {
+    animatedStyle: shrinkStyle,
+    originStyle: shrinkOrigin,
+    reset: resetShrink,
+    commit: commitShrink,
+  } = useBackShrink();
+
   const openSubPanel = useCallback((panel) => {
     if (panel === 'import') {
       setImportStep('source');
@@ -182,9 +191,10 @@ export default function SettingsScreen({ setSubPanelActive }) {
     if (panel === 'export') {
       setExportStep('list');
     }
+    resetShrink();
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setActiveSubPanel(panel);
-  }, [loadStoredBackups]);
+  }, [loadStoredBackups, resetShrink]);
 
   const closeSubPanel = useCallback(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -203,6 +213,11 @@ export default function SettingsScreen({ setSubPanelActive }) {
     setDownloadedApks([]);
   }, []);
 
+  // Back-gesture close: play the Telegram-style shrink, then dismiss the panel.
+  const closeWithShrink = useCallback(() => {
+    commitShrink(closeSubPanel);
+  }, [commitShrink, closeSubPanel]);
+
   useEffect(() => {
     setSubPanelActive(activeSubPanel !== null);
   }, [activeSubPanel, setSubPanelActive]);
@@ -211,11 +226,11 @@ export default function SettingsScreen({ setSubPanelActive }) {
   useEffect(() => {
     if (!activeSubPanel) return;
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
-      closeSubPanel();
+      closeWithShrink();
       return true;
     });
     return () => subscription.remove();
-  }, [activeSubPanel, closeSubPanel]);
+  }, [activeSubPanel, closeWithShrink]);
 
   const handleLanguageSelect = useCallback((lng) => {
     setLanguage(lng);
@@ -754,8 +769,8 @@ export default function SettingsScreen({ setSubPanelActive }) {
   const handleSubPanelBack = useMemo(() => {
     if (activeSubPanel === 'import') return handleImportBack;
     if (activeSubPanel === 'export') return handleExportBack;
-    return closeSubPanel;
-  }, [activeSubPanel, handleImportBack, handleExportBack, closeSubPanel]);
+    return closeWithShrink;
+  }, [activeSubPanel, handleImportBack, handleExportBack, closeWithShrink]);
 
   const isBackDisabled = useMemo(() => {
     if (activeSubPanel === 'export' && exportStep === 'sheets-progress') {
@@ -771,8 +786,8 @@ export default function SettingsScreen({ setSubPanelActive }) {
   // ─── RENDER ───
   if (activeSubPanel !== null) {
     return (
-      <View
-        style={[styles.container, { backgroundColor: colors.background }]}
+      <Animated.View
+        style={[styles.container, styles.subPanelShrink, { backgroundColor: colors.background }, shrinkOrigin, shrinkStyle]}
       >
         {/* Subpanel header */}
         <View style={styles.subPanelHeader}>
@@ -1234,7 +1249,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
             </View>
           )}
         </View>
-      </View>
+      </Animated.View>
     );
   }
 
@@ -1681,6 +1696,12 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.lg,
+  },
+  subPanelShrink: {
+    // Clip content to the rounded corners while the panel shrinks, and lift it
+    // off the backdrop so the Telegram-style shrink reads clearly.
+    elevation: 8,
+    overflow: 'hidden',
   },
   subPanelTitle: {
     fontWeight: '600',


### PR DESCRIPTION
## What

Adds the Telegram-style "predictive back" shrink to the app's panels: as the Android back gesture closes a panel, the panel scales down anchored to its **bottom-right** corner, pulls slightly inward, rounds its corners, and fades a touch — revealing whatever sits behind it.

## How

New reusable hook **`app/hooks/useBackShrink.js`** (the "separate importable function" requested). It:

- Exposes a single `progress` shared value (`0` = at rest, `1` = fully shrunk) and an `animatedStyle` mapping that progress onto the shrink transform, plus an `originStyle` that anchors the scale to `right bottom`.
- Provides `reset()` (call on open), `commit(onClose)` (play shrink → dismiss), `cancel()` (ease back), and `setProgress(p)`.
- Is intentionally shaped so a **native predictive-back progress source** (an Android `OnBackAnimationCallback` bridged to JS) can drive the gesture **live** later via `setProgress`/`cancel`/`commit` — no panel code changes needed when that lands.

### Why `commit`-on-release for now
RN 0.81 routes the Android system back through legacy callbacks → JS `BackHandler` / `Modal.onRequestClose`, which only fire **on release** — the in-progress predictive stream isn't exposed to JS in this stack. So today the shrink plays as a close animation triggered by back. (Per the chosen approach: *JS shrink now, native-pluggable later*.)

## Wiring (scope: subpanels + modals)

- **`ModalShell`** — covers all data-entry modals (Operation, Budget, Category, Planned, …). Back/`onRequestClose` now shrinks the card then dismisses; open always resets translate + shrink so the slide-in is correct regardless of how it was closed.
- **`SettingsScreen` subpanels** — the case in the reference screenshot. Hardware back and the top-level back arrow play the shrink before returning to the settings list. Intra-panel step-backs (import/export sub-steps) are unchanged.

## Tests

- New `__tests__/hooks/useBackShrink.test.js` (API shape, bottom-right origin, control behavior).
- Full suite green: **117 suites / 3549 tests passing**; lint clean on changed files.

## Notes / follow-ups

- Standalone picker modals (`PickerModal`, `CurrencyPickerModal`, `IconPicker`, `SplitOperationModal`, `MaterialDialog`, `ChartModal`) can adopt the same hook in a follow-up — they each have bespoke modal/animation code.
- The native predictive-back progress bridge (live finger-following) would be a separate config-plugin/native-module change; this PR lays the JS groundwork for it.

https://claude.ai/code/session_01VntNrhowu9mXk9xB4dAXKu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VntNrhowu9mXk9xB4dAXKu)_