### PR TITLE
fix: stop revealing main settings on step-back swipe; align Categories form footer

### DIFF
--- a/app/hooks/useSwipeDismiss.js
+++ b/app/hooks/useSwipeDismiss.js
@@ -115,6 +115,12 @@ export function useSwipeDismiss({ onDismiss, onStepBack, canStepBack = false, en
       .onUpdate((event) => {
         'worklet';
         if (!valid.value) return;
+        // For a step-back the parent lives INSIDE this panel (a nested step or an
+        // embedded screen level), so dragging the whole overlay would wrongly
+        // reveal the layer beneath it (the main settings list). Recognize the
+        // swipe but leave the overlay in place; the inner level plays its own
+        // transition when we trigger the step-back on release.
+        if (canStepBack) return;
         translateX.value = Math.max(0, event.translationX - dragStart.value);
       })
       .onEnd((event) => {
@@ -123,10 +129,9 @@ export function useSwipeDismiss({ onDismiss, onStepBack, canStepBack = false, en
         const dx = event.translationX - dragStart.value;
         const past = dx > DISTANCE_THRESHOLD || event.velocityX > VELOCITY_THRESHOLD;
         if (past && canStepBack) {
-          // Go one level up within the panel and spring the surface back to rest
-          // so the parent step's content takes its place (mirrors the back arrow).
+          // Go one level up within the panel; the overlay never moved, so there is
+          // nothing to spring back — the inner level animates itself.
           if (onStepBack) runOnJS(onStepBack)();
-          translateX.value = withTiming(0, { duration: EXIT_DURATION, easing: ENTER_EASING });
         } else if (past) {
           // Reuse dismiss() so the completion + re-entrancy guard live in one place.
           runOnJS(dismiss)();

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -13,6 +13,7 @@ import {
   Keyboard,
 } from 'react-native';
 import { Text, TouchableRipple, TextInput as PaperTextInput } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS } from '../styles/designTokens';
@@ -35,6 +36,7 @@ const DEFAULT_FORM_VALUES = {
 
 const CategoriesScreen = ({ onBackStateChange }) => {
   const { colors } = useThemeColors();
+  const insets = useSafeAreaInsets();
   const { paperInputTheme } = makeModalStyles(colors);
   const themed = useMemo(() => ({
     pickerItemText: { color: colors.text, fontSize: 18 },
@@ -442,7 +444,7 @@ const CategoriesScreen = ({ onBackStateChange }) => {
           </ScrollView>
 
           {/* Form footer */}
-          <View style={[styles.formPanelFooter, { borderTopColor: colors.border }]}>
+          <View style={[styles.formPanelFooter, { borderTopColor: colors.border, paddingBottom: insets.bottom + 80 }]}>
             <TouchableRipple
               onPress={closeForm}
               style={[styles.formFooterBtn, { borderColor: colors.border }]}
@@ -642,7 +644,8 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     gap: 8,
-    padding: 12,
+    paddingHorizontal: 12,
+    paddingTop: 12,
   },
   formPanelHeader: {
     alignItems: 'center',


### PR DESCRIPTION
## What

Two polish fixes for the settings-subpanel swipe navigation (follow-up to #1005 / #1009).

### 1. Step-back swipe no longer flashes the main settings list
When swiping to go back **within** a panel — a nested Import/Export step, or an embedded Accounts/Categories level (subcategory grid, edit form) — the gesture used to drag the **whole** subpanel overlay rightward, briefly revealing the **main settings list** behind it, then spring back while the inner level closed. For a step-back the parent lives *inside* the panel, not behind it, so the overlay shouldn't move at all.

Now the swipe is still recognized but leaves the overlay in place when `canStepBack` is true; on release it triggers the step-back and lets the inner level play its own transition (e.g. the category form's slide-out). Full-surface dismiss — where the parent really is the main settings list — still follows the finger as before.

### 2. Categories form Save/Cancel positioning matches Accounts
The Categories edit-form footer used a flat `padding: 12`, so the Save/Cancel buttons sat flush under the floating tab bar. It now lifts them with `paddingBottom: insets.bottom + 80` (and `paddingHorizontal`/`paddingTop: 12`), matching the Accounts form.

## Changes
- `useSwipeDismiss.js`: skip overlay translation during the gesture when `canStepBack`; no spring-back needed since the overlay never moved.
- `CategoriesScreen.js`: use `useSafeAreaInsets`; lift the form footer above the tab bar to match `AccountsScreen`.

## Testing
Full suite green: **3621 tests across 119 suites passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016J681zhxvovdB7q49CSHsv)_