### PR TITLE
ci: add PR title validation for release-please convention

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,42 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-pr-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The PR title must have a non-empty description after the type/scope prefix.
+            Examples:
+              feat: add dark mode
+              fix(auth): handle expired tokens
+              chore!: drop support for Node 14


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-title-check.yml` that runs on every PR open/edit/sync/reopen event
- Uses `amannn/action-semantic-pull-request@v5` to validate titles against the Conventional Commits spec
- Allows all standard types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
- Breaking changes supported via `!` suffix (e.g. `feat!: drop legacy API`)
- Scope is optional; description must be non-empty

## Test plan

- [ ] Open a PR with a valid title (e.g. `feat: add something`) — check passes
- [ ] Edit a PR title to be invalid (e.g. `WIP: stuff`) — check fails with a clear error
- [ ] Confirm breaking-change titles like `fix!: remove deprecated endpoint` pass

https://claude.ai/code/session_015WtzMtunSKvd5besYtMw6a

---
_Generated by [Claude Code](https://claude.ai/code/session_015WtzMtunSKvd5besYtMw6a)_