### PR TITLE
feat: re-download corrupt cached APK on the updates page

### DIFF
--- a/__tests__/components/UpdateContentPanel.test.js
+++ b/__tests__/components/UpdateContentPanel.test.js
@@ -357,6 +357,29 @@ describe('UpdateContentPanel', () => {
       expect(getByText('update_install_now')).toBeTruthy();
     });
 
+    it('shows the corrupt-redownload note and an Update now button when the cached APK was damaged', async () => {
+      const { getByText, queryByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{ ...availableResult, alreadyDownloaded: false, localUri: null, previousDownloadCorrupted: true }}
+        />,
+      );
+      expect(getByText('apk_corrupt_redownload')).toBeTruthy();
+      // The damaged file was discarded, so we offer a fresh re-download, not an install.
+      expect(getByText('update_now')).toBeTruthy();
+      expect(queryByText('update_install_now')).toBeNull();
+    });
+
+    it('does not show the corrupt-redownload note when the cached APK is valid', async () => {
+      const { queryByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{ ...availableResult, alreadyDownloaded: true, localUri: 'file:///cache/penny-2.0.0.apk' }}
+        />,
+      );
+      expect(queryByText('apk_corrupt_redownload')).toBeNull();
+    });
+
     it('shows install hint when no releaseNotes', async () => {
       const { getByText } = await render(
         <UpdateContentPanel

--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -226,6 +226,7 @@ jest.mock('../../app/services/AppUpdateService', () => ({
   listDownloadedApks: jest.fn(() => Promise.resolve([])),
   installApk: jest.fn(() => Promise.resolve()),
   checkAlreadyDownloaded: jest.fn(() => Promise.resolve(null)),
+  verifyCachedApk: jest.fn(() => Promise.resolve({ exists: false })),
 }));
 
 const mockGetDefaultAccountId = jest.fn(() => Promise.resolve(null));

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -6,6 +6,7 @@ import {
   checkForAppUpdate,
   cleanupOldApks,
   checkAlreadyDownloaded,
+  verifyCachedApk,
   sanitizeFilename,
   fetchExpectedChecksum,
   computeSha256,
@@ -705,6 +706,108 @@ describe('AppUpdateService', () => {
       FileSystem.readAsStringAsync.mockRejectedValue(new Error('read failed'));
 
       await expect(computeSha256('file:///cache/penny.apk')).rejects.toThrow('read failed');
+    });
+  });
+
+  describe('verifyCachedApk', () => {
+    const URL = 'https://example.com/penny-v1.0.0.apk';
+    // 'aGVsbG8=' = base64("hello"); SHA-256("hello") is this known constant
+    const HELLO_B64 = 'aGVsbG8=';
+    const HELLO_SHA = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+
+    it('reports exists:false when no cached APK is present', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: false, size: 0 });
+
+      const result = await verifyCachedApk(URL, {
+        checksumUrl: 'https://example.com/penny-v1.0.0.apk.sha256',
+        cacheDir: 'file:///cache/',
+        fetchImpl: jest.fn(),
+      });
+
+      expect(result).toEqual({ exists: false });
+    });
+
+    it('returns verified:false when no checksum URL is provided', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+
+      const result = await verifyCachedApk(URL, { cacheDir: 'file:///cache/' });
+
+      expect(result).toEqual({ exists: true, uri: 'file:///cache/penny-v1.0.0.apk', verified: false });
+      expect(FileSystem.readAsStringAsync).not.toHaveBeenCalled();
+    });
+
+    it('returns verified:true when the cached APK matches the checksum', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+      FileSystem.readAsStringAsync.mockResolvedValue(HELLO_B64);
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () => `${HELLO_SHA}  penny-v1.0.0.apk\n`,
+      });
+
+      const result = await verifyCachedApk(URL, {
+        checksumUrl: 'https://example.com/penny-v1.0.0.apk.sha256',
+        cacheDir: 'file:///cache/',
+        fetchImpl,
+      });
+
+      expect(result).toEqual({ exists: true, uri: 'file:///cache/penny-v1.0.0.apk', verified: true });
+      expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+    });
+
+    it('deletes the file and reports corrupted when the checksum does not match', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+      FileSystem.readAsStringAsync.mockResolvedValue(HELLO_B64);
+      FileSystem.deleteAsync.mockResolvedValue();
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () => 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff  penny-v1.0.0.apk\n',
+      });
+
+      const result = await verifyCachedApk(URL, {
+        checksumUrl: 'https://example.com/penny-v1.0.0.apk.sha256',
+        cacheDir: 'file:///cache/',
+        fetchImpl,
+      });
+
+      expect(result).toEqual({ exists: false, corrupted: true });
+      expect(FileSystem.deleteAsync).toHaveBeenCalledWith(
+        'file:///cache/penny-v1.0.0.apk',
+        { idempotent: true },
+      );
+    });
+
+    it('keeps the file (verified:false) when the checksum file cannot be fetched', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: false });
+
+      const result = await verifyCachedApk(URL, {
+        checksumUrl: 'https://example.com/penny-v1.0.0.apk.sha256',
+        cacheDir: 'file:///cache/',
+        fetchImpl,
+      });
+
+      expect(result).toEqual({ exists: true, uri: 'file:///cache/penny-v1.0.0.apk', verified: false });
+      expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+    });
+
+    it('keeps the file (verified:false) when hashing throws (OOM / read error)', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 50_000_000 });
+      FileSystem.readAsStringAsync.mockRejectedValue(new RangeError('Array buffer allocation failed'));
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        text: async () => `${HELLO_SHA}  penny-v1.0.0.apk\n`,
+      });
+
+      const result = await verifyCachedApk(URL, {
+        checksumUrl: 'https://example.com/penny-v1.0.0.apk.sha256',
+        cacheDir: 'file:///cache/',
+        fetchImpl,
+      });
+
+      expect(result).toEqual({ exists: true, uri: 'file:///cache/penny-v1.0.0.apk', verified: false });
+      expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -105,6 +105,8 @@ const formatApkDate = (modificationTime) => {
 
 // Green used for the "installed / up to date" status, matching the checkmark elsewhere in this panel.
 const INSTALLED_GREEN = '#4caf50';
+// Amber used to warn that a corrupt cached download was discarded and is being re-downloaded.
+const WARNING_AMBER = '#f0a500';
 
 function ReleaseCard({ version, notes, badge, buildProgress, matchedApk, repoBase, onInstallApk, colors, t, isInstalled, isLatestInstalled, isUpdateCandidate }) {
   const { date, body } = parseReleaseNotes(notes, version);
@@ -395,6 +397,14 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
               </Text>
             )}
             <Divider style={styles.updateDivider} />
+            {updateResult.previousDownloadCorrupted ? (
+              <View style={styles.corruptNoteRow} accessibilityRole="text">
+                <Ionicons name="alert-circle-outline" size={14} color={WARNING_AMBER} />
+                <Text style={[styles.corruptNoteText, { color: WARNING_AMBER }]}>
+                  {t('apk_corrupt_redownload') || 'The previous download was damaged and was removed. Tap Update now to download it again.'}
+                </Text>
+              </View>
+            ) : null}
             <View style={styles.updateBottomRow}>
               {releaseNotes ? (
                 <UnmatchedApks apks={unmatched} onInstallApk={onInstallApk} colors={colors} t={t} compact />
@@ -562,6 +572,7 @@ UpdateContentPanel.propTypes = {
     releasesUrl: PropTypes.string,
     alreadyDownloaded: PropTypes.bool,
     localUri: PropTypes.string,
+    previousDownloadCorrupted: PropTypes.bool,
     errorCode: PropTypes.string,
     buildProgress: PropTypes.shape({
       percent: PropTypes.number,
@@ -642,6 +653,17 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 22,
     textAlign: 'center',
+  },
+  corruptNoteRow: {
+    alignItems: 'flex-start',
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    paddingTop: SPACING.sm,
+  },
+  corruptNoteText: {
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 17,
   },
   downloadedApksCompact: {
     flex: 1,

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -25,7 +25,7 @@ import { useLogEntries } from '../hooks/useLogEntries';
 import { File, Paths } from 'expo-file-system';
 import * as LegacyFileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
-import { checkForAppUpdate, listDownloadedApks, installApk, checkAlreadyDownloaded } from '../services/AppUpdateService';
+import { checkForAppUpdate, listDownloadedApks, installApk, verifyCachedApk } from '../services/AppUpdateService';
 import { getPreference, setPreference, PREF_KEYS, getDefaultAccountId, setDefaultAccountId } from '../services/PreferencesDB';
 import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
@@ -673,7 +673,10 @@ export default function SettingsScreen({ setSubPanelActive }) {
           releasesUrl: result.releasesUrl || null,
         });
       } else {
-        const alreadyDownloadedUri = await checkAlreadyDownloaded(result.downloadUrl);
+        // Verify any cached APK against the release checksum. A corrupt leftover download is
+        // deleted here so we offer a fresh "Update now" (re-download) instead of an "Install now"
+        // that would launch a broken installer.
+        const cached = await verifyCachedApk(result.downloadUrl, { checksumUrl: result.checksumUrl });
         setUpdateResult({
           type: 'available',
           latestVersion: result.latestVersion,
@@ -683,8 +686,9 @@ export default function SettingsScreen({ setSubPanelActive }) {
           releaseNotes: result.releaseNotes || null,
           recentReleaseNotes: result.recentReleaseNotes || null,
           releasesUrl: result.releasesUrl || null,
-          alreadyDownloaded: !!alreadyDownloadedUri,
-          localUri: alreadyDownloadedUri,
+          alreadyDownloaded: cached.exists,
+          localUri: cached.exists ? cached.uri : null,
+          previousDownloadCorrupted: !!cached.corrupted,
         });
       }
     } catch (error) {

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -409,6 +409,58 @@ export const checkAlreadyDownloaded = async (downloadUrl, cacheDir = FileSystem.
   }
 };
 
+// Verifies the integrity of an APK already sitting in the cache for the given download URL.
+// A previous download can be left truncated or corrupt (interrupted transfer, full disk), in
+// which case offering "Install now" would launch a broken installer. When a checksum is
+// available we hash the cached file and, on mismatch, delete it so callers re-download cleanly.
+//
+// Returns one of:
+//   { exists: false }                          — no usable cached file (absent or zero-size)
+//   { exists: false, corrupted: true }         — cached file failed the checksum and was deleted
+//   { exists: true, uri, verified: true }      — checksum matched
+//   { exists: true, uri, verified: false }     — present but integrity could not be confirmed
+//                                                 (no checksum, unfetchable checksum, or hash error)
+export const verifyCachedApk = async (
+  downloadUrl,
+  { checksumUrl = null, cacheDir = FileSystem.cacheDirectory, fetchImpl = fetch } = {},
+) => {
+  const localUri = await checkAlreadyDownloaded(downloadUrl, cacheDir);
+  if (!localUri) {
+    return { exists: false };
+  }
+
+  // Without a checksum we can confirm the file is present and non-empty, but not prove
+  // integrity — treat it as usable but unverified.
+  if (!checksumUrl) {
+    return { exists: true, uri: localUri, verified: false };
+  }
+
+  const filename = localUri.split('/').pop();
+  const expectedHash = await fetchExpectedChecksum(checksumUrl, filename, fetchImpl);
+  if (!expectedHash) {
+    // Checksum file unavailable or unparseable — cannot verify, keep the file.
+    return { exists: true, uri: localUri, verified: false };
+  }
+
+  let actualHash;
+  try {
+    actualHash = await computeSha256(localUri);
+  } catch (e) {
+    // Hashing can OOM on large APKs (reads the whole file into the JS heap). A failure here
+    // means "unable to verify", not "corrupt" — keep the file rather than discarding a good one.
+    console.warn('[AppUpdate] cached APK checksum computation failed; skipping verification', e.message);
+    return { exists: true, uri: localUri, verified: false };
+  }
+
+  if (actualHash !== expectedHash) {
+    await FileSystem.deleteAsync(localUri, { idempotent: true });
+    console.warn('[AppUpdate] cached APK failed checksum; deleted corrupt file', localUri);
+    return { exists: false, corrupted: true };
+  }
+
+  return { exists: true, uri: localUri, verified: true };
+};
+
 // Pre-built lookup table for base64 → 6-bit value. Avoids atob() + charCodeAt loop.
 const BASE64_LOOKUP = (() => {
   const t = new Uint8Array(256);

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -388,6 +388,7 @@
   "update_phase_verifying": "APK wird geprüft…",
   "update_phase_backing_up": "Sicherung wird erstellt…",
   "update_install_now": "Jetzt installieren",
+  "apk_corrupt_redownload": "Der vorherige Download war beschädigt und wurde entfernt. Tippe auf „Jetzt aktualisieren“, um ihn erneut herunterzuladen.",
   "downloaded_apks": "Heruntergeladene APKs",
   "installed": "Installiert",
   "update_candidate": "Verfügbar",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -392,6 +392,7 @@
   "update_phase_verifying": "Verifying APK…",
   "update_phase_backing_up": "Backing up…",
   "update_install_now": "Install now",
+  "apk_corrupt_redownload": "The previous download was damaged and was removed. Tap Update now to download it again.",
   "downloaded_apks": "Downloaded APKs",
   "installed": "Installed",
   "update_candidate": "Available",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -388,6 +388,7 @@
   "update_phase_verifying": "Verificando APK…",
   "update_phase_backing_up": "Creando copia de seguridad…",
   "update_install_now": "Instalar ahora",
+  "apk_corrupt_redownload": "La descarga anterior estaba dañada y se eliminó. Toca Actualizar ahora para descargarla de nuevo.",
   "downloaded_apks": "APKs descargados",
   "installed": "Instalada",
   "update_candidate": "Disponible",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -392,6 +392,7 @@
   "update_phase_verifying": "Vérification APK…",
   "update_phase_backing_up": "Sauvegarde…",
   "update_install_now": "Installer maintenant",
+  "apk_corrupt_redownload": "Le téléchargement précédent était endommagé et a été supprimé. Touchez Mettre à jour maintenant pour le télécharger à nouveau.",
   "downloaded_apks": "APKs téléchargés",
   "installed": "Installée",
   "update_candidate": "Disponible",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -388,6 +388,7 @@
   "update_phase_verifying": "APK-ի ստուգում…",
   "update_phase_backing_up": "Կրկնօրինակ ստեղծում…",
   "update_install_now": "Տեղադրել հիմա",
+  "apk_corrupt_redownload": "Նախորդ ներբեռնումը վնասված էր և հեռացվեց։ Սեղմեք «Թարմացնել հիմա»՝ կրկին ներբեռնելու համար։",
   "downloaded_apks": "Ներբեռնված APK-ներ",
   "installed": "Տեղադրված է",
   "update_candidate": "Հասանելի",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -392,6 +392,7 @@
   "update_phase_verifying": "Verifica APK…",
   "update_phase_backing_up": "Backup in corso…",
   "update_install_now": "Installa ora",
+  "apk_corrupt_redownload": "Il download precedente era danneggiato ed è stato rimosso. Tocca Aggiorna ora per scaricarlo di nuovo.",
   "downloaded_apks": "APK scaricati",
   "installed": "Installato",
   "update_candidate": "Disponibile",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -392,6 +392,7 @@
   "update_phase_verifying": "APK検証中…",
   "update_phase_backing_up": "バックアップ作成中…",
   "update_install_now": "今すぐインストール",
+  "apk_corrupt_redownload": "前回のダウンロードは破損していたため削除されました。「今すぐ更新」をタップして再ダウンロードしてください。",
   "downloaded_apks": "ダウンロード済みAPK",
   "installed": "インストール済み",
   "update_candidate": "利用可能",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -392,6 +392,7 @@
   "update_phase_verifying": "APK 검증 중…",
   "update_phase_backing_up": "백업 생성 중…",
   "update_install_now": "지금 설치",
+  "apk_corrupt_redownload": "이전 다운로드가 손상되어 제거되었습니다. 지금 업데이트를 눌러 다시 다운로드하세요.",
   "downloaded_apks": "다운로드된 APK",
   "installed": "설치됨",
   "update_candidate": "사용 가능",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -392,6 +392,7 @@
   "update_phase_verifying": "Verificando APK…",
   "update_phase_backing_up": "Criando backup…",
   "update_install_now": "Instalar agora",
+  "apk_corrupt_redownload": "O download anterior estava corrompido e foi removido. Toque em Atualizar agora para baixá-lo novamente.",
   "downloaded_apks": "APKs baixados",
   "installed": "Instalada",
   "update_candidate": "Disponível",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -392,6 +392,7 @@
   "update_phase_verifying": "Проверка APK…",
   "update_phase_backing_up": "Создание резервной копии…",
   "update_install_now": "Установить сейчас",
+  "apk_corrupt_redownload": "Предыдущая загрузка была повреждена и удалена. Нажмите «Обновить сейчас», чтобы загрузить заново.",
   "downloaded_apks": "Загруженные APK",
   "installed": "Установлено",
   "update_candidate": "Доступно",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -388,6 +388,7 @@
   "update_phase_verifying": "正在验证 APK…",
   "update_phase_backing_up": "正在备份…",
   "update_install_now": "立即安装",
+  "apk_corrupt_redownload": "上一次下载已损坏并被删除。点按“立即更新”重新下载。",
   "downloaded_apks": "已下载 APK",
   "installed": "已安装",
   "update_candidate": "可用",


### PR DESCRIPTION
## Summary

The updates page caches the downloaded APK so it can offer **Install now** instead of re-downloading. But a cached APK can be left **truncated or corrupt** (interrupted transfer, full disk), and the previous check only verified the file *existed* and was *non-empty* (`checkAlreadyDownloaded`). That meant the panel would happily offer **Install now** on a broken file, launching a failing Android installer with no way out.

This change auto-detects a bad cached APK and re-downloads instead of installing it.

## What changed

- **New `verifyCachedApk(downloadUrl, { checksumUrl })`** in `AppUpdateService.js`. When a cached APK exists and the release ships a SHA-256 checksum, it hashes the cached file and compares:
  - **match** → `{ exists: true, verified: true }` — keep offering *Install now*.
  - **mismatch** → deletes the corrupt file, returns `{ exists: false, corrupted: true }`.
  - **no checksum / unfetchable checksum / hashing error (e.g. OOM on large APKs)** → keeps the file as *unverified* rather than discarding a good download.
- **`runUpdateCheck`** (`SettingsScreen.js`) now calls `verifyCachedApk` in place of `checkAlreadyDownloaded`. A corrupt cached file is deleted, so the panel falls back to **Update now** (a fresh re-download) automatically and sets `previousDownloadCorrupted`.
- **`UpdateContentPanel.js`** shows an amber note explaining the previous download was damaged and is being re-downloaded.
- **i18n**: added `apk_corrupt_redownload` across all 11 locales.

## Why this approach

The checksum mismatch is the only reliable signal that a cached APK is actually bad. Hashing only happens when an update is available **and** a matching APK is already cached **and** the release has a checksum — a narrow, user-initiated path (it is not reached by the silent build-progress poller). Hashing failures are treated as "unable to verify", never as corruption, so a healthy download is never thrown away.

## Tests

- `verifyCachedApk`: absent file, no checksum, checksum match, checksum mismatch (deletes + corrupted), unfetchable checksum, hashing OOM.
- `UpdateContentPanel`: shows the corrupt note + *Update now* when damaged; hides it when the cache is valid.
- Full suite green: **3636 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhoCzrsE55cJrxV3soW46e)_