### PR TITLE
fix(update): move up-to-date confirmation onto highlighted latest release card

### DIFF
--- a/__tests__/components/UpdateContentPanel.test.js
+++ b/__tests__/components/UpdateContentPanel.test.js
@@ -404,5 +404,42 @@ describe('UpdateContentPanel', () => {
       expect(queryByText('installed')).toBeNull();
       expect(queryByText('installed_latest_hint')).toBeNull();
     });
+
+    it('puts the up-to-date confirmation on the highlighted latest card, not at the bottom', async () => {
+      const { queryByText, getByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            currentVersion: '1.2.0',
+            recentReleaseNotes: [
+              { version: '1.2.0', notes: 'Latest release' },
+              { version: '1.1.0', notes: 'Older release' },
+            ],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      // The confirmation lives on the green latest-release card...
+      expect(getByText('installed_latest_hint')).toBeTruthy();
+      // ...and the standalone bottom status is gone.
+      expect(queryByText('up_to_date')).toBeNull();
+    });
+
+    it('falls back to the bottom up-to-date status when the latest version is not shown as a card', async () => {
+      const { getByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            currentVersion: '9.9.9',
+            recentReleaseNotes: [{ version: '1.2.0', notes: 'Latest release' }],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      // No card matches the installed version, so the confirmation falls back to the bottom.
+      expect(getByText('up_to_date')).toBeTruthy();
+    });
   });
 });

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -391,6 +391,11 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
           {updateResult.recentReleaseNotes ? (() => {
             const releases = updateResult.recentReleaseNotes;
             const unmatched = unmatchedApksFor(downloadedApks, releases);
+            // The installed version is also the latest one here, so it is rendered as a
+            // green-highlighted card carrying the "you're on the latest version" hint inline.
+            // Only fall back to a standalone bottom status when that card is absent (the
+            // installed version isn't among the listed releases).
+            const latestShownOnCard = !!installedVersion && releases.some((r) => r.version === installedVersion);
             return (
               <>
                 <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
@@ -406,16 +411,22 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
                     <MoreReleasesLink url={updateResult.releasesUrl} colors={colors} t={t} />
                   )}
                 </ScrollView>
-                <Divider style={styles.updateDivider} />
-                <View style={styles.updateBottomRow}>
-                  <UnmatchedApks apks={unmatched} onInstallApk={onInstallApk} colors={colors} t={t} compact />
-                  <View style={styles.upToDateBottomRight}>
-                    <Ionicons name="checkmark-circle-outline" size={24} color="#4caf50" />
-                    <Text style={[styles.upToDateHeaderText, { color: colors.text }]}>
-                      {t('up_to_date') || 'You already have the latest version installed.'}
-                    </Text>
-                  </View>
-                </View>
+                {(unmatched.length > 0 || !latestShownOnCard) && (
+                  <>
+                    <Divider style={styles.updateDivider} />
+                    <View style={styles.updateBottomRow}>
+                      <UnmatchedApks apks={unmatched} onInstallApk={onInstallApk} colors={colors} t={t} compact />
+                      {!latestShownOnCard ? (
+                        <View style={styles.upToDateBottomRight}>
+                          <Ionicons name="checkmark-circle-outline" size={24} color="#4caf50" />
+                          <Text style={[styles.upToDateHeaderText, { color: colors.text }]}>
+                            {t('up_to_date') || 'You already have the latest version installed.'}
+                          </Text>
+                        </View>
+                      ) : null}
+                    </View>
+                  </>
+                )}
               </>
             );
           })() : (


### PR DESCRIPTION
## Summary

When no update is available, the "you're on the latest version" confirmation was rendered as a **standalone block pinned to the bottom** of the release history — separate from the green-highlighted latest-release card that already carries an inline confirmation hint.

This consolidates the messaging onto that green card and removes the redundant bottom block, so the confirmation now sits directly on the currently-installed / latest release where the user is looking.

### Before vs after
- **Before:** latest release card (green-highlighted) + a separate checkmark + "You already have the latest version installed." row at the bottom.
- **After:** confirmation lives only on the green-highlighted latest release card via its inline hint.

### Robustness
A bottom fallback status is kept for the edge case where the installed version is **not** among the listed release cards (so the user never loses the up-to-date confirmation). The divider + bottom row also only render when there's something to show (unmatched downloaded APKs, or the fallback status).

## Testing
- Added tests covering both branches: confirmation on the highlighted card (no bottom status) and the fallback bottom status when the installed version isn't shown as a card.
- `npm test -- UpdateContentPanel UpdateAvailableModal AppUpdateService` → 99 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLHWq3TgXZKfPev1JgRrR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLHWq3TgXZKfPev1JgRrR2)_