### PR TITLE
feat: remove labels picker from search filters

### DIFF
--- a/__tests__/components/search/ExpandableFilters.test.js
+++ b/__tests__/components/search/ExpandableFilters.test.js
@@ -105,36 +105,6 @@ describe('ExpandableFilters', () => {
     });
   });
 
-  describe('Labels filter', () => {
-    it('renders a chip for a selected label even when it is absent from availableLabels', async () => {
-      // e.g. the only operation carrying "Coffee" was deleted, so getDistinctLabels
-      // no longer returns it — the chip must still appear so it can be toggled off.
-      const { getByTestId } = await render(
-        <ExpandableFilters
-          {...defaultProps}
-          availableLabels={['Food']}
-          filters={{ ...defaultFilters, labels: ['Coffee'] }}
-        />,
-      );
-      expect(getByTestId('filter-label-Coffee')).toBeTruthy();
-      expect(getByTestId('filter-label-Food')).toBeTruthy();
-    });
-
-    it('toggles a selected label off case-insensitively', async () => {
-      const { getByTestId } = await render(
-        <ExpandableFilters
-          {...defaultProps}
-          availableLabels={['coffee']}
-          filters={{ ...defaultFilters, labels: ['Coffee'] }}
-        />,
-      );
-      // The shown chip keeps the selected casing ("Coffee"); pressing it should
-      // DESELECT the already-selected label case-insensitively, not add a duplicate.
-      await fireEvent.press(getByTestId('filter-label-Coffee'));
-      expect(defaultProps.onFilterChange).toHaveBeenCalledWith({ labels: [] });
-    });
-  });
-
   describe('Amount range input', () => {
     it('preserves decimal point mid-typing without calling onFilterChange', async () => {
       const { getByPlaceholderText } = await render(<ExpandableFilters {...defaultProps} />);

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -10,7 +10,6 @@ const ExpandableFilters = ({
   filters,
   onFilterChange,
   accounts,
-  availableLabels = [],
   colors,
   t,
   isExpanded,
@@ -70,36 +69,6 @@ const ExpandableFilters = ({
       : [...filters.accountIds, accountId];
     onFilterChange({ accountIds: newAccountIds });
   };
-
-  // Case-insensitive toggle — labels are matched case-insensitively everywhere
-  // else (matchesAllLabels, getDistinctLabels de-dup), so the filter UI must be
-  // consistent or a label can end up both "selected" and re-addable.
-  const toggleLabel = (label) => {
-    const current = filters.labels || [];
-    const key = label.toLowerCase();
-    const exists = current.some(l => l.toLowerCase() === key);
-    const newLabels = exists
-      ? current.filter(l => l.toLowerCase() !== key)
-      : [...current, label];
-    onFilterChange({ labels: newLabels });
-  };
-
-  // Show every available label plus any currently-selected label that is no longer
-  // in availableLabels (e.g. the only operation carrying it was deleted, or casing
-  // drifted). Without this a stale selected label keeps filtering to zero results
-  // with no chip to toggle it off. De-duplicated case-insensitively, selected first.
-  const selectedLabels = filters.labels || [];
-  const labelsToShow = (() => {
-    const seen = new Set();
-    const out = [];
-    for (const l of [...selectedLabels, ...availableLabels]) {
-      const key = l.toLowerCase();
-      if (seen.has(key)) continue;
-      seen.add(key);
-      out.push(l);
-    }
-    return out;
-  })();
 
   const handleStartDateChange = (event, selectedDate) => {
     setShowStartDatePicker(false);
@@ -270,36 +239,6 @@ const ExpandableFilters = ({
           </View>
         </View>
 
-        {/* Labels Section */}
-        {labelsToShow.length > 0 && (
-          <View style={[styles.section, { borderBottomColor: colors.border }]}>
-            <Text style={[styles.sectionLabel, { color: colors.mutedText }]}>
-              {t('labels')}
-            </Text>
-            <View style={styles.chipContainer}>
-              {labelsToShow.map(label => {
-                const isSelected = selectedLabels.some(l => l.toLowerCase() === label.toLowerCase());
-                const chipTextColor = isSelected ? '#fff' : colors.text;
-                return (
-                  <TouchableOpacity
-                    key={label}
-                    testID={`filter-label-${label}`}
-                    style={[styles.chip, {
-                      backgroundColor: isSelected ? colors.primary : colors.inputBackground,
-                      borderColor: colors.border,
-                    }]}
-                    onPress={() => toggleLabel(label)}
-                  >
-                    <Text style={[styles.chipText, { color: chipTextColor }]}>
-                      {label}
-                    </Text>
-                  </TouchableOpacity>
-                );
-              })}
-            </View>
-          </View>
-        )}
-
         <TouchableOpacity
           testID="clear-all-button"
           style={styles.clearAllButton}
@@ -354,7 +293,6 @@ ExpandableFilters.propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
   })).isRequired,
-  availableLabels: PropTypes.arrayOf(PropTypes.string),
   colors: PropTypes.shape({
     background: PropTypes.string,
     text: PropTypes.string,

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   StyleSheet,
   Dimensions,
@@ -10,7 +10,6 @@ import { useOperationsData } from '../../contexts/OperationsDataContext';
 import { useOperationsActions } from '../../contexts/OperationsActionsContext';
 import { useAccountsData } from '../../contexts/AccountsDataContext';
 import { useSearch } from '../../contexts/SearchContext';
-import { getDistinctLabels } from '../../services/OperationsDB';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 
@@ -19,17 +18,6 @@ const SearchOverlay = ({ colors, t, visible, onHeightChange, topOffset }) => {
   const { filtersExpanded } = useSearch();
   const { updateSearchFilters } = useOperationsActions();
   const { visibleAccounts } = useAccountsData();
-
-  // Available labels for the label filter chips — refreshed each time the overlay opens.
-  const [availableLabels, setAvailableLabels] = useState([]);
-  useEffect(() => {
-    if (!visible) return undefined;
-    let cancelled = false;
-    getDistinctLabels(50)
-      .then(labels => { if (!cancelled) setAvailableLabels(labels); })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [visible]);
 
   const translateY = useSharedValue(-SCREEN_HEIGHT);
 
@@ -73,7 +61,6 @@ const SearchOverlay = ({ colors, t, visible, onHeightChange, topOffset }) => {
         filters={searchState}
         onFilterChange={handleFilterChange}
         accounts={visibleAccounts}
-        availableLabels={availableLabels}
         colors={colors}
         t={t}
         isExpanded={filtersExpanded}


### PR DESCRIPTION
## Summary

Disables choosing labels in the search filter panel, as requested. Free-text search still finds operations by their labels.

Labels are stored inside an operation's `description` field (see `labelUtils.js`), and free-text search already matches `op.description`. The dedicated label-filter section in the filter panel was therefore redundant — removing it disables structured label filtering while keeping label search via the search box.

## Changes

- **`ExpandableFilters.js`** — removed the "Labels" filter section along with its `toggleLabel` handler, the `labelsToShow`/`selectedLabels` computation, and the `availableLabels` prop.
- **`SearchOverlay.js`** — stopped fetching distinct labels (`getDistinctLabels`) and dropped the `availableLabels` state/effect that only fed the picker.
- **`ExpandableFilters.test.js`** — removed the now-obsolete "Labels filter" test block.

## Notes

- Free-text label search is unchanged (labels live in the description, which the text query matches).
- Any pre-existing/persisted label filter remains visible and clearable via the filter chip strip and the "Clear all" button — it just can no longer be re-added from the panel.
- Labels on operations themselves (adding/suggesting labels) are untouched.
- All 3690 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PsicUCRgqk71MJ3HfrQ4R

---
_Generated by [Claude Code](https://claude.ai/code/session_011PsicUCRgqk71MJ3HfrQ4R)_