### PR TITLE
fix: make swipe-to-dismiss consistent across all subpanels (incl. nested steps)

### DIFF
--- a/__tests__/hooks/useSwipeDismiss.test.js
+++ b/__tests__/hooks/useSwipeDismiss.test.js
@@ -57,6 +57,14 @@ describe('useSwipeDismiss', () => {
       );
       expect(result.current.gesture).toBeDefined();
     });
+
+    it('accepts canStepBack / onStepBack for one-level-up navigation', async () => {
+      const onStepBack = jest.fn();
+      const { result } = await renderHook(() =>
+        useSwipeDismiss({ onDismiss: jest.fn(), canStepBack: true, onStepBack }),
+      );
+      expect(result.current.gesture).toBeDefined();
+    });
   });
 
   describe('Controls', () => {

--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -275,16 +275,26 @@ jest.mock('../../app/components/UpdateContentPanel', () => {
   };
 });
 
+// Captures the embedded accounts screen's reported internal back handler so a
+// test can verify the parent drills into it before closing the panel.
+const mockAccountsBack = { goBack: null };
+
 // Mock AccountsScreen (embedded in the accounts subpanel) to avoid pulling in
 // its heavy dependency tree (draggable list, accounts/operations contexts, etc.)
 jest.mock('../../app/screens/AccountsScreen', () => {
   const React = require('react');
   const { View } = require('react-native');
   const PropTypes = require('prop-types');
-  function AccountsScreen({ embedded }) {
+  function AccountsScreen({ embedded, onBackStateChange }) {
+    // Simulate an internal level being open so the parent should step back here.
+    React.useEffect(() => {
+      mockAccountsBack.goBack = jest.fn();
+      onBackStateChange?.(mockAccountsBack.goBack);
+      return () => onBackStateChange?.(null);
+    }, [onBackStateChange]);
     return React.createElement(View, { testID: 'accounts-screen', accessibilityLabel: embedded ? 'embedded' : 'standalone' });
   }
-  AccountsScreen.propTypes = { embedded: PropTypes.bool };
+  AccountsScreen.propTypes = { embedded: PropTypes.bool, onBackStateChange: PropTypes.func };
   return AccountsScreen;
 });
 
@@ -349,6 +359,26 @@ describe('SettingsScreen', () => {
 
       expect(getByTestId('accounts-screen')).toBeTruthy();
       expect(mockSetSubPanelActive).toHaveBeenCalledWith(true);
+    });
+
+    it('back navigation drills into the embedded accounts screen before closing the panel', async () => {
+      const { getByTestId } = await render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+
+      await act(async () => {
+        await fireEvent.press(getByTestId('settings-accounts-row'));
+      });
+
+      // The embedded screen reported an internal back handler (form/picker open);
+      // pressing back should step up there rather than close the whole panel.
+      await act(async () => {
+        await fireEvent.press(getByTestId('settings-subpanel-back'));
+      });
+
+      expect(mockAccountsBack.goBack).toHaveBeenCalled();
+      // Panel stays open — the embedded screen popped a level, not the panel.
+      expect(getByTestId('accounts-screen')).toBeTruthy();
     });
 
     it('renders categories row', async () => {

--- a/app/hooks/useSwipeDismiss.js
+++ b/app/hooks/useSwipeDismiss.js
@@ -34,6 +34,11 @@ const ACTIVE_OFFSET_X = 16;
  *
  * @param {object}   options
  * @param {Function} options.onDismiss  Called once the panel has slid fully away.
+ * @param {Function} [options.onStepBack]  Called instead of onDismiss when the panel
+ *   has a parent step (canStepBack). Navigates one level up; the surface springs
+ *   back to rest rather than sliding off, so the parent step's content takes over.
+ * @param {boolean}  [options.canStepBack=false]  When true, a completed swipe steps
+ *   one level up (onStepBack) instead of dismissing the whole panel.
  * @param {boolean}  [options.enabled=true]  Gates the gesture (e.g. mid-operation).
  *   Read from a shared value inside the worklets so toggling it never rebuilds
  *   the native recognizer (which would jitter an in-flight gesture).
@@ -45,7 +50,7 @@ const ACTIVE_OFFSET_X = 16;
  *   stolen by the dismiss gesture. 0 = the whole surface is swipeable.
  * @returns {{ gesture: object, animatedStyle: object, open: () => void, dismiss: () => void }}
  */
-export function useSwipeDismiss({ onDismiss, enabled = true, width: widthProp, edgeWidth = 0 } = {}) {
+export function useSwipeDismiss({ onDismiss, onStepBack, canStepBack = false, enabled = true, width: widthProp, edgeWidth = 0 } = {}) {
   const { width: windowWidth } = useWindowDimensions();
   const width = widthProp ?? windowWidth;
 
@@ -116,14 +121,20 @@ export function useSwipeDismiss({ onDismiss, enabled = true, width: widthProp, e
         'worklet';
         if (!valid.value) return;
         const dx = event.translationX - dragStart.value;
-        if (dx > DISTANCE_THRESHOLD || event.velocityX > VELOCITY_THRESHOLD) {
+        const past = dx > DISTANCE_THRESHOLD || event.velocityX > VELOCITY_THRESHOLD;
+        if (past && canStepBack) {
+          // Go one level up within the panel and spring the surface back to rest
+          // so the parent step's content takes its place (mirrors the back arrow).
+          if (onStepBack) runOnJS(onStepBack)();
+          translateX.value = withTiming(0, { duration: EXIT_DURATION, easing: ENTER_EASING });
+        } else if (past) {
           // Reuse dismiss() so the completion + re-entrancy guard live in one place.
           runOnJS(dismiss)();
         } else {
           translateX.value = withTiming(0, { duration: EXIT_DURATION, easing: ENTER_EASING });
         }
       });
-  }, [translateX, dragStart, valid, dismissing, enabledShared, width, edgeWidth, dismiss]);
+  }, [translateX, dragStart, valid, dismissing, enabledShared, width, edgeWidth, dismiss, canStepBack, onStepBack]);
 
   return { gesture, animatedStyle, open, dismiss };
 }

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, memo, useRef } from 'react';
+import React, { useState, useCallback, useMemo, memo, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, Keyboard, FlatList, TouchableOpacity, Pressable, Animated, Dimensions, ScrollView, Easing } from 'react-native';
 import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
@@ -424,7 +424,7 @@ AccountRow.defaultProps = {
   isActive: false,
 };
 
-export default function AccountsScreen() {
+export default function AccountsScreen({ onBackStateChange }) {
 
   const [editingId, setEditingId] = useState(null);
   const [editValues, setEditValues] = useState({});
@@ -776,6 +776,22 @@ export default function AccountsScreen() {
     <View style={[styles.divider, { backgroundColor: colors.border }]} />
   ), [colors.border]);
 
+  // Report internal back capability to an embedding parent (the Settings subpanel)
+  // so a swipe / hardware-back pops one level here (currency picker → edit form)
+  // before the parent closes the whole panel.
+  const internalCanGoBack = currencyPanelVisible || editingId !== null;
+
+  const internalGoBack = useCallback(() => {
+    if (currencyPanelVisible) { handleClosePicker(); return; }
+    if (editingId !== null) { closeFormPanel(); return; }
+  }, [currencyPanelVisible, editingId, handleClosePicker, closeFormPanel]);
+
+  useEffect(() => {
+    onBackStateChange?.(internalCanGoBack ? internalGoBack : null);
+  }, [internalCanGoBack, internalGoBack, onBackStateChange]);
+
+  useEffect(() => () => onBackStateChange?.(null), [onBackStateChange]);
+
   if (loading) {
     return <LoadingView message={t('loading_accounts') || 'Loading accounts...'} />;
   }
@@ -1069,7 +1085,9 @@ export default function AccountsScreen() {
   );
 }
 
-AccountsScreen.propTypes = {};
+AccountsScreen.propTypes = {
+  onBackStateChange: PropTypes.func,
+};
 
 AccountsScreen.defaultProps = {};
 

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -1,4 +1,5 @@
-import React, { useState, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   StyleSheet,
@@ -32,7 +33,7 @@ const DEFAULT_FORM_VALUES = {
   category_type: 'expense',
 };
 
-const CategoriesScreen = () => {
+const CategoriesScreen = ({ onBackStateChange }) => {
   const { colors } = useThemeColors();
   const { paperInputTheme } = makeModalStyles(colors);
   const themed = useMemo(() => ({
@@ -260,6 +261,25 @@ const CategoriesScreen = () => {
       </TouchableOpacity>
     );
   }, [colors, t, getChildren, handleGridCellPress, handleCategoryLongPress]);
+
+  // Report internal back capability to an embedding parent (the Settings subpanel)
+  // so a swipe / hardware-back pops one level here (picker → form → subcategory
+  // grid) before the parent closes the whole panel.
+  const internalCanGoBack =
+    iconPickerVisible || activePicker !== null || activePanel === 'form' || gridParentId !== null;
+
+  const internalGoBack = useCallback(() => {
+    if (iconPickerVisible) { setIconPickerVisible(false); return; }
+    if (activePicker !== null) { handleClosePicker(); return; }
+    if (activePanel === 'form') { closeForm(); return; }
+    if (gridParentId !== null) { setGridParentId(null); return; }
+  }, [iconPickerVisible, activePicker, activePanel, gridParentId, handleClosePicker, closeForm]);
+
+  useEffect(() => {
+    onBackStateChange?.(internalCanGoBack ? internalGoBack : null);
+  }, [internalCanGoBack, internalGoBack, onBackStateChange]);
+
+  useEffect(() => () => onBackStateChange?.(null), [onBackStateChange]);
 
   if (loading) {
     return <LoadingView message={t('loading_categories') || 'Loading categories...'} />;
@@ -717,5 +737,9 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.sm,
   },
 });
+
+CategoriesScreen.propTypes = {
+  onBackStateChange: PropTypes.func,
+};
 
 export default CategoriesScreen;

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -214,18 +214,32 @@ export default function SettingsScreen({ setSubPanelActive }) {
     return false;
   }, [activeSubPanel, exportStep, importStep, sheetsSteps, sheetsImportSteps]);
 
-  // Multi-step panels (Import / Export) have parent steps; a swipe on a nested
-  // step should go one level up (like the back arrow), not close the whole panel.
+  // Embedded screens (Accounts/Categories) report whether they can navigate back
+  // one level internally (edit form open, subcategory drill, picker, …) so a swipe
+  // / hardware-back steps up there before closing the whole panel.
+  const embeddedBackRef = useRef(null);
+  const [embeddedCanGoBack, setEmbeddedCanGoBack] = useState(false);
+  const handleEmbeddedBackStateChange = useCallback((goBack) => {
+    embeddedBackRef.current = typeof goBack === 'function' ? goBack : null;
+    setEmbeddedCanGoBack(!!goBack);
+  }, []);
+
+  // Whether a completed swipe (or hardware-back) should step one level up rather
+  // than dismiss the whole panel: nested Import/Export steps, or an embedded
+  // Accounts/Categories screen that still has an internal level to pop.
   const canSwipeStepBack = useMemo(() => {
     if (activeSubPanel === 'import') return importStep !== 'source';
     if (activeSubPanel === 'export') return exportStep !== 'list';
+    if (activeSubPanel === 'accounts' || activeSubPanel === 'categories') return embeddedCanGoBack;
     return false;
-  }, [activeSubPanel, importStep, exportStep]);
+  }, [activeSubPanel, importStep, exportStep, embeddedCanGoBack]);
 
-  // The step-back handler is defined further down (it depends on dismissPanel,
-  // which this hook returns), so reach it through a ref kept current each render.
+  // Unified back navigation for the swipe, hardware-back, and the header arrow.
+  // The resolver is defined further down (it depends on dismissPanel, which this
+  // hook returns), so reach it through a ref kept current each render. It pops one
+  // level when possible (embedded screen / nested step) and otherwise closes.
   const subPanelBackRef = useRef(null);
-  const handleSwipeStepBack = useCallback(() => {
+  const navigateBack = useCallback(() => {
     subPanelBackRef.current?.();
   }, []);
 
@@ -238,7 +252,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
   const { gesture: swipeGesture, animatedStyle: swipeStyle, open: openPanelAnim, dismiss: dismissPanel } =
     useSwipeDismiss({
       onDismiss: closeSubPanel,
-      onStepBack: handleSwipeStepBack,
+      onStepBack: navigateBack,
       canStepBack: canSwipeStepBack,
       enabled: !isBackDisabled,
     });
@@ -270,16 +284,17 @@ export default function SettingsScreen({ setSubPanelActive }) {
     setSubPanelActive(activeSubPanel !== null);
   }, [activeSubPanel, setSubPanelActive]);
 
-  // Android hardware back button closes subpanel
+  // Android hardware back: step one level up when possible (nested step / embedded
+  // screen), otherwise close the panel — mirroring the swipe and the back arrow.
   useEffect(() => {
     if (!activeSubPanel) return;
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
       if (isBackDisabled) return true;
-      dismissPanel();
+      navigateBack();
       return true;
     });
     return () => subscription.remove();
-  }, [activeSubPanel, isBackDisabled, dismissPanel]);
+  }, [activeSubPanel, isBackDisabled, navigateBack]);
 
   const handleLanguageSelect = useCallback((lng) => {
     setLanguage(lng);
@@ -854,10 +869,17 @@ export default function SettingsScreen({ setSubPanelActive }) {
     return dismissPanel;
   }, [activeSubPanel, handleImportBack, handleExportBack, dismissPanel]);
 
-  // Keep the swipe's step-back ref pointing at the current back handler. The
-  // swipe only invokes this when canSwipeStepBack is true (a nested step), where
-  // handleImportBack/handleExportBack step up one level rather than dismiss.
-  subPanelBackRef.current = handleSubPanelBack;
+  // Resolver behind navigateBack (swipe / hardware-back / header arrow): if an
+  // embedded Accounts/Categories screen can still pop a level (form, picker,
+  // subcategory), defer to it; otherwise step up the Import/Export flow or close
+  // the panel (handleSubPanelBack).
+  subPanelBackRef.current = () => {
+    if ((activeSubPanel === 'accounts' || activeSubPanel === 'categories') && embeddedBackRef.current) {
+      embeddedBackRef.current();
+      return;
+    }
+    handleSubPanelBack();
+  };
 
 
   // ─── RENDER ───
@@ -872,7 +894,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
         {/* Subpanel header */}
         <View style={styles.subPanelHeader}>
           <TouchableOpacity
-            onPress={handleSubPanelBack}
+            onPress={navigateBack}
             style={styles.backButton}
             testID="settings-subpanel-back"
             disabled={isBackDisabled}
@@ -899,8 +921,8 @@ export default function SettingsScreen({ setSubPanelActive }) {
           (activeSubPanel === 'accounts' || activeSubPanel === 'categories') && styles.subPanelBodyFlush,
           !(activeSubPanel === 'accounts' || activeSubPanel === 'categories') && { paddingBottom: insets.bottom + 80 },
         ]}>
-          {activeSubPanel === 'accounts' && <AccountsScreen />}
-          {activeSubPanel === 'categories' && <CategoriesScreen />}
+          {activeSubPanel === 'accounts' && <AccountsScreen onBackStateChange={handleEmbeddedBackStateChange} />}
+          {activeSubPanel === 'categories' && <CategoriesScreen onBackStateChange={handleEmbeddedBackStateChange} />}
 
           {activeSubPanel === 'defaultAccount' && (
             <ScrollView

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -61,11 +61,6 @@ const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 
 const SPRING_CONFIG = { mass: 1, damping: 20, stiffness: 200 };
 
-// Left-edge region (px) from which a swipe can dismiss panels that embed their
-// own horizontal/drag gestures (Accounts, Categories), so a body drag isn't
-// hijacked by the dismiss gesture.
-const EDGE_SWIPE_WIDTH = 48;
-
 // How often to re-poll CI build progress while the update panel shows an in-progress build.
 const BUILD_PROGRESS_POLL_MS = 30000;
 
@@ -220,15 +215,15 @@ export default function SettingsScreen({ setSubPanelActive }) {
   }, [activeSubPanel, exportStep, importStep, sheetsSteps, sheetsImportSteps]);
 
   // Telegram-style interactive swipe: drag the subpanel right and it follows the
-  // finger, sliding away to reveal the main settings list behind it. The Accounts
-  // and Categories panels embed a drag-to-reorder list, so their swipe is limited
-  // to a left-edge start (edgeWidth) to avoid stealing reorder/body drags.
-  const isEmbeddedScreenPanel = activeSubPanel === 'accounts' || activeSubPanel === 'categories';
+  // finger, sliding away to reveal the main settings list behind it. Every panel
+  // is swipeable from anywhere on its surface; inside the Accounts/Categories
+  // reorder lists, vertical drags/scroll yield to those gestures via failOffsetY,
+  // and the drag handle is long-press activated, so the swipe never steals a
+  // reorder.
   const { gesture: swipeGesture, animatedStyle: swipeStyle, open: openPanelAnim, dismiss: dismissPanel } =
     useSwipeDismiss({
       onDismiss: closeSubPanel,
       enabled: !isBackDisabled,
-      edgeWidth: isEmbeddedScreenPanel ? EDGE_SWIPE_WIDTH : 0,
     });
 
   const openSubPanel = useCallback((panel) => {

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -214,6 +214,21 @@ export default function SettingsScreen({ setSubPanelActive }) {
     return false;
   }, [activeSubPanel, exportStep, importStep, sheetsSteps, sheetsImportSteps]);
 
+  // Multi-step panels (Import / Export) have parent steps; a swipe on a nested
+  // step should go one level up (like the back arrow), not close the whole panel.
+  const canSwipeStepBack = useMemo(() => {
+    if (activeSubPanel === 'import') return importStep !== 'source';
+    if (activeSubPanel === 'export') return exportStep !== 'list';
+    return false;
+  }, [activeSubPanel, importStep, exportStep]);
+
+  // The step-back handler is defined further down (it depends on dismissPanel,
+  // which this hook returns), so reach it through a ref kept current each render.
+  const subPanelBackRef = useRef(null);
+  const handleSwipeStepBack = useCallback(() => {
+    subPanelBackRef.current?.();
+  }, []);
+
   // Telegram-style interactive swipe: drag the subpanel right and it follows the
   // finger, sliding away to reveal the main settings list behind it. Every panel
   // is swipeable from anywhere on its surface; inside the Accounts/Categories
@@ -223,6 +238,8 @@ export default function SettingsScreen({ setSubPanelActive }) {
   const { gesture: swipeGesture, animatedStyle: swipeStyle, open: openPanelAnim, dismiss: dismissPanel } =
     useSwipeDismiss({
       onDismiss: closeSubPanel,
+      onStepBack: handleSwipeStepBack,
+      canStepBack: canSwipeStepBack,
       enabled: !isBackDisabled,
     });
 
@@ -836,6 +853,11 @@ export default function SettingsScreen({ setSubPanelActive }) {
     if (activeSubPanel === 'export') return handleExportBack;
     return dismissPanel;
   }, [activeSubPanel, handleImportBack, handleExportBack, dismissPanel]);
+
+  // Keep the swipe's step-back ref pointing at the current back handler. The
+  // swipe only invokes this when canSwipeStepBack is true (a nested step), where
+  // handleImportBack/handleExportBack step up one level rather than dismiss.
+  subPanelBackRef.current = handleSubPanelBack;
 
 
   // ─── RENDER ───


### PR DESCRIPTION
## What

Follow-up to #1005, making the subpanel swipe-to-dismiss behave consistently and one-level-at-a-time across **every** subpanel and nested level.

### 1. Accounts & Categories are fully swipeable
Removed the 48px left-edge restriction that made the swipe feel missing on those panels. Reorder is long-press-activated on a far-right drag handle and is a vertical motion, so a rightward dismiss swipe never steals it (vertical reorder/scroll yield via `failOffsetY`).

### 2. Swipe steps one level up on nested Import/Export steps
The Import/Export panels have sub-steps (e.g. Import → "From local backup" → confirm). Previously the back arrow stepped up one level but a swipe closed the whole panel. `useSwipeDismiss` now takes `canStepBack` / `onStepBack`; on a nested step the swipe navigates one level up (surface springs back to rest) instead of dismissing.

### 3. Drill back through Accounts/Categories internal levels
The embedded `AccountsScreen` / `CategoriesScreen` have their own nested levels — edit form, currency/icon/type pickers, and (categories) a subcategory grid. A swipe/back used to close the whole panel from any of these, and full-surface swipe risked discarding an open form. Now each embedded screen reports its internal back capability up via an `onBackStateChange` callback, and a **unified back navigator** (shared by the swipe, the Android hardware-back, and the header arrow) pops one level there first — picker → form → subcategory grid → close — mirroring the in-screen back buttons.

## Changes
- `useSwipeDismiss.js`: add `canStepBack` / `onStepBack` (general, documented, unit-tested); keep `edgeWidth` option.
- `SettingsScreen.js`: remove edge special-casing; compute `canSwipeStepBack`; unify swipe / hardware-back / header arrow through one `navigateBack` resolver that defers to the embedded screen's reported back handler.
- `AccountsScreen.js` / `CategoriesScreen.js`: report internal back capability up via `onBackStateChange`.

## Testing
Full suite green: **3621 tests across 119 suites passing**, including a new SettingsScreen test asserting back navigation drills into the embedded screen before closing, and hook coverage for the step-back option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)