### PR TITLE
feat: check CI build progress for each no-APK release

### DIFF
--- a/__tests__/components/UpdateContentPanel.test.js
+++ b/__tests__/components/UpdateContentPanel.test.js
@@ -259,6 +259,27 @@ describe('UpdateContentPanel', () => {
       expect(queryByText('No APK')).toBeNull(); // sanity: still the no-APK branch
     });
 
+    it('shows a build progress chip on each no-APK release that is building', async () => {
+      const { getAllByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'error',
+            errorCode: 'releases_without_apks',
+            releaseNotes: [
+              { version: '0.142.0', notes: 'Building newer', hasApk: false, buildProgress: { percent: 31, status: 'in_progress' } },
+              { version: '0.141.4', notes: 'Building older', hasApk: false, buildProgress: { percent: 70, status: 'in_progress' } },
+            ],
+            recentReleaseNotes: null,
+            releasesUrl: null,
+            buildProgress: { percent: 31, status: 'in_progress' },
+          }}
+        />,
+      );
+      // Both building releases surface their own chip (the mock t() collapses each to its key).
+      expect(getAllByText('build_in_progress')).toHaveLength(2);
+    });
+
     it('does not show a build progress chip when buildProgress is null', async () => {
       const { queryByText } = await render(
         <UpdateContentPanel

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -12,6 +12,8 @@ import {
   computeSha256,
   downloadAndInstallApk,
   fetchBuildProgress,
+  fetchBuildProgressByVersion,
+  fetchActiveBuildRuns,
 } from '../../app/services/AppUpdateService';
 
 jest.mock('expo-file-system/legacy', () => ({
@@ -404,6 +406,46 @@ describe('AppUpdateService', () => {
       expect(result.recentReleaseNotes.length).toBe(2);
       expect(result.recentReleaseNotes[0].version).toBe('0.50.0');
       expect(result.recentReleaseNotes[1].version).toBe('0.49.9');
+    });
+
+    it('attaches a CI build progress to each no-APK release that is still building', async () => {
+      const MINUTE = 60000;
+      const now = Date.now();
+      // Route releases vs. workflow-runs requests to different payloads so each no-APK release
+      // can be matched to its own active build run by tag.
+      const fetchImpl = jest.fn(async (url) => {
+        if (url.includes('/actions/workflows/')) {
+          return {
+            ok: true,
+            json: async () => ({
+              workflow_runs: [
+                { status: 'in_progress', head_branch: 'penny-v0.50.5', run_started_at: new Date(now - 1.7 * MINUTE).toISOString() },
+                { status: 'in_progress', head_branch: 'penny-v0.50.4', run_started_at: new Date(now - 8.5 * MINUTE).toISOString() },
+              ],
+            }),
+          };
+        }
+        return {
+          ok: true,
+          json: async () => ([
+            { tag_name: 'v0.50.5', assets: [], body: 'Notes for 0.50.5' },
+            { tag_name: 'v0.50.4', assets: [], body: 'Notes for 0.50.4' },
+            { tag_name: 'v0.50.0', assets: [{ name: 'penny-0.50.0.apk', browser_download_url: 'https://example.com/penny-0.50.0.apk' }], body: 'Notes for 0.50.0' },
+          ]),
+        };
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.0',
+        fetchImpl,
+      });
+
+      expect(result.errorCode).toBe('releases_without_apks');
+      const byVersion = Object.fromEntries(result.releaseNotes.map((r) => [r.version, r]));
+      expect(byVersion['0.50.5'].buildProgress.percent).toBe(10);
+      expect(byVersion['0.50.4'].buildProgress.percent).toBe(50);
+      // The newest active run is still surfaced top-level for the poller / legacy consumers.
+      expect(result.buildProgress.version).toBe('0.50.5');
     });
 
     it('returns invalid_release_data when releases list is empty', async () => {
@@ -1000,6 +1042,107 @@ describe('AppUpdateService', () => {
       const result = await fetchBuildProgress({ fetchImpl, now });
 
       expect(result).toBeNull();
+    });
+
+    it('derives the release version from the run head_branch (tag)', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue(runsResponse([
+        {
+          status: 'in_progress',
+          head_branch: 'penny-v0.142.0',
+          run_started_at: new Date(now - 8.5 * MINUTE).toISOString(),
+        },
+      ]));
+
+      const result = await fetchBuildProgress({ fetchImpl, now });
+
+      expect(result.version).toBe('0.142.0');
+    });
+  });
+
+  describe('fetchActiveBuildRuns', () => {
+    const MINUTE = 60000;
+    const now = new Date('2026-06-18T12:00:00Z').getTime();
+
+    const runsResponse = (runs) => ({
+      ok: true,
+      json: async () => ({ workflow_runs: runs }),
+    });
+
+    it('returns every active run with progress, newest first', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue(runsResponse([
+        { status: 'in_progress', head_branch: 'penny-v0.141.4', run_started_at: new Date(now - 8.5 * MINUTE).toISOString() },
+        { status: 'queued', head_branch: 'penny-v0.142.0', run_started_at: new Date(now - 1.7 * MINUTE).toISOString() },
+        { status: 'completed', head_branch: 'penny-v0.140.0', run_started_at: new Date(now - 30 * MINUTE).toISOString() },
+      ]));
+
+      const result = await fetchActiveBuildRuns({ fetchImpl, now });
+
+      expect(result).toHaveLength(2);
+      // Newest first: 0.142.0 (1.7 min ago) then 0.141.4 (8.5 min ago).
+      expect(result[0].version).toBe('0.142.0');
+      expect(result[0].percent).toBe(10);
+      expect(result[1].version).toBe('0.141.4');
+      expect(result[1].percent).toBe(50);
+    });
+
+    it('returns an empty array on API error', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+
+      const result = await fetchActiveBuildRuns({ fetchImpl, now });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchBuildProgressByVersion', () => {
+    const MINUTE = 60000;
+    const now = new Date('2026-06-18T12:00:00Z').getTime();
+
+    const runsResponse = (runs) => ({
+      ok: true,
+      json: async () => ({ workflow_runs: runs }),
+    });
+
+    it('maps each release version to its own build progress', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue(runsResponse([
+        { status: 'in_progress', head_branch: 'penny-v0.141.4', run_started_at: new Date(now - 8.5 * MINUTE).toISOString() },
+        { status: 'queued', head_branch: 'penny-v0.142.0', run_started_at: new Date(now - 1.7 * MINUTE).toISOString() },
+      ]));
+
+      const result = await fetchBuildProgressByVersion({ fetchImpl, now });
+
+      expect(result['0.142.0'].percent).toBe(10);
+      expect(result['0.141.4'].percent).toBe(50);
+    });
+
+    it('keeps the most recent run when multiple runs map to the same version', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue(runsResponse([
+        { status: 'in_progress', head_branch: 'penny-v0.142.0', run_started_at: new Date(now - 1.7 * MINUTE).toISOString() },
+        { status: 'in_progress', head_branch: 'penny-v0.142.0', run_started_at: new Date(now - 15 * MINUTE).toISOString() },
+      ]));
+
+      const result = await fetchBuildProgressByVersion({ fetchImpl, now });
+
+      expect(Object.keys(result)).toEqual(['0.142.0']);
+      expect(result['0.142.0'].percent).toBe(10);
+    });
+
+    it('skips runs whose version cannot be derived', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue(runsResponse([
+        { status: 'in_progress', head_branch: 'main', run_started_at: new Date(now - 5 * MINUTE).toISOString() },
+      ]));
+
+      const result = await fetchBuildProgressByVersion({ fetchImpl, now });
+
+      expect(result).toEqual({});
+    });
+
+    it('returns an empty map on API error', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+
+      const result = await fetchBuildProgressByVersion({ fetchImpl, now });
+
+      expect(result).toEqual({});
     });
   });
 });

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -517,17 +517,28 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
       )}
 
       {updateResult.type === 'error' && updateResult.errorCode === 'releases_without_apks' && (updateResult.releaseNotes || updateResult.recentReleaseNotes) ? (() => {
-        // Surface CI build progress on the newest release awaiting its APK — that is the build
-        // currently running. Older no-APK releases (if any) get no progress chip.
-        let buildProgressShown = false;
-        const noApkReleases = (updateResult.releaseNotes || []).map((r) => {
-          const showProgress = !r.hasApk && !buildProgressShown && !!updateResult.buildProgress;
-          if (showProgress) buildProgressShown = true;
+        // Surface CI build progress per release awaiting its APK. The service resolves each
+        // no-APK release's own build run, so when several releases are building at once each
+        // gets its own "Building N%" chip. Older payloads carry only a single top-level
+        // buildProgress; fall back to showing that on the newest no-APK release alone.
+        const releaseNotesList = updateResult.releaseNotes || [];
+        const hasPerReleaseProgress = releaseNotesList.some((r) => r.buildProgress);
+        let legacyProgressShown = false;
+        const noApkReleases = releaseNotesList.map((r) => {
+          let buildProgress = null;
+          if (!r.hasApk) {
+            if (hasPerReleaseProgress) {
+              buildProgress = r.buildProgress || null;
+            } else if (!legacyProgressShown && updateResult.buildProgress) {
+              buildProgress = updateResult.buildProgress;
+              legacyProgressShown = true;
+            }
+          }
           return {
             version: r.version,
             notes: r.notes,
             badge: !r.hasApk ? (t('no_apk_attached') || 'NO_APK_ATTACHED') : undefined,
-            buildProgress: showProgress ? updateResult.buildProgress : null,
+            buildProgress,
           };
         });
         const recentReleases = updateResult.recentReleaseNotes || [];
@@ -575,6 +586,9 @@ UpdateContentPanel.propTypes = {
       version: PropTypes.string,
       notes: PropTypes.string,
       hasApk: PropTypes.bool,
+      buildProgress: PropTypes.shape({
+        percent: PropTypes.number,
+      }),
     })),
     recentReleaseNotes: PropTypes.arrayOf(PropTypes.shape({
       version: PropTypes.string,

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -108,20 +108,55 @@ const BUILD_WORKFLOW_FILE = 'build-release-apk.yml';
 // A full APK build takes ~17 minutes on the GitHub Actions runner; we treat that as 100%.
 const BUILD_DURATION_MINUTES = 17;
 
-// Queries the GitHub Actions API for the most recent in-progress run of the APK build workflow
-// and derives a rough completion percentage from how long it has been running. Used to show the
-// user that a release's APK is on its way when the tag exists but the asset is not uploaded yet.
-//
-// Returns null when there is no active run, when the API is unreachable, or when the timing data
-// is unusable — callers should treat null as "no progress information available".
-export const fetchBuildProgress = async ({
+// Tag pushes (penny-v*) drive the build workflow, so a run's head_branch is the tag that
+// triggered it. We use that — falling back to the run's display title — to tie a build run to
+// the release version whose APK it is producing.
+const versionFromRun = (run) =>
+  normalizeVersion(run?.head_branch) || normalizeVersion(run?.display_title) || null;
+
+// Derives a rough completion percentage for a single active workflow run from how long it has
+// been running. Returns null when the run has no usable start time.
+const computeRunProgress = (run, now, expectedDurationMinutes) => {
+  if (!run) {
+    return null;
+  }
+
+  const startMs = new Date(run.run_started_at || run.created_at || 0).getTime();
+  if (!Number.isFinite(startMs) || startMs <= 0) {
+    return null;
+  }
+
+  const elapsedMinutes = (now - startMs) / 60000;
+  if (elapsedMinutes < 0) {
+    return null;
+  }
+
+  // Cap below 100%: the build is by definition not finished (no APK yet), so never show 100%.
+  const rawPercent = Math.round((elapsedMinutes / expectedDurationMinutes) * 100);
+  const percent = Math.min(99, Math.max(0, rawPercent));
+
+  return {
+    percent,
+    elapsedMinutes: Math.floor(elapsedMinutes),
+    status: run.status,
+    startedAt: run.run_started_at || run.created_at || null,
+    htmlUrl: run.html_url || null,
+    version: versionFromRun(run),
+  };
+};
+
+// Queries the GitHub Actions API for all currently active (not yet completed) runs of the APK
+// build workflow and maps each to a rough completion percentage. Returned newest-first so the
+// most recently started run is first. Returns an empty array when the API is unreachable, when
+// there are no active runs, or when timing data is unusable.
+export const fetchActiveBuildRuns = async ({
   owner = DEFAULT_GITHUB_OWNER,
   repo = DEFAULT_GITHUB_REPO,
   fetchImpl = fetch,
   now = Date.now(),
   expectedDurationMinutes = BUILD_DURATION_MINUTES,
 } = {}) => {
-  const endpoint = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${BUILD_WORKFLOW_FILE}/runs?per_page=10`;
+  const endpoint = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${BUILD_WORKFLOW_FILE}/runs?per_page=20`;
 
   try {
     const response = await fetchWithTimeout(
@@ -138,7 +173,7 @@ export const fetchBuildProgress = async ({
     );
 
     if (!response.ok) {
-      return null;
+      return [];
     }
 
     const data = await response.json();
@@ -147,37 +182,44 @@ export const fetchBuildProgress = async ({
     // A run is "active" until GitHub marks it completed (queued / in_progress / waiting / etc.).
     const activeRuns = runs.filter((run) => run && run.status && run.status !== 'completed');
     if (activeRuns.length === 0) {
-      return null;
+      return [];
     }
 
     const startedMs = (run) => new Date(run.run_started_at || run.created_at || 0).getTime();
     activeRuns.sort((a, b) => startedMs(b) - startedMs(a));
-    const run = activeRuns[0];
 
-    const startMs = startedMs(run);
-    if (!Number.isFinite(startMs) || startMs <= 0) {
-      return null;
-    }
-
-    const elapsedMinutes = (now - startMs) / 60000;
-    if (elapsedMinutes < 0) {
-      return null;
-    }
-
-    // Cap below 100%: the build is by definition not finished (no APK yet), so never show 100%.
-    const rawPercent = Math.round((elapsedMinutes / expectedDurationMinutes) * 100);
-    const percent = Math.min(99, Math.max(0, rawPercent));
-
-    return {
-      percent,
-      elapsedMinutes: Math.floor(elapsedMinutes),
-      status: run.status,
-      startedAt: run.run_started_at || run.created_at || null,
-      htmlUrl: run.html_url || null,
-    };
+    return activeRuns
+      .map((run) => computeRunProgress(run, now, expectedDurationMinutes))
+      .filter(Boolean);
   } catch {
-    return null;
+    return [];
   }
+};
+
+// Returns a rough completion percentage for the most recently started active APK build run.
+// Used to show the user that a release's APK is on its way when the tag exists but the asset is
+// not uploaded yet.
+//
+// Returns null when there is no active run, when the API is unreachable, or when the timing data
+// is unusable — callers should treat null as "no progress information available".
+export const fetchBuildProgress = async (options = {}) => {
+  const runs = await fetchActiveBuildRuns(options);
+  return runs.length > 0 ? runs[0] : null;
+};
+
+// Like fetchBuildProgress, but returns a map of release version → build progress so that each
+// release still awaiting its APK can surface its own CI build status. When more than one active
+// run maps to the same version, the most recently started one wins (runs are pre-sorted
+// newest-first). Versions that cannot be derived from a run are skipped.
+export const fetchBuildProgressByVersion = async (options = {}) => {
+  const runs = await fetchActiveBuildRuns(options);
+  const byVersion = {};
+  for (const progress of runs) {
+    if (progress.version && !(progress.version in byVersion)) {
+      byVersion[progress.version] = progress;
+    }
+  }
+  return byVersion;
 };
 
 export const checkForAppUpdate = async ({
@@ -289,12 +331,28 @@ export const checkForAppUpdate = async ({
 
     if (!bestRelease) {
       if (foundReleasesWithoutApk) {
+        // The newer release(s) have no APK yet — a CI build is likely still running for each.
+        // Fetch every active build run once and tie each one to its release version, so when
+        // several releases are awaiting APKs we can show how far along each individual build is
+        // (not just the newest). The most recently started run is also surfaced top-level as
+        // `buildProgress` for the build-progress poller and legacy single-progress consumers.
+        const activeRuns = await fetchActiveBuildRuns({ owner, repo, fetchImpl });
+        const progressByVersion = {};
+        for (const progress of activeRuns) {
+          if (progress.version && !(progress.version in progressByVersion)) {
+            progressByVersion[progress.version] = progress;
+          }
+        }
+        const buildProgress = activeRuns.length > 0 ? activeRuns[0] : null;
+
         const releaseNotes = newerReleases
           .filter((r) => r.notes)
-          .map((r) => ({ version: r.version, notes: r.notes, hasApk: r.hasApk }));
-        // The newer release(s) have no APK yet — the CI build is likely still running. Surface
-        // how far along that build is so the user knows the APK is on its way.
-        const buildProgress = await fetchBuildProgress({ owner, repo, fetchImpl });
+          .map((r) => ({
+            version: r.version,
+            notes: r.notes,
+            hasApk: r.hasApk,
+            buildProgress: !r.hasApk ? (progressByVersion[r.version] || null) : null,
+          }));
         return {
           success: false,
           isUpdateAvailable: false,


### PR DESCRIPTION
## Summary

On the "Check for updates" page, when several newer releases are awaiting their APKs, only the single newest one showed a "Building N%" chip — driven by one top-level build-progress value. Older no-APK releases got nothing, even though each has its own CI build running.

This change checks the build for **each** no-APK release. Every active CI build run is matched to the release version it produces (via the tag in the run's `head_branch`), so each release that is still building surfaces its own progress chip.

## Changes

- **`app/services/AppUpdateService.js`**
  - Factor the workflow-runs fetch into `fetchActiveBuildRuns`, returning all active runs (newest-first), each tagged with the release version derived from its `head_branch`/`display_title`.
  - `fetchBuildProgress` now delegates to it (returns the newest run) — behavior unchanged.
  - Add `fetchBuildProgressByVersion`, mapping release version → build progress (most recent run wins on ties).
  - In `checkForAppUpdate`, attach a per-release `buildProgress` to each no-APK release in `releaseNotes`. The newest run is still surfaced top-level as `buildProgress` for the build-progress poller and legacy consumers.

- **`app/components/UpdateContentPanel.js`**
  - Render each release's own `buildProgress` chip. Falls back to the legacy single top-level progress on the newest no-APK release for older payloads.

## Tests

- New service tests for `fetchActiveBuildRuns`, `fetchBuildProgressByVersion`, version derivation from `head_branch`, and per-release progress in `checkForAppUpdate`.
- New `UpdateContentPanel` test asserting a chip appears on each building no-APK release.
- Full suite green: 3645 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WF5Qka9MZipXZNVPmeDgmb)_