### PR TITLE
feat: highlight install candidate instead of installed version

### DIFF
--- a/__tests__/components/UpdateContentPanel.test.js
+++ b/__tests__/components/UpdateContentPanel.test.js
@@ -384,9 +384,55 @@ describe('UpdateContentPanel', () => {
           }}
         />,
       );
-      // Installed version is highlighted, but it is not the latest, so no green hint.
+      // Installed version still carries its informational chip, but with no green latest hint.
       expect(getByText('installed')).toBeTruthy();
       expect(queryByText('installed_latest_hint')).toBeNull();
+    });
+
+    it('highlights the candidate for installation, not the installed version, when an update is available', async () => {
+      const { getByText, getByLabelText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'available',
+            latestVersion: '2.0.0',
+            currentVersion: '1.9.0',
+            downloadUrl: 'https://example.com/penny-2.0.0.apk',
+            checksumUrl: null,
+            releaseNotes: null,
+            recentReleaseNotes: [
+              { version: '2.0.0', notes: 'New release' },
+              { version: '1.9.0', notes: 'Installed release' },
+            ],
+            releasesUrl: null,
+            alreadyDownloaded: false,
+            localUri: null,
+          }}
+        />,
+      );
+      // The newest release is flagged as the install candidate...
+      expect(getByText('update_candidate')).toBeTruthy();
+      expect(getByLabelText('update_candidate')).toBeTruthy();
+      // ...while the installed version keeps only its informational chip.
+      expect(getByText('installed')).toBeTruthy();
+    });
+
+    it('does not show an install candidate chip when already up to date', async () => {
+      const { queryByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            currentVersion: '1.2.0',
+            recentReleaseNotes: [
+              { version: '1.2.0', notes: 'Latest release' },
+              { version: '1.1.0', notes: 'Older release' },
+            ],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      expect(queryByText('update_candidate')).toBeNull();
     });
 
     it('does not highlight any release when the installed version is not in the list', async () => {

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -106,15 +106,22 @@ const formatApkDate = (modificationTime) => {
 // Green used for the "installed / up to date" status, matching the checkmark elsewhere in this panel.
 const INSTALLED_GREEN = '#4caf50';
 
-function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk, colors, t, isInstalled, isLatestInstalled }) {
+function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk, colors, t, isInstalled, isLatestInstalled, isUpdateCandidate }) {
   const { date, body } = parseReleaseNotes(notes, version);
+  // We highlight a single card: the candidate for installation when an update is available,
+  // otherwise the installed-and-latest card when we are already up to date. The candidate
+  // takes the primary accent; the up-to-date installed card keeps the green "latest" accent.
+  const highlighted = isUpdateCandidate || isLatestInstalled;
   const accent = isLatestInstalled ? INSTALLED_GREEN : colors.primary;
+  // Once an update is available the installed card is no longer the highlighted one, so its
+  // "Installed" chip recedes to a muted, purely informational treatment.
+  const installedChipColor = isLatestInstalled ? accent : colors.mutedText;
   return (
     <View
       style={[
         styles.releaseCard,
-        { backgroundColor: colors.surface, borderColor: isInstalled ? accent : colors.border },
-        isInstalled && styles.releaseCardInstalled,
+        { backgroundColor: colors.surface, borderColor: highlighted ? accent : colors.border },
+        highlighted && styles.releaseCardHighlighted,
       ]}
     >
       <View style={styles.releaseHeader}>
@@ -128,9 +135,21 @@ function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk
               {badge}
             </Text>
           ) : null}
+          {isUpdateCandidate ? (
+            <View
+              style={[styles.installedChip, { borderColor: colors.primary }]}
+              accessibilityRole="text"
+              accessibilityLabel={t('update_candidate') || 'Available to install'}
+            >
+              <Ionicons name="arrow-up-circle" size={13} color={colors.primary} />
+              <Text style={[styles.installedChipText, { color: colors.primary }]}>
+                {t('update_candidate') || 'Available'}
+              </Text>
+            </View>
+          ) : null}
           {isInstalled ? (
             <View
-              style={[styles.installedChip, { borderColor: accent }]}
+              style={[styles.installedChip, { borderColor: installedChipColor }]}
               accessibilityRole="text"
               accessibilityLabel={isLatestInstalled
                 ? (t('installed_latest_hint') || 'Installed — you are on the latest version')
@@ -139,7 +158,7 @@ function ReleaseCard({ version, notes, badge, matchedApk, repoBase, onInstallApk
               {isLatestInstalled ? (
                 <Ionicons name="checkmark-circle" size={13} color={accent} />
               ) : null}
-              <Text style={[styles.installedChipText, { color: accent }]}>
+              <Text style={[styles.installedChipText, { color: installedChipColor }]}>
                 {t('installed') || 'Installed'}
               </Text>
             </View>
@@ -185,6 +204,7 @@ ReleaseCard.propTypes = {
   t: PropTypes.func,
   isInstalled: PropTypes.bool,
   isLatestInstalled: PropTypes.bool,
+  isUpdateCandidate: PropTypes.bool,
 };
 
 function MoreReleasesLink({ url, colors, t }) {
@@ -300,9 +320,13 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
   // the installed version is also the latest one and earns the green checkmark + hint.
   const installedVersion = updateResult.currentVersion;
   const installedIsLatest = updateResult.type === 'up_to_date';
+  // When an update is available, the release we want the user to install is the highlighted
+  // one — not the version they already have.
+  const candidateVersion = updateResult.type === 'available' ? updateResult.latestVersion : null;
 
   const renderReleaseCards = (releases) => releases.map((release) => {
     const isInstalled = !!installedVersion && release.version === installedVersion;
+    const isUpdateCandidate = !!candidateVersion && release.version === candidateVersion;
     return (
       <ReleaseCard
         key={release.version}
@@ -316,6 +340,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
         t={t}
         isInstalled={isInstalled}
         isLatestInstalled={isInstalled && installedIsLatest}
+        isUpdateCandidate={isUpdateCandidate}
       />
     );
   });
@@ -673,7 +698,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.md,
   },
-  releaseCardInstalled: {
+  releaseCardHighlighted: {
     borderWidth: 1.5,
   },
   releaseDate: {

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -390,6 +390,7 @@
   "update_install_now": "Jetzt installieren",
   "downloaded_apks": "Heruntergeladene APKs",
   "installed": "Installiert",
+  "update_candidate": "Verfügbar",
   "installed_latest_hint": "Du hast die neueste Version.",
   "release_history": "Versionsverlauf",
   "no_apk_attached": "Kein APK",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -394,6 +394,7 @@
   "update_install_now": "Install now",
   "downloaded_apks": "Downloaded APKs",
   "installed": "Installed",
+  "update_candidate": "Available",
   "installed_latest_hint": "You're on the latest version.",
   "release_history": "Release history",
   "no_apk_attached": "No APK",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -390,6 +390,7 @@
   "update_install_now": "Instalar ahora",
   "downloaded_apks": "APKs descargados",
   "installed": "Instalada",
+  "update_candidate": "Disponible",
   "installed_latest_hint": "Tienes la última versión.",
   "release_history": "Historial de versiones",
   "no_apk_attached": "Sin APK",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -394,6 +394,7 @@
   "update_install_now": "Installer maintenant",
   "downloaded_apks": "APKs téléchargés",
   "installed": "Installée",
+  "update_candidate": "Disponible",
   "installed_latest_hint": "Vous avez la dernière version.",
   "release_history": "Historique des versions",
   "no_apk_attached": "Pas d'APK",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -390,6 +390,7 @@
   "update_install_now": "Տեղադրել հիմա",
   "downloaded_apks": "Ներբեռնված APK-ներ",
   "installed": "Տեղադրված է",
+  "update_candidate": "Հասանելի",
   "installed_latest_hint": "Դուք ունեք վերջին տարբերակը։",
   "release_history": "Թողարկումների պատմություն",
   "no_apk_attached": "APK չկա",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -394,6 +394,7 @@
   "update_install_now": "Installa ora",
   "downloaded_apks": "APK scaricati",
   "installed": "Installato",
+  "update_candidate": "Disponibile",
   "installed_latest_hint": "Hai l'ultima versione.",
   "release_history": "Cronologia versioni",
   "no_apk_attached": "Nessun APK",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -394,6 +394,7 @@
   "update_install_now": "今すぐインストール",
   "downloaded_apks": "ダウンロード済みAPK",
   "installed": "インストール済み",
+  "update_candidate": "利用可能",
   "installed_latest_hint": "最新バージョンです。",
   "release_history": "リリース履歴",
   "no_apk_attached": "APKなし",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -394,6 +394,7 @@
   "update_install_now": "지금 설치",
   "downloaded_apks": "다운로드된 APK",
   "installed": "설치됨",
+  "update_candidate": "사용 가능",
   "installed_latest_hint": "최신 버전입니다.",
   "release_history": "릴리스 기록",
   "no_apk_attached": "APK 없음",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -394,6 +394,7 @@
   "update_install_now": "Instalar agora",
   "downloaded_apks": "APKs baixados",
   "installed": "Instalada",
+  "update_candidate": "Disponível",
   "installed_latest_hint": "Você está na versão mais recente.",
   "release_history": "Histórico de versões",
   "no_apk_attached": "Sem APK",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -394,6 +394,7 @@
   "update_install_now": "Установить сейчас",
   "downloaded_apks": "Загруженные APK",
   "installed": "Установлено",
+  "update_candidate": "Доступно",
   "installed_latest_hint": "У вас последняя версия.",
   "release_history": "История версий",
   "no_apk_attached": "Нет APK",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -390,6 +390,7 @@
   "update_install_now": "立即安装",
   "downloaded_apks": "已下载 APK",
   "installed": "已安装",
+  "update_candidate": "可用",
   "installed_latest_hint": "您使用的是最新版本。",
   "release_history": "版本历史",
   "no_apk_attached": "无 APK",


### PR DESCRIPTION
## Summary

When an update is available, the update panel highlighted the **currently installed** release. This change moves the highlight to the **candidate for installation** (the latest version) — the release the user actually needs to act on.

### Behavior

- **Update available:** the latest release card gets the primary-accent highlight border and a new **"Available"** chip (with an up-arrow icon). The installed version keeps a muted, informational **"Installed"** chip — no highlight border.
- **Up to date:** unchanged. The installed-and-latest card keeps its green highlight, checkmark, and "you're on the latest version" hint.

### Changes

- `app/components/UpdateContentPanel.js`
  - `ReleaseCard` now takes an `isUpdateCandidate` prop; highlight is driven by `isUpdateCandidate || isLatestInstalled` instead of `isInstalled`.
  - The candidate version is derived from `updateResult.latestVersion` when `type === 'available'`.
  - The "Installed" chip recedes to `mutedText` when its card isn't the highlighted one.
  - Renamed style `releaseCardInstalled` → `releaseCardHighlighted`.
- Added `update_candidate` ("Available") translation key across all 11 languages.
- Added test coverage for candidate highlighting and the up-to-date no-candidate case.

## Testing

- `npm test` — all 3598 tests pass (118 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2X1KGDMMnm1fkQc2rnA72)_