### PR TITLE
fix(modal): stop keyboard double-push on Android by removing KAV behavior (#918)

### DIFF
--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -144,7 +144,7 @@ export default function ModalShell({
         transparent={true}
         onRequestClose={handleBackDismiss}
       >
-        <KeyboardAvoidingView behavior="padding" style={styles.flex1}>
+        <KeyboardAvoidingView style={styles.flex1}>
           <Pressable style={styles.overlay} onPress={() => animateOut(onDismiss)}>
             <Animated.View style={{ transform: [{ translateY }] }}>
               <Reanimated.View style={[originStyle, shrinkStyle]}>


### PR DESCRIPTION
## Summary
KeyboardAvoidingView with behavior='padding' in ModalShell caused the content to be pushed up twice on Android — once by the OS and once by KAV. The app targets Android only.

## Changes
- Removed behavior='padding' from KeyboardAvoidingView in ModalShell.js
- Without a behavior prop, KAV renders as a plain View on Android with no keyboard adjustment (the OS handles it natively)

## Manual Testing
1. Open any modal (add operation, add category, etc.)
2. Tap any text input to bring up the keyboard
3. Verify the modal content rises once (not twice/jumpy) when keyboard appears
4. Verify typing and form interaction still work normally

resolves #918