### PR TITLE
fix: keyboard overlapping input when editing operation description

### DIFF
--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -10,6 +10,7 @@ import {
   PanResponder,
   Animated,
   Dimensions,
+  Platform,
 } from 'react-native';
 import Reanimated from 'react-native-reanimated';
 import { Text, TouchableRipple } from 'react-native-paper';
@@ -144,7 +145,10 @@ export default function ModalShell({
         transparent={true}
         onRequestClose={handleBackDismiss}
       >
-        <KeyboardAvoidingView style={styles.flex1}>
+        <KeyboardAvoidingView
+          style={styles.flex1}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
           <Pressable style={styles.overlay} onPress={() => animateOut(onDismiss)}>
             <Animated.View style={{ transform: [{ translateY }] }}>
               <Reanimated.View style={[originStyle, shrinkStyle]}>


### PR DESCRIPTION
## Problem

When opening the operation modal and editing the description field, the software keyboard covered the input — the field was hidden behind the keyboard (see attached screenshot in the issue).

## Root cause

`ModalShell` (the shared bottom-sheet wrapper used by `OperationModal` and other modals) rendered its `KeyboardAvoidingView` **without a `behavior` prop**:

```jsx
<KeyboardAvoidingView style={styles.flex1}>
```

A `KeyboardAvoidingView` with no `behavior` is effectively a no-op. Combined with `edgeToEdgeEnabled: true` (set in `app.config.js`), the Android window no longer resizes automatically when the keyboard appears, so the bottom-anchored sheet (`justifyContent: 'flex-end'`) stayed in place and the description field at the bottom of the sheet was hidden behind the keyboard.

## Fix

Set `behavior="height"` on Android (and `"padding"` on iOS for completeness), matching the pattern already used in `BudgetModal.js` and `SplitOperationModal.js`. This lets the bottom sheet rise above the keyboard so the focused input stays visible.

## Testing

- `npm test` — all 1041 tests pass across the modal and component suites.

https://claude.ai/code/session_013rJCxzS6dYijyGjQ84LvSn

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJCxzS6dYijyGjQ84LvSn)_