### PR TITLE
fix: put quick-add category gap between rows, not between tiles

### DIFF
--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -673,7 +673,7 @@ const OperationFormFields = memo(({
         layout={LinearTransition.duration(240)}
         style={[styles.categoryRowsWrapper, compact && styles.categoryRowsWrapperCompact]}
       >
-        <Reanimated.View key={levelKey} entering={entering}>
+        <Reanimated.View key={levelKey} entering={entering} style={styles.categoryRows}>
           {content}
         </Reanimated.View>
       </Reanimated.View>
@@ -956,7 +956,7 @@ const styles = StyleSheet.create({
   },
   categoryButtonsContainer: {
     flexDirection: 'row',
-    gap: SPACING.sm,
+    gap: SPACING.xs,
   },
   categoryPickerButton: {
     alignItems: 'center',
@@ -975,8 +975,10 @@ const styles = StyleSheet.create({
     marginTop: 2,
     textAlign: 'center',
   },
-  categoryRowsWrapper: {
+  categoryRows: {
     gap: SPACING.sm,
+  },
+  categoryRowsWrapper: {
     marginBottom: SPACING.md,
   },
   categoryRowsWrapperCompact: {


### PR DESCRIPTION
## What

Follow-up to the tile-spacing change: I'd widened **both** axes, but only the **vertical** gap (between the two rows of tiles) was wanted.

- Reverted the horizontal gap between tiles in a row back to **4px**.
- Put the **8px vertical gap** on the actual rows container. (The earlier animation refactor moved the rows inside a keyed wrapper, so the gap that used to live on the outer wrapper no longer applied between the rows — this puts it where the rows actually are.)

Net: tiles in a row sit close together again; the two rows are now clearly separated.

## Testing
- Lint clean; `OperationFormFields` tests pass (36). 1-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJKWgTJsLrdzzmwezVAgzA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJKWgTJsLrdzzmwezVAgzA)_