### PR TITLE
fix(i18n): add missing translation keys across all 11 languages

### DIFF
--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -414,5 +414,18 @@
   "offline_rate": "offline",
   "rate_unavailable": "Kurs nicht verfügbar",
   "exchange_rate_unavailable": "Wechselkurs nicht verfügbar. Bitte Verbindung prüfen und erneut versuchen.",
-  "exchange_rate_required": "Wechselkurs ist für Fremdwährungstransaktionen erforderlich"
+  "exchange_rate_required": "Wechselkurs ist für Fremdwährungstransaktionen erforderlich",
+  "exporting": "Exportieren…",
+  "export_success": "Export abgeschlossen",
+  "add_account_hint": "Öffnet das Formular zum Erstellen eines neuen Kontos",
+  "add_category_hint": "Öffnet das Formular zum Erstellen einer neuen Kategorie",
+  "back": "Zurück",
+  "currency": "Währung",
+  "drag_to_reorder": "Zum Neuordnen ziehen",
+  "error_loading_accounts": "Konten konnten nicht geladen werden",
+  "execute": "Ausführen",
+  "loading_accounts": "Konten werden geladen...",
+  "loading_categories": "Kategorien werden geladen...",
+  "none": "Keine",
+  "update_download_failed": "Update konnte nicht heruntergeladen werden. Bitte erneut versuchen."
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -414,5 +414,18 @@
   "pending_in": "Pending in",
   "done_this_month": "Done this month",
   "done": "Done",
-  "remaining": "remaining"
+  "remaining": "remaining",
+  "exporting": "Exporting…",
+  "export_success": "Export complete",
+  "add_account_hint": "Opens form to create a new account",
+  "add_category_hint": "Opens form to create a new category",
+  "back": "Back",
+  "currency": "Currency",
+  "drag_to_reorder": "Drag to reorder",
+  "error_loading_accounts": "Failed to load accounts",
+  "execute": "Execute",
+  "loading_accounts": "Loading accounts...",
+  "loading_categories": "Loading categories...",
+  "none": "None",
+  "update_download_failed": "Could not download the update. Please try again."
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -414,5 +414,18 @@
   "offline_rate": "sin conexión",
   "rate_unavailable": "Tipo no disponible",
   "exchange_rate_unavailable": "Tipo de cambio no disponible. Por favor, comprueba tu conexión e inténtalo de nuevo.",
-  "exchange_rate_required": "El tipo de cambio es obligatorio para operaciones en moneda extranjera"
+  "exchange_rate_required": "El tipo de cambio es obligatorio para operaciones en moneda extranjera",
+  "exporting": "Exportando…",
+  "export_success": "Exportación completada",
+  "add_account_hint": "Abre el formulario para crear una nueva cuenta",
+  "add_category_hint": "Abre el formulario para crear una nueva categoría",
+  "back": "Atrás",
+  "currency": "Moneda",
+  "drag_to_reorder": "Arrastra para reordenar",
+  "error_loading_accounts": "Error al cargar las cuentas",
+  "execute": "Ejecutar",
+  "loading_accounts": "Cargando cuentas...",
+  "loading_categories": "Cargando categorías...",
+  "none": "Ninguno",
+  "update_download_failed": "No se pudo descargar la actualización. Inténtalo de nuevo."
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -414,5 +414,18 @@
   "pending_in": "Entrée en attente",
   "done_this_month": "Fait ce mois-ci",
   "done": "Terminé",
-  "remaining": "restant"
+  "remaining": "restant",
+  "exporting": "Exportation…",
+  "export_success": "Exportation terminée",
+  "add_account_hint": "Ouvre le formulaire pour créer un nouveau compte",
+  "add_category_hint": "Ouvre le formulaire pour créer une nouvelle catégorie",
+  "back": "Retour",
+  "currency": "Devise",
+  "drag_to_reorder": "Glisser pour réorganiser",
+  "error_loading_accounts": "Échec du chargement des comptes",
+  "execute": "Exécuter",
+  "loading_accounts": "Chargement des comptes...",
+  "loading_categories": "Chargement des catégories...",
+  "none": "Aucun",
+  "update_download_failed": "Impossible de télécharger la mise à jour. Veuillez réessayer."
 }

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -414,5 +414,18 @@
   "offline_rate": "artakain",
   "rate_unavailable": "Kurs hasaneli che",
   "exchange_rate_unavailable": "Poharzheku hasaneli che: Xndrum enk stavrel kapoghutyuny ev krkin forcel:",
-  "exchange_rate_required": "Փոխարժեքը պարտադիր է արտաքին արժույթով գործողությունների համար"
+  "exchange_rate_required": "Փոխարժեքը պարտադիր է արտաքին արժույթով գործողությունների համար",
+  "exporting": "Արտահանում…",
+  "export_success": "Արտահանումն ավարտված է",
+  "add_account_hint": "Բացում է նոր հաշիվ ստեղծելու ձևը",
+  "add_category_hint": "Բացում է նոր կատեգորիա ստեղծելու ձևը",
+  "back": "Հետ",
+  "currency": "Արժույթ",
+  "drag_to_reorder": "Քաշեք՝ վերադասավորելու համար",
+  "error_loading_accounts": "Չհաջողվեց բեռնել հաշիվները",
+  "execute": "Կատարել",
+  "loading_accounts": "Հաշիվների բեռնում...",
+  "loading_categories": "Կատեգորիաների բեռնում...",
+  "none": "Չկա",
+  "update_download_failed": "Չհաջողվեց ներբեռնել թարմացումը։ Խնդրում ենք նորից փորձել։"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -414,5 +414,18 @@
   "pending_in": "In entrata",
   "done_this_month": "Fatto questo mese",
   "done": "Fatto",
-  "remaining": "rimanente"
+  "remaining": "rimanente",
+  "exporting": "Esportazione…",
+  "export_success": "Esportazione completata",
+  "add_account_hint": "Apre il modulo per creare un nuovo conto",
+  "add_category_hint": "Apre il modulo per creare una nuova categoria",
+  "back": "Indietro",
+  "currency": "Valuta",
+  "drag_to_reorder": "Trascina per riordinare",
+  "error_loading_accounts": "Impossibile caricare i conti",
+  "execute": "Esegui",
+  "loading_accounts": "Caricamento conti...",
+  "loading_categories": "Caricamento categorie...",
+  "none": "Nessuno",
+  "update_download_failed": "Impossibile scaricare l'aggiornamento. Riprova."
 }

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -414,5 +414,18 @@
   "pending_in": "収入予定",
   "done_this_month": "今月の完了",
   "done": "完了",
-  "remaining": "残り"
+  "remaining": "残り",
+  "exporting": "エクスポート中…",
+  "export_success": "エクスポート完了",
+  "add_account_hint": "新しいアカウントを作成するフォームを開きます",
+  "add_category_hint": "新しいカテゴリを作成するフォームを開きます",
+  "back": "戻る",
+  "currency": "通貨",
+  "drag_to_reorder": "ドラッグして並べ替え",
+  "error_loading_accounts": "アカウントの読み込みに失敗しました",
+  "execute": "実行",
+  "loading_accounts": "アカウントを読み込み中...",
+  "loading_categories": "カテゴリを読み込み中...",
+  "none": "なし",
+  "update_download_failed": "更新をダウンロードできませんでした。もう一度お試しください。"
 }

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -414,5 +414,18 @@
   "pending_in": "수입 예정",
   "done_this_month": "이번 달 완료",
   "done": "완료",
-  "remaining": "남은 금액"
+  "remaining": "남은 금액",
+  "exporting": "내보내는 중…",
+  "export_success": "내보내기 완료",
+  "add_account_hint": "새 계정을 만드는 양식을 엽니다",
+  "add_category_hint": "새 카테고리를 만드는 양식을 엽니다",
+  "back": "뒤로",
+  "currency": "통화",
+  "drag_to_reorder": "드래그하여 순서 변경",
+  "error_loading_accounts": "계정을 불러오지 못했습니다",
+  "execute": "실행",
+  "loading_accounts": "계정 불러오는 중...",
+  "loading_categories": "카테고리 불러오는 중...",
+  "none": "없음",
+  "update_download_failed": "업데이트를 다운로드할 수 없습니다. 다시 시도해 주세요."
 }

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -414,5 +414,18 @@
   "pending_in": "Entrada pendente",
   "done_this_month": "Feito este mês",
   "done": "Pronto",
-  "remaining": "restante"
+  "remaining": "restante",
+  "exporting": "Exportando…",
+  "export_success": "Exportação concluída",
+  "add_account_hint": "Abre o formulário para criar uma nova conta",
+  "add_category_hint": "Abre o formulário para criar uma nova categoria",
+  "back": "Voltar",
+  "currency": "Moeda",
+  "drag_to_reorder": "Arraste para reordenar",
+  "error_loading_accounts": "Falha ao carregar as contas",
+  "execute": "Executar",
+  "loading_accounts": "Carregando contas...",
+  "loading_categories": "Carregando categorias...",
+  "none": "Nenhum",
+  "update_download_failed": "Não foi possível baixar a atualização. Tente novamente."
 }

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -414,5 +414,18 @@
   "pending_in": "Предстоящий доход",
   "done_this_month": "Выполнено в этом месяце",
   "done": "Готово",
-  "remaining": "остаток"
+  "remaining": "остаток",
+  "exporting": "Экспорт…",
+  "export_success": "Экспорт завершён",
+  "add_account_hint": "Открывает форму создания нового счёта",
+  "add_category_hint": "Открывает форму создания новой категории",
+  "back": "Назад",
+  "currency": "Валюта",
+  "drag_to_reorder": "Перетащите для изменения порядка",
+  "error_loading_accounts": "Не удалось загрузить счета",
+  "execute": "Выполнить",
+  "loading_accounts": "Загрузка счетов...",
+  "loading_categories": "Загрузка категорий...",
+  "none": "Нет",
+  "update_download_failed": "Не удалось загрузить обновление. Попробуйте ещё раз."
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -414,5 +414,18 @@
   "offline_rate": "离线",
   "rate_unavailable": "汇率不可用",
   "exchange_rate_unavailable": "汇率不可用，请检查网络连接后重试。",
-  "exchange_rate_required": "外币操作需要提供汇率"
+  "exchange_rate_required": "外币操作需要提供汇率",
+  "exporting": "正在导出…",
+  "export_success": "导出完成",
+  "add_account_hint": "打开创建新账户的表单",
+  "add_category_hint": "打开创建新分类的表单",
+  "back": "返回",
+  "currency": "货币",
+  "drag_to_reorder": "拖动以重新排序",
+  "error_loading_accounts": "加载账户失败",
+  "execute": "执行",
+  "loading_accounts": "正在加载账户...",
+  "loading_categories": "正在加载分类...",
+  "none": "无",
+  "update_download_failed": "无法下载更新。请重试。"
 }


### PR DESCRIPTION
## Summary

The export progress/success labels `exporting` and `export_success` (shown on the export rows in `SettingsScreen`) had **no translation entries** in any language file — they only rendered through their inline English fallbacks (`'Exporting…'`, `'Export complete'`).

While fixing those, I scanned the whole `app/` tree for every `t('...')` key and compared it against `en.json` to find all keys that were missing and silently falling back to inline English. There were **13** in total.

## Keys added (all 11 languages: en, it, ru, es, fr, zh, de, hy, ja, ko, pt)

| Key | English |
| --- | --- |
| `exporting` | Exporting… |
| `export_success` | Export complete |
| `add_account_hint` | Opens form to create a new account |
| `add_category_hint` | Opens form to create a new category |
| `back` | Back |
| `currency` | Currency |
| `drag_to_reorder` | Drag to reorder |
| `error_loading_accounts` | Failed to load accounts |
| `execute` | Execute |
| `loading_accounts` | Loading accounts... |
| `loading_categories` | Loading categories... |
| `none` | None |
| `update_download_failed` | Could not download the update. Please try again. |

Note: `back` and `execute` were previously used as `accessibilityLabel` / visible text **without** an inline fallback, so they would have surfaced as empty/raw on non-English locales — now properly translated everywhere.

## Verification

- A scripted scan of `t('...')` usages across `app/` now reports **0** missing static keys.
- All 11 JSON files validated as parseable.
- Full test suite: **3589 passed / 118 suites**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lgt5voZhXmS8GHvDDxPKhm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgt5voZhXmS8GHvDDxPKhm)_