### PR TITLE
fix: bottom sheet staying lifted after keyboard dismiss on Android

### DIFF
--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -147,7 +147,15 @@ export default function ModalShell({
       >
         <KeyboardAvoidingView
           style={styles.flex1}
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          // On Android, RN's Modal window already uses SOFT_INPUT_ADJUST_RESIZE,
+          // so its content area shrinks above the keyboard on its own. Adding a
+          // `behavior="height"` KeyboardAvoidingView on top double-adjusts the
+          // layout and leaves the bottom sheet "stuck" slightly lifted after the
+          // keyboard is dismissed (e.g. via the back button). Disable the KAV on
+          // Android and let the native resize handle it; the overlay's
+          // justifyContent: 'flex-end' keeps the card riding above the keyboard.
+          enabled={Platform.OS === 'ios'}
         >
           <Pressable style={styles.overlay} onPress={() => animateOut(onDismiss)}>
             <Animated.View style={{ transform: [{ translateY }] }}>


### PR DESCRIPTION
## Problem

When opening the operation modal, editing the description so the keyboard lifts up, then dismissing the keyboard with the back button, the bottom sheet does **not** slide all the way back down — it stays a little bit lifted.

## Root cause

React Native's `Modal` hardcodes its window's soft input mode to `SOFT_INPUT_ADJUST_RESIZE` (see `ReactModalHostView`). That means the modal's content area already resizes itself to sit above the keyboard, natively, with no JS help.

`ModalShell` wrapped its content in a `KeyboardAvoidingView` with `behavior="height"` on Android, applying a **second** layout adjustment on top of the native one. When the keyboard was dismissed (e.g. via the back button), the `behavior="height"` animation left a residual offset, leaving the sheet stuck slightly lifted. This is a well-known Android `behavior="height"`-inside-`Modal` interaction bug.

## Fix

Disable the redundant `KeyboardAvoidingView` on Android and let the Modal's native `ADJUST_RESIZE` handle keyboard avoidance. The overlay already uses `justifyContent: 'flex-end'`, so the card naturally rides above the keyboard and snaps cleanly back to the bottom when the keyboard hides. The `padding` behavior is retained for iOS, where it's still needed.

This change lives in the shared `ModalShell`, so every modal built on it (operations, budgets, categories, planned operations, etc.) gets the same correct, single-adjustment keyboard behavior.

## Testing

- `npm test` — all 118 test suites / 3583 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8uLh16YiMR25JkS8P6dVV)_