### PR TITLE
test(graphs): align hook loading expectations with #933

### DIFF
--- a/__tests__/hooks/useBalanceHistory.test.js
+++ b/__tests__/hooks/useBalanceHistory.test.js
@@ -43,7 +43,9 @@ describe('useBalanceHistory', () => {
       const { result } = await renderHook(() => useBalanceHistory(mockAccountId, mockYear, mockMonth));
 
       expect(result.current.balanceHistoryData).toEqual({ labels: [] });
-      expect(result.current.loadingBalanceHistory).toBe(true);
+      // loading starts false — the mount spinner was removed in #933 to avoid
+      // a loading flash on the Graphs screen; load() flips it true on demand.
+      expect(result.current.loadingBalanceHistory).toBe(false);
       expect(result.current.balanceHistoryTableData).toEqual([]);
       expect(result.current.editingBalanceRow).toBeNull();
       expect(result.current.editingBalanceValue).toBe('');

--- a/__tests__/hooks/useExpenseData.test.js
+++ b/__tests__/hooks/useExpenseData.test.js
@@ -64,7 +64,9 @@ describe('useExpenseData', () => {
       );
 
       expect(result.current.chartData).toEqual([]);
-      expect(result.current.loading).toBe(true);
+      // loading starts false — the mount spinner was removed in #933 to avoid
+      // a loading flash on the Graphs screen; load() flips it true on demand.
+      expect(result.current.loading).toBe(false);
       expect(result.current.totalExpenses).toBe(0);
     });
   });
@@ -80,7 +82,8 @@ describe('useExpenseData', () => {
       });
 
       expect(OperationsDB.getSpendingByCategoryAndCurrency).not.toHaveBeenCalled();
-      expect(result.current.loading).toBe(true);
+      // Early return on missing currency never sets loading true
+      expect(result.current.loading).toBe(false);
     });
 
     it('should load expense data for a single month', async () => {

--- a/__tests__/hooks/useIncomeData.test.js
+++ b/__tests__/hooks/useIncomeData.test.js
@@ -62,7 +62,9 @@ describe('useIncomeData', () => {
       );
 
       expect(result.current.incomeChartData).toEqual([]);
-      expect(result.current.loadingIncome).toBe(true);
+      // loading starts false — the mount spinner was removed in #933 to avoid
+      // a loading flash on the Graphs screen; load() flips it true on demand.
+      expect(result.current.loadingIncome).toBe(false);
       expect(result.current.totalIncome).toBe(0);
     });
   });
@@ -78,7 +80,8 @@ describe('useIncomeData', () => {
       });
 
       expect(OperationsDB.getIncomeByCategoryAndCurrency).not.toHaveBeenCalled();
-      expect(result.current.loadingIncome).toBe(true);
+      // Early return on missing currency never sets loading true
+      expect(result.current.loadingIncome).toBe(false);
     });
 
     it('should load income data for a single month', async () => {


### PR DESCRIPTION
## Problem

5 tests across 3 graph-data hook suites were failing on `main`:

- `__tests__/hooks/useExpenseData.test.js` (2)
- `__tests__/hooks/useIncomeData.test.js` (2)
- `__tests__/hooks/useBalanceHistory.test.js` (1)

All failures were the same shape — asserting the hook's loading flag is `true` on initialization (and on the early-return-when-no-currency path), but receiving `false`.

## Root cause

PR #933 (`perf(graphs): remove loading spinner flash on Graphs screen mount`) intentionally changed the initial loading state in `useExpenseData`, `useIncomeData`, and `useBalanceHistory` from `true` to `false`, so the Graphs screen no longer flashes a spinner on mount. The hooks now flip loading to `true` on demand when `load*()` runs.

The hook tests predate that change (written in #908) and still asserted the old `loading === true` initial behavior, so they broke. The implementation is correct; the test expectations were stale.

## Fix

Update the stale assertions to expect `loading === false`:
- on initialization (mount no longer triggers a load)
- on the early-return path when no currency is selected (returns before `setLoading(true)`)

No production code changed — this only corrects test expectations to match the intentional behavior from #933.

## Testing

- `npm test` — full suite green: **118 suites, 3583 tests passing**.

https://claude.ai/code/session_013rJCxzS6dYijyGjQ84LvSn

---
_Generated by [Claude Code](https://claude.ai/code/session_013rJCxzS6dYijyGjQ84LvSn)_