### PR TITLE
fix: block accidental touches and add dark gradient in tab bar area

### DIFF
--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -570,16 +570,16 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingVertical: 8,
   },
-  tabLabel: {
-    fontSize: 11,
-    letterSpacing: 0.2,
-  },
   tabGradientOverlay: {
     bottom: 0,
     height: TAB_OVERLAY_HEIGHT,
     left: 0,
     position: 'absolute',
     right: 0,
+  },
+  tabLabel: {
+    fontSize: 11,
+    letterSpacing: 0.2,
   },
   tabsRow: {
     flexDirection: 'row',

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -201,6 +201,33 @@ TabButton.defaultProps = {
   updateProgress: null,
 };
 
+// Pre-computed gradient steps: transparent → very dark black overlay
+// Cubic ease-in gives a natural-looking gradient
+const TAB_OVERLAY_HEIGHT = 130;
+const GRADIENT_STEPS = 20;
+const gradientStepColors = Array.from({ length: GRADIENT_STEPS }, (_, i) => {
+  const t = i / (GRADIENT_STEPS - 1);
+  const easedT = t * t * t; // cubic ease-in
+  const opacity = (easedT * 0.82).toFixed(3);
+  return `rgba(0, 0, 0, ${opacity})`;
+});
+
+// Covers the tab bar region, blocks accidental touches falling through
+// to the list content below, and shows a darkening gradient as a visual cue.
+// Rendered before floatingBarWrapper so tab buttons (higher z-order) remain clickable.
+const TabGradientBlocker = memo(() => {
+  const stepHeight = TAB_OVERLAY_HEIGHT / GRADIENT_STEPS;
+  return (
+    <View style={styles.tabGradientOverlay}>
+      {gradientStepColors.map((color, i) => (
+        <View key={i} style={{ height: stepHeight, backgroundColor: color }} />
+      ))}
+    </View>
+  );
+});
+
+TabGradientBlocker.displayName = 'TabGradientBlocker';
+
 export default function SimpleTabs() {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
@@ -434,6 +461,10 @@ export default function SimpleTabs() {
           </Animated.View>
         </GestureDetector>
       </View>
+      {/* Gradient touch blocker — rendered before floatingBarWrapper so the
+          tab buttons (higher z-order, box-none wrapper) remain clickable while
+          the empty space around the pill catches accidental taps */}
+      <TabGradientBlocker />
       {/* Floating bar overlays content so screen shows through behind it */}
       <SafeAreaView edges={['bottom']} style={styles.floatingBarWrapper} pointerEvents="box-none">
         <View
@@ -542,6 +573,13 @@ const styles = StyleSheet.create({
   tabLabel: {
     fontSize: 11,
     letterSpacing: 0.2,
+  },
+  tabGradientOverlay: {
+    bottom: 0,
+    height: TAB_OVERLAY_HEIGHT,
+    left: 0,
+    position: 'absolute',
+    right: 0,
   },
   tabsRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary

- Adds a `TabGradientBlocker` component rendered just before the floating tab bar in `SimpleTabs.js`
- Blocks accidental touches in the empty space below/around the tab pill — prevents the common issue of tapping behind the tab bar and accidentally opening an operation edit modal
- Shows a darkening gradient (130px tall, transparent → `rgba(0,0,0,0.82)` with cubic ease-in) as a visual cue that the area is inactive
- Tab buttons remain fully clickable: the blocker is rendered at lower z-order than the tab bar wrapper, and the wrapper has `pointerEvents="box-none"` so its children (the buttons) are still highest priority for touches

## How it works

React Native resolves touches depth-first by z-order (last rendered = on top). The `TabGradientBlocker` is inserted *before* `floatingBarWrapper` in JSX, so:
- Touch on a tab button → `floatingBarWrapper` (higher z-order, `box-none`) → child `floatingBar` → button handles it ✓
- Touch in empty space around the pill → `floatingBarWrapper` (higher z-order, `box-none`) → no child found → falls to `TabGradientBlocker` → blocked ✓

## Test plan
- [ ] Tap in the area below the operations list but above the tab bar — should NOT open any operation
- [ ] Tap each of the 4 tab buttons — should still navigate correctly
- [ ] Swipe left/right between tabs — gesture should still work
- [ ] Verify gradient is visible at the bottom of each screen

https://claude.ai/code/session_01PWqej3DUy33A2qVG1fnNu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWqej3DUy33A2qVG1fnNu5)_