### PR TITLE
fix: mark installed version as latest when newer release has no APK

### DIFF
--- a/__tests__/components/UpdateContentPanel.test.js
+++ b/__tests__/components/UpdateContentPanel.test.js
@@ -291,6 +291,29 @@ describe('UpdateContentPanel', () => {
       );
       expect(getByText('more_releases')).toBeTruthy();
     });
+
+    it('marks the installed version as latest with the green hint when newer releases lack an APK', async () => {
+      // The newest release (1.3.0) has no downloadable APK yet, so the installed 1.2.0 remains
+      // the latest version the user can actually run — it should get the green "latest" treatment.
+      const { getAllByText, getByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'error',
+            errorCode: 'releases_without_apks',
+            currentVersion: '1.2.0',
+            releaseNotes: [{ version: '1.3.0', notes: 'New release, no APK yet', hasApk: false }],
+            recentReleaseNotes: [
+              { version: '1.2.0', notes: 'Installed release' },
+              { version: '1.1.0', notes: 'Older release' },
+            ],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      expect(getAllByText('installed').length).toBeGreaterThan(0);
+      expect(getByText('installed_latest_hint')).toBeTruthy();
+    });
   });
 
   describe('available', () => {

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -331,10 +331,14 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
   const repoBase = repoBaseFromReleasesUrl(updateResult.releasesUrl);
   const apkLookup = buildApkLookup(downloadedApks);
 
-  // The currently installed app version. When there is no newer release (up_to_date),
-  // the installed version is also the latest one and earns the green checkmark + hint.
+  // The currently installed app version. We treat it as the latest — green checkmark + hint —
+  // whenever there is no newer *installable* release. That covers two cases: being fully up to
+  // date, and a newer release existing but having no APK attached yet (CI build still running).
+  // In the latter case the user still holds the newest installable APK, so the installed version
+  // is the latest one they can actually run.
   const installedVersion = updateResult.currentVersion;
-  const installedIsLatest = updateResult.type === 'up_to_date';
+  const installedIsLatest = updateResult.type === 'up_to_date'
+    || (updateResult.type === 'error' && updateResult.errorCode === 'releases_without_apks');
   // When an update is available, the release we want the user to install is the highlighted
   // one — not the version they already have.
   const candidateVersion = updateResult.type === 'available' ? updateResult.latestVersion : null;


### PR DESCRIPTION
## Summary

In the update panel, when the only release newer than the installed version has **no downloadable APK yet** (typically because the CI build is still running), the installed version was shown with only a muted grey "Installed" badge — no green highlight, no confirmation.

But in that situation the installed version is still the newest APK the user can actually install and run. This change treats it as the latest version in that case: its release card now gets the **green checkmark highlight** and the **"you're on the latest version"** hint, matching the behavior when fully up to date.

### Before / After

Reported scenario: a newer release `v0.138.0` is tagged with "НЕТ АПК" (no APK attached), while the installed `v0.137.4` only showed a muted "Installed" badge. Now `v0.137.4` is highlighted green and labelled as the latest installed version.

## Changes

- `app/components/UpdateContentPanel.js`: `installedIsLatest` is now also true for the `error` / `releases_without_apks` case, so the installed card receives the green "latest" accent and hint.
- `__tests__/components/UpdateContentPanel.test.js`: added a regression test for this case.

## Testing

- `UpdateContentPanel.test.js` — 33 passed
- `SettingsScreen.test.js`, `AppUpdateService.test.js`, `UpdateAvailableModal.test.js` — 128 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011v2LBmnj3aKAkipE7eHGv2

---
_Generated by [Claude Code](https://claude.ai/code/session_011v2LBmnj3aKAkipE7eHGv2)_