### PR TITLE
perf(tabs): lazy-mount tab screens on first visit (#910)

### DIFF
--- a/__tests__/navigation/SimpleTabs.test.js
+++ b/__tests__/navigation/SimpleTabs.test.js
@@ -328,13 +328,21 @@ describe('SimpleTabs Component Rendering', () => {
     expect(getByText('settings')).toBeTruthy();
   });
 
-  it('renders all four screens', async () => {
+  it('renders all four screens after visiting each tab', async () => {
     const { getByTestId } = await render(<SimpleTabs />);
 
+    // Operations mounts immediately (index 0 pre-visited)
     expect(getByTestId('operations-screen')).toBeTruthy();
-    expect(getByTestId('graphs-screen')).toBeTruthy();
-    expect(getByTestId('planned-screen')).toBeTruthy();
-    expect(getByTestId('settings-screen')).toBeTruthy();
+
+    // Visit remaining tabs via pressIn to trigger lazy mount
+    await act(async () => { fireEvent(getByTestId('tab-Graphs'), 'pressIn'); });
+    await waitFor(() => expect(getByTestId('graphs-screen')).toBeTruthy());
+
+    await act(async () => { fireEvent(getByTestId('tab-Planned'), 'pressIn'); });
+    await waitFor(() => expect(getByTestId('planned-screen')).toBeTruthy());
+
+    await act(async () => { fireEvent(getByTestId('tab-settings'), 'pressIn'); });
+    await waitFor(() => expect(getByTestId('settings-screen')).toBeTruthy());
   });
 
   it('switches active tab when tab is pressed', async () => {
@@ -415,11 +423,15 @@ describe('SimpleTabs Component Rendering', () => {
   it('handles tab press callback correctly', async () => {
     const { getByTestId } = await render(<SimpleTabs />);
 
-    // Press Graphs tab
-    await fireEvent.press(getByTestId('tab-Graphs'));
+    // pressIn matches the actual onPressIn handler on TabButton
+    await act(async () => {
+      fireEvent(getByTestId('tab-Graphs'), 'pressIn');
+    });
 
-    // Component should still be rendered
-    expect(getByTestId('graphs-screen')).toBeTruthy();
+    // Wait for Graphs screen to mount after lazy-visit
+    await waitFor(() => {
+      expect(getByTestId('graphs-screen')).toBeTruthy();
+    });
   });
 
   it('renders with correct initial active tab (Operations)', async () => {
@@ -441,11 +453,25 @@ describe('SimpleTabs Component Rendering', () => {
     });
   });
 
-  it('renders all screen content areas', async () => {
-    const { getByText } = await render(<SimpleTabs />);
+  it('renders only the initial Operations screen on cold start (lazy mount)', async () => {
+    const { getByText, queryByText } = await render(<SimpleTabs />);
 
+    // Only Operations (index 0) should be mounted initially
     expect(getByText('Operations Screen')).toBeTruthy();
-    expect(getByText('Graphs Screen')).toBeTruthy();
+    // Graphs (index 1) is lazy — not mounted until visited
+    expect(queryByText('Graphs Screen')).toBeNull();
+  });
+
+  it('mounts Graphs screen after navigating to it', async () => {
+    const { getByText, getByTestId } = await render(<SimpleTabs />);
+
+    await act(async () => {
+      fireEvent(getByTestId('tab-Graphs'), 'pressIn');
+    });
+
+    await waitFor(() => {
+      expect(getByText('Graphs Screen')).toBeTruthy();
+    });
   });
 
   it('handles tab bar layout event', async () => {

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -208,6 +208,9 @@ export default function SimpleTabs() {
   const [active, setActive] = React.useState('Operations');
   const [subPanelActive, setSubPanelActive] = React.useState(false);
   const [tabBarWidth, setTabBarWidth] = React.useState(SCREEN_WIDTH);
+  // Track which tab indices have been visited so we lazy-mount their screens.
+  // Index 0 (Operations) is pre-visited so it renders immediately on cold start.
+  const [visited, setVisited] = React.useState(() => ({ 0: true }));
 
   // Guard ref — updated synchronously so handleTabPress never reads stale state.
   const isTransitioningRef = useRef(false);
@@ -267,6 +270,8 @@ export default function SimpleTabs() {
 
     const distance = Math.abs(newIndex - oldIndex);
 
+    // Mark target tab visited before animation so the screen mounts in time.
+    setVisited(prev => prev[newIndex] ? prev : { ...prev, [newIndex]: true });
     setActive(tabKey);
     activeIndex.value = newIndex;
     pillPosition.value = withTiming(newIndex, PILL_TIMING);
@@ -371,6 +376,7 @@ export default function SimpleTabs() {
         if (newIndex !== currentIndex) {
           activeIndex.value = newIndex;
           pillPosition.value = withTiming(newIndex, PILL_TIMING);
+          runOnJS(setVisited)((prev) => prev[newIndex] ? prev : { ...prev, [newIndex]: true });
           translateX.value = withTiming(-newIndex * SCREEN_WIDTH, SCREEN_TIMING, (isFinished) => {
             if (isFinished) {
               runOnJS(setActive)(TABS[newIndex].key);
@@ -407,20 +413,20 @@ export default function SimpleTabs() {
     return (
       <>
         <Animated.View style={[styles.screen, screenAdjustedStyle0]}>
-          <OperationsScreen />
+          {visited[0] ? <OperationsScreen /> : null}
         </Animated.View>
         <Animated.View style={[styles.screen, screenAdjustedStyle1]}>
-          <GraphsScreen />
+          {visited[1] ? <GraphsScreen /> : null}
         </Animated.View>
         <Animated.View style={[styles.screen, screenAdjustedStyle2]}>
-          <PlannedOperationsScreen />
+          {visited[2] ? <PlannedOperationsScreen /> : null}
         </Animated.View>
         <Animated.View style={[styles.screen, screenAdjustedStyle3]}>
-          <SettingsScreen setSubPanelActive={setSubPanelActive} />
+          {visited[3] ? <SettingsScreen setSubPanelActive={setSubPanelActive} /> : null}
         </Animated.View>
       </>
     );
-  }, [setSubPanelActive, screenAdjustedStyle0, screenAdjustedStyle1, screenAdjustedStyle2, screenAdjustedStyle3]);
+  }, [visited, setSubPanelActive, screenAdjustedStyle0, screenAdjustedStyle1, screenAdjustedStyle2, screenAdjustedStyle3]);
 
   const displayedTab = active;
 


### PR DESCRIPTION
## Summary
Only mount tab screen content when the tab is first visited, saving startup cost of Graphs/Planned/Settings screens on cold start.

## Problem
All 4 tab screens mounted simultaneously on app start, including heavy screens like Graphs (multiple charts, data hooks) and Settings.

## Solution
- Add visited state initialized to { 0: true } so Operations renders immediately
- Mark tab visited before animation in handleTabPress and swipe onEnd handler
- Wrap screen content in {visited[N] ? <Screen /> : null} inside always-mounted Animated.View wrappers (preserving all animation shared values at their indices)
- Update tests to reflect lazy-mount behavior: initially only Operations screen is in DOM

## Changes
- app/navigation/SimpleTabs.js: visited state, conditional screen content
- __tests__/navigation/SimpleTabs.test.js: fix 3 tests for lazy-mount behavior

## Manual Testing Instructions
- Cold start: only Operations tab content mounts
- Tap Graphs tab: GraphsScreen mounts and charts load
- Switch back to Operations and back to Graphs: state is preserved (no re-mount)
- Swipe between tabs: works the same, screens mount on first swipe-in
- 2 pre-existing test failures (container API renamed) are unrelated to this change

resolves #910