### PR TITLE
fix(update): pass currentVersion to panel when up to date

### DIFF
--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -263,11 +263,14 @@ jest.mock('../../app/services/GoogleSheetsService', () => ({
   importFromSheets: jest.fn(() => Promise.resolve()),
 }));
 
-// Mock UpdateContentPanel
+// Mock UpdateContentPanel — capture the props it receives so tests can assert
+// what the screen forwards (e.g. currentVersion for installed-version highlighting).
+const updatePanelProps = { last: null };
 jest.mock('../../app/components/UpdateContentPanel', () => {
   const React = require('react');
   const { View } = require('react-native');
-  return function UpdateContentPanel() {
+  return function UpdateContentPanel(props) {
+    updatePanelProps.last = props;
     return React.createElement(View, { testID: 'update-content-panel' });
   };
 });
@@ -881,6 +884,37 @@ describe('SettingsScreen', () => {
         expect(getByTestId('default-account-option-1')).toBeTruthy();
         expect(getByTestId('default-account-option-2')).toBeTruthy();
       });
+    });
+  });
+
+  describe('Update check', () => {
+    // eslint-disable-next-line global-require
+    const { checkForAppUpdate } = require('../../app/services/AppUpdateService');
+
+    it('forwards currentVersion to the panel when up to date so the latest card can be highlighted', async () => {
+      checkForAppUpdate.mockResolvedValueOnce({
+        success: true,
+        isUpdateAvailable: false,
+        currentVersion: '1.2.3',
+        recentReleaseNotes: [{ version: '1.2.3', notes: 'Latest release' }],
+        releasesUrl: 'https://github.com/example/releases',
+      });
+
+      const { getByTestId } = await render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId('check-updates-row'));
+      });
+
+      await waitFor(() => {
+        expect(updatePanelProps.last?.updateResult?.type).toBe('up_to_date');
+      });
+      // Regression: the up_to_date result must carry currentVersion, otherwise the
+      // installed/latest release is never matched to its card and the confirmation
+      // falls back to a standalone bottom block instead of the green card hint.
+      expect(updatePanelProps.last.updateResult.currentVersion).toBe('1.2.3');
     });
   });
 });

--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -888,7 +888,6 @@ describe('SettingsScreen', () => {
   });
 
   describe('Update check', () => {
-    // eslint-disable-next-line global-require
     const { checkForAppUpdate } = require('../../app/services/AppUpdateService');
 
     it('forwards currentVersion to the panel when up to date so the latest card can be highlighted', async () => {

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -607,6 +607,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
         setUpdateResult({
           type: 'error',
           errorCode: result.errorCode,
+          currentVersion: result.currentVersion,
           releaseNotes: result.releaseNotes || null,
           recentReleaseNotes: result.recentReleaseNotes || null,
           releasesUrl: result.releasesUrl || null,
@@ -614,6 +615,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
       } else if (!result.isUpdateAvailable) {
         setUpdateResult({
           type: 'up_to_date',
+          currentVersion: result.currentVersion,
           recentReleaseNotes: result.recentReleaseNotes || null,
           releasesUrl: result.releasesUrl || null,
         });


### PR DESCRIPTION
## Summary

Follow-up to #989. That PR moved the "you're on the latest version" confirmation onto the green-highlighted latest-release card — but in practice the card was still never highlighted and the bottom text persisted (see the v0.136.3 build).

**Root cause:** in `SettingsScreen.runUpdateCheck`, the `up_to_date` (and `error`) result objects were built **without `currentVersion`**, unlike the `available` branch which includes it. `UpdateContentPanel` derives `installedVersion` from `updateResult.currentVersion`, so it was always `undefined` → no release card ever matched the installed version → no green highlight, and the `latestShownOnCard` check from #989 was always false → the confirmation always fell back to the standalone bottom block.

This also explains why the original screenshots never showed the highlight in the up-to-date view: the data was missing all along, independent of the layout work.

## Change
- Thread `result.currentVersion` into both the `up_to_date` and `error` result objects in `SettingsScreen.js`. The `available` branch already had it.

With this, the installed/latest release card is matched, highlighted green, and carries the confirmation inline — and the redundant bottom block disappears.

## Testing
- Added a regression test in `SettingsScreen.test.js`: the mocked `UpdateContentPanel` now captures its props, and the test asserts the `up_to_date` result forwards `currentVersion`.
- `npm test -- SettingsScreen UpdateContentPanel` → 75 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLHWq3TgXZKfPev1JgRrR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLHWq3TgXZKfPev1JgRrR2)_