### PR TITLE
feat: hide imported metadata labels in operation list and protect MoneyOK operations

### DIFF
--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -164,6 +164,25 @@ describe('OperationListItem', () => {
       expect(getByText('lunch')).toBeTruthy();
     });
 
+    it('hides imported system metadata labels in the list', async () => {
+      const { getByText, queryByText } = await render(
+        <OperationListItem
+          {...baseProps}
+          operation={{
+            ...baseOperation,
+            description: '[MoneyOK] | Account: Cash | groceries | Category: Food | Category group: Expenses',
+          }}
+        />,
+      );
+      // Ordinary labels and the [MoneyOK] marker remain visible...
+      expect(getByText('groceries')).toBeTruthy();
+      expect(getByText('[MoneyOK]')).toBeTruthy();
+      // ...but the Account:/Category:/Category group: metadata labels are hidden.
+      expect(queryByText('Account: Cash')).toBeNull();
+      expect(queryByText('Category: Food')).toBeNull();
+      expect(queryByText('Category group: Expenses')).toBeNull();
+    });
+
     it('summarises overflow labels as +N', async () => {
       const { getByText } = await render(
         <OperationListItem

--- a/__tests__/hooks/useOperationForm.test.js
+++ b/__tests__/hooks/useOperationForm.test.js
@@ -214,6 +214,64 @@ describe('useOperationForm', () => {
     });
   });
 
+  describe('Protected MoneyOK Operations', () => {
+    it('should not allow deletion of operations with system metadata labels', async () => {
+      const importedOperation = {
+        id: 'op-1',
+        categoryId: 'cat-1',
+        date: new Date().toISOString().split('T')[0],
+        description: 'Account: Cash | groceries',
+      };
+
+      const props = { ...defaultProps, operation: importedOperation, isNew: false };
+      const { result } = await renderHook(() => useOperationForm(props));
+
+      expect(result.current.canDeleteShadowOperation).toBe(false);
+    });
+
+    it('should not allow deletion of operations with the [MoneyOK] marker', async () => {
+      const importedOperation = {
+        id: 'op-1',
+        categoryId: 'cat-1',
+        date: new Date().toISOString().split('T')[0],
+        description: '[MoneyOK] | groceries',
+      };
+
+      const props = { ...defaultProps, operation: importedOperation, isNew: false };
+      const { result } = await renderHook(() => useOperationForm(props));
+
+      expect(result.current.canDeleteShadowOperation).toBe(false);
+    });
+
+    it('should not allow deletion of operations with a Category group: label', async () => {
+      const importedOperation = {
+        id: 'op-1',
+        categoryId: 'cat-1',
+        date: new Date().toISOString().split('T')[0],
+        description: 'Category group: Expenses | rent',
+      };
+
+      const props = { ...defaultProps, operation: importedOperation, isNew: false };
+      const { result } = await renderHook(() => useOperationForm(props));
+
+      expect(result.current.canDeleteShadowOperation).toBe(false);
+    });
+
+    it('should still allow deletion of operations without protected labels', async () => {
+      const regularOperation = {
+        id: 'op-1',
+        categoryId: 'cat-1',
+        date: new Date().toISOString().split('T')[0],
+        description: 'groceries | food',
+      };
+
+      const props = { ...defaultProps, operation: regularOperation, isNew: false };
+      const { result } = await renderHook(() => useOperationForm(props));
+
+      expect(result.current.canDeleteShadowOperation).toBe(true);
+    });
+  });
+
   describe('Multi-Currency Transfers', () => {
     it('should detect multi-currency transfers', async () => {
       const { result } = await renderHook(() => useOperationForm(defaultProps));

--- a/__tests__/utils/labelUtils.test.js
+++ b/__tests__/utils/labelUtils.test.js
@@ -11,6 +11,9 @@ import {
   addLabel,
   removeLabel,
   matchesAllLabels,
+  isSystemLabel,
+  visibleListLabels,
+  isProtectedOperation,
 } from '../../app/utils/labelUtils';
 
 describe('labelUtils', () => {
@@ -209,6 +212,77 @@ describe('labelUtils', () => {
     it('matches a legacy [MoneyOK] segment as a filterable label', () => {
       expect(matchesAllLabels('[MoneyOK] | groceries', ['[MoneyOK]'])).toBe(true);
       expect(matchesAllLabels('[MoneyOK] | groceries', ['groceries'])).toBe(true);
+    });
+  });
+
+  describe('isSystemLabel', () => {
+    it('flags Account:/Category:/Category group: labels (case-insensitive)', () => {
+      expect(isSystemLabel('Account: Cash')).toBe(true);
+      expect(isSystemLabel('Category: Food')).toBe(true);
+      expect(isSystemLabel('Category group: Expenses')).toBe(true);
+      expect(isSystemLabel('account: cash')).toBe(true);
+      expect(isSystemLabel('  Category group:  Income ')).toBe(true);
+    });
+
+    it('does not flag ordinary labels or the [MoneyOK] marker', () => {
+      expect(isSystemLabel('groceries')).toBe(false);
+      expect(isSystemLabel('[MoneyOK]')).toBe(false);
+      expect(isSystemLabel('Accountant')).toBe(false);
+      expect(isSystemLabel('My Category')).toBe(false);
+    });
+
+    it('returns false for empty or non-string input', () => {
+      expect(isSystemLabel('')).toBe(false);
+      expect(isSystemLabel(null)).toBe(false);
+      expect(isSystemLabel(undefined)).toBe(false);
+      expect(isSystemLabel(42)).toBe(false);
+    });
+  });
+
+  describe('visibleListLabels', () => {
+    it('drops system labels but keeps ordinary ones and [MoneyOK]', () => {
+      const labels = parseLabels('[MoneyOK] | Account: Cash | groceries | Category: Food | Category group: Expenses');
+      expect(visibleListLabels(labels)).toEqual(['[MoneyOK]', 'groceries']);
+    });
+
+    it('returns all labels when none are system labels', () => {
+      expect(visibleListLabels(['work', 'food'])).toEqual(['work', 'food']);
+    });
+
+    it('returns [] for non-arrays', () => {
+      expect(visibleListLabels(null)).toEqual([]);
+      expect(visibleListLabels(undefined)).toEqual([]);
+    });
+
+    it('does not mutate the input array', () => {
+      const input = ['Account: Cash', 'food'];
+      const result = visibleListLabels(input);
+      expect(input).toEqual(['Account: Cash', 'food']);
+      expect(result).toEqual(['food']);
+    });
+  });
+
+  describe('isProtectedOperation', () => {
+    it('protects operations carrying a system metadata label', () => {
+      expect(isProtectedOperation('Account: Cash | groceries')).toBe(true);
+      expect(isProtectedOperation('Category: Food')).toBe(true);
+      expect(isProtectedOperation('Category group: Expenses | rent')).toBe(true);
+    });
+
+    it('protects operations carrying the [MoneyOK] marker', () => {
+      expect(isProtectedOperation('[MoneyOK] | groceries')).toBe(true);
+      expect(isProtectedOperation('[moneyok]')).toBe(true);
+    });
+
+    it('does not protect ordinary operations', () => {
+      expect(isProtectedOperation('groceries | food')).toBe(false);
+      expect(isProtectedOperation('Coffee at the airport')).toBe(false);
+    });
+
+    it('returns false for empty or non-string input', () => {
+      expect(isProtectedOperation('')).toBe(false);
+      expect(isProtectedOperation(null)).toBe(false);
+      expect(isProtectedOperation(undefined)).toBe(false);
     });
   });
 });

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -4,7 +4,7 @@ import { TouchableRipple } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
-import { parseLabels } from '../../utils/labelUtils';
+import { parseLabels, visibleListLabels } from '../../utils/labelUtils';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
@@ -60,8 +60,10 @@ const OperationListItem = ({
   // The description column holds a delimited list of labels (see labelUtils).
   // Memoised so the parse only re-runs when the description string changes,
   // not on every re-render of this memoised row (scroll, theme, selection, …).
+  // Imported metadata labels (Account:/Category:/Category group:) are hidden in
+  // the list; they remain visible when the operation is opened.
   const labels = useMemo(
-    () => parseLabels(operation.description),
+    () => visibleListLabels(parseLabels(operation.description)),
     [operation.description],
   );
   const visibleLabels = labels.slice(0, MAX_VISIBLE_LABELS);

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -3,6 +3,7 @@ import { Keyboard } from 'react-native';
 import { formatDate } from '../services/BalanceHistoryDB';
 import { getLastAccessedAccount, setLastAccessedAccount } from '../services/LastAccount';
 import { getCategoryDisplayName } from '../utils/categoryUtils';
+import { isProtectedOperation } from '../utils/labelUtils';
 import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
 import * as Currency from '../services/currency';
 import currencies from '../../assets/currencies.json';
@@ -76,10 +77,19 @@ const useOperationForm = ({
     return operation.date === today;
   }, [operation]);
 
-  // Shadow operations can only be deleted if they were made today
+  // Imported MoneyOK operations carry protected metadata labels (Account:/Category:/
+  // Category group:/[MoneyOK]) and must never be deletable.
+  const isProtectedImport = useMemo(() => {
+    if (!operation) return false;
+    return isProtectedOperation(operation.description);
+  }, [operation]);
+
+  // Delete is allowed unless the operation is a protected import, or a shadow
+  // operation that was not created today.
   const canDeleteShadowOperation = useMemo(() => {
+    if (isProtectedImport) return false;
     return !isShadowOperation || isOperationToday;
-  }, [isShadowOperation, isOperationToday]);
+  }, [isShadowOperation, isOperationToday, isProtectedImport]);
 
   // Multi-currency transfer logic
   const sourceAccount = useMemo(() => {

--- a/app/utils/labelUtils.js
+++ b/app/utils/labelUtils.js
@@ -23,6 +23,14 @@ export const LABEL_JOIN = ' | ';
 export const MAX_LABELS = 30;
 export const MAX_LABEL_LENGTH = 60;
 
+// Prefixes that mark a label as imported metadata (e.g. from a MoneyOK export).
+// These clutter the operation list, so they are hidden there while still shown
+// when the operation is opened for editing. Matching is case-insensitive.
+export const SYSTEM_LABEL_PREFIXES = ['Account:', 'Category:', 'Category group:'];
+
+// Marker tag identifying an operation imported from MoneyOK.
+export const MONEYOK_LABEL = '[MoneyOK]';
+
 /**
  * Normalise a single label WITHOUT enforcing the length cap: drop the delimiter,
  * collapse internal whitespace, and trim. Returns '' for anything unusable.
@@ -139,6 +147,44 @@ export const removeLabel = (labels, target) => {
   const clean = normalizeLabel(target).toLowerCase();
   if (!clean) return labels.slice();
   return labels.filter((l) => normalizeLabel(l).toLowerCase() !== clean);
+};
+
+/**
+ * Whether a single label is a hidden "system" label — imported metadata such as
+ * "Account: Cash" or "Category group: Expenses". Matching is case-insensitive and
+ * tolerant of surrounding whitespace.
+ * @param {*} label
+ * @returns {boolean}
+ */
+export const isSystemLabel = (label) => {
+  const clean = normalizeLabel(label).toLowerCase();
+  if (!clean) return false;
+  return SYSTEM_LABEL_PREFIXES.some((prefix) => clean.startsWith(prefix.toLowerCase()));
+};
+
+/**
+ * Return only the labels meant for the operation list, dropping hidden system
+ * labels. Never mutates the input.
+ * @param {string[]} labels
+ * @returns {string[]}
+ */
+export const visibleListLabels = (labels) => {
+  if (!Array.isArray(labels)) return [];
+  return labels.filter((l) => !isSystemLabel(l));
+};
+
+/**
+ * Whether an operation's description marks it as a protected import — it carries
+ * either a system label (Account:/Category:/Category group:) or the [MoneyOK]
+ * marker. Protected operations are non-deletable.
+ * @param {*} description
+ * @returns {boolean}
+ */
+export const isProtectedOperation = (description) => {
+  const labels = parseLabels(description);
+  if (labels.length === 0) return false;
+  const moneyOk = MONEYOK_LABEL.toLowerCase();
+  return labels.some((l) => isSystemLabel(l) || normalizeLabel(l).toLowerCase() === moneyOk);
 };
 
 /**


### PR DESCRIPTION
## Summary

Imported MoneyOK operations store metadata inside their `description` field as labels — e.g. `Account: Cash`, `Category: Food`, `Category group: Expenses` — alongside a `[MoneyOK]` marker. These metadata labels clutter the operations list.

This PR:

- **Hides** labels starting with `Account:`, `Category:`, or `Category group:` from the operations **list** (chips). Ordinary labels and the `[MoneyOK]` marker still show.
- **Still shows** all labels (including the hidden metadata ones) when the operation is **opened** for editing, via the existing label editor in `OperationModal`.
- **Protects** operations carrying any of those system labels or the `[MoneyOK]` marker by making them **non-deletable** (the delete action is disabled in the modal, same mechanism used for shadow operations).

## Implementation

New helpers in `app/utils/labelUtils.js` (single source of truth for labels):

- `isSystemLabel(label)` — case-insensitive prefix check against `Account:` / `Category:` / `Category group:`.
- `visibleListLabels(labels)` — drops system labels for list display.
- `isProtectedOperation(description)` — true when a description carries a system label or the `[MoneyOK]` marker.

Wiring:

- `OperationListItem.js` filters labels through `visibleListLabels` before rendering chips.
- `useOperationForm.js` computes `isProtectedImport` and folds it into `canDeleteShadowOperation`, which `OperationModal` already uses to gate deletion.

## Testing

- Added unit tests for the three new `labelUtils` helpers.
- Added `OperationListItem` test asserting metadata labels are hidden while ordinary labels and `[MoneyOK]` remain.
- Added `useOperationForm` tests asserting protected operations are non-deletable and ordinary ones remain deletable.
- Full suite: **3708 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYJUGbc2JcDjdKwCwMXm2e)_