### PR TITLE
feat: reduce CI build progress poll to 5s and animate sync icon

### DIFF
--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -982,7 +982,7 @@ describe('SettingsScreen', () => {
 
         // Advancing past the poll interval triggers a silent re-check that updates the percent.
         await act(async () => {
-          jest.advanceTimersByTime(30000);
+          jest.advanceTimersByTime(5000);
         });
 
         await waitFor(() => {
@@ -1028,7 +1028,7 @@ describe('SettingsScreen', () => {
         });
 
         await act(async () => {
-          jest.advanceTimersByTime(30000);
+          jest.advanceTimersByTime(5000);
         });
 
         await waitFor(() => {

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -108,6 +108,15 @@ const INSTALLED_GREEN = '#4caf50';
 
 function ReleaseCard({ version, notes, badge, buildProgress, matchedApk, repoBase, onInstallApk, colors, t, isInstalled, isLatestInstalled, isUpdateCandidate }) {
   const { date, body } = parseReleaseNotes(notes, version);
+  const spinAnim = useRef(new Animated.Value(0)).current;
+  useEffect(() => {
+    if (!buildProgress) return undefined;
+    const loop = Animated.loop(
+      Animated.timing(spinAnim, { toValue: 1, duration: 1500, easing: Easing.linear, useNativeDriver: true }),
+    );
+    loop.start();
+    return () => { loop.stop(); spinAnim.setValue(0); };
+  }, [buildProgress, spinAnim]);
   // We highlight a single card: the candidate for installation when an update is available,
   // otherwise the installed-and-latest card when we are already up to date. The candidate
   // takes the primary accent; the up-to-date installed card keeps the green "latest" accent.
@@ -141,7 +150,9 @@ function ReleaseCard({ version, notes, badge, buildProgress, matchedApk, repoBas
               accessibilityRole="text"
               accessibilityLabel={(t('build_in_progress') || 'Building {percent}%').replace('{percent}', String(buildProgress.percent))}
             >
-              <Ionicons name="sync-outline" size={13} color={colors.primary} />
+              <Animated.View style={{ transform: [{ rotate: spinAnim.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '360deg'] }) }] }}>
+                <Ionicons name="sync-outline" size={13} color={colors.primary} />
+              </Animated.View>
               <Text style={[styles.buildProgressText, { color: colors.primary }]}>
                 {(t('build_in_progress') || 'Building {percent}%').replace('{percent}', String(buildProgress.percent))}
               </Text>

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -62,7 +62,7 @@ const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 const SPRING_CONFIG = { mass: 1, damping: 20, stiffness: 200 };
 
 // How often to re-poll CI build progress while the update panel shows an in-progress build.
-const BUILD_PROGRESS_POLL_MS = 30000;
+const BUILD_PROGRESS_POLL_MS = 5000;
 
 
 export default function SettingsScreen({ setSubPanelActive }) {


### PR DESCRIPTION
## Summary

- Reduce CI build progress poll interval from 30s to 5s so the "Building N%" percentage advances more responsively
- Add a looping `sync-outline` icon rotation animation (1.5s per revolution) to the build progress chip — runs on the native thread via `useNativeDriver: true`, stops and resets when the build finishes

## Test plan

- Open the update panel while a build is in progress
- Confirm the sync icon spins continuously
- Confirm the percentage updates roughly every 5 seconds
- Confirm the spinner stops once the APK is published and the chip disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP3AL5htvfL9ZduWBjV5Be

---
_Generated by [Claude Code](https://claude.ai/code/session_01CP3AL5htvfL9ZduWBjV5Be)_