### PR TITLE
fix: show release list instead of error when releases have no APKs

### DIFF
--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -276,7 +276,36 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
         </View>
       )}
 
-      {updateResult.type === 'error' && (
+      {updateResult.type === 'error' && updateResult.errorCode === 'releases_without_apks' && updateResult.releaseNotes ? (
+        <View style={styles.upToDateContent}>
+          <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
+            {t('release_history') || 'Release history'}
+          </Text>
+          <ScrollView style={styles.changelogScroll} showsVerticalScrollIndicator={false} nestedScrollEnabled>
+            {updateResult.releaseNotes.map(({ version, notes, hasApk }) => (
+              <View key={version} style={styles.changelogSection}>
+                <Text style={[styles.changelogVersion, { color: colors.mutedText }]}>
+                  v{version}{!hasApk ? ` · ${t('no_apk_attached') || 'no APK'}` : ''}
+                </Text>
+                <Text style={[styles.changelogText, { color: colors.text }]}>
+                  {stripMarkdown(notes)}
+                </Text>
+              </View>
+            ))}
+            {updateResult.releasesUrl && (
+              <TouchableOpacity
+                onPress={() => Linking.openURL(updateResult.releasesUrl)}
+                style={styles.moreReleasesLink}
+              >
+                <Text style={[styles.moreReleasesLinkText, { color: colors.primary }]}>
+                  {t('more_releases') || 'More on GitHub'}
+                </Text>
+                <Ionicons name="open-outline" size={14} color={colors.primary} />
+              </TouchableOpacity>
+            )}
+          </ScrollView>
+        </View>
+      ) : updateResult.type === 'error' && (
         <View style={styles.errorContent}>
           <Ionicons name="cloud-offline-outline" size={48} color={colors.mutedText} style={styles.centeredIcon} />
           <Text style={[styles.updateVersionText, { color: colors.text }]}>
@@ -301,6 +330,7 @@ UpdateContentPanel.propTypes = {
     releaseNotes: PropTypes.arrayOf(PropTypes.shape({
       version: PropTypes.string,
       notes: PropTypes.string,
+      hasApk: PropTypes.bool,
     })),
     recentReleaseNotes: PropTypes.arrayOf(PropTypes.shape({
       version: PropTypes.string,

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -588,7 +588,12 @@ export default function SettingsScreen({ setSubPanelActive }) {
       await setPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, new Date().toISOString());
 
       if (!result.success) {
-        setUpdateResult({ type: 'error', errorCode: result.errorCode });
+        setUpdateResult({
+          type: 'error',
+          errorCode: result.errorCode,
+          releaseNotes: result.releaseNotes || null,
+          releasesUrl: result.releasesUrl || null,
+        });
       } else if (!result.isUpdateAvailable) {
         setUpdateResult({
           type: 'up_to_date',

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -210,11 +210,24 @@ export const checkForAppUpdate = async ({
     }
 
     if (!bestRelease) {
+      if (foundReleasesWithoutApk) {
+        const releaseNotes = newerReleases
+          .filter((r) => r.notes)
+          .map((r) => ({ version: r.version, notes: r.notes, hasApk: r.hasApk }));
+        return {
+          success: false,
+          isUpdateAvailable: false,
+          currentVersion: currentNormalized,
+          errorCode: 'releases_without_apks',
+          releaseNotes: releaseNotes.length > 0 ? releaseNotes : null,
+          releasesUrl,
+        };
+      }
       return {
         success: false,
         isUpdateAvailable: false,
         currentVersion: currentNormalized,
-        errorCode: foundReleasesWithoutApk ? 'releases_without_apks' : 'invalid_release_data',
+        errorCode: 'invalid_release_data',
       };
     }
 


### PR DESCRIPTION
When GitHub has releases but none have APKs attached, instead of showing a generic error screen, show the release notes list with a "no APK" note on each entry that lacks one.

## Changes

- **AppUpdateService.js**: when `releases_without_apks`, include `releaseNotes` (with `hasApk` per entry) and `releasesUrl` in the return
- **SettingsScreen.js**: pass `releaseNotes` and `releasesUrl` through to `updateResult` on error
- **UpdateContentPanel.js**: render changelog ScrollView for `releases_without_apks` + notes present; append `· no APK` to the version label for entries without an APK; fall through to the existing cloud-offline error view for all other error codes