### PR TITLE
feat: highlight installed version in update release list

### DIFF
--- a/__tests__/components/UpdateContentPanel.test.js
+++ b/__tests__/components/UpdateContentPanel.test.js
@@ -341,4 +341,68 @@ describe('UpdateContentPanel', () => {
       expect(getByText('Recent release notes')).toBeTruthy();
     });
   });
+
+  describe('installed version highlighting', () => {
+    it('marks the installed version as latest with a checkmark hint when up to date', async () => {
+      const { getAllByText, getByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            currentVersion: '1.2.0',
+            recentReleaseNotes: [
+              { version: '1.2.0', notes: 'Latest release' },
+              { version: '1.1.0', notes: 'Older release' },
+            ],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      // The installed (and latest) release shows the "Installed" chip and the latest hint.
+      expect(getAllByText('installed').length).toBeGreaterThan(0);
+      expect(getByText('installed_latest_hint')).toBeTruthy();
+    });
+
+    it('marks the installed version without the latest hint when an update is available', async () => {
+      const { getByText, queryByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'available',
+            latestVersion: '2.0.0',
+            currentVersion: '1.9.0',
+            downloadUrl: 'https://example.com/penny-2.0.0.apk',
+            checksumUrl: null,
+            releaseNotes: null,
+            recentReleaseNotes: [
+              { version: '2.0.0', notes: 'New release' },
+              { version: '1.9.0', notes: 'Installed release' },
+            ],
+            releasesUrl: null,
+            alreadyDownloaded: false,
+            localUri: null,
+          }}
+        />,
+      );
+      // Installed version is highlighted, but it is not the latest, so no green hint.
+      expect(getByText('installed')).toBeTruthy();
+      expect(queryByText('installed_latest_hint')).toBeNull();
+    });
+
+    it('does not highlight any release when the installed version is not in the list', async () => {
+      const { queryByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            currentVersion: '9.9.9',
+            recentReleaseNotes: [{ version: '1.2.0', notes: 'Latest release' }],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      expect(queryByText('installed')).toBeNull();
+      expect(queryByText('installed_latest_hint')).toBeNull();
+    });
+  });
 });

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -103,10 +103,20 @@ const formatApkDate = (modificationTime) => {
   return new Date(modificationTime * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 };
 
-function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk, colors }) {
+// Green used for the "installed / up to date" status, matching the checkmark elsewhere in this panel.
+const INSTALLED_GREEN = '#4caf50';
+
+function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk, colors, t, isInstalled, isLatestInstalled }) {
   const { date, body } = parseReleaseNotes(notes, version);
+  const accent = isLatestInstalled ? INSTALLED_GREEN : colors.primary;
   return (
-    <View style={[styles.releaseCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+    <View
+      style={[
+        styles.releaseCard,
+        { backgroundColor: colors.surface, borderColor: isInstalled ? accent : colors.border },
+        isInstalled && styles.releaseCardInstalled,
+      ]}
+    >
       <View style={styles.releaseHeader}>
         <View style={styles.releaseHeaderLeft}>
           <Text style={[styles.releaseVersion, { color: colors.text }]}>v{version}</Text>
@@ -117,6 +127,22 @@ function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk
             <Text style={[styles.releaseBadge, { color: colors.mutedText, borderColor: colors.border }]}>
               {badge}
             </Text>
+          ) : null}
+          {isInstalled ? (
+            <View
+              style={[styles.installedChip, { borderColor: accent }]}
+              accessibilityRole="text"
+              accessibilityLabel={isLatestInstalled
+                ? (t('installed_latest_hint') || 'Installed — you are on the latest version')
+                : (t('installed') || 'Installed')}
+            >
+              {isLatestInstalled ? (
+                <Ionicons name="checkmark-circle" size={13} color={accent} />
+              ) : null}
+              <Text style={[styles.installedChipText, { color: accent }]}>
+                {t('installed') || 'Installed'}
+              </Text>
+            </View>
           ) : null}
         </View>
         {matchedApk ? (
@@ -131,6 +157,14 @@ function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk
           </TouchableOpacity>
         ) : null}
       </View>
+      {isLatestInstalled ? (
+        <View style={styles.installedHintRow}>
+          <Ionicons name="information-circle-outline" size={13} color={INSTALLED_GREEN} />
+          <Text style={[styles.installedHintText, { color: INSTALLED_GREEN }]}>
+            {t('installed_latest_hint') || "You're on the latest version."}
+          </Text>
+        </View>
+      ) : null}
       {body ? (
         <Text style={[styles.releaseBody, { color: colors.text }]}>
           {renderNotesWithLinks(body, repoBase, colors.primary)}
@@ -148,6 +182,9 @@ ReleaseCard.propTypes = {
   repoBase: PropTypes.string,
   onInstallApk: PropTypes.func,
   colors: PropTypes.object,
+  t: PropTypes.func,
+  isInstalled: PropTypes.bool,
+  isLatestInstalled: PropTypes.bool,
 };
 
 function MoreReleasesLink({ url, colors, t }) {
@@ -259,18 +296,29 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
   const repoBase = repoBaseFromReleasesUrl(updateResult.releasesUrl);
   const apkLookup = buildApkLookup(downloadedApks);
 
-  const renderReleaseCards = (releases) => releases.map((release) => (
-    <ReleaseCard
-      key={release.version}
-      version={release.version}
-      notes={release.notes}
-      badge={release.badge}
-      matchedApk={apkLookup.get(release.version)}
-      repoBase={repoBase}
-      onInstallApk={onInstallApk}
-      colors={colors}
-    />
-  ));
+  // The currently installed app version. When there is no newer release (up_to_date),
+  // the installed version is also the latest one and earns the green checkmark + hint.
+  const installedVersion = updateResult.currentVersion;
+  const installedIsLatest = updateResult.type === 'up_to_date';
+
+  const renderReleaseCards = (releases) => releases.map((release) => {
+    const isInstalled = !!installedVersion && release.version === installedVersion;
+    return (
+      <ReleaseCard
+        key={release.version}
+        version={release.version}
+        notes={release.notes}
+        badge={release.badge}
+        matchedApk={apkLookup.get(release.version)}
+        repoBase={repoBase}
+        onInstallApk={onInstallApk}
+        colors={colors}
+        t={t}
+        isInstalled={isInstalled}
+        isLatestInstalled={isInstalled && installedIsLatest}
+      />
+    );
+  });
 
   return (
     <Animated.View style={[styles.resultContainer, { opacity: contentAnim }]}>
@@ -543,6 +591,32 @@ const styles = StyleSheet.create({
     paddingHorizontal: HORIZONTAL_PADDING * 2,
     paddingVertical: SPACING.xl,
   },
+  installedChip: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: 2,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: 1,
+  },
+  installedChipText: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  installedHintRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    marginBottom: SPACING.sm,
+    paddingLeft: SPACING.sm,
+  },
+  installedHintText: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
   moreReleasesLink: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -587,6 +661,9 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.md,
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.md,
+  },
+  releaseCardInstalled: {
+    borderWidth: 1.5,
   },
   releaseDate: {
     fontSize: 12,

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -389,6 +389,8 @@
   "update_phase_backing_up": "Sicherung wird erstellt…",
   "update_install_now": "Jetzt installieren",
   "downloaded_apks": "Heruntergeladene APKs",
+  "installed": "Installiert",
+  "installed_latest_hint": "Du hast die neueste Version.",
   "release_history": "Versionsverlauf",
   "no_apk_attached": "Kein APK",
   "more_releases": "Mehr auf GitHub",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -393,6 +393,8 @@
   "update_phase_backing_up": "Backing up…",
   "update_install_now": "Install now",
   "downloaded_apks": "Downloaded APKs",
+  "installed": "Installed",
+  "installed_latest_hint": "You're on the latest version.",
   "release_history": "Release history",
   "no_apk_attached": "No APK",
   "more_releases": "More on GitHub",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -389,6 +389,8 @@
   "update_phase_backing_up": "Creando copia de seguridad…",
   "update_install_now": "Instalar ahora",
   "downloaded_apks": "APKs descargados",
+  "installed": "Instalada",
+  "installed_latest_hint": "Tienes la última versión.",
   "release_history": "Historial de versiones",
   "no_apk_attached": "Sin APK",
   "more_releases": "Más en GitHub",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -393,6 +393,8 @@
   "update_phase_backing_up": "Sauvegarde…",
   "update_install_now": "Installer maintenant",
   "downloaded_apks": "APKs téléchargés",
+  "installed": "Installée",
+  "installed_latest_hint": "Vous avez la dernière version.",
   "release_history": "Historique des versions",
   "no_apk_attached": "Pas d'APK",
   "more_releases": "Plus sur GitHub",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -389,6 +389,8 @@
   "update_phase_backing_up": "Կրկնօրինակ ստեղծում…",
   "update_install_now": "Տեղադրել հիմա",
   "downloaded_apks": "Ներբեռնված APK-ներ",
+  "installed": "Տեղադրված է",
+  "installed_latest_hint": "Դուք ունեք վերջին տարբերակը։",
   "release_history": "Թողարկումների պատմություն",
   "no_apk_attached": "APK չկա",
   "more_releases": "Ավելին GitHub-ում",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -393,6 +393,8 @@
   "update_phase_backing_up": "Backup in corso…",
   "update_install_now": "Installa ora",
   "downloaded_apks": "APK scaricati",
+  "installed": "Installato",
+  "installed_latest_hint": "Hai l'ultima versione.",
   "release_history": "Cronologia versioni",
   "no_apk_attached": "Nessun APK",
   "more_releases": "Altro su GitHub",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -393,6 +393,8 @@
   "update_phase_backing_up": "バックアップ作成中…",
   "update_install_now": "今すぐインストール",
   "downloaded_apks": "ダウンロード済みAPK",
+  "installed": "インストール済み",
+  "installed_latest_hint": "最新バージョンです。",
   "release_history": "リリース履歴",
   "no_apk_attached": "APKなし",
   "more_releases": "GitHubで詳細を見る",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -393,6 +393,8 @@
   "update_phase_backing_up": "백업 생성 중…",
   "update_install_now": "지금 설치",
   "downloaded_apks": "다운로드된 APK",
+  "installed": "설치됨",
+  "installed_latest_hint": "최신 버전입니다.",
   "release_history": "릴리스 기록",
   "no_apk_attached": "APK 없음",
   "more_releases": "GitHub에서 더 보기",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -393,6 +393,8 @@
   "update_phase_backing_up": "Criando backup…",
   "update_install_now": "Instalar agora",
   "downloaded_apks": "APKs baixados",
+  "installed": "Instalada",
+  "installed_latest_hint": "Você está na versão mais recente.",
   "release_history": "Histórico de versões",
   "no_apk_attached": "Sem APK",
   "more_releases": "Mais no GitHub",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -393,6 +393,8 @@
   "update_phase_backing_up": "Создание резервной копии…",
   "update_install_now": "Установить сейчас",
   "downloaded_apks": "Загруженные APK",
+  "installed": "Установлено",
+  "installed_latest_hint": "У вас последняя версия.",
   "release_history": "История версий",
   "no_apk_attached": "Нет APK",
   "more_releases": "Больше на GitHub",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -389,6 +389,8 @@
   "update_phase_backing_up": "正在备份…",
   "update_install_now": "立即安装",
   "downloaded_apks": "已下载 APK",
+  "installed": "已安装",
+  "installed_latest_hint": "您使用的是最新版本。",
   "release_history": "版本历史",
   "no_apk_attached": "无 APK",
   "more_releases": "更多内容见 GitHub",


### PR DESCRIPTION
## Summary

Highlights the currently installed app version in the update panel's release list, and flags it with a green checkmark + hint when it's the latest.

- **Installed version is highlighted** in the changelog/release list — an accent border plus an "Installed" chip on the matching release card.
- **When installed == latest** (the up-to-date case), the highlight turns **green**, a **green checkmark** appears in the chip, and a **hint line** ("You're on the latest version.") is shown so the user can tell at a glance they're fully up to date.
- **When a newer release exists**, the installed version is still highlighted (accent border + chip) but without the green "latest" treatment — because it isn't the latest.
- Adds the `installed` and `installed_latest_hint` i18n keys across **all 11 languages**.

The "installed" status is derived from `updateResult.currentVersion`; "latest" is true when `updateResult.type === 'up_to_date'`.

## Testing
- `npm test` — **3592 passed** (118 suites)
- Added 3 tests: latest-installed shows checkmark + hint, available-but-installed shows highlight without hint, and no highlight when the installed version isn't listed.
- `eslint` clean on the changed component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEqYxTVtec7haoeeaJ7gzn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEqYxTVtec7haoeeaJ7gzn)_