### PR TITLE
fix(splash): hold splash screen until app ready (#909)

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,7 @@
 import { logService } from './app/services/LogService';
 logService.install();
+import * as SplashScreen from 'expo-splash-screen';
+SplashScreen.preventAutoHideAsync().catch(() => {});
 import React from 'react';
 import AppInitializer from './app/screens/AppInitializer';
 import { ThemeConfigProvider } from './app/contexts/ThemeConfigContext';

--- a/app/contexts/LocalizationContext.js
+++ b/app/contexts/LocalizationContext.js
@@ -1,5 +1,6 @@
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import * as SplashScreen from 'expo-splash-screen';
 import PropTypes from 'prop-types';
 import enTranslations from '../../assets/i18n/en.json';
 import itTranslations from '../../assets/i18n/it.json';
@@ -112,22 +113,26 @@ export function LocalizationProvider({ children }) {
     }
   }, []);
 
-  const t = (key) => i18nData[language]?.[key] || key;
+  const t = useCallback((key) => i18nData[language]?.[key] || key, [language]);
 
-  // Don't render children until we've checked if this is first launch
-  if (isLoading) {
-    return null;
-  }
+  // Hide splash screen once language preference has been loaded
+  useEffect(() => {
+    if (!isLoading) {
+      SplashScreen.hideAsync().catch(() => {});
+    }
+  }, [isLoading]);
+
+  const value = useMemo(() => ({
+    t,
+    language,
+    setLanguage,
+    availableLanguages: Object.keys(i18nData),
+    isFirstLaunch,
+    setFirstLaunchComplete,
+  }), [t, language, setLanguage, isFirstLaunch, setFirstLaunchComplete]);
 
   return (
-    <LocalizationContext.Provider value={{
-      t,
-      language,
-      setLanguage,
-      availableLanguages: Object.keys(i18nData),
-      isFirstLaunch,
-      setFirstLaunchComplete,
-    }}>
+    <LocalizationContext.Provider value={value}>
       {children}
     </LocalizationContext.Provider>
   );


### PR DESCRIPTION
## Summary
Prevents the blank white flash between the native splash screen and first render by holding the splash open until localization is loaded.

## Problem
LocalizationProvider returned null while loading language preference, causing a blank frame visible to users on cold start.

## Solution
- Call SplashScreen.preventAutoHideAsync() at module level in App.js before any renders
- Remove the early null return from LocalizationProvider so children render immediately (covered by splash)
- Add useEffect that calls SplashScreen.hideAsync() once isLoading becomes false
- Memoize t() and provider value while here

## Changes
- App.js: add preventAutoHideAsync() call at module level
- app/contexts/LocalizationContext.js: remove null return, add hideAsync on load complete, memoize value

## Manual Testing Instructions
- Cold start the app — no blank white frame between native splash and first render
- Switch language in Settings — all strings update correctly
- App still shows LanguageSelectionScreen on first launch (isFirstLaunch logic unchanged)

resolves #909