### PR TITLE
perf(graphs): remove loading spinner flash on Graphs screen mount (#915)

### DIFF
--- a/app/hooks/useBalanceHistory.js
+++ b/app/hooks/useBalanceHistory.js
@@ -9,7 +9,7 @@ import { appEvents, EVENTS } from '../services/eventEmitter';
  */
 const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
   const [balanceHistoryData, setBalanceHistoryData] = useState({ labels: [] });
-  const [loadingBalanceHistory, setLoadingBalanceHistory] = useState(true);
+  const [loadingBalanceHistory, setLoadingBalanceHistory] = useState(false);
   const [balanceHistoryTableData, setBalanceHistoryTableData] = useState([]);
   const [editingBalanceRow, setEditingBalanceRow] = useState(null);
   const [editingBalanceValue, setEditingBalanceValue] = useState('');

--- a/app/hooks/useCategoryMonthlySpending.js
+++ b/app/hooks/useCategoryMonthlySpending.js
@@ -14,7 +14,7 @@ import { appEvents, EVENTS } from '../services/eventEmitter';
  */
 const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, categories) => {
   const [monthlyData, setMonthlyData] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   // Generate the last 12 months as YYYY-MM strings
   const last12Months = useMemo(() => {

--- a/app/hooks/useExpenseData.js
+++ b/app/hooks/useExpenseData.js
@@ -17,7 +17,7 @@ const CHART_COLORS = [
  */
 const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t) => {
   const [rawSpending, setRawSpending] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   const loadExpenseData = useCallback(async () => {
     if (!selectedCurrency) return;

--- a/app/hooks/useIncomeData.js
+++ b/app/hooks/useIncomeData.js
@@ -17,7 +17,7 @@ const CHART_COLORS = [
  */
 const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIncomeCategory, categories, colors, t) => {
   const [rawIncome, setRawIncome] = useState(null);
-  const [loadingIncome, setLoadingIncome] = useState(true);
+  const [loadingIncome, setLoadingIncome] = useState(false);
 
   const loadIncomeData = useCallback(async () => {
     if (!selectedCurrency) return;


### PR DESCRIPTION
## Summary
Graph screen hooks (useExpenseData, useIncomeData, useBalanceHistory, useCategoryMonthlySpending) all started with `loading: true`, causing spinners to flash before any fetch was triggered.

## Problem
On mount, the Graphs tab showed activity spinners in all cards before any data was even requested from the DB.

## Solution
Change all four hooks to `useState(false)` — the spinner only appears once a fetch is actually in flight.

## Manual Testing
1. Open the Graphs tab from scratch
2. Verify no spinner flash before data appears
3. Change period/currency — spinner should appear during fetch then resolve normally

resolves #915