### PR TITLE
perf(operations): optimistic insert in addOperation, rollback on error (#911)

### DIFF
--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -397,6 +397,10 @@ export const OperationsActionsProvider = ({ children }) => {
   // after default accounts are created, then RELOAD_ALL is emitted to refresh everything.
 
   const addOperation = useCallback(async (operation) => {
+    const tempId = `_temp_${Date.now()}`;
+    const optimisticOp = { ...operation, id: tempId };
+    _setOperations(prev => [optimisticOp, ...prev]);
+
     try {
       // Create operation in DB (ID will be auto-generated, handles balance updates automatically)
       const createdOperation = await OperationsDB.createOperation(operation);
@@ -406,20 +410,15 @@ export const OperationsActionsProvider = ({ children }) => {
         allOpsCacheRef.current = [createdOperation, ...allOpsCacheRef.current];
       }
 
-      // Reload operations to include the new one (without showing loading spinner)
-      // Note: We reload to ensure consistency with lazy-loaded week ranges
       await loadInitialOperations(activeFiltersRef.current, false);
 
       _setSaveError(null);
-
-      // Reload accounts to reflect balance changes
       await reloadAccounts();
-
-      // Emit event to refresh budget statuses
       appEvents.emit(EVENTS.OPERATION_CHANGED);
 
       return createdOperation;
     } catch (error) {
+      _setOperations(prev => prev.filter(op => op.id !== tempId));
       console.error('Failed to add operation:', error);
       _setSaveError(error.message);
       showDialog(
@@ -429,7 +428,7 @@ export const OperationsActionsProvider = ({ children }) => {
       );
       throw error;
     }
-  }, [reloadAccounts, showDialog, loadInitialOperations, _setSaveError]);
+  }, [reloadAccounts, showDialog, loadInitialOperations, _setSaveError, _setOperations]);
 
   const splitOperation = useCallback(async (id, updates, newOperationData) => {
     try {


### PR DESCRIPTION
## Summary
Adding an operation previously required a full DB round-trip before anything appeared in the list. The new operation now appears immediately on tap, then gets replaced with the real DB row once the write completes.

## Changes
- addOperation: prepend a temp operation (id=_temp_${Date.now()}) to state before the DB write
- On success: loadInitialOperations replaces the temp item with the real data
- On error: filter out the temp item to rollback, then show error dialog

## Manual Testing
1. Open Operations tab
2. Add a new operation via the + button
3. On save, the operation should appear in the list instantly (before the modal closes)
4. Verify the operation is correct after the list refreshes
5. Test with poor network/slow device to see the instant feedback effect
6. To test rollback: temporarily break createOperation and confirm the temp item disappears on error

resolves #911