### PR TITLE
fix: keep all tab screens mounted to stop blank screens on swipe

### DIFF
--- a/__tests__/navigation/SimpleTabs.test.js
+++ b/__tests__/navigation/SimpleTabs.test.js
@@ -309,55 +309,19 @@ jest.mock('../../app/contexts/UpdateDownloadContext', () => ({
   }),
 }));
 
-// Mock OperationsDataContext — `loading` drives the progressive pre-warm.
-// Defaults to true (cold start) so lazy-mount behavior is exercised; individual
-// tests can flip mockOperationsLoading to false to exercise pre-warming.
-let mockOperationsLoading = true;
-jest.mock('../../app/contexts/OperationsDataContext', () => ({
-  useOperationsData: () => ({ loading: mockOperationsLoading }),
-}));
-
 describe('SimpleTabs Component Rendering', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockOperationsLoading = true;
   });
 
-  afterEach(() => {
-    mockOperationsLoading = true;
-  });
-
-  it('progressively pre-warms remaining screens once operations finish loading', async () => {
-    mockOperationsLoading = false;
+  it('mounts all four screens immediately (no lazy mount)', async () => {
+    // Every screen stays mounted so a swipe never reveals an unmounted
+    // (blank/black) screen — no tab press or data load required.
     const { getByText } = await render(<SimpleTabs />);
 
-    // Operations is mounted immediately; the rest are mounted lazily during
-    // idle time after loading completes — without any tab being pressed.
     expect(getByText('Operations Screen')).toBeTruthy();
-    await waitFor(() => expect(getByText('Graphs Screen')).toBeTruthy());
-    await waitFor(() => expect(getByText('Planned Screen')).toBeTruthy());
-  });
-
-  it('does not pre-warm screens while operations are still loading', async () => {
-    mockOperationsLoading = true;
-    const { getByText, queryByText } = await render(<SimpleTabs />);
-
-    expect(getByText('Operations Screen')).toBeTruthy();
-    // Graphs stays unmounted because the first screen hasn't finished loading.
-    expect(queryByText('Graphs Screen')).toBeNull();
-  });
-
-  it('pre-warms after loading transitions from true to false', async () => {
-    // Cold start: loading true, nothing pre-warmed yet.
-    mockOperationsLoading = true;
-    const { rerender, getByText, queryByText } = await render(<SimpleTabs />);
-    expect(queryByText('Graphs Screen')).toBeNull();
-
-    // Operations data finishes loading — pre-warm should now mount the rest.
-    mockOperationsLoading = false;
-    rerender(<SimpleTabs />);
-    await waitFor(() => expect(getByText('Graphs Screen')).toBeTruthy());
-    await waitFor(() => expect(getByText('Planned Screen')).toBeTruthy());
+    expect(getByText('Graphs Screen')).toBeTruthy();
+    expect(getByText('Planned Screen')).toBeTruthy();
   });
 
   it('renders without crashing', async () => {
@@ -377,10 +341,10 @@ describe('SimpleTabs Component Rendering', () => {
   it('renders all four screens after visiting each tab', async () => {
     const { getByTestId } = await render(<SimpleTabs />);
 
-    // Operations mounts immediately (index 0 pre-visited)
+    // All screens are mounted up front
     expect(getByTestId('operations-screen')).toBeTruthy();
 
-    // Visit remaining tabs via pressIn to trigger lazy mount
+    // Switching tabs keeps each screen present
     await act(async () => { fireEvent(getByTestId('tab-Graphs'), 'pressIn'); });
     await waitFor(() => expect(getByTestId('graphs-screen')).toBeTruthy());
 
@@ -474,7 +438,7 @@ describe('SimpleTabs Component Rendering', () => {
       fireEvent(getByTestId('tab-Graphs'), 'pressIn');
     });
 
-    // Wait for Graphs screen to mount after lazy-visit
+    // Graphs screen is present after activating its tab
     await waitFor(() => {
       expect(getByTestId('graphs-screen')).toBeTruthy();
     });
@@ -499,13 +463,13 @@ describe('SimpleTabs Component Rendering', () => {
     });
   });
 
-  it('renders only the initial Operations screen on cold start (lazy mount)', async () => {
-    const { getByText, queryByText } = await render(<SimpleTabs />);
+  it('keeps every screen mounted on cold start (no lazy mount)', async () => {
+    const { getByText } = await render(<SimpleTabs />);
 
-    // Only Operations (index 0) should be mounted initially
+    // All screens are mounted up front so a swipe never reveals a blank screen.
     expect(getByText('Operations Screen')).toBeTruthy();
-    // Graphs (index 1) is lazy — not mounted until visited
-    expect(queryByText('Graphs Screen')).toBeNull();
+    expect(getByText('Graphs Screen')).toBeTruthy();
+    expect(getByText('Planned Screen')).toBeTruthy();
   });
 
   it('mounts Graphs screen after navigating to it', async () => {

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback, useRef, useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, Dimensions, Platform, BackHandler, InteractionManager } from 'react-native';
+import { View, StyleSheet, Dimensions, Platform, BackHandler } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { TouchableRipple, Text } from 'react-native-paper';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
@@ -24,7 +24,6 @@ import PlannedOperationsScreen from '../screens/PlannedOperationsScreen';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
-import { useOperationsData } from '../contexts/OperationsDataContext';
 import Header from '../components/Header';
 import SettingsScreen from '../screens/SettingsScreen';
 
@@ -233,15 +232,9 @@ export default function SimpleTabs() {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { isDownloading, downloadProgress, downloadPhase } = useUpdateDownload();
-  // Drives progressive pre-warming: once the first screen's operations have
-  // finished loading we mount the remaining screens during idle time.
-  const { loading: operationsLoading } = useOperationsData();
   const [active, setActive] = React.useState('Operations');
   const [subPanelActive, setSubPanelActive] = React.useState(false);
   const [tabBarWidth, setTabBarWidth] = React.useState(SCREEN_WIDTH);
-  // Track which tab indices have been visited so we lazy-mount their screens.
-  // Index 0 (Operations) is pre-visited so it renders immediately on cold start.
-  const [visited, setVisited] = React.useState(() => ({ 0: true }));
 
   // Guard ref — updated synchronously so handleTabPress never reads stale state.
   const isTransitioningRef = useRef(false);
@@ -301,13 +294,10 @@ export default function SimpleTabs() {
 
     const distance = Math.abs(newIndex - oldIndex);
 
-    // ---- Start the animation FIRST, before any React state update ----
+    // ---- Start the animation FIRST, before the setActive React update ----
     // Writing shared values schedules the slide/pill animation directly on the
-    // UI thread and does not depend on a React render. Previously setVisited +
-    // setActive ran first; mounting the (heavy) destination screen and
-    // re-rendering blocked the JS thread, so the slide only began *after* that
-    // work finished — the lag between tapping a tab and the animation starting.
-    // Scheduling the animation up front makes it start on the very next frame.
+    // UI thread and does not depend on a React render, so it starts on the very
+    // next frame instead of waiting for React to commit the tab-highlight change.
     activeIndex.value = newIndex;
     pillPosition.value = withTiming(newIndex, PILL_TIMING);
 
@@ -353,14 +343,8 @@ export default function SimpleTabs() {
     }
 
     // ---- React state AFTER the animation is scheduled ----
-    // Mount the destination synchronously so its content is on-screen and
-    // slides in together with the strip. Deferring the mount (e.g. to the next
-    // frame) leaves the target blank while the strip moves, so the content just
-    // pops in at the end — which looks like an instant switch, not a slide.
-    // The animation was already scheduled above, so it starts immediately on
-    // the UI thread regardless of this mount; and because the screens are
-    // pre-warmed this is usually a no-op anyway.
-    setVisited(prev => prev[newIndex] ? prev : { ...prev, [newIndex]: true });
+    // Only the tab highlight changes; all screens are already mounted, so the
+    // destination content is on-screen and slides in together with the strip.
     setActive(tabKey);
   }, [TABS, active, activeIndex, translateX, pillPosition, isTransitioningShared,
     screenAdjust0, screenAdjust1, screenAdjust2, screenAdjust3,
@@ -378,39 +362,6 @@ export default function SimpleTabs() {
     });
     return () => subscription.remove();
   }, [active, handleTabPress]);
-
-  // ---- Progressive idle pre-warm ----
-  // Once the first (Operations) screen's data has loaded, mount the remaining
-  // screens one at a time during idle time so later tab switches are instant
-  // and already populated — without paying their mount cost at cold start.
-  // runAfterInteractions waits until the initial render/touch interactions
-  // settle; staggering each mount onto its own frame keeps any single heavy
-  // screen from janking. If the user taps a not-yet-warmed tab first,
-  // handleTabPress still mounts it on demand.
-  //
-  // Guarded on completion (all screens visited) rather than a fire-once flag:
-  // `loading` can flip back to true on a data reload (import/restore, filter
-  // re-query), so a one-shot latch would cancel an in-flight warm and never
-  // restart. Re-running until every screen is mounted is resilient to that.
-  React.useEffect(() => {
-    if (operationsLoading || (visited[1] && visited[2] && visited[3])) return;
-
-    let cancelled = false;
-    const order = [1, 2, 3]; // Graphs, Planned, Settings
-    let i = 0;
-    const mountNext = () => {
-      if (cancelled || i >= order.length) return;
-      const idx = order[i++];
-      setVisited(prev => (prev[idx] ? prev : { ...prev, [idx]: true }));
-      requestAnimationFrame(mountNext);
-    };
-    const task = InteractionManager.runAfterInteractions(mountNext);
-
-    return () => {
-      cancelled = true;
-      if (task && task.cancel) task.cancel();
-    };
-  }, [operationsLoading, visited]);
 
   // Pan gesture for swipe navigation with real-time feedback.
   // isTransitioningShared guards against swipe during non-adjacent transitions
@@ -454,7 +405,6 @@ export default function SimpleTabs() {
         if (newIndex !== currentIndex) {
           activeIndex.value = newIndex;
           pillPosition.value = withTiming(newIndex, PILL_TIMING);
-          runOnJS(setVisited)((prev) => prev[newIndex] ? prev : { ...prev, [newIndex]: true });
           translateX.value = withTiming(-newIndex * SCREEN_WIDTH, SCREEN_TIMING, (isFinished) => {
             if (isFinished) {
               runOnJS(setActive)(TABS[newIndex].key);
@@ -487,13 +437,15 @@ export default function SimpleTabs() {
     };
   });
 
-  // Memoize each screen element so SimpleTabs re-renders (active-tab highlight,
-  // tab-bar layout, pre-warm mounts, swipe completion) don't re-render the heavy
-  // screen subtrees. A stable element reference lets React skip reconciling them
-  // entirely — without this, setActive at the end of a tab-switch/swipe animation
-  // re-renders all four mounted screens and drops frames, causing a stutter as
-  // the slide settles. Lazy mount is preserved: the element only mounts when its
-  // `visited` flag flips it in.
+  // All four screens stay mounted for the whole session. Navigation only ever
+  // moves the strip (swipe to a neighbour, tap to any tab), so every screen
+  // must already be on-screen — lazy mounting left a not-yet-mounted screen
+  // blank/black when a swipe revealed it before its mount committed.
+  //
+  // Each screen element is memoized so SimpleTabs re-renders (active-tab
+  // highlight, tab-bar layout) don't re-render the heavy screen subtrees: a
+  // stable element reference lets React skip reconciling them, which avoids a
+  // frame drop / stutter as a switch animation settles.
   const operationsScreen = useMemo(() => <OperationsScreen />, []);
   const graphsScreen = useMemo(() => <GraphsScreen />, []);
   const plannedScreen = useMemo(() => <PlannedOperationsScreen />, []);
@@ -506,20 +458,20 @@ export default function SimpleTabs() {
     return (
       <>
         <Animated.View style={[styles.screen, screenAdjustedStyle0]}>
-          {visited[0] ? operationsScreen : null}
+          {operationsScreen}
         </Animated.View>
         <Animated.View style={[styles.screen, screenAdjustedStyle1]}>
-          {visited[1] ? graphsScreen : null}
+          {graphsScreen}
         </Animated.View>
         <Animated.View style={[styles.screen, screenAdjustedStyle2]}>
-          {visited[2] ? plannedScreen : null}
+          {plannedScreen}
         </Animated.View>
         <Animated.View style={[styles.screen, screenAdjustedStyle3]}>
-          {visited[3] ? settingsScreen : null}
+          {settingsScreen}
         </Animated.View>
       </>
     );
-  }, [visited, operationsScreen, graphsScreen, plannedScreen, settingsScreen,
+  }, [operationsScreen, graphsScreen, plannedScreen, settingsScreen,
     screenAdjustedStyle0, screenAdjustedStyle1, screenAdjustedStyle2, screenAdjustedStyle3]);
 
   const displayedTab = active;


### PR DESCRIPTION
## Problem

Swiping between tabs could reveal a **black/blank screen**, and screens appeared to "initialize" only after the gesture finished.

**Cause:** screens were lazy-mounted (`visited` state), and the swipe path only set the visited flag in the pan gesture's `onEnd` — i.e. when you *release*. But `onUpdate` already drags the strip toward the neighbouring screen, which is still unmounted (`null` → black) until release. A progressive pre-warm effect was meant to cover this, but it was gated behind `operationsLoading === false` **and** `InteractionManager.runAfterInteractions` (which can stall while any interaction handle is open), so the mount was unreliable — hence the intermittent black screens.

Taps were unaffected because `handleTabPress` mounted the target synchronously.

## Fix

With only four screens, and navigation limited to a **neighbour** (swipe) or **any tab** (tap), there's no reason to lazy-mount at all. This PR mounts all four screens up front and removes the machinery that caused the bug:

- Removed the `visited` state and the conditional `visited[i] ? screen : null` rendering — all four screens render unconditionally.
- Removed the progressive pre-warm `useEffect` (and the `useOperationsData`/`operationsLoading` dependency and `InteractionManager` import).
- Removed the per-transition `setVisited` calls in `handleTabPress` and the swipe `onEnd`.
- Kept the memoized screen elements so tab-switch re-renders (active highlight, tab-bar layout) don't re-render the heavy screen subtrees — preserves the smooth-slide fix.

Net effect: a swipe or tap only moves the strip over already-mounted content, so no screen can be blank.

### Trade-off

All four screens now mount at cold start instead of on demand. For four screens this is acceptable, and the previous design already pre-warmed them all shortly after launch anyway — this just makes it deterministic. If startup cost ever becomes a concern, deferring the non-active mounts by a frame (without reintroducing the swipe gap) can be done separately.

## Testing

- Updated `SimpleTabs` tests: replaced the lazy-mount/pre-warm cases with assertions that all four screens are mounted immediately.
- `npm test` — all tests pass (118 suites / 3599 tests).
- `eslint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StquHzQLxwrmRHTBfpgE8q

---
_Generated by [Claude Code](https://claude.ai/code/session_01StquHzQLxwrmRHTBfpgE8q)_