### PR TITLE
fix: account edit buttons hidden behind floating tab bar on gesture-nav devices

### DIFF
--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -9,6 +9,7 @@ import EmptyState from '../components/EmptyState';
 import { NestableScrollContainer, NestableDraggableFlatList } from 'react-native-draggable-flatlist';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeConfig } from '../contexts/ThemeConfigContext';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
@@ -445,6 +446,7 @@ export default function AccountsScreen() {
   const [noCurrencyMatchVisible, setNoCurrencyMatchVisible] = useState(false);
   const [noCurrencyMatchMessage, setNoCurrencyMatchMessage] = useState('');
 
+  const insets = useSafeAreaInsets();
   const { colorScheme } = useThemeConfig();
   const { colors } = useThemeColors();
   const { paperInputTheme } = makeModalStyles(colors);
@@ -970,7 +972,7 @@ export default function AccountsScreen() {
           </ScrollView>
 
           {/* Footer with Save/Cancel buttons */}
-          <View style={[styles.formPanelFooter, { borderTopColor: colors.border }]}>
+          <View style={[styles.formPanelFooter, { borderTopColor: colors.border, paddingBottom: insets.bottom + 80 }]}>
             <TouchableRipple onPress={handleCloseModal} style={[styles.formFooterBtn, { borderColor: colors.border }]}>
               <Text style={{ color: colors.text }}>{t('cancel') || 'Cancel'}</Text>
             </TouchableRipple>
@@ -1240,7 +1242,6 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     gap: 8,
-    paddingBottom: HEIGHTS.tabBar,
     paddingHorizontal: 12,
     paddingTop: 12,
   },


### PR DESCRIPTION
## Summary

- The Cancel/Save buttons in the Edit Account form were being hidden behind the floating tab bar on devices with gesture navigation (larger `insets.bottom`)
- Root cause: `formPanelFooter` used a static `paddingBottom: HEIGHTS.tabBar` (80px) which assumed a fixed 24px safe area inset — not true on gesture-nav devices
- Fix: import `useSafeAreaInsets` in `AccountsScreen` and compute `paddingBottom: insets.bottom + 80` dynamically, matching the same pattern already used in `SettingsScreen`

## Test plan

- [ ] Open the app on a device with gesture navigation (bottom inset > 12px)
- [ ] Navigate to Settings → Accounts → tap any account to edit
- [ ] Verify the Cancel and Save buttons are fully visible above the floating tab bar
- [ ] Verify buttons are tappable and function correctly
- [ ] Test on a device with 3-button nav to confirm no regression

https://claude.ai/code/session_01CcVBJ3m62LysJia8Zz4gpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcVBJ3m62LysJia8Zz4gpD)_