### PR TITLE
fix(i18n): complete translations across all 11 languages

### DIFF
--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -70,7 +70,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
               <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
                 {t('whats_new') || "What's new"}
               </Text>
-              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
+              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false} nestedScrollEnabled>
                 {releaseNotes.map(({ version, notes }) => (
                   <View key={version} style={styles.changelogSection}>
                     <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
@@ -167,7 +167,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
               <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
                 {t('release_history') || 'Release history'}
               </Text>
-              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false}>
+              <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false} nestedScrollEnabled>
                 {updateResult.recentReleaseNotes.map(({ version, notes }) => (
                   <View key={version} style={styles.changelogSection}>
                     <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler, LayoutAnimation } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler, LayoutAnimation, RefreshControl } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Text, Divider, TouchableRipple } from 'react-native-paper';
@@ -579,10 +579,9 @@ export default function SettingsScreen({ setSubPanelActive }) {
     }
   }, [showDialog, t]);
 
-  const handleCheckForUpdates = useCallback(async () => {
+  const runUpdateCheck = useCallback(async () => {
     setUpdateResult(null);
     setIsCheckingUpdate(true);
-    openSubPanel('update');
     loadDownloadedApks();
     try {
       const result = await checkForAppUpdate();
@@ -612,12 +611,16 @@ export default function SettingsScreen({ setSubPanelActive }) {
         });
       }
     } catch (error) {
-      console.error('Manual update check failed:', error);
       setUpdateResult({ type: 'error', errorCode: null });
     } finally {
       setIsCheckingUpdate(false);
     }
-  }, [openSubPanel, loadDownloadedApks]);
+  }, [loadDownloadedApks]);
+
+  const handleCheckForUpdates = useCallback(() => {
+    openSubPanel('update');
+    runUpdateCheck();
+  }, [openSubPanel, runUpdateCheck]);
 
   const handleUpdateFromSettings = useCallback(async (downloadUrl, checksumUrl) => {
     if (updateResult) {
@@ -1240,7 +1243,16 @@ export default function SettingsScreen({ setSubPanelActive }) {
           )}
 
           {activeSubPanel === 'update' && (
-            <View style={styles.updatePanelWrapper}>
+            <ScrollView
+              style={styles.updatePanelWrapper}
+              refreshControl={
+                <RefreshControl
+                  refreshing={isCheckingUpdate}
+                  onRefresh={runUpdateCheck}
+                  colors={[colors.primary]}
+                />
+              }
+            >
               <UpdateContentPanel
                 isChecking={isCheckingUpdate}
                 updateResult={updateResult}
@@ -1248,7 +1260,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 onUpdate={handleUpdateFromSettings}
                 onInstallApk={handleInstallApk}
               />
-            </View>
+            </ScrollView>
           )}
         </View>
       </Animated.View>

--- a/docs/superpowers/plans/2026-06-13-e2e-agent.md
+++ b/docs/superpowers/plans/2026-06-13-e2e-agent.md
@@ -1,0 +1,1626 @@
+# E2E Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an autonomous Android e2e testing agent that visually interacts with the Penny app via ADB + Claude vision, in two modes: PR-review (posts findings to GitHub PR comment) and Comprehensive (terminal + report file).
+
+**Architecture:** Node.js CLI at `scripts/e2e-agent/` uses ADB to screenshot and control an Android emulator, sends screen state to Claude API (vision + UI tree), and executes Claude's action decisions. A prerequisite database seeder in the app provides deterministic test data. Two modes scope the test plan differently: PR-review reads `gh pr diff` and maps to affected scenarios; Comprehensive walks all 5 tabs.
+
+**Tech Stack:** Node.js (ES modules), `@anthropic-ai/sdk`, `sharp` (image resize), `fast-xml-parser` (UIAutomator XML), `commander` (CLI), ADB (Android Debug Bridge), `gh` CLI (GitHub), Drizzle ORM (app seeder), React Native (app seeder UI)
+
+---
+
+## Phase 1: Database Seeder (app-side)
+
+### Task 1: generateSeedData pure function
+
+**Files:**
+- Create: `app/defaults/seedData.js`
+- Create: `__tests__/defaults/seedData.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// __tests__/defaults/seedData.test.js
+import { generateSeedData } from '../../app/defaults/seedData';
+
+describe('generateSeedData', () => {
+  const today = new Date('2026-06-13');
+  let data;
+
+  beforeEach(() => {
+    data = generateSeedData(today);
+  });
+
+  it('returns 3 account templates', () => {
+    expect(data.accountTemplates).toHaveLength(3);
+    expect(data.accountTemplates[0].name).toBe('Checking');
+    expect(data.accountTemplates[1].name).toBe('Savings');
+    expect(data.accountTemplates[2].name).toBe('Cash');
+  });
+
+  it('returns 10 categories', () => {
+    expect(data.categories).toHaveLength(10);
+  });
+
+  it('returns 60 operation templates', () => {
+    expect(data.operationTemplates).toHaveLength(60);
+  });
+
+  it('all operation dates are within the last 61 days', () => {
+    const todayStr = today.toISOString().slice(0, 10);
+    const cutoff = new Date(today);
+    cutoff.setDate(cutoff.getDate() - 61);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    data.operationTemplates.forEach(op => {
+      expect(op.date <= todayStr).toBe(true);
+      expect(op.date >= cutoffStr).toBe(true);
+    });
+  });
+
+  it('all operation account indices are 0, 1, or 2', () => {
+    data.operationTemplates.forEach(op => {
+      expect([0, 1, 2]).toContain(op.accountIndex);
+    });
+  });
+
+  it('transfer operations have toAccountIndex', () => {
+    const transfers = data.operationTemplates.filter(op => op.type === 'transfer');
+    transfers.forEach(op => {
+      expect(typeof op.toAccountIndex).toBe('number');
+    });
+  });
+
+  it('produces same output for same today', () => {
+    const data2 = generateSeedData(today);
+    expect(data.operationTemplates).toEqual(data2.operationTemplates);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+npm test -- --silent __tests__/defaults/seedData.test.js
+```
+
+Expected: FAIL — `Cannot find module '../../app/defaults/seedData'`
+
+- [ ] **Step 3: Create seedData.js**
+
+```javascript
+// app/defaults/seedData.js
+
+const ACCOUNT_TEMPLATES = [
+  { name: 'Checking', balance: '0.00', currency: 'USD' },
+  { name: 'Savings',  balance: '0.00', currency: 'USD' },
+  { name: 'Cash',     balance: '0.00', currency: 'USD' },
+];
+
+// accountIndex: 0=Checking, 1=Savings, 2=Cash
+const OPERATION_TEMPLATES = [
+  // --- Month 1: days 60-31 ago ---
+  { daysAgo: 60, type: 'income',   amount: '3500.00', description: 'Monthly salary',    accountIndex: 0, categoryId: 'seed-cat-salary',        toAccountIndex: null },
+  { daysAgo: 59, type: 'expense',  amount: '1200.00', description: 'Rent',              accountIndex: 0, categoryId: 'seed-cat-rent',          toAccountIndex: null },
+  { daysAgo: 57, type: 'expense',  amount: '89.50',   description: 'Weekly groceries',  accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo: 56, type: 'expense',  amount: '42.00',   description: 'Gas station',       accountIndex: 0, categoryId: 'seed-cat-transport',     toAccountIndex: null },
+  { daysAgo: 54, type: 'expense',  amount: '28.50',   description: 'Restaurant',        accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 53, type: 'expense',  amount: '15.99',   description: 'Netflix',           accountIndex: 0, categoryId: 'seed-cat-entertainment', toAccountIndex: null },
+  { daysAgo: 52, type: 'expense',  amount: '23.00',   description: 'Pharmacy',          accountIndex: 2, categoryId: 'seed-cat-health',        toAccountIndex: null },
+  { daysAgo: 51, type: 'expense',  amount: '6.50',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 50, type: 'transfer', amount: '300.00',  description: 'ATM withdrawal',    accountIndex: 0, categoryId: null,                     toAccountIndex: 2    },
+  { daysAgo: 49, type: 'expense',  amount: '76.30',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo: 48, type: 'expense',  amount: '45.00',   description: 'Monthly bus pass',  accountIndex: 0, categoryId: 'seed-cat-transport',     toAccountIndex: null },
+  { daysAgo: 47, type: 'expense',  amount: '30.00',   description: 'Gym membership',    accountIndex: 0, categoryId: 'seed-cat-health',        toAccountIndex: null },
+  { daysAgo: 46, type: 'expense',  amount: '52.00',   description: 'Dinner out',        accountIndex: 0, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 45, type: 'expense',  amount: '67.99',   description: 'Amazon order',      accountIndex: 0, categoryId: 'seed-cat-shopping',      toAccountIndex: null },
+  { daysAgo: 44, type: 'expense',  amount: '85.00',   description: 'Electricity bill',  accountIndex: 0, categoryId: 'seed-cat-utilities',     toAccountIndex: null },
+  { daysAgo: 43, type: 'income',   amount: '800.00',  description: 'Freelance project', accountIndex: 0, categoryId: 'seed-cat-freelance',     toAccountIndex: null },
+  { daysAgo: 42, type: 'expense',  amount: '5.50',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 41, type: 'expense',  amount: '93.20',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo: 40, type: 'expense',  amount: '150.00',  description: 'Dentist',           accountIndex: 0, categoryId: 'seed-cat-health',        toAccountIndex: null },
+  { daysAgo: 39, type: 'expense',  amount: '38.50',   description: 'Restaurant',        accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 38, type: 'expense',  amount: '45.00',   description: 'Phone bill',        accountIndex: 0, categoryId: 'seed-cat-utilities',     toAccountIndex: null },
+  { daysAgo: 37, type: 'expense',  amount: '29.99',   description: 'Bookstore',         accountIndex: 0, categoryId: 'seed-cat-shopping',      toAccountIndex: null },
+  { daysAgo: 36, type: 'expense',  amount: '7.00',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 35, type: 'expense',  amount: '81.70',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo: 34, type: 'expense',  amount: '48.00',   description: 'Gas station',       accountIndex: 0, categoryId: 'seed-cat-transport',     toAccountIndex: null },
+  { daysAgo: 33, type: 'expense',  amount: '24.00',   description: 'Movie tickets',     accountIndex: 0, categoryId: 'seed-cat-entertainment', toAccountIndex: null },
+  { daysAgo: 32, type: 'transfer', amount: '200.00',  description: 'Savings transfer',  accountIndex: 0, categoryId: null,                     toAccountIndex: 1    },
+  { daysAgo: 31, type: 'expense',  amount: '44.00',   description: 'Restaurant',        accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  // --- Month 2: days 30-0 ago ---
+  { daysAgo: 30, type: 'income',   amount: '3500.00', description: 'Monthly salary',    accountIndex: 0, categoryId: 'seed-cat-salary',        toAccountIndex: null },
+  { daysAgo: 29, type: 'expense',  amount: '1200.00', description: 'Rent',              accountIndex: 0, categoryId: 'seed-cat-rent',          toAccountIndex: null },
+  { daysAgo: 28, type: 'expense',  amount: '59.99',   description: 'Internet bill',     accountIndex: 0, categoryId: 'seed-cat-utilities',     toAccountIndex: null },
+  { daysAgo: 27, type: 'expense',  amount: '88.40',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo: 26, type: 'expense',  amount: '5.00',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 25, type: 'expense',  amount: '39.00',   description: 'Gas station',       accountIndex: 0, categoryId: 'seed-cat-transport',     toAccountIndex: null },
+  { daysAgo: 24, type: 'expense',  amount: '62.00',   description: 'Dinner',            accountIndex: 0, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 23, type: 'expense',  amount: '35.00',   description: 'Haircut',           accountIndex: 2, categoryId: 'seed-cat-health',        toAccountIndex: null },
+  { daysAgo: 22, type: 'expense',  amount: '30.00',   description: 'Gym membership',    accountIndex: 0, categoryId: 'seed-cat-health',        toAccountIndex: null },
+  { daysAgo: 21, type: 'expense',  amount: '125.00',  description: 'Clothes shopping',  accountIndex: 0, categoryId: 'seed-cat-shopping',      toAccountIndex: null },
+  { daysAgo: 20, type: 'expense',  amount: '71.90',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo: 19, type: 'expense',  amount: '6.00',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 18, type: 'expense',  amount: '18.00',   description: 'Cinema',            accountIndex: 0, categoryId: 'seed-cat-entertainment', toAccountIndex: null },
+  { daysAgo: 17, type: 'expense',  amount: '15.50',   description: 'Pharmacy',          accountIndex: 2, categoryId: 'seed-cat-health',        toAccountIndex: null },
+  { daysAgo: 16, type: 'transfer', amount: '500.00',  description: 'Savings transfer',  accountIndex: 0, categoryId: null,                     toAccountIndex: 1    },
+  { daysAgo: 15, type: 'expense',  amount: '48.50',   description: 'Restaurant',        accountIndex: 0, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 14, type: 'expense',  amount: '95.60',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo: 13, type: 'income',   amount: '450.00',  description: 'Freelance payment', accountIndex: 0, categoryId: 'seed-cat-freelance',     toAccountIndex: null },
+  { daysAgo: 12, type: 'expense',  amount: '3.50',    description: 'Bus ticket',        accountIndex: 2, categoryId: 'seed-cat-transport',     toAccountIndex: null },
+  { daysAgo: 11, type: 'expense',  amount: '5.50',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo: 10, type: 'expense',  amount: '199.99',  description: 'Headphones',        accountIndex: 0, categoryId: 'seed-cat-shopping',      toAccountIndex: null },
+  { daysAgo:  9, type: 'expense',  amount: '33.00',   description: 'Restaurant',        accountIndex: 0, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo:  8, type: 'expense',  amount: '82.30',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo:  7, type: 'expense',  amount: '51.00',   description: 'Gas station',       accountIndex: 0, categoryId: 'seed-cat-transport',     toAccountIndex: null },
+  { daysAgo:  6, type: 'expense',  amount: '4.50',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo:  5, type: 'expense',  amount: '120.00',  description: 'Car insurance',     accountIndex: 0, categoryId: 'seed-cat-utilities',     toAccountIndex: null },
+  { daysAgo:  4, type: 'expense',  amount: '29.00',   description: 'Restaurant',        accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo:  3, type: 'expense',  amount: '66.20',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo:  2, type: 'expense',  amount: '6.00',    description: 'Coffee',            accountIndex: 2, categoryId: 'seed-cat-dining',        toAccountIndex: null },
+  { daysAgo:  1, type: 'expense',  amount: '12.00',   description: 'Pharmacy',          accountIndex: 2, categoryId: 'seed-cat-health',        toAccountIndex: null },
+  { daysAgo:  0, type: 'expense',  amount: '44.80',   description: 'Groceries',         accountIndex: 0, categoryId: 'seed-cat-groceries',     toAccountIndex: null },
+  { daysAgo:  0, type: 'income',   amount: '250.00',  description: 'Side project',      accountIndex: 0, categoryId: 'seed-cat-freelance',     toAccountIndex: null },
+];
+
+export function generateSeedData(today) {
+  const daysAgo = (n) => {
+    const d = new Date(today);
+    d.setDate(d.getDate() - n);
+    return d.toISOString().slice(0, 10);
+  };
+
+  const ts = today.toISOString();
+
+  const categories = [
+    { id: 'seed-cat-groceries',     name: 'Groceries',    type: 'entry', categoryType: 'expense', icon: 'cart',                  isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-dining',        name: 'Dining',        type: 'entry', categoryType: 'expense', icon: 'silverware-fork-knife', isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-transport',     name: 'Transport',     type: 'entry', categoryType: 'expense', icon: 'car',                   isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-utilities',     name: 'Utilities',     type: 'entry', categoryType: 'expense', icon: 'lightning-bolt',        isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-entertainment', name: 'Entertainment', type: 'entry', categoryType: 'expense', icon: 'movie',                 isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-health',        name: 'Health',        type: 'entry', categoryType: 'expense', icon: 'heart-pulse',           isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-shopping',      name: 'Shopping',      type: 'entry', categoryType: 'expense', icon: 'shopping',              isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-rent',          name: 'Rent',          type: 'entry', categoryType: 'expense', icon: 'home',                  isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-salary',        name: 'Salary',        type: 'entry', categoryType: 'income',  icon: 'cash',                  isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+    { id: 'seed-cat-freelance',     name: 'Freelance',     type: 'entry', categoryType: 'income',  icon: 'laptop',                isShadow: 0, parentId: null, createdAt: ts, updatedAt: ts },
+  ];
+
+  const operationTemplates = OPERATION_TEMPLATES.map(t => ({
+    ...t,
+    date: daysAgo(t.daysAgo),
+    createdAt: ts,
+  }));
+
+  const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0, 10);
+
+  const budgets = [
+    { id: 'seed-bgt-groceries', categoryId: 'seed-cat-groceries', amount: '400.00', currency: 'USD', periodType: 'monthly', startDate: startOfMonth, endDate: null, isRecurring: 1, rolloverEnabled: 0, createdAt: ts, updatedAt: ts },
+    { id: 'seed-bgt-dining',    categoryId: 'seed-cat-dining',    amount: '200.00', currency: 'USD', periodType: 'monthly', startDate: startOfMonth, endDate: null, isRecurring: 1, rolloverEnabled: 0, createdAt: ts, updatedAt: ts },
+  ];
+
+  const plannedOperations = [
+    { id: 'seed-pln-salary', name: 'Monthly salary', type: 'income',  amount: '3500.00', accountIndex: 0, categoryId: 'seed-cat-salary', toAccountIndex: null, description: 'Regular monthly income', isRecurring: 1, createdAt: ts, updatedAt: ts },
+    { id: 'seed-pln-rent',   name: 'Rent',           type: 'expense', amount: '1200.00', accountIndex: 0, categoryId: 'seed-cat-rent',   toAccountIndex: null, description: 'Monthly rent payment',  isRecurring: 1, createdAt: ts, updatedAt: ts },
+  ];
+
+  return {
+    accountTemplates: ACCOUNT_TEMPLATES,
+    categories,
+    operationTemplates,
+    budgets,
+    plannedOperations,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+npm test -- --silent __tests__/defaults/seedData.test.js
+```
+
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/defaults/seedData.js __tests__/defaults/seedData.test.js
+git commit -m "feat(seeder): add generateSeedData pure function with 60 relative-date operations"
+```
+
+---
+
+### Task 2: SeedService
+
+**Files:**
+- Create: `app/services/SeedService.js`
+- Create: `__tests__/services/SeedService.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// __tests__/services/SeedService.test.js
+jest.mock('../../app/utils/resetDatabase', () => ({ resetDatabase: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../../app/services/AccountsDB', () => ({ createAccount: jest.fn() }));
+jest.mock('../../app/services/CategoriesDB', () => ({ createCategory: jest.fn() }));
+jest.mock('../../app/services/OperationsDB', () => ({ createOperation: jest.fn() }));
+jest.mock('../../app/services/BudgetsDB', () => ({ createBudget: jest.fn() }));
+jest.mock('../../app/services/PlannedOperationsDB', () => ({ createPlannedOperation: jest.fn() }));
+jest.mock('../../app/services/eventEmitter', () => ({
+  appEvents: { emit: jest.fn() },
+  EVENTS: { RELOAD_ALL: 'RELOAD_ALL' },
+}));
+
+import { seedDatabase } from '../../app/services/SeedService';
+import { resetDatabase } from '../../app/utils/resetDatabase';
+import * as AccountsDB from '../../app/services/AccountsDB';
+import * as CategoriesDB from '../../app/services/CategoriesDB';
+import * as OperationsDB from '../../app/services/OperationsDB';
+import * as BudgetsDB from '../../app/services/BudgetsDB';
+import * as PlannedOperationsDB from '../../app/services/PlannedOperationsDB';
+import { appEvents, EVENTS } from '../../app/services/eventEmitter';
+
+describe('seedDatabase', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AccountsDB.createAccount
+      .mockResolvedValueOnce({ id: 1 })
+      .mockResolvedValueOnce({ id: 2 })
+      .mockResolvedValueOnce({ id: 3 });
+    CategoriesDB.createCategory.mockResolvedValue({});
+    OperationsDB.createOperation.mockResolvedValue({});
+    BudgetsDB.createBudget.mockResolvedValue({});
+    PlannedOperationsDB.createPlannedOperation.mockResolvedValue({});
+  });
+
+  it('calls resetDatabase first', async () => {
+    await seedDatabase();
+    expect(resetDatabase).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates 3 accounts', async () => {
+    await seedDatabase();
+    expect(AccountsDB.createAccount).toHaveBeenCalledTimes(3);
+  });
+
+  it('creates 10 categories', async () => {
+    await seedDatabase();
+    expect(CategoriesDB.createCategory).toHaveBeenCalledTimes(10);
+  });
+
+  it('creates 60 operations', async () => {
+    await seedDatabase();
+    expect(OperationsDB.createOperation).toHaveBeenCalledTimes(60);
+  });
+
+  it('resolves accountIndex 0 to id 1 in operations', async () => {
+    await seedDatabase();
+    expect(OperationsDB.createOperation.mock.calls[0][0].accountId).toBe(1);
+  });
+
+  it('resolves toAccountIndex for transfers', async () => {
+    await seedDatabase();
+    const transferCall = OperationsDB.createOperation.mock.calls.find(c => c[0].toAccountId != null);
+    expect(transferCall[0].toAccountId).toBe(3); // Cash is index 2 → id 3
+  });
+
+  it('creates 2 budgets', async () => {
+    await seedDatabase();
+    expect(BudgetsDB.createBudget).toHaveBeenCalledTimes(2);
+  });
+
+  it('creates 2 planned operations', async () => {
+    await seedDatabase();
+    expect(PlannedOperationsDB.createPlannedOperation).toHaveBeenCalledTimes(2);
+  });
+
+  it('emits RELOAD_ALL after all inserts', async () => {
+    await seedDatabase();
+    expect(appEvents.emit).toHaveBeenCalledWith(EVENTS.RELOAD_ALL);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+npm test -- --silent __tests__/services/SeedService.test.js
+```
+
+Expected: FAIL — `Cannot find module '../../app/services/SeedService'`
+
+- [ ] **Step 3: Create SeedService.js**
+
+```javascript
+// app/services/SeedService.js
+import { resetDatabase } from '../utils/resetDatabase';
+import { createAccount } from './AccountsDB';
+import { createCategory } from './CategoriesDB';
+import { createOperation } from './OperationsDB';
+import { createBudget } from './BudgetsDB';
+import { createPlannedOperation } from './PlannedOperationsDB';
+import { generateSeedData } from '../defaults/seedData';
+import { appEvents, EVENTS } from './eventEmitter';
+
+export const seedDatabase = async () => {
+  await resetDatabase();
+
+  const data = generateSeedData(new Date());
+
+  const accountIds = [];
+  for (const template of data.accountTemplates) {
+    const created = await createAccount(template);
+    accountIds.push(created.id);
+  }
+
+  for (const category of data.categories) {
+    await createCategory(category);
+  }
+
+  for (const template of data.operationTemplates) {
+    const { accountIndex, toAccountIndex, daysAgo, ...rest } = template;
+    await createOperation({
+      ...rest,
+      accountId: accountIds[accountIndex],
+      toAccountId: toAccountIndex != null ? accountIds[toAccountIndex] : null,
+    });
+  }
+
+  for (const budget of data.budgets) {
+    await createBudget(budget);
+  }
+
+  for (const template of data.plannedOperations) {
+    const { accountIndex, toAccountIndex, ...rest } = template;
+    await createPlannedOperation({
+      ...rest,
+      accountId: accountIds[accountIndex],
+      toAccountId: toAccountIndex != null ? accountIds[toAccountIndex] : null,
+    });
+  }
+
+  appEvents.emit(EVENTS.RELOAD_ALL);
+};
+```
+
+**Note:** If `createCategory`, `createBudget`, or `createPlannedOperation` don't exist yet in their DB modules, add them following the same pattern as `createAccount` in `AccountsDB.js`: `db.insert(table).values(data).returning()`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -- --silent __tests__/services/SeedService.test.js
+```
+
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/SeedService.js __tests__/services/SeedService.test.js
+git commit -m "feat(seeder): add SeedService that clears db and inserts deterministic seed data"
+```
+
+---
+
+### Task 3: Settings UI — Reset to Demo Data button
+
+**Files:**
+- Modify: `app/modals/SettingsModal.js`
+
+SettingsModal already has a developer tools section (logs viewer, emergency reset). Find it by searching for `emergencyReset` or `__DEV__` in the file.
+
+- [ ] **Step 1: Add import**
+
+At the top of `app/modals/SettingsModal.js`, add:
+
+```javascript
+import { seedDatabase } from '../services/SeedService';
+```
+
+- [ ] **Step 2: Add state inside component**
+
+Near other dev tool states inside the component:
+
+```javascript
+const [seeding, setSeeding] = useState(false);
+const [seedDone, setSeedDone] = useState(false);
+```
+
+- [ ] **Step 3: Add handler**
+
+```javascript
+const handleSeedDatabase = useCallback(async () => {
+  setSeeding(true);
+  setSeedDone(false);
+  try {
+    await seedDatabase();
+    setSeedDone(true);
+  } catch (e) {
+    showDialog('Error', 'Seed failed: ' + e.message, [{ text: 'OK' }]);
+  } finally {
+    setSeeding(false);
+  }
+}, [showDialog]);
+```
+
+- [ ] **Step 4: Add button in the dev tools subpanel**
+
+In the existing dev tools section (wherever `emergencyReset` button is), add alongside it:
+
+```jsx
+{__DEV__ && (
+  <TouchableRipple
+    testID="seed-demo-data"
+    onPress={seeding ? undefined : handleSeedDatabase}
+    disabled={seeding}
+    style={[styles.settingsRow, { borderBottomColor: colors.border }]}
+    rippleColor={colors.primary + '18'}
+  >
+    <View style={styles.settingsRowContent}>
+      <Icon name="database-refresh" size={20} color={colors.primary} />
+      <View style={styles.settingsRowText}>
+        <Text style={[styles.settingsRowTitle, { color: colors.text }]}>
+          {seeding ? 'Seeding…' : seedDone ? '✓ Demo data loaded' : 'Reset to Demo Data'}
+        </Text>
+        <Text style={[styles.settingsRowSubtitle, { color: colors.mutedText }]}>
+          Clears all data and loads 2 months of test transactions
+        </Text>
+      </View>
+    </View>
+  </TouchableRipple>
+)}
+```
+
+- [ ] **Step 5: Verify manually**
+
+Run `expo start`, open Settings, navigate to the developer tools section. Confirm the button appears. Tap it — Operations tab should show ~60 transactions afterwards.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/modals/SettingsModal.js
+git commit -m "feat(seeder): add Reset to Demo Data button in Settings developer tools (testID=seed-demo-data)"
+```
+
+---
+
+## Phase 2: Agent Infrastructure
+
+### Task 4: Agent project scaffold
+
+**Files:**
+- Create: `scripts/e2e-agent/package.json`
+- Create: `scripts/e2e-agent/jest.config.json`
+- Create: `scripts/e2e-agent/index.js`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "penny-e2e-agent",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --experimental-vm-modules ../../node_modules/.bin/jest --config jest.config.json"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.30.0",
+    "commander": "^12.0.0",
+    "fast-xml-parser": "^4.4.0",
+    "sharp": "^0.33.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create jest.config.json**
+
+```json
+{
+  "transform": {},
+  "extensionsToTreatAsEsm": [".js"],
+  "testMatch": ["**/__tests__/**/*.test.js"]
+}
+```
+
+- [ ] **Step 3: Create index.js**
+
+```javascript
+// scripts/e2e-agent/index.js
+import { program } from 'commander';
+
+program
+  .name('e2e-agent')
+  .description('Autonomous Android e2e tester for Penny')
+  .requiredOption('--mode <mode>', 'pr or comprehensive')
+  .option('--pr <number>', 'PR number (required for --mode pr)')
+  .option('--device <serial>', 'ADB device serial (default: first connected)')
+  .option('--max-steps <n>', 'Max actions per scenario', '50')
+  .parse();
+
+const opts = program.opts();
+
+if (opts.mode === 'pr' && !opts.pr) {
+  console.error('--pr <number> is required for --mode pr');
+  process.exit(1);
+}
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error('ANTHROPIC_API_KEY environment variable is required');
+  process.exit(1);
+}
+
+const maxSteps = parseInt(opts.maxSteps, 10);
+
+if (opts.mode === 'pr') {
+  const { runPRReview } = await import('./src/modes/pr-review.js');
+  await runPRReview(opts.pr, { device: opts.device, maxSteps });
+} else if (opts.mode === 'comprehensive') {
+  const { runComprehensive } = await import('./src/modes/comprehensive.js');
+  await runComprehensive({ device: opts.device, maxSteps });
+} else {
+  console.error('--mode must be "pr" or "comprehensive"');
+  process.exit(1);
+}
+```
+
+- [ ] **Step 4: Install dependencies**
+
+```bash
+cd scripts/e2e-agent && npm install
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-agent/
+git commit -m "feat(e2e-agent): scaffold agent project with commander CLI and ES module config"
+```
+
+---
+
+### Task 5: ADB wrapper
+
+**Files:**
+- Create: `scripts/e2e-agent/src/android/adb.js`
+
+- [ ] **Step 1: Create adb.js**
+
+```javascript
+// scripts/e2e-agent/src/android/adb.js
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const PACKAGE = 'com.heywood8.monkeep';
+
+function adb(serial, command) {
+  const flag = serial ? `-s ${serial} ` : '';
+  return execSync(`adb ${flag}${command}`, { encoding: 'utf8' });
+}
+
+export function takeScreenshot(serial) {
+  adb(serial, 'shell screencap -p /sdcard/e2e_screen.png');
+  const dest = join(tmpdir(), 'e2e_screen.png');
+  adb(serial, `pull /sdcard/e2e_screen.png ${dest}`);
+  return readFileSync(dest);
+}
+
+export function dumpUITree(serial) {
+  adb(serial, 'shell uiautomator dump /sdcard/e2e_ui.xml');
+  const dest = join(tmpdir(), 'e2e_ui.xml');
+  adb(serial, `pull /sdcard/e2e_ui.xml ${dest}`);
+  return readFileSync(dest, 'utf8');
+}
+
+export function tap(serial, x, y) {
+  adb(serial, `shell input tap ${x} ${y}`);
+}
+
+export function typeText(serial, text) {
+  const escaped = text.replace(/['"\\]/g, '\\$&').replace(/ /g, '%s');
+  adb(serial, `shell input text "${escaped}"`);
+}
+
+export function pressBack(serial) {
+  adb(serial, 'shell input keyevent KEYCODE_BACK');
+}
+
+export function swipe(serial, x1, y1, x2, y2, durationMs = 300) {
+  adb(serial, `shell input swipe ${x1} ${y1} ${x2} ${y2} ${durationMs}`);
+}
+
+export function isAppRunning(serial) {
+  try {
+    const result = adb(serial, `shell pidof ${PACKAGE}`).trim();
+    return result.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function launchApp(serial) {
+  adb(serial, `shell am start -n ${PACKAGE}/.MainActivity`);
+  execSync('sleep 1');
+}
+
+export function getFirstDevice() {
+  const output = execSync('adb devices', { encoding: 'utf8' });
+  for (const line of output.split('\n').slice(1)) {
+    const parts = line.trim().split('\t');
+    if (parts.length === 2 && parts[1] === 'device') return parts[0];
+  }
+  throw new Error('No connected ADB device found. Start an emulator first.');
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/e2e-agent/src/android/adb.js
+git commit -m "feat(e2e-agent): add ADB wrapper for screenshot, tap, type, swipe, crash detection"
+```
+
+---
+
+### Task 6: UI tree parser + tests
+
+**Files:**
+- Create: `scripts/e2e-agent/src/utils/ui-tree.js`
+- Create: `scripts/e2e-agent/__tests__/ui-tree.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+```javascript
+// scripts/e2e-agent/__tests__/ui-tree.test.js
+import { parseUITree } from '../src/utils/ui-tree.js';
+
+const SAMPLE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="com.heywood8.monkeep:id/root" class="android.widget.FrameLayout" package="com.heywood8.monkeep" content-desc="" clickable="false" enabled="true" bounds="[0,0][1080,2400]">
+    <node index="0" text="Add expense" resource-id="com.heywood8.monkeep:id/fab" class="android.widget.Button" package="com.heywood8.monkeep" content-desc="Add expense" clickable="true" enabled="true" bounds="[948,2268][1068,2388]"></node>
+    <node index="1" text="Operations" resource-id="com.heywood8.monkeep:id/tab" class="android.widget.TextView" package="com.heywood8.monkeep" content-desc="" clickable="true" enabled="true" bounds="[0,2320][216,2400]"></node>
+    <node index="2" text="System" resource-id="android:id/something" class="android.widget.TextView" package="android" content-desc="" clickable="false" enabled="true" bounds="[0,0][100,50]"></node>
+  </node>
+</hierarchy>`;
+
+describe('parseUITree', () => {
+  let elements;
+  beforeEach(() => { elements = parseUITree(SAMPLE_XML); });
+
+  it('filters out non-app elements', () => {
+    expect(elements.some(e => e.resourceId && e.resourceId.startsWith('android:'))).toBe(false);
+  });
+
+  it('parses bounds to [x1,y1,x2,y2] array', () => {
+    const fab = elements.find(e => e.text === 'Add expense');
+    expect(fab.bounds).toEqual([948, 2268, 1068, 2388]);
+  });
+
+  it('includes clickable elements', () => {
+    expect(elements.find(e => e.text === 'Add expense')).toBeDefined();
+  });
+
+  it('includes contentDesc', () => {
+    expect(elements.find(e => e.text === 'Add expense').contentDesc).toBe('Add expense');
+  });
+
+  it('computes center coordinates', () => {
+    const fab = elements.find(e => e.text === 'Add expense');
+    expect(fab.centerX).toBe(1008);
+    expect(fab.centerY).toBe(2328);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/ui-tree.test.js
+```
+
+- [ ] **Step 3: Create ui-tree.js**
+
+```javascript
+// scripts/e2e-agent/src/utils/ui-tree.js
+import { XMLParser } from 'fast-xml-parser';
+
+const APP_PACKAGE = 'com.heywood8.monkeep';
+
+function parseBounds(str) {
+  const m = str.match(/\[(\d+),(\d+)\]\[(\d+),(\d+)\]/);
+  if (!m) return [0, 0, 0, 0];
+  return [parseInt(m[1]), parseInt(m[2]), parseInt(m[3]), parseInt(m[4])];
+}
+
+function extractNodes(node, results = []) {
+  if (!node) return results;
+  const pkg = node['@_package'] || '';
+  const text = node['@_text'] || '';
+  const contentDesc = node['@_content-desc'] || '';
+  const clickable = node['@_clickable'] === 'true';
+  const enabled = node['@_enabled'] === 'true';
+  const resourceId = node['@_resource-id'] || '';
+  const boundsStr = node['@_bounds'] || '';
+
+  if (pkg === APP_PACKAGE && enabled && (clickable || text || contentDesc)) {
+    const bounds = parseBounds(boundsStr);
+    results.push({
+      text, contentDesc, resourceId, clickable, bounds,
+      centerX: Math.round((bounds[0] + bounds[2]) / 2),
+      centerY: Math.round((bounds[1] + bounds[3]) / 2),
+    });
+  }
+
+  const children = node.node ? (Array.isArray(node.node) ? node.node : [node.node]) : [];
+  for (const child of children) extractNodes(child, results);
+  return results;
+}
+
+export function parseUITree(xml) {
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+  const parsed = parser.parse(xml);
+  return parsed.hierarchy ? extractNodes(parsed.hierarchy.node) : [];
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/ui-tree.test.js
+```
+
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-agent/src/utils/ui-tree.js scripts/e2e-agent/__tests__/ui-tree.test.js
+git commit -m "feat(e2e-agent): add UIAutomator XML parser filtering to app elements"
+```
+
+---
+
+### Task 7: Screenshot utility
+
+**Files:**
+- Create: `scripts/e2e-agent/src/utils/screenshot.js`
+
+- [ ] **Step 1: Create screenshot.js**
+
+```javascript
+// scripts/e2e-agent/src/utils/screenshot.js
+import sharp from 'sharp';
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+export async function resizeBuffer(buffer, percent) {
+  const meta = await sharp(buffer).metadata();
+  const width = Math.round(meta.width * percent);
+  return sharp(buffer).resize(width).png().toBuffer();
+}
+
+export function toBase64(buffer) {
+  return buffer.toString('base64');
+}
+
+export function savePng(buffer, filePath) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, buffer);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/e2e-agent/src/utils/screenshot.js
+git commit -m "feat(e2e-agent): add screenshot resize/base64/save utilities using sharp"
+```
+
+---
+
+## Phase 3: Agent Brain
+
+### Task 8: app-map.json
+
+**Files:**
+- Create: `scripts/e2e-agent/app-map.json`
+
+- [ ] **Step 1: Create app-map.json**
+
+```json
+{
+  "app/contexts/Operations*":              ["add-operation", "edit-operation", "delete-operation", "operations-list"],
+  "app/contexts/OperationsData*":          ["operations-list", "search-filter"],
+  "app/contexts/OperationsActions*":       ["add-operation", "edit-operation", "delete-operation"],
+  "app/contexts/Accounts*":               ["accounts-list", "add-account", "edit-account", "transfer"],
+  "app/contexts/AccountsData*":           ["accounts-list"],
+  "app/contexts/AccountsActions*":        ["add-account", "edit-account", "delete-account", "transfer"],
+  "app/contexts/Categories*":             ["categories-list", "add-category", "edit-category"],
+  "app/contexts/Budgets*":                ["budgets"],
+  "app/contexts/PlannedOperations*":      ["planned-list", "add-planned", "edit-planned"],
+  "app/screens/OperationsScreen*":        ["operations-list", "search-filter", "add-operation"],
+  "app/screens/AccountsScreen*":          ["accounts-list", "add-account", "transfer"],
+  "app/screens/CategoriesScreen*":        ["categories-list", "add-category"],
+  "app/screens/GraphsScreen*":            ["graphs"],
+  "app/screens/PlannedOperationsScreen*": ["planned-list"],
+  "app/modals/OperationModal*":           ["add-operation", "edit-operation"],
+  "app/modals/SettingsModal*":            ["settings", "backup", "restore"],
+  "app/modals/CategoryModal*":            ["add-category", "edit-category"],
+  "app/modals/BudgetModal*":              ["budgets"],
+  "app/modals/PlannedOperationModal*":    ["add-planned", "edit-planned"],
+  "app/components/Calculator*":           ["add-operation", "edit-operation", "add-planned"],
+  "app/components/operations/*":          ["operations-list", "add-operation", "quick-add"],
+  "app/components/search/*":             ["search-filter"],
+  "app/components/graphs/*":             ["graphs"],
+  "app/services/OperationsDB*":           ["add-operation", "edit-operation", "delete-operation", "operations-list"],
+  "app/services/AccountsDB*":             ["accounts-list", "add-account", "edit-account", "transfer"],
+  "app/services/BackupRestore*":          ["backup", "restore"],
+  "app/services/GoogleSheetsService*":    ["google-sheets-export"]
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/e2e-agent/app-map.json
+git commit -m "feat(e2e-agent): add app-map.json mapping file patterns to test scenario IDs"
+```
+
+---
+
+### Task 9: Claude prompts module
+
+**Files:**
+- Create: `scripts/e2e-agent/src/agent/prompts.js`
+- Create: `scripts/e2e-agent/__tests__/prompts.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+```javascript
+// scripts/e2e-agent/__tests__/prompts.test.js
+import { buildMessages, parseAction, SYSTEM_PROMPT } from '../src/agent/prompts.js';
+
+describe('buildMessages', () => {
+  it('returns array ending with user message', () => {
+    const msgs = buildMessages({ name: 'Test', description: 'desc' }, [], [], 'img');
+    expect(msgs[msgs.length - 1].role).toBe('user');
+  });
+
+  it('includes image block with provided base64', () => {
+    const msgs = buildMessages({ name: 'T', description: 'd' }, [], [], 'abc123');
+    const img = msgs[msgs.length - 1].content.find(b => b.type === 'image');
+    expect(img.source.data).toBe('abc123');
+    expect(img.source.media_type).toBe('image/png');
+  });
+
+  it('includes scenario name in text block', () => {
+    const msgs = buildMessages({ name: 'Add expense', description: 'test' }, [], [], 'img');
+    const text = msgs[msgs.length - 1].content.find(b => b.type === 'text');
+    expect(text.text).toContain('Add expense');
+  });
+
+  it('prepends conversation history', () => {
+    const history = [
+      { role: 'user', content: [{ type: 'text', text: 'prev' }] },
+      { role: 'assistant', content: '{"action":"back"}' },
+    ];
+    const msgs = buildMessages({ name: 'T', description: 'd' }, history, [], 'img');
+    expect(msgs).toHaveLength(3);
+  });
+});
+
+describe('parseAction', () => {
+  it('parses tap action', () => {
+    expect(parseAction('{"action":"tap","bounds":[10,20,110,60]}')).toEqual({ action: 'tap', bounds: [10, 20, 110, 60] });
+  });
+
+  it('parses done:bug', () => {
+    const a = parseAction('{"action":"done","result":"bug","description":"oops"}');
+    expect(a.result).toBe('bug');
+    expect(a.description).toBe('oops');
+  });
+
+  it('extracts JSON from prose', () => {
+    expect(parseAction('I see the screen. {"action":"back"}')).toEqual({ action: 'back' });
+  });
+
+  it('throws when no JSON present', () => {
+    expect(() => parseAction('no json')).toThrow();
+  });
+});
+
+describe('SYSTEM_PROMPT', () => {
+  it('contains package name', () => { expect(SYSTEM_PROMPT).toContain('com.heywood8.monkeep'); });
+  it('mentions all 5 tabs', () => {
+    ['Operations', 'Accounts', 'Categories', 'Graphs', 'Planned'].forEach(tab => {
+      expect(SYSTEM_PROMPT).toContain(tab);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/prompts.test.js
+```
+
+- [ ] **Step 3: Create prompts.js**
+
+```javascript
+// scripts/e2e-agent/src/agent/prompts.js
+
+export const SYSTEM_PROMPT = `You are an autonomous Android UI tester for the Penny personal finance app.
+
+APP DETAILS:
+- Package: com.heywood8.monkeep
+- 5 tabs: Operations (transaction list + FAB + quick-add bar), Accounts (account list + balances), Categories (category grid), Graphs (charts), Planned (recurring transactions)
+- Seed data present: 3 accounts (Checking, Savings, Cash), 10 categories, ~60 operations over last 2 months, 2 monthly budgets
+
+YOUR JOB: Execute test scenarios by interacting with the UI. Each turn you receive a screenshot and a JSON list of UI elements with their pixel bounds.
+
+RESPOND WITH EXACTLY ONE JSON object (no prose before or after):
+{
+  "observation": "one sentence: what you see",
+  "action": "tap" | "type" | "swipe" | "back" | "done",
+  "bounds": [x1, y1, x2, y2],   // for tap — always use element bounds from UI JSON
+  "text": "...",                  // for type only
+  "from": [x, y], "to": [x, y], // for swipe only
+  "result": "pass" | "bug",      // for done only
+  "description": "..."           // for done:bug — expected vs actual behavior
+}
+
+RULES:
+- Use element bounds from the UI JSON for tapping, not coordinates guessed from the image
+- Scenario complete and correct → {"action":"done","result":"pass"}
+- Bug found (crash, wrong data, missing element) → {"action":"done","result":"bug","description":"..."}
+- Stuck on same screen 3+ steps → try pressing back or tapping the Operations tab
+- Always include the "observation" field`;
+
+export function buildMessages(scenario, history, uiElements, imageBase64) {
+  const newMessage = {
+    role: 'user',
+    content: [
+      {
+        type: 'text',
+        text: `SCENARIO: ${scenario.name}\nGOAL: ${scenario.description}\n\nUI ELEMENTS:\n${JSON.stringify(uiElements, null, 2)}`,
+      },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: imageBase64 },
+      },
+    ],
+  };
+  return [...history, newMessage];
+}
+
+export function parseAction(responseText) {
+  const match = responseText.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error(`No JSON in response: ${responseText.slice(0, 200)}`);
+  return JSON.parse(match[0]);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/prompts.test.js
+```
+
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-agent/src/agent/prompts.js scripts/e2e-agent/__tests__/prompts.test.js
+git commit -m "feat(e2e-agent): add prompts module — system prompt, message builder, action parser"
+```
+
+---
+
+### Task 10: Core action loop + tests
+
+**Files:**
+- Create: `scripts/e2e-agent/src/agent/loop.js`
+- Create: `scripts/e2e-agent/__tests__/loop.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+```javascript
+// scripts/e2e-agent/__tests__/loop.test.js
+import { jest } from '@jest/globals';
+
+const mockTakeScreenshot = jest.fn().mockReturnValue(Buffer.from('screenshot'));
+const mockDumpUITree = jest.fn().mockReturnValue('<xml></xml>');
+const mockTap = jest.fn();
+const mockTypeText = jest.fn();
+const mockPressBack = jest.fn();
+const mockIsAppRunning = jest.fn().mockReturnValue(true);
+const mockLaunchApp = jest.fn();
+
+jest.unstable_mockModule('../src/android/adb.js', () => ({
+  takeScreenshot: mockTakeScreenshot, dumpUITree: mockDumpUITree, tap: mockTap,
+  typeText: mockTypeText, pressBack: mockPressBack, isAppRunning: mockIsAppRunning,
+  launchApp: mockLaunchApp, swipe: jest.fn(),
+}));
+jest.unstable_mockModule('../src/utils/screenshot.js', () => ({
+  resizeBuffer: jest.fn().mockResolvedValue(Buffer.from('resized')),
+  toBase64: jest.fn().mockReturnValue('base64img'),
+  savePng: jest.fn(),
+}));
+jest.unstable_mockModule('../src/utils/ui-tree.js', () => ({
+  parseUITree: jest.fn().mockReturnValue([{ text: 'Save', clickable: true, bounds: [0,0,100,50], centerX: 50, centerY: 25 }]),
+}));
+
+const mockCreate = jest.fn();
+jest.unstable_mockModule('@anthropic-ai/sdk', () => ({
+  default: class { constructor() { this.messages = { create: mockCreate }; } },
+}));
+
+const { runScenario } = await import('../src/agent/loop.js');
+const scenario = { name: 'Test', description: 'Do something' };
+const options = { device: null, maxSteps: 50, reportsDir: '/tmp/e2e' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockTakeScreenshot.mockReturnValue(Buffer.from('screenshot'));
+  mockDumpUITree.mockReturnValue('<xml></xml>');
+  mockIsAppRunning.mockReturnValue(true);
+});
+
+describe('runScenario', () => {
+  it('returns pass on done:pass', async () => {
+    mockCreate.mockResolvedValue({ content: [{ text: '{"observation":"ok","action":"done","result":"pass"}' }] });
+    const r = await runScenario(scenario, options);
+    expect(r.result).toBe('pass');
+    expect(r.steps).toBe(1);
+  });
+
+  it('returns bug on done:bug with description', async () => {
+    mockCreate.mockResolvedValue({ content: [{ text: '{"observation":"x","action":"done","result":"bug","description":"Missing button"}' }] });
+    const r = await runScenario(scenario, options);
+    expect(r.result).toBe('bug');
+    expect(r.description).toBe('Missing button');
+  });
+
+  it('calls tap with center of bounds', async () => {
+    mockCreate
+      .mockResolvedValueOnce({ content: [{ text: '{"observation":"x","action":"tap","bounds":[0,0,100,50]}' }] })
+      .mockResolvedValueOnce({ content: [{ text: '{"observation":"ok","action":"done","result":"pass"}' }] });
+    await runScenario(scenario, options);
+    expect(mockTap).toHaveBeenCalledWith(null, 50, 25);
+  });
+
+  it('returns inconclusive at maxSteps', async () => {
+    mockCreate.mockResolvedValue({ content: [{ text: '{"observation":"x","action":"tap","bounds":[0,0,100,50]}' }] });
+    const r = await runScenario(scenario, { ...options, maxSteps: 3 });
+    expect(r.result).toBe('inconclusive');
+    expect(r.steps).toBe(3);
+  });
+
+  it('returns bug:crash when app stops running', async () => {
+    mockCreate.mockResolvedValue({ content: [{ text: '{"observation":"x","action":"tap","bounds":[0,0,100,50]}' }] });
+    mockIsAppRunning.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    const r = await runScenario(scenario, options);
+    expect(r.result).toBe('bug');
+    expect(r.description).toContain('crash');
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/loop.test.js
+```
+
+- [ ] **Step 3: Create loop.js**
+
+```javascript
+// scripts/e2e-agent/src/agent/loop.js
+import Anthropic from '@anthropic-ai/sdk';
+import { join } from 'path';
+import { takeScreenshot, dumpUITree, tap, typeText, pressBack, swipe, isAppRunning, launchApp } from '../android/adb.js';
+import { resizeBuffer, toBase64, savePng } from '../utils/screenshot.js';
+import { parseUITree } from '../utils/ui-tree.js';
+import { buildMessages, parseAction, SYSTEM_PROMPT } from './prompts.js';
+
+const client = new Anthropic();
+
+async function executeAction(device, action) {
+  const cx = action.bounds ? Math.round((action.bounds[0] + action.bounds[2]) / 2) : 0;
+  const cy = action.bounds ? Math.round((action.bounds[1] + action.bounds[3]) / 2) : 0;
+  switch (action.action) {
+    case 'tap':   tap(device, cx, cy); break;
+    case 'type':  typeText(device, action.text || ''); break;
+    case 'swipe': swipe(device, action.from[0], action.from[1], action.to[0], action.to[1]); break;
+    case 'back':  pressBack(device); break;
+  }
+}
+
+export async function runScenario(scenario, { device = null, maxSteps = 50, reportsDir = 'e2e-reports' } = {}) {
+  launchApp(device);
+  const history = [];
+  let steps = 0;
+
+  while (steps < maxSteps) {
+    const rawScreenshot = takeScreenshot(device);
+    const resized = await resizeBuffer(rawScreenshot, 0.3);
+    const imageBase64 = toBase64(resized);
+    const uiElements = parseUITree(dumpUITree(device));
+
+    const messages = buildMessages(scenario, history, uiElements, imageBase64);
+    const response = await client.messages.create({
+      model: 'claude-opus-4-7',
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages,
+    });
+
+    const responseText = response.content[0].text;
+    const action = parseAction(responseText);
+
+    history.push({ role: 'user', content: messages[messages.length - 1].content });
+    history.push({ role: 'assistant', content: responseText });
+    if (history.length > 20) history.splice(0, 2);
+
+    if (action.action === 'done') {
+      if (action.result === 'bug') {
+        const slug = scenario.name.replace(/\s+/g, '-');
+        savePng(rawScreenshot, join(reportsDir, 'screenshots', `${slug}-${Date.now()}.png`));
+      }
+      return { result: action.result, steps: steps + 1, description: action.description || '' };
+    }
+
+    await executeAction(device, action);
+    steps++;
+
+    if (!isAppRunning(device)) {
+      const slug = scenario.name.replace(/\s+/g, '-');
+      savePng(rawScreenshot, join(reportsDir, 'screenshots', `${slug}-crash-${Date.now()}.png`));
+      launchApp(device);
+      return { result: 'bug', steps, description: `App crash after action: ${JSON.stringify(action)}` };
+    }
+  }
+
+  return { result: 'inconclusive', steps, description: 'Reached max step limit' };
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/loop.test.js
+```
+
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-agent/src/agent/loop.js scripts/e2e-agent/__tests__/loop.test.js
+git commit -m "feat(e2e-agent): add core action loop — 50-step max, crash detection, history windowing"
+```
+
+---
+
+### Task 11: Test plan generator + tests
+
+**Files:**
+- Create: `scripts/e2e-agent/src/agent/planner.js`
+- Create: `scripts/e2e-agent/__tests__/planner.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+```javascript
+// scripts/e2e-agent/__tests__/planner.test.js
+import { ALL_SCENARIOS, matchDiffToScenarios, generateComprehensivePlan } from '../src/agent/planner.js';
+
+describe('ALL_SCENARIOS', () => {
+  it('has at least 15 scenarios', () => { expect(ALL_SCENARIOS.length).toBeGreaterThanOrEqual(15); });
+  it('each has name and description', () => {
+    ALL_SCENARIOS.forEach(s => { expect(s.name.length).toBeGreaterThan(0); expect(s.description.length).toBeGreaterThan(0); });
+  });
+});
+
+describe('matchDiffToScenarios', () => {
+  const appMap = {
+    'app/contexts/Operations*': ['add-operation', 'operations-list'],
+    'app/screens/AccountsScreen*': ['accounts-list'],
+  };
+
+  it('returns scenarios for matching changed files', () => {
+    const diff = 'diff --git a/app/contexts/OperationsActionsContext.js b/app/contexts/OperationsActionsContext.js\nindex abc..def 100644';
+    const result = matchDiffToScenarios(diff, appMap);
+    expect(result.some(s => s.id === 'add-operation')).toBe(true);
+  });
+
+  it('returns empty array for unmatched files', () => {
+    expect(matchDiffToScenarios('diff --git a/docs/README.md b/docs/README.md', appMap)).toHaveLength(0);
+  });
+
+  it('deduplicates scenarios', () => {
+    const diff = 'diff --git a/app/contexts/OperationsActionsContext.js b/x\ndiff --git a/app/contexts/OperationsDataContext.js b/y';
+    const map = { 'app/contexts/OperationsActions*': ['add-operation'], 'app/contexts/OperationsData*': ['add-operation', 'operations-list'] };
+    const result = matchDiffToScenarios(diff, map);
+    expect(result.filter(s => s.id === 'add-operation')).toHaveLength(1);
+  });
+});
+
+describe('generateComprehensivePlan', () => {
+  it('returns all scenarios', () => { expect(generateComprehensivePlan()).toEqual(ALL_SCENARIOS); });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/planner.test.js
+```
+
+- [ ] **Step 3: Create planner.js**
+
+```javascript
+// scripts/e2e-agent/src/agent/planner.js
+
+export const ALL_SCENARIOS = [
+  { id: 'add-operation',    name: 'Add expense operation',          description: 'Tap the FAB on Operations tab. Fill amount 45.50, select Groceries category, Checking account, tap Save. Verify the new operation appears at the top of the list.' },
+  { id: 'add-income',       name: 'Add income operation',           description: 'Add an income: amount 500, Salary category, Checking account. Verify it appears in the list.' },
+  { id: 'edit-operation',   name: 'Edit existing operation',        description: 'Tap an operation in the list to open edit modal. Change the amount, save. Verify the change is reflected.' },
+  { id: 'delete-operation', name: 'Delete operation',               description: 'Open an operation, find and tap the delete button, confirm. Verify it is removed from the list.' },
+  { id: 'operations-list',  name: 'Operations list loads',          description: 'Open Operations tab. Verify the list is not empty and shows entries with dates and amounts.' },
+  { id: 'quick-add',        name: 'Quick-add form',                 description: 'Use the quick-add bar at the bottom of Operations. Type amount 12.50, select a category, tap add. Verify the operation appears.' },
+  { id: 'search-filter',    name: 'Search operations',              description: 'Tap search on Operations tab. Type "Groceries". Verify only matching operations appear.' },
+  { id: 'accounts-list',    name: 'Accounts list loads',            description: 'Tap Accounts tab. Verify at least one account is visible with name and balance.' },
+  { id: 'add-account',      name: 'Add account',                    description: 'Tap FAB on Accounts. Fill name "Test Account", balance 100.00, currency USD. Save. Verify it appears.' },
+  { id: 'edit-account',     name: 'Edit account',                   description: 'Tap an existing account. Change the name. Save. Verify updated name appears in the list.' },
+  { id: 'transfer',         name: 'Transfer between accounts',      description: 'Add a transfer from Checking to Cash, amount 50.00. Verify both account balances reflect the change.' },
+  { id: 'categories-list',  name: 'Categories list loads',          description: 'Tap Categories tab. Verify the category grid is not empty.' },
+  { id: 'add-category',     name: 'Add category',                   description: 'Tap FAB on Categories. Enter name "Test Category", select an icon, save. Verify it appears in the grid.' },
+  { id: 'graphs',           name: 'Graphs screen loads',            description: 'Tap Graphs tab. Verify at least one chart is visible without error.' },
+  { id: 'planned-list',     name: 'Planned operations loads',       description: 'Tap Planned tab. Verify the screen loads without error and shows planned items.' },
+  { id: 'add-planned',      name: 'Add planned operation',          description: 'Tap FAB on Planned. Fill name "Monthly test", amount 100, select category, save. Verify it appears.' },
+  { id: 'empty-search',     name: 'Search with no results',         description: 'Search for "xyzzy123". Verify an empty state message appears rather than a crash.' },
+  { id: 'back-navigation',  name: 'Back navigation from modals',    description: 'Open add-operation modal, press Android back button. Verify modal closes and list is still visible.' },
+  { id: 'balance-update',   name: 'Balance updates after operation',description: 'Note Checking balance on Accounts tab. Add expense of 25.00 from Checking. Return to Accounts. Verify balance decreased by 25.00.' },
+  { id: 'budgets',          name: 'Budget progress visible',        description: 'Open Graphs tab. Find budget progress bars. Verify Groceries budget shows spending (seed data includes grocery expenses).' },
+];
+
+function matchesPattern(filePath, pattern) {
+  const regex = new RegExp('^' + pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*'));
+  return regex.test(filePath);
+}
+
+export function matchDiffToScenarios(diffText, appMap) {
+  const changedFiles = [];
+  for (const line of diffText.split('\n')) {
+    const m = line.match(/^diff --git a\/(.+) b\/.+/);
+    if (m) changedFiles.push(m[1]);
+  }
+
+  const matchedIds = new Set();
+  for (const file of changedFiles) {
+    for (const [pattern, ids] of Object.entries(appMap)) {
+      if (matchesPattern(file, pattern)) {
+        for (const id of ids) matchedIds.add(id);
+      }
+    }
+  }
+
+  return ALL_SCENARIOS.filter(s => matchedIds.has(s.id));
+}
+
+export function generateComprehensivePlan() {
+  return ALL_SCENARIOS;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd scripts/e2e-agent && npm test -- __tests__/planner.test.js
+```
+
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/e2e-agent/src/agent/planner.js scripts/e2e-agent/__tests__/planner.test.js
+git commit -m "feat(e2e-agent): add planner with 20 scenarios and diff-to-scenario mapping"
+```
+
+---
+
+## Phase 4: Modes + Reporting
+
+### Task 12: Reporters
+
+**Files:**
+- Create: `scripts/e2e-agent/src/reporting/terminal.js`
+- Create: `scripts/e2e-agent/src/reporting/markdown.js`
+- Create: `scripts/e2e-agent/src/reporting/pr-comment.js`
+
+- [ ] **Step 1: Create terminal.js**
+
+```javascript
+// scripts/e2e-agent/src/reporting/terminal.js
+export function printHeader(mode, total) {
+  process.stdout.write(`[e2e] Mode: ${mode}\n[e2e] Running ${total} scenarios\n\n`);
+}
+
+export function printScenarioResult(name, result, steps) {
+  const icon = result === 'pass' ? '✅' : result === 'bug' ? '❌' : '⚠️';
+  process.stdout.write(`${icon} ${name.padEnd(40)} (${steps} steps)\n`);
+}
+
+export function printSummary(results) {
+  const pass = results.filter(r => r.result === 'pass').length;
+  const fail = results.filter(r => r.result === 'bug').length;
+  const inc  = results.filter(r => r.result === 'inconclusive').length;
+  process.stdout.write(`\n[e2e] Done: ${pass} passed, ${fail} failed, ${inc} inconclusive\n`);
+}
+```
+
+- [ ] **Step 2: Create markdown.js**
+
+```javascript
+// scripts/e2e-agent/src/reporting/markdown.js
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+export function buildMarkdownReport(results, mode) {
+  const pass = results.filter(r => r.result === 'pass').length;
+  const fail = results.filter(r => r.result === 'bug').length;
+  const inc  = results.filter(r => r.result === 'inconclusive').length;
+
+  const lines = [
+    `# E2E Report — ${mode}`,
+    `**Date:** ${new Date().toISOString()}`,
+    `**Result:** ${pass} passed, ${fail} failed, ${inc} inconclusive\n`,
+  ];
+
+  for (const r of results) {
+    if (r.result === 'bug') {
+      lines.push(`### ❌ ${r.name}\n${r.description || 'No description.'}\n`);
+    } else if (r.result === 'inconclusive') {
+      lines.push(`### ⚠️ ${r.name}\nReached step limit (${r.steps} steps).\n`);
+    } else {
+      lines.push(`### ✅ ${r.name}\n`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function saveReport(results, mode, reportsDir = 'e2e-reports') {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 16);
+  const filePath = join(reportsDir, `${ts}.md`);
+  mkdirSync(reportsDir, { recursive: true });
+  writeFileSync(filePath, buildMarkdownReport(results, mode));
+  return filePath;
+}
+```
+
+- [ ] **Step 3: Create pr-comment.js**
+
+```javascript
+// scripts/e2e-agent/src/reporting/pr-comment.js
+import { execSync } from 'child_process';
+
+export function buildPRComment(prNumber, results, totalAvailable) {
+  const pass = results.filter(r => r.result === 'pass').length;
+  const fail = results.filter(r => r.result === 'bug').length;
+  const inc  = results.filter(r => r.result === 'inconclusive').length;
+
+  const lines = [
+    `## E2E Agent Report — PR #${prNumber}`,
+    `**Scenarios run:** ${results.length} / ${totalAvailable} (scoped to changed files)`,
+    `**Result:** ${fail > 0 ? `${fail} failure(s)` : 'all passed'}${inc > 0 ? `, ${inc} inconclusive` : ''}\n`,
+  ];
+
+  for (const r of results.filter(r => r.result === 'bug')) {
+    lines.push(`### ❌ ${r.name} — FAILED\n${r.description || 'No description.'}\n`);
+  }
+  for (const r of results.filter(r => r.result === 'pass')) {
+    lines.push(`### ✅ ${r.name} — passed`);
+  }
+  for (const r of results.filter(r => r.result === 'inconclusive')) {
+    lines.push(`### ⚠️ ${r.name} — inconclusive (step limit reached)`);
+  }
+
+  return lines.join('\n');
+}
+
+export function postPRComment(prNumber, body) {
+  const escaped = body.replace(/'/g, "'\\''");
+  execSync(`gh pr comment ${prNumber} --repo heywood8/money-tracker --body '${escaped}'`);
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/e2e-agent/src/reporting/
+git commit -m "feat(e2e-agent): add terminal, markdown, and PR comment reporters"
+```
+
+---
+
+### Task 13: PR-review mode
+
+**Files:**
+- Create: `scripts/e2e-agent/src/modes/pr-review.js`
+
+- [ ] **Step 1: Create pr-review.js**
+
+```javascript
+// scripts/e2e-agent/src/modes/pr-review.js
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+import { runScenario } from '../agent/loop.js';
+import { matchDiffToScenarios, ALL_SCENARIOS } from '../agent/planner.js';
+import { printHeader, printScenarioResult, printSummary } from '../reporting/terminal.js';
+import { buildPRComment, postPRComment } from '../reporting/pr-comment.js';
+
+const APP_MAP_PATH = join(dirname(fileURLToPath(import.meta.url)), '../../app-map.json');
+
+export async function runPRReview(prNumber, { device, maxSteps } = {}) {
+  console.log(`[e2e] Fetching diff for PR #${prNumber}…`);
+  const diff = execSync(`gh pr diff ${prNumber} --repo heywood8/money-tracker`, { encoding: 'utf8' });
+  const appMap = JSON.parse(readFileSync(APP_MAP_PATH, 'utf8'));
+  const scenarios = matchDiffToScenarios(diff, appMap);
+
+  if (scenarios.length === 0) {
+    console.log('[e2e] No matching scenarios for changed files. Nothing to run.');
+    return;
+  }
+
+  printHeader('PR-review', scenarios.length);
+  const reportsDir = 'e2e-reports';
+  const results = [];
+
+  for (const scenario of scenarios) {
+    process.stdout.write(`[e2e] Running: ${scenario.name}…\n`);
+    const result = await runScenario(scenario, { device, maxSteps, reportsDir });
+    results.push({ ...result, name: scenario.name });
+    printScenarioResult(scenario.name, result.result, result.steps);
+  }
+
+  printSummary(results);
+  console.log('\n[e2e] Posting PR comment…');
+  postPRComment(prNumber, buildPRComment(prNumber, results, ALL_SCENARIOS.length));
+  console.log('[e2e] Done.');
+
+  if (results.some(r => r.result === 'bug')) process.exit(1);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/e2e-agent/src/modes/pr-review.js
+git commit -m "feat(e2e-agent): add PR-review mode — diff to scoped scenarios, posts gh pr comment"
+```
+
+---
+
+### Task 14: Comprehensive mode
+
+**Files:**
+- Create: `scripts/e2e-agent/src/modes/comprehensive.js`
+
+- [ ] **Step 1: Create comprehensive.js**
+
+```javascript
+// scripts/e2e-agent/src/modes/comprehensive.js
+import { runScenario } from '../agent/loop.js';
+import { generateComprehensivePlan } from '../agent/planner.js';
+import { printHeader, printScenarioResult, printSummary } from '../reporting/terminal.js';
+import { saveReport } from '../reporting/markdown.js';
+
+export async function runComprehensive({ device, maxSteps } = {}) {
+  const scenarios = generateComprehensivePlan();
+  printHeader('comprehensive', scenarios.length);
+  const reportsDir = 'e2e-reports';
+  const results = [];
+
+  for (const scenario of scenarios) {
+    process.stdout.write(`[e2e] Running: ${scenario.name}…\n`);
+    const result = await runScenario(scenario, { device, maxSteps, reportsDir });
+    results.push({ ...result, name: scenario.name });
+    printScenarioResult(scenario.name, result.result, result.steps);
+  }
+
+  printSummary(results);
+  const reportPath = saveReport(results, 'comprehensive', reportsDir);
+  console.log(`[e2e] Report: ${reportPath}`);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/e2e-agent/src/modes/comprehensive.js
+git commit -m "feat(e2e-agent): add comprehensive mode — walks all 20 scenarios, saves markdown report"
+```
+
+---
+
+### Task 15: Smoke test the full agent
+
+- [ ] **Step 1: Add e2e-reports to .gitignore**
+
+Open `.gitignore` and add:
+```
+e2e-reports/
+```
+
+Then commit:
+```bash
+git add .gitignore
+git commit -m "chore: ignore e2e-reports directory"
+```
+
+- [ ] **Step 2: Start emulator and install app**
+
+```bash
+npx expo run:android
+```
+
+Wait for the app to install and launch on the emulator.
+
+- [ ] **Step 3: Seed via Settings**
+
+Open the app → Settings → Developer Tools → "Reset to Demo Data". Verify Operations tab shows data.
+
+- [ ] **Step 4: Smoke test the loop (5 steps)**
+
+```bash
+cd scripts/e2e-agent
+node -e "import('./src/agent/loop.js').then(async m => { const r = await m.runScenario({name:'Smoke',description:'Verify Operations tab loads with data'},{maxSteps:5,reportsDir:'/tmp/smoke'}); console.log(r); })"
+```
+
+Expected: `{ result: 'pass' }` or `{ result: 'inconclusive' }` — either means the loop executed without crashing.
+
+- [ ] **Step 5: Run comprehensive mode**
+
+```bash
+ANTHROPIC_API_KEY=sk-... node scripts/e2e-agent/index.js --mode comprehensive
+```
+
+Verify terminal output appears and `e2e-reports/` is created with a `.md` file.
+
+- [ ] **Step 6: Run PR-review mode**
+
+```bash
+ANTHROPIC_API_KEY=sk-... node scripts/e2e-agent/index.js --mode pr --pr 929
+```
+
+Verify a comment appears on PR #929.
+
+---
+
+## File Summary
+
+| Task | Files created/modified |
+|------|------------------------|
+| 1 | `app/defaults/seedData.js`, `__tests__/defaults/seedData.test.js` |
+| 2 | `app/services/SeedService.js`, `__tests__/services/SeedService.test.js` |
+| 3 | `app/modals/SettingsModal.js` (modified) |
+| 4 | `scripts/e2e-agent/package.json`, `jest.config.json`, `index.js` |
+| 5 | `scripts/e2e-agent/src/android/adb.js` |
+| 6 | `scripts/e2e-agent/src/utils/ui-tree.js`, `__tests__/ui-tree.test.js` |
+| 7 | `scripts/e2e-agent/src/utils/screenshot.js` |
+| 8 | `scripts/e2e-agent/app-map.json` |
+| 9 | `scripts/e2e-agent/src/agent/prompts.js`, `__tests__/prompts.test.js` |
+| 10 | `scripts/e2e-agent/src/agent/loop.js`, `__tests__/loop.test.js` |
+| 11 | `scripts/e2e-agent/src/agent/planner.js`, `__tests__/planner.test.js` |
+| 12 | `scripts/e2e-agent/src/reporting/terminal.js`, `markdown.js`, `pr-comment.js` |
+| 13 | `scripts/e2e-agent/src/modes/pr-review.js` |
+| 14 | `scripts/e2e-agent/src/modes/comprehensive.js` |
+| 15 | `.gitignore` (modified), manual smoke test |

--- a/docs/superpowers/specs/2026-06-13-e2e-agent-design.md
+++ b/docs/superpowers/specs/2026-06-13-e2e-agent-design.md
@@ -1,0 +1,208 @@
+# E2E Agent Design
+
+**Date:** 2026-06-13
+**Status:** Approved
+
+## Summary
+
+An autonomous Android e2e testing agent that runs locally against an emulator. Two modes: PR-review (scoped to changed code, posts findings as a PR comment) and Comprehensive (full app walk, terminal output + report file). Built on raw ADB + Claude vision — no external e2e framework in the initial phase.
+
+---
+
+## 1. Architecture
+
+Five components in a Node.js CLI at `scripts/e2e-agent/`:
+
+```
+Context Gatherer
+  └─▶ Test Plan Generator
+        └─▶ Action Loop  (core)
+              └─▶ Findings Collector
+                    └─▶ Reporter
+```
+
+### File structure
+
+```
+scripts/e2e-agent/
+  index.js                  # CLI entry point
+  app-map.json              # file-pattern → feature mapping
+  src/
+    modes/
+      pr-review.js
+      comprehensive.js
+    agent/
+      loop.js               # core action loop
+      planner.js            # test plan generation
+      prompts.js            # Claude system prompts
+    android/
+      adb.js                # ADB wrapper
+    reporting/
+      pr-comment.js         # gh pr comment integration
+      terminal.js           # console reporter
+      markdown.js           # report file writer
+    utils/
+      screenshot.js         # capture + resize
+      ui-tree.js            # UIAutomator XML → simplified JSON
+```
+
+### CLI
+
+```bash
+node scripts/e2e-agent --mode pr --pr 123
+node scripts/e2e-agent --mode comprehensive
+
+Options:
+  --device <serial>    ADB device serial (default: first connected)
+  --max-steps <n>      Max actions per scenario (default: 50)
+```
+
+---
+
+## 2. Prerequisite: Database Seeder
+
+Built before the agent. A **"Reset to Demo Data"** button in Settings → Developer Tools.
+
+### Behavior
+
+- Clears all operations, accounts, categories, budgets, planned operations
+- Inserts a fixed, deterministic dataset built relative to `today`:
+  - 3 accounts: Checking, Savings, Cash
+  - ~15 categories covering common types
+  - ~60 operations across the last 2 months (expenses, income, transfers)
+  - 2–3 budgets
+  - 1–2 planned operations
+- Dates are computed as `today - N days` — the dataset always looks "live" regardless of when it runs
+
+### Implementation
+
+- `app/defaults/seedData.js` exports `generateSeedData(today: Date)` — all dates relative to the argument
+- Button only visible behind `__DEV__` flag
+- Button has `testID="seed-demo-data"` for ADB access without visual lookup
+- The agent triggers it via the UIAutomator tree before each run
+
+---
+
+## 3. Action Loop
+
+The core of the agent. Max **50 steps** per scenario; records "inconclusive" if limit hit.
+
+### Each iteration
+
+1. `adb shell screencap -p /sdcard/s.png` + pull → resize to **30% resolution** → base64
+2. `adb shell uiautomator dump` + pull → parse XML → simplified JSON `{text, bounds, contentDesc, clickable}`
+3. Send to Claude: system prompt + current scenario + conversation history + UI JSON + 30% image
+4. Claude responds with a structured action:
+
+```json
+{ "action": "tap",   "bounds": [x1, y1, x2, y2] }
+{ "action": "type",  "text": "..." }
+{ "action": "swipe", "from": [x1,y1], "to": [x2,y2] }
+{ "action": "back" }
+{ "action": "done",  "result": "pass" }
+{ "action": "done",  "result": "bug", "description": "..." }
+```
+
+5. Execute via ADB
+6. Check `adb shell pidof com.heywood8.monkeep` — if missing, record crash as bug, relaunch, move to next scenario
+
+### On bug capture
+
+- Save **full-resolution** screenshot to `e2e-reports/screenshots/`
+- Record plain-English description: what was expected, what happened, which screen
+- Continue to next scenario
+
+### System prompt seeds
+
+- Package name: `com.heywood8.monkeep`
+- The 5 tabs and their purpose
+- What "normal" looks like per screen
+- Known data from the seeder (account names, approximate operation counts)
+
+---
+
+## 4. PR-Review Mode
+
+### Flow
+
+1. `gh pr diff <number>` → raw diff
+2. Match changed files against `app-map.json`:
+
+```json
+{
+  "app/contexts/Operations*":     ["operations-list", "add-operation", "edit-operation"],
+  "app/contexts/Accounts*":       ["accounts-list", "add-account", "transfer"],
+  "app/screens/GraphsScreen*":    ["graphs"],
+  "app/services/BackupRestore*":  ["backup", "restore"],
+  "app/components/Calculator*":   ["add-operation", "edit-operation"]
+}
+```
+
+3. Claude receives diff + mapping + full scenario list → produces prioritized subset to run (direct + adjacent risk)
+4. Seed the database, run scoped scenarios via action loop
+5. Post PR comment via `gh pr comment`
+
+### PR comment format
+
+```
+## E2E Agent Report — PR #123
+
+**Scenarios run:** 4 / 12 total (scoped to changed files)
+**Result:** 1 failure, 3 passed
+
+### ❌ Add Operation — FAILED
+After filling in amount "150.00" and tapping Save, the app returned
+to the operations list but the new operation did not appear. Expected
+to see it at the top of the list. Reproduced consistently.
+
+### ✅ Edit Operation — passed
+### ✅ Operations search — passed
+### ✅ Quick-add form — passed
+```
+
+- No image attachments — failures described in plain English only
+- Exit code 1 if any failures
+
+---
+
+## 5. Comprehensive Mode
+
+### Flow
+
+1. Seed the database
+2. Claude generates full scenario list from system prompt's app map:
+   - Happy paths: add/edit/delete for each entity type
+   - Edge cases: empty states, max-length inputs, zero amounts, same-account transfer
+   - Navigation: all tabs reachable, back buttons work, modals dismiss
+   - Data integrity: balance updates after operations, budget progress reflects spending
+3. Execution order: data-mutation scenarios first, then read-only flows
+4. Run all scenarios via action loop
+
+### Output
+
+Live terminal:
+```
+[e2e] Seeding database...
+[e2e] Running 24 scenarios
+
+✅ Add expense operation        (12 steps)
+✅ Add income operation         (8 steps)
+❌ Transfer between accounts    (23 steps) — see report
+✅ Edit operation               (9 steps)
+...
+
+[e2e] Done: 21 passed, 1 failed, 2 inconclusive
+[e2e] Report: e2e-reports/2026-06-13-14-32.md
+```
+
+Report file saved to `e2e-reports/YYYY-MM-DD-HH-MM.md` with full failure descriptions.
+
+---
+
+## 6. Out of Scope (Phase 1)
+
+- CI/CD integration
+- Maestro codification of discovered flows (Phase 2)
+- Screenshot attachment in PR comments
+- Physical device support (emulator only)
+- iOS


### PR DESCRIPTION
## Summary
- Italian: full rewrite — 200+ keys untranslated (graphs, operations, settings, categories, validation messages, months, budgets, and more)
- Japanese, Korean, Portuguese: near-complete rewrites — were ~95% English
- German, Spanish, French, Armenian, Russian, Chinese: fix ~24 common English strings that slipped through on every file
- Russian: restore missing `no_accounts` and `delete_account` keys
- Armenian: add 14 missing keys (`category_spending_trend`, yearly/12-month totals, `no_spending_data`, developer section, all log level keys)

## Common strings fixed across all languages
`import_from_file`, `import_from_local`, `save_local_backup`, `loading_newer`, `check_updates`, `update_available_title/message`, `update_install_hint`, `update_now`, `later`, `pending_out`, `pending_in`, `done_this_month`, `remaining`, `offline_rate`, `rate_unavailable`, `exchange_rate_unavailable`

## Test plan
- [ ] Open app in Italian — verify graphs/operations/settings tabs show Italian text
- [ ] Open app in Japanese/Korean/Portuguese — verify UI is no longer English
- [ ] Check Settings modal in German/Spanish/French — verify import/backup strings are translated
- [ ] Check planned operations section in Armenian — verify developer/logs entries present