### PR TITLE
fix: detect truncated cached APK without a checksum before offering install

### DIFF
--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -7,6 +7,7 @@ import {
   cleanupOldApks,
   checkAlreadyDownloaded,
   verifyCachedApk,
+  verifyApkStructure,
   sanitizeFilename,
   fetchExpectedChecksum,
   computeSha256,
@@ -756,6 +757,15 @@ describe('AppUpdateService', () => {
     // 'aGVsbG8=' = base64("hello"); SHA-256("hello") is this known constant
     const HELLO_B64 = 'aGVsbG8=';
     const HELLO_SHA = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+    // Base64 of the ZIP signatures used by the structural integrity fallback.
+    const APK_HEAD_B64 = 'UEsDBA=='; // PK\x03\x04 — local file header
+    const APK_EOCD_B64 = 'UEsFBg=='; // PK\x05\x06 — End Of Central Directory record
+    // Make the structural check (head read, then tail read) see a complete archive.
+    const mockIntactApkStructure = () => {
+      FileSystem.readAsStringAsync
+        .mockResolvedValueOnce(APK_HEAD_B64)
+        .mockResolvedValueOnce(APK_EOCD_B64);
+    };
 
     it('reports exists:false when no cached APK is present', async () => {
       FileSystem.getInfoAsync.mockResolvedValue({ exists: false, size: 0 });
@@ -769,13 +779,32 @@ describe('AppUpdateService', () => {
       expect(result).toEqual({ exists: false });
     });
 
-    it('returns verified:false when no checksum URL is provided', async () => {
+    it('returns verified:false when no checksum URL is provided and the file is structurally intact', async () => {
       FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+      mockIntactApkStructure();
 
       const result = await verifyCachedApk(URL, { cacheDir: 'file:///cache/' });
 
       expect(result).toEqual({ exists: true, uri: 'file:///cache/penny-v1.0.0.apk', verified: false });
-      expect(FileSystem.readAsStringAsync).not.toHaveBeenCalled();
+      expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+    });
+
+    it('deletes the file and reports corrupted when no checksum and the file is structurally truncated', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+      FileSystem.deleteAsync.mockResolvedValue();
+      // Valid header but the tail has no End Of Central Directory record (truncated download).
+      FileSystem.readAsStringAsync
+        .mockResolvedValueOnce(APK_HEAD_B64)
+        .mockResolvedValueOnce('AAAAAAAA'); // decodes to zero bytes — no EOCD signature
+
+      const result = await verifyCachedApk(URL, { cacheDir: 'file:///cache/' });
+
+      expect(result).toEqual({ exists: false, corrupted: true });
+      expect(FileSystem.deleteAsync).toHaveBeenCalledWith(
+        'file:///cache/penny-v1.0.0.apk',
+        { idempotent: true },
+      );
     });
 
     it('returns verified:true when the cached APK matches the checksum', async () => {
@@ -819,8 +848,9 @@ describe('AppUpdateService', () => {
       );
     });
 
-    it('keeps the file (verified:false) when the checksum file cannot be fetched', async () => {
+    it('falls back to the structural check (verified:false) when the checksum file cannot be fetched', async () => {
       FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+      mockIntactApkStructure();
       const fetchImpl = jest.fn().mockResolvedValue({ ok: false });
 
       const result = await verifyCachedApk(URL, {
@@ -831,6 +861,25 @@ describe('AppUpdateService', () => {
 
       expect(result).toEqual({ exists: true, uri: 'file:///cache/penny-v1.0.0.apk', verified: false });
       expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+    });
+
+    it('deletes the file when the checksum is unfetchable AND the file is structurally truncated', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 12345 });
+      FileSystem.deleteAsync.mockResolvedValue();
+      FileSystem.readAsStringAsync
+        .mockResolvedValueOnce(APK_HEAD_B64)
+        .mockResolvedValueOnce('AAAAAAAA'); // no EOCD
+      const fetchImpl = jest.fn().mockResolvedValue({ ok: false });
+
+      const result = await verifyCachedApk(URL, {
+        checksumUrl: 'https://example.com/penny-v1.0.0.apk.sha256',
+        cacheDir: 'file:///cache/',
+        fetchImpl,
+      });
+
+      expect(result).toEqual({ exists: false, corrupted: true });
+      expect(FileSystem.deleteAsync).toHaveBeenCalled();
     });
 
     it('keeps the file (verified:false) when hashing throws (OOM / read error)', async () => {
@@ -850,6 +899,73 @@ describe('AppUpdateService', () => {
 
       expect(result).toEqual({ exists: true, uri: 'file:///cache/penny-v1.0.0.apk', verified: false });
       expect(FileSystem.deleteAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyApkStructure', () => {
+    const FILE = 'file:///cache/penny-v1.0.0.apk';
+    const APK_HEAD_B64 = 'UEsDBA=='; // PK\x03\x04
+    const APK_EOCD_B64 = 'UEsFBg=='; // PK\x05\x06
+
+    it('returns true for a complete archive (valid header + trailing EOCD)', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 40_000_000 });
+      FileSystem.readAsStringAsync
+        .mockResolvedValueOnce(APK_HEAD_B64)
+        .mockResolvedValueOnce(APK_EOCD_B64);
+
+      expect(await verifyApkStructure(FILE)).toBe(true);
+    });
+
+    it('reads only the head and tail, never the whole file', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 40_000_000 });
+      FileSystem.readAsStringAsync
+        .mockResolvedValueOnce(APK_HEAD_B64)
+        .mockResolvedValueOnce(APK_EOCD_B64);
+
+      await verifyApkStructure(FILE);
+
+      expect(FileSystem.readAsStringAsync).toHaveBeenCalledTimes(2);
+      // Head: first 4 bytes from position 0.
+      expect(FileSystem.readAsStringAsync).toHaveBeenNthCalledWith(1, FILE, {
+        encoding: 'base64', position: 0, length: 4,
+      });
+      // Tail: the last ≤64KB, never offset 0 on a large file.
+      const tailCall = FileSystem.readAsStringAsync.mock.calls[1][1];
+      expect(tailCall.length).toBe(65557);
+      expect(tailCall.position).toBe(40_000_000 - 65557);
+    });
+
+    it('returns false when the End Of Central Directory record is missing (truncated)', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 40_000_000 });
+      FileSystem.readAsStringAsync
+        .mockResolvedValueOnce(APK_HEAD_B64)
+        .mockResolvedValueOnce('AAAAAAAA'); // zero bytes, no signature
+
+      expect(await verifyApkStructure(FILE)).toBe(false);
+    });
+
+    it('returns false when the local file header magic is wrong', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 40_000_000 });
+      FileSystem.readAsStringAsync.mockResolvedValueOnce('AAAAAAAA'); // not PK\x03\x04
+
+      expect(await verifyApkStructure(FILE)).toBe(false);
+      // Bails out after the header read — never bothers reading the tail.
+      expect(FileSystem.readAsStringAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when the file is too small to be a valid archive', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 10 });
+
+      expect(await verifyApkStructure(FILE)).toBe(false);
+      expect(FileSystem.readAsStringAsync).not.toHaveBeenCalled();
+    });
+
+    it('returns true (cannot determine) when the file cannot be read', async () => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+      FileSystem.getInfoAsync.mockResolvedValue({ exists: true, size: 40_000_000 });
+      FileSystem.readAsStringAsync.mockRejectedValue(new Error('read failed'));
+
+      expect(await verifyApkStructure(FILE)).toBe(true);
     });
   });
 

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -468,16 +468,21 @@ export const checkAlreadyDownloaded = async (downloadUrl, cacheDir = FileSystem.
 };
 
 // Verifies the integrity of an APK already sitting in the cache for the given download URL.
-// A previous download can be left truncated or corrupt (interrupted transfer, full disk), in
-// which case offering "Install now" would launch a broken installer. When a checksum is
-// available we hash the cached file and, on mismatch, delete it so callers re-download cleanly.
+// A previous download can be left truncated or corrupt (interrupted transfer, app killed
+// mid-download, full disk), in which case offering "Install now" launches a broken installer
+// that Android rejects with "There's a problem with the app file".
+//
+// Two layers of defence:
+//   1. Checksum — when the release ships a .sha256 we hash the file and compare (strongest signal).
+//   2. Structure — when no checksum is usable (asset missing, unfetchable, or hashing OOMed) we
+//      fall back to a lightweight ZIP-structure check that still catches truncated downloads.
+// A file that fails either layer is deleted so callers re-download cleanly.
 //
 // Returns one of:
 //   { exists: false }                          — no usable cached file (absent or zero-size)
-//   { exists: false, corrupted: true }         — cached file failed the checksum and was deleted
+//   { exists: false, corrupted: true }         — cached file failed verification and was deleted
 //   { exists: true, uri, verified: true }      — checksum matched
-//   { exists: true, uri, verified: false }     — present but integrity could not be confirmed
-//                                                 (no checksum, unfetchable checksum, or hash error)
+//   { exists: true, uri, verified: false }     — checksum unavailable but the file is structurally intact
 export const verifyCachedApk = async (
   downloadUrl,
   { checksumUrl = null, cacheDir = FileSystem.cacheDirectory, fetchImpl = fetch } = {},
@@ -487,36 +492,38 @@ export const verifyCachedApk = async (
     return { exists: false };
   }
 
-  // Without a checksum we can confirm the file is present and non-empty, but not prove
-  // integrity — treat it as usable but unverified.
-  if (!checksumUrl) {
-    return { exists: true, uri: localUri, verified: false };
+  // Layer 1: checksum verification when a checksum is available — the strongest proof.
+  if (checksumUrl) {
+    const filename = localUri.split('/').pop();
+    const expectedHash = await fetchExpectedChecksum(checksumUrl, filename, fetchImpl);
+    if (expectedHash) {
+      try {
+        const actualHash = await computeSha256(localUri);
+        if (actualHash !== expectedHash) {
+          await FileSystem.deleteAsync(localUri, { idempotent: true });
+          console.warn('[AppUpdate] cached APK failed checksum; deleted corrupt file', localUri);
+          return { exists: false, corrupted: true };
+        }
+        return { exists: true, uri: localUri, verified: true };
+      } catch (e) {
+        // Hashing can OOM on large APKs (reads the whole file into the JS heap). Fall through to
+        // the structural check rather than trusting the file outright.
+        console.warn('[AppUpdate] cached APK checksum computation failed; falling back to structure check', e.message);
+      }
+    }
+    // expectedHash null → checksum asset missing/unfetchable/unparseable; fall through to structure.
   }
 
-  const filename = localUri.split('/').pop();
-  const expectedHash = await fetchExpectedChecksum(checksumUrl, filename, fetchImpl);
-  if (!expectedHash) {
-    // Checksum file unavailable or unparseable — cannot verify, keep the file.
-    return { exists: true, uri: localUri, verified: false };
-  }
-
-  let actualHash;
-  try {
-    actualHash = await computeSha256(localUri);
-  } catch (e) {
-    // Hashing can OOM on large APKs (reads the whole file into the JS heap). A failure here
-    // means "unable to verify", not "corrupt" — keep the file rather than discarding a good one.
-    console.warn('[AppUpdate] cached APK checksum computation failed; skipping verification', e.message);
-    return { exists: true, uri: localUri, verified: false };
-  }
-
-  if (actualHash !== expectedHash) {
+  // Layer 2: no usable checksum — verify the file is a structurally complete ZIP/APK so we still
+  // catch truncated or partially-written downloads.
+  const intact = await verifyApkStructure(localUri);
+  if (!intact) {
     await FileSystem.deleteAsync(localUri, { idempotent: true });
-    console.warn('[AppUpdate] cached APK failed checksum; deleted corrupt file', localUri);
+    console.warn('[AppUpdate] cached APK is structurally invalid; deleted corrupt file', localUri);
     return { exists: false, corrupted: true };
   }
 
-  return { exists: true, uri: localUri, verified: true };
+  return { exists: true, uri: localUri, verified: false };
 };
 
 // Pre-built lookup table for base64 → 6-bit value. Avoids atob() + charCodeAt loop.
@@ -544,6 +551,61 @@ const base64ToBytes = (b64) => {
     if (j < byteLen) out[j++] = v & 0xff;
   }
   return out;
+};
+
+// ZIP signatures, little-endian, in the byte order they appear on disk.
+const ZIP_LOCAL_HEADER = [0x50, 0x4b, 0x03, 0x04]; // "PK\x03\x04" — first local file header
+const ZIP_EOCD = [0x50, 0x4b, 0x05, 0x06];         // "PK\x05\x06" — End Of Central Directory record
+// The EOCD is 22 bytes plus an optional comment of up to 0xFFFF bytes, so it lives within the
+// last ~64KB of a valid archive. We never need to read more than this to find it.
+const MAX_EOCD_SCAN = 22 + 0xffff; // 65557
+const EOCD_MIN_SIZE = 22; // a ZIP with no entries is still at least one 22-byte EOCD record
+
+// Checksum-independent integrity check for a cached APK. An APK is a ZIP archive: it must begin
+// with a local file header (PK\x03\x04) and end with an End Of Central Directory record
+// (PK\x05\x06) within the last ~64KB. A truncated or partially-written download — the usual cause
+// of Android's "There's a problem with the app file" — is missing the trailing EOCD, so this
+// catches exactly the corruption the OS installer would reject.
+//
+// Reads only the head (4 bytes) and tail (≤64KB), never the whole 30-50MB file, so it is cheap
+// and OOM-safe. Returns true when the file looks intact OR when it cannot be inspected (a read
+// error must not cause us to delete a possibly-good file — let other signals decide).
+export const verifyApkStructure = async (fileUri) => {
+  try {
+    const info = await FileSystem.getInfoAsync(fileUri);
+    const size = info?.size;
+    if (!Number.isFinite(size) || size < EOCD_MIN_SIZE) {
+      return false; // too small to be a valid APK/ZIP
+    }
+
+    const headB64 = await FileSystem.readAsStringAsync(fileUri, {
+      encoding: FileSystem.EncodingType.Base64,
+      position: 0,
+      length: 4,
+    });
+    const head = base64ToBytes(headB64);
+    if (head.length < 4 || !ZIP_LOCAL_HEADER.every((b, i) => head[i] === b)) {
+      return false;
+    }
+
+    const tailLen = Math.min(size, MAX_EOCD_SCAN);
+    const tailB64 = await FileSystem.readAsStringAsync(fileUri, {
+      encoding: FileSystem.EncodingType.Base64,
+      position: size - tailLen,
+      length: tailLen,
+    });
+    const tail = base64ToBytes(tailB64);
+    for (let i = tail.length - 4; i >= 0; i -= 1) {
+      if (tail[i] === ZIP_EOCD[0] && tail[i + 1] === ZIP_EOCD[1]
+        && tail[i + 2] === ZIP_EOCD[2] && tail[i + 3] === ZIP_EOCD[3]) {
+        return true; // found the End Of Central Directory record — archive is complete
+      }
+    }
+    return false; // no EOCD in the tail → truncated/corrupt
+  } catch (e) {
+    console.warn('[AppUpdate] APK structure check could not read file; skipping', e.message);
+    return true; // unable to determine → do not treat as corrupt
+  }
 };
 
 // Uses the native Web Crypto API (crypto.subtle) available in Hermes (RN 0.71+).


### PR DESCRIPTION
## Problem

A user hit **"Can't install app — There's a problem with the app file"** when tapping **Install now** on a cached update APK (see report screenshot).

The cached-APK guard added in #1017 (`verifyCachedApk`) only re-downloads when the release's `.sha256` checksum is **both present and fetchable**. If the checksum couldn't be fetched — network blip, GitHub rate limit, or the `.sha256` asset not uploaded yet — a **truncated leftover download was kept** and still offered as *Install now*. Android then rejects the incomplete file with the "problem with the app file" dialog, with no way out.

## Fix

Add a **checksum-independent structural integrity check** as a second layer of defence:

- An APK is a ZIP archive — it must begin with a local file header (`PK\x03\x04`) and end with an **End Of Central Directory** record (`PK\x05\x06`) within the last ~64 KB.
- A truncated / partially written download is missing the trailing EOCD — which is precisely the corruption Android's installer rejects.
- **`verifyApkStructure`** reads only the **head (4 bytes)** and **tail (≤64 KB)**, never the whole 30–50 MB file, so it stays cheap and OOM-safe (verified against the Expo `readAsStringAsync` `position`/`length` partial-read API).

`verifyCachedApk` now layers the two checks:

1. **Checksum** when a usable `.sha256` is available (strongest signal — unchanged).
2. **Structure** whenever the checksum is missing, unfetchable, or hashing OOMs.

A file that fails either layer is deleted, so the updates panel falls back to **Update now** (a fresh re-download) and shows the existing "previous download was damaged" note — no UI or i18n changes needed.

## Tests

- New `verifyApkStructure` suite: complete archive → true; missing EOCD (truncated) → false; bad header magic → false; too small → false; unreadable file → true (can't-determine, never deletes a good file); asserts only head + tail are read.
- Updated `verifyCachedApk` suite: structurally intact no-checksum file kept; truncated no-checksum file deleted; unfetchable checksum now falls through to the structural check (kept when intact, deleted when truncated).
- Full suite green: **3714 passed**, ESLint clean.

## Note
This is a follow-up to the now-merged #1017. The reporter's installed build (v0.144.1) predates both fixes, so they'll get the improved behaviour once on a build that includes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhoCzrsE55cJrxV3soW46e)_