### PR TITLE
fix(i18n): translate dark/light theme label for all 11 languages

### DIFF
--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -1362,7 +1362,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
               <View style={styles.settingsRowText}>
                 <Text style={[styles.settingsRowLabel, { color: colors.text }]}>{t('theme') || 'Theme'}</Text>
                 <Text style={[styles.settingsRowValue, { color: colors.mutedText }]}>
-                  {colorScheme === 'dark' ? 'Dark' : 'Light'}
+                  {colorScheme === 'dark' ? t('theme_dark') : t('theme_light')}
                 </Text>
               </View>
             </View>

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -8,6 +8,8 @@
   "settings": "Einstellungen",
   "language": "Sprache",
   "theme": "Design",
+  "theme_dark": "Dunkel",
+  "theme_light": "Hell",
   "hide_balances": "Guthaben verbergen",
   "hide_balances_hint": "Kontoguthaben aus Datenschutzgründen maskieren",
   "cancel": "Abbrechen",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -8,6 +8,8 @@
   "settings": "Settings",
   "language": "Language",
   "theme": "Theme",
+  "theme_dark": "Dark",
+  "theme_light": "Light",
   "hide_balances": "Hide balances",
   "hide_balances_hint": "Mask account balances for privacy",
   "cancel": "Cancel",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -8,6 +8,8 @@
   "settings": "Configuración",
   "language": "Idioma",
   "theme": "Tema",
+  "theme_dark": "Oscuro",
+  "theme_light": "Claro",
   "hide_balances": "Ocultar saldos",
   "hide_balances_hint": "Enmascarar saldos de cuentas por privacidad",
   "cancel": "Cancelar",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -8,6 +8,8 @@
   "settings": "Paramètres",
   "language": "Langue",
   "theme": "Thème",
+  "theme_dark": "Sombre",
+  "theme_light": "Clair",
   "hide_balances": "Masquer les soldes",
   "hide_balances_hint": "Masquer les soldes des comptes pour la confidentialité",
   "cancel": "Annuler",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -8,6 +8,8 @@
   "settings": "Կարգավորումներ",
   "language": "Լեզու",
   "theme": "Թեմա",
+  "theme_dark": "Մութ",
+  "theme_light": "Պայծառ",
   "hide_balances": "Թաքցնել մնացորդները",
   "hide_balances_hint": "Ծածկել հաշվի մնացորդները գաղտնիության համար",
   "cancel": "Չեղարկել",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -8,6 +8,8 @@
   "settings": "Impostazioni",
   "language": "Lingua",
   "theme": "Tema",
+  "theme_dark": "Scuro",
+  "theme_light": "Chiaro",
   "hide_balances": "Nascondi saldi",
   "hide_balances_hint": "Maschera i saldi dei conti per la privacy",
   "cancel": "Annulla",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -8,6 +8,8 @@
   "settings": "設定",
   "language": "言語",
   "theme": "テーマ",
+  "theme_dark": "ダーク",
+  "theme_light": "ライト",
   "hide_balances": "残高を隠す",
   "hide_balances_hint": "プライバシーのため口座残高を非表示にする",
   "cancel": "キャンセル",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -8,6 +8,8 @@
   "settings": "설정",
   "language": "언어",
   "theme": "테마",
+  "theme_dark": "어두운",
+  "theme_light": "밝은",
   "hide_balances": "잔액 숨기기",
   "hide_balances_hint": "개인 정보 보호를 위해 계정 잔액 마스크",
   "cancel": "취소",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -8,6 +8,8 @@
   "settings": "Configurações",
   "language": "Idioma",
   "theme": "Tema",
+  "theme_dark": "Escuro",
+  "theme_light": "Claro",
   "hide_balances": "Ocultar saldos",
   "hide_balances_hint": "Mascarar saldos de contas por privacidade",
   "cancel": "Cancelar",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -8,6 +8,8 @@
   "settings": "Настройки",
   "language": "Язык",
   "theme": "Тема",
+  "theme_dark": "Тёмная",
+  "theme_light": "Светлая",
   "hide_balances": "Скрыть балансы",
   "hide_balances_hint": "Маскировать балансы счетов для конфиденциальности",
   "cancel": "Отмена",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -8,6 +8,8 @@
   "settings": "设置",
   "language": "语言",
   "theme": "主题",
+  "theme_dark": "深色",
+  "theme_light": "浅色",
   "hide_balances": "隐藏余额",
   "hide_balances_hint": "为隐私起见遮蔽账户余额",
   "cancel": "取消",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The theme toggle in SettingsScreen showed hardcoded English "Dark"/"Light" strings regardless of the selected language
- Added `theme_dark` and `theme_light` keys to all 11 language files (en, it, ru, es, fr, zh, de, hy, ja, ko, pt)
- Replaced hardcoded strings in `SettingsScreen.js` with `t('theme_dark')` / `t('theme_light')` calls

## Translations added

| Language | Dark | Light |
|----------|------|-------|
| English | Dark | Light |
| Italian | Scuro | Chiaro |
| Russian | Тёмная | Светлая |
| Spanish | Oscuro | Claro |
| French | Sombre | Clair |
| Chinese | 深色 | 浅色 |
| German | Dunkel | Hell |
| Armenian | Մութ | Պայծառ |
| Japanese | ダーク | ライト |
| Korean | 어두운 | 밝은 |
| Portuguese | Escuro | Claro |

## Test plan

- [ ] Switch app language to Italian (or any non-English language) and verify the theme toggle shows translated "Dark"/"Light" label
- [ ] Toggle the theme and confirm the label updates correctly

https://claude.ai/code/session_018xwQMek3aBRRmGjbvCPtA3
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018xwQMek3aBRRmGjbvCPtA3)_