### PR TITLE
perf(operations): decouple filteredOperations from account balance changes (#914)

### DIFF
--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -135,7 +135,6 @@ export const OperationsDataProvider = ({ children }) => {
   // not when balances change. Prevents filteredOperations from recomputing on every
   // operation add/edit (which triggers an account balance reload).
   const accountNamesKey = accounts.map(a => `${a.id}:${a.name}`).join('|');
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const accountNameById = useMemo(() => new Map(accounts.map(a => [a.id, a.name])), [accountNamesKey]);
 
   // Filtered operations based on search state

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -131,6 +131,13 @@ export const OperationsDataProvider = ({ children }) => {
     );
   }, [searchState]);
 
+  // Stable account name lookup — only rebuilds when account IDs or names change,
+  // not when balances change. Prevents filteredOperations from recomputing on every
+  // operation add/edit (which triggers an account balance reload).
+  const accountNamesKey = accounts.map(a => `${a.id}:${a.name}`).join('|');
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const accountNameById = useMemo(() => new Map(accounts.map(a => [a.id, a.name])), [accountNamesKey]);
+
   // Filtered operations based on search state
   const filteredOperations = useMemo(() => {
     let result = operations;
@@ -158,8 +165,8 @@ export const OperationsDataProvider = ({ children }) => {
         }
 
         // match account name
-        const account = accounts.find(acc => acc.id === op.accountId);
-        if (account && normalizeSearchText(account.name).includes(searchLower)) {
+        const accountName = accountNameById.get(op.accountId);
+        if (accountName && normalizeSearchText(accountName).includes(searchLower)) {
           return true;
         }
 
@@ -230,7 +237,7 @@ export const OperationsDataProvider = ({ children }) => {
     }
 
     return result;
-  }, [operations, searchState, accounts, getCategoryPath, t]);
+  }, [operations, searchState, accountNameById, getCategoryPath, t]);
 
   // Count active filter groups (excluding text search)
   const getSearchFilterCount = useCallback(() => {


### PR DESCRIPTION
## Summary
filteredOperations useMemo depended on accounts, which changes reference on every operation add/edit (because account balances reload). This caused the entire filter to recompute after every operation — including heavy text-search normalization.

## Changes
- Added accountNameById: a useMemo keyed on account id+name only, not balances
- filteredOperations now depends on accountNameById instead of accounts
- Account name lookup changed from accounts.find() to accountNameById.get() (O(1) vs O(n))

## Manual Testing
1. Add several operations
2. Verify the operations list still shows correct account names in search
3. Search by account name — should still work
4. Verify filter by account still works in the filter panel

resolves #914