### PR TITLE
fix: wrap operation labels to a second line instead of truncating the category name

### DIFF
--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -116,27 +116,23 @@ const OperationListItem = ({
           {/* Text */}
           <View style={styles.textContainer}>
             <View style={styles.titleRow}>
-              <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
+              <Text style={[styles.title, { color: colors.text }]}>
                 {title}
               </Text>
-              {visibleLabels.length > 0 && (
-                <View style={styles.labelRow}>
-                  {visibleLabels.map((label) => (
-                    <View
-                      key={label}
-                      style={[styles.labelChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
-                      testID={`op-label-${label}`}
-                    >
-                      <Text style={[styles.labelChipText, { color: colors.mutedText }]} numberOfLines={1}>
-                        {label}
-                      </Text>
-                    </View>
-                  ))}
-                  {overflowCount > 0 && (
-                    <View style={[styles.labelChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
-                      <Text style={[styles.labelChipText, { color: colors.mutedText }]}>{`+${overflowCount}`}</Text>
-                    </View>
-                  )}
+              {visibleLabels.map((label) => (
+                <View
+                  key={label}
+                  style={[styles.labelChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+                  testID={`op-label-${label}`}
+                >
+                  <Text style={[styles.labelChipText, { color: colors.mutedText }]} numberOfLines={1}>
+                    {label}
+                  </Text>
+                </View>
+              ))}
+              {overflowCount > 0 && (
+                <View style={[styles.labelChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
+                  <Text style={[styles.labelChipText, { color: colors.mutedText }]}>{`+${overflowCount}`}</Text>
                 </View>
               )}
             </View>
@@ -254,13 +250,6 @@ const styles = StyleSheet.create({
     fontWeight: FONT_WEIGHT.medium,
     maxWidth: 140,
   },
-  labelRow: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    flexShrink: 1,
-    gap: SPACING.xs,
-    marginLeft: SPACING.sm,
-  },
   row: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -291,6 +280,8 @@ const styles = StyleSheet.create({
   titleRow: {
     alignItems: 'center',
     flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.xs,
   },
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #1030. With long labels (e.g. imported `[MoneyOK] | Date: … | Amount: …` notes), the labels-beside-the-name row didn't wrap: it truncated the category name and spilled the chips over the amount on the right.

This makes the title row wrap so all three issues are fixed:

- **Category name is no longer truncated** — the title keeps its full width and wraps to additional lines if genuinely long, instead of ellipsis-truncating.
- **Labels no longer overlap the amount** — chips stay within the text column (`flex: 1`), never under the amount on the right.
- **Labels flow onto a second line** — `flexWrap` moves any chips that don't fit beside the name onto the next line. Short labels still sit next to the name; long ones wrap below.

## Implementation

In `OperationListItem.js`:
- `titleRow` is now `flexWrap: 'wrap'` with a `gap`, and the chips are rendered as direct siblings of the title (removed the inner non-wrapping `labelRow`).
- The title uses `flexShrink: 1` with no `numberOfLines`, so it wraps rather than truncates.

## Testing

- `npm test -- OperationListItem` → 26 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzABoxRn5j1dw4UasezyPa)_