### PR TITLE
fix(theme): derive colorScheme synchronously — remove double-render flash on theme switch (#919)

### DIFF
--- a/app/contexts/ThemeConfigContext.js
+++ b/app/contexts/ThemeConfigContext.js
@@ -8,8 +8,6 @@ const ThemeConfigContext = createContext();
 export const ThemeConfigProvider = ({ children }) => {
   const [theme, setTheme] = useState('system'); // 'light' | 'dark' | 'system'
   const [osColorScheme, setOsColorScheme] = useState(Appearance.getColorScheme() || 'light');
-  const [colorScheme, setColorScheme] = useState('light'); // Effective color scheme
-
   // Load theme preference from storage
   useEffect(() => {
     getPreference(PREF_KEYS.THEME, 'system').then(stored => {
@@ -24,14 +22,7 @@ export const ThemeConfigProvider = ({ children }) => {
     return () => sub.remove();
   }, []);
 
-  // Compute effective color scheme: if user selected 'system', use OS scheme
-  useEffect(() => {
-    if (theme === 'system') {
-      setColorScheme(osColorScheme);
-    } else {
-      setColorScheme(theme);
-    }
-  }, [theme, osColorScheme]);
+  const colorScheme = theme === 'system' ? osColorScheme : theme;
 
   const updateTheme = async (newTheme) => {
     setTheme(newTheme);


### PR DESCRIPTION
## Summary
Removes the derived-state-in-effect anti-pattern in ThemeConfigContext that caused every theme switch to produce two renders — one with the stale colorScheme, then a corrected one — resulting in a brief wrong-colors flash visible to users.

## Problem
colorScheme was computed in a useEffect fired *after* the render where theme changed. All consumers (ThemeColorsContext, etc.) received the stale intermediate value for one frame.

## Solution
Delete the colorScheme state and the deriving effect. Compute inline before the return:
`const colorScheme = theme === 'system' ? osColorScheme : theme;`

Bonus: first render now uses the correct scheme for system-dark users instead of hardcoded 'light'.

## Changes
- `app/contexts/ThemeConfigContext.js`: removed `colorScheme` state and deriving effect (11 lines → 1 line)

## Manual Testing Instructions
1. Open the app in system-dark mode — verify no light flash on first frame
2. Go to Settings → Theme and switch between Light, Dark, System — verify the entire UI updates in one smooth step with no intermediate wrong-color frame
3. Set to System, then toggle your phone's dark mode from the notification shade — verify the app theme updates correctly
4. Run `npm test -- --silent` — all tests should pass

resolves #919