### PR TITLE
perf(localization): stabilize t() with useCallback, memoize provider value (#912)

### DIFF
--- a/app/contexts/LocalizationContext.js
+++ b/app/contexts/LocalizationContext.js
@@ -1,5 +1,5 @@
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import enTranslations from '../../assets/i18n/en.json';
 import itTranslations from '../../assets/i18n/it.json';
@@ -112,7 +112,16 @@ export function LocalizationProvider({ children }) {
     }
   }, []);
 
-  const t = (key) => i18nData[language]?.[key] || key;
+  const t = useCallback((key) => i18nData[language]?.[key] || key, [language]);
+
+  const contextValue = useMemo(() => ({
+    t,
+    language,
+    setLanguage,
+    availableLanguages: Object.keys(i18nData),
+    isFirstLaunch,
+    setFirstLaunchComplete,
+  }), [t, language, setLanguage, isFirstLaunch, setFirstLaunchComplete]);
 
   // Don't render children until we've checked if this is first launch
   if (isLoading) {
@@ -120,14 +129,7 @@ export function LocalizationProvider({ children }) {
   }
 
   return (
-    <LocalizationContext.Provider value={{
-      t,
-      language,
-      setLanguage,
-      availableLanguages: Object.keys(i18nData),
-      isFirstLaunch,
-      setFirstLaunchComplete,
-    }}>
+    <LocalizationContext.Provider value={contextValue}>
       {children}
     </LocalizationContext.Provider>
   );


### PR DESCRIPTION
## Summary
Stabilizes the `t()` translation function reference with `useCallback` and memoizes the LocalizationContext provider value to prevent cascading re-renders on every provider re-render.

## Problem
Every time LocalizationContext re-rendered, all consumers received a new context value object (even when locale/translations hadn't changed), causing unnecessary child re-renders across the entire app.

## Solution
- Wrap `t()` in `useCallback` so its reference is stable across renders
- Memoize the context value object with `useMemo`

## Changes
- `app/contexts/LocalizationContext.js`: added `useCallback` for `t()`, `useMemo` for provider value

## Manual Testing Instructions
- Switch language in Settings — all strings update correctly
- No visible behavior change; memoization prevents cascading re-renders on every provider re-render
- Verify that translations still work across all 11 supported languages

resolves #912