### PR TITLE
fix(db): save emergency backup before corruption recovery wipes all tables (#873)

### DIFF
--- a/app/services/db.js
+++ b/app/services/db.js
@@ -358,6 +358,35 @@ const detectAppliedMigrations = async (rawDb) => {
 };
 
 /**
+ * Dump all user tables to a JSON file before a destructive schema reset.
+ * Uses a dynamic import so expo-file-system is never loaded during normal startup.
+ * Returns the saved file path on success, null on failure.
+ */
+const saveEmergencyBackup = async (rawDb) => {
+  try {
+    const FileSystem = await import('expo-file-system/legacy');
+    const tables = await rawDb.getAllAsync(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
+    );
+    const data = {};
+    for (const { name } of tables) {
+      try {
+        data[name] = await rawDb.getAllAsync(`SELECT * FROM "${name}"`);
+      } catch {
+        data[name] = null;
+      }
+    }
+    const filename = `penny_emergency_backup_${Date.now()}.json`;
+    const path = `${FileSystem.documentDirectory}${filename}`;
+    await FileSystem.writeAsStringAsync(path, JSON.stringify({ timestamp: new Date().toISOString(), data }));
+    return path;
+  } catch (err) {
+    console.error('[DB] Emergency backup failed:', err);
+    return null;
+  }
+};
+
+/**
  * Check if database is in a corrupted migration state
  */
 const isDatabaseCorrupted = async (rawDb) => {
@@ -411,8 +440,16 @@ const initializeDatabase = async (rawDb, db) => {
     // Check for corrupted migration state
     const isCorrupted = await isDatabaseCorrupted(rawDb);
     if (isCorrupted) {
-      console.warn('Database is in a corrupted state - attempting recovery...');
-      console.warn('This will reset all data. To avoid this, please use Settings > Reset Database before updating the app.');
+      console.warn('[DB] Corrupted schema detected (text account IDs — migration 0002 not applied)');
+      console.warn('[DB] Saving emergency backup before schema reset...');
+
+      const backupPath = await saveEmergencyBackup(rawDb);
+      if (backupPath) {
+        console.warn(`[DB] Emergency backup saved: ${backupPath}`);
+        console.warn('[DB] To recover data: Settings → Import → Restore from file');
+      } else {
+        console.warn('[DB] Emergency backup could not be saved — data will be lost after reset');
+      }
 
       // Drop all tables and start fresh
       await rawDb.runAsync('PRAGMA foreign_keys = OFF');
@@ -423,7 +460,7 @@ const initializeDatabase = async (rawDb, db) => {
         await rawDb.runAsync(`DROP TABLE IF EXISTS "${table.name}"`);
       }
       await rawDb.runAsync('PRAGMA foreign_keys = ON');
-      console.log('All tables dropped for recovery');
+      console.log('[DB] Schema reset complete');
     }
 
     // Check current migration state before running


### PR DESCRIPTION
## Summary
Before the schema reset that drops all tables, attempt to dump all user data to a JSON file in the app's document directory. The path is logged prominently so the user can restore from Settings → Import.

## Problem
When `isDatabaseCorrupted` returns true (accounts.id column is `text` instead of `integer` — migration 0002 never applied), the recovery path drops every table with no warning and no data preservation. Complete, silent, unrecoverable data loss.

## Solution
Added `saveEmergencyBackup(rawDb)` — a private async helper that:
1. Queries all user tables via the raw SQLite connection (works even with the wrong schema)
2. Serializes to JSON
3. Writes to `documentDirectory/penny_emergency_backup_<timestamp>.json`
4. Returns the path for logging

Uses a dynamic `import('expo-file-system/legacy')` so the module is never loaded during normal startup — zero cost on the happy path.

The recovery block now logs the backup path and restore instructions before proceeding with the drop. If the backup itself fails, it logs that too so the user at least knows data was lost.

## Changes
- `app/services/db.js`: added `saveEmergencyBackup` helper; updated recovery block to call it and log actionable instructions

## Manual Testing Instructions
1. This path is hard to trigger manually — requires an old database with text account IDs
2. To verify the backup logic: temporarily add a unit test that calls `saveEmergencyBackup` with a mock rawDb and checks the file is written
3. Check the Logs panel (Settings → Logs) after any app startup — if corruption was detected, you should see the emergency backup path in the log entries
4. If you have access to a device that had the old UUID schema: after upgrading, check `documentDirectory` for `penny_emergency_backup_*.json` and verify it can be imported via Settings → Import

resolves #873