### PR TITLE
feat(updates): pull-to-refresh on check for updates panel

### DIFF
--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -70,7 +70,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
               <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
                 {t('whats_new') || "What's new"}
               </Text>
-              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
+              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false} nestedScrollEnabled>
                 {releaseNotes.map(({ version, notes }) => (
                   <View key={version} style={styles.changelogSection}>
                     <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
@@ -167,7 +167,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
               <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
                 {t('release_history') || 'Release history'}
               </Text>
-              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
+              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false} nestedScrollEnabled>
                 {updateResult.recentReleaseNotes.map(({ version, notes }) => (
                   <View key={version} style={styles.changelogSection}>
                     <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler, LayoutAnimation } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler, LayoutAnimation, RefreshControl } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Text, Divider, TouchableRipple } from 'react-native-paper';
@@ -579,10 +579,9 @@ export default function SettingsScreen({ setSubPanelActive }) {
     }
   }, [showDialog, t]);
 
-  const handleCheckForUpdates = useCallback(async () => {
+  const runUpdateCheck = useCallback(async () => {
     setUpdateResult(null);
     setIsCheckingUpdate(true);
-    openSubPanel('update');
     loadDownloadedApks();
     try {
       const result = await checkForAppUpdate();
@@ -612,12 +611,16 @@ export default function SettingsScreen({ setSubPanelActive }) {
         });
       }
     } catch (error) {
-      console.error('Manual update check failed:', error);
       setUpdateResult({ type: 'error', errorCode: null });
     } finally {
       setIsCheckingUpdate(false);
     }
-  }, [openSubPanel, loadDownloadedApks]);
+  }, [loadDownloadedApks]);
+
+  const handleCheckForUpdates = useCallback(() => {
+    openSubPanel('update');
+    runUpdateCheck();
+  }, [openSubPanel, runUpdateCheck]);
 
   const handleUpdateFromSettings = useCallback(async (downloadUrl, checksumUrl) => {
     if (updateResult) {
@@ -1240,7 +1243,16 @@ export default function SettingsScreen({ setSubPanelActive }) {
           )}
 
           {activeSubPanel === 'update' && (
-            <View style={styles.updatePanelWrapper}>
+            <ScrollView
+              style={styles.updatePanelWrapper}
+              refreshControl={
+                <RefreshControl
+                  refreshing={isCheckingUpdate}
+                  onRefresh={runUpdateCheck}
+                  colors={[colors.primary]}
+                />
+              }
+            >
               <UpdateContentPanel
                 isChecking={isCheckingUpdate}
                 updateResult={updateResult}
@@ -1248,7 +1260,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 onUpdate={handleUpdateFromSettings}
                 onInstallApk={handleInstallApk}
               />
-            </View>
+            </ScrollView>
           )}
         </View>
       </Animated.View>


### PR DESCRIPTION
## Summary
- Drag down on the check for updates panel to re-trigger the update check
- Extracted check logic into  shared between initial open and refresh gesture
- Added  on changelog ScrollViews to prevent vertical gesture conflicts on Android

## Problem
No way to re-check for updates without closing and reopening the panel.

## Solution
Wrapped the update subpanel in a  with .  mirrors  so the native spinner stays visible during the check. The actual check is extracted into  so both the initial open () and the pull gesture use the same path.

## Changes
- : add  import, extract , replace  wrapper with 
- : add  to vertical changelog ScrollViews

## Test plan
- [ ] Open Settings → Check for Updates
- [ ] Pull down on the panel — spinner appears and re-check triggers
- [ ] Verify changelog ScrollView still scrolls independently (nested scroll)
- [ ] Verify behavior on both "update available" and "up to date" states