### PR TITLE
fix(settings): show error dialogs on database reset and Sheets restore failure (#836 #837)

### DIFF
--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -355,9 +355,10 @@ export default function SettingsScreen({ setSubPanelActive }) {
     try {
       await resetDatabase();
     } catch (error) {
-      // Error already handled in resetDatabase
+      console.error('[Settings] Database reset failed:', error);
+      showDialog(t('error') || 'Error', error.message || 'Database reset failed', [{ text: 'OK' }]);
     }
-  }, [closeSubPanel, resetDatabase]);
+  }, [closeSubPanel, resetDatabase, showDialog, t]);
 
   const confirmImportBackup = useCallback(async () => {
     if (importPickInProgress.current) return;
@@ -470,9 +471,10 @@ export default function SettingsScreen({ setSubPanelActive }) {
       cancelImport();
       if (!(restoreError instanceof CancelledImportError)) {
         console.error('[SheetsImport] restore error:', restoreError);
+        showDialog(t('error') || 'Error', restoreError.message || t('restore_error') || 'Failed to restore backup', [{ text: 'OK' }]);
       }
     }
-  }, [t, closeSubPanel, startImport, completeImport, cancelImport, getCancelToken]);
+  }, [t, closeSubPanel, startImport, completeImport, cancelImport, getCancelToken, showDialog]);
 
   const handleImportLocalBackupSelect = useCallback((item) => {
     setImportSelectedBackup(item);


### PR DESCRIPTION
## Summary
Two silent failure paths in SettingsModal now show user-visible error dialogs, matching the pattern already used for file import errors.

## Problem
- **#836**: `confirmResetDatabase` had an empty catch block — if `resetDatabase()` threw, the subpanel closed silently and the user had no idea the reset failed.
- **#837**: The Google Sheets restore catch block only called `cancelImport()` and logged to console — no dialog was shown. The settings modal had already closed (`closeSubPanel` + `onClose` called before the try), so the user saw a closed modal with no feedback.

## Solution
Both catch blocks now call `showDialog` with a user-readable error message, consistent with `confirmImportBackup` and `confirmRestoreLocalBackup` which already do this correctly. Added `showDialog` and `t` to the respective `useCallback` dependency arrays.

## Manual Testing Instructions
**#836 — Database reset error:**
1. Go to Settings → Developer → Reset Database
2. Confirm the destructive action
3. Normal path: DB resets and app reloads — no change in behavior
4. Error path (hard to trigger in prod; verify with a unit test or temporary throw): a dialog should appear with the error message instead of silent failure

**#837 — Google Sheets restore error:**
1. Go to Settings → Import → Google Sheets
2. Authenticate with a Google account that has a Sheets backup
3. Trigger a restore that fails (e.g. corrupted backup, revoked access mid-restore)
4. Verify an error dialog appears explaining the failure — previously the modal closed silently

resolves #836
resolves #837