### PR TITLE
feat: refine operation label display (imported metadata, Note, balance adjustments)

### DIFF
--- a/__tests__/components/operations/LabelInput.test.js
+++ b/__tests__/components/operations/LabelInput.test.js
@@ -34,6 +34,15 @@ describe('LabelInput', () => {
     expect(getByText('food')).toBeTruthy();
   });
 
+  it('shows a balance-adjustment label without the "Balance adjusted from" prefix', async () => {
+    const { getByText, queryByText } = await renderInput({
+      value: 'Balance adjusted from 62000.00 → 66000.00',
+      editable: false,
+    });
+    expect(getByText('62000.00 → 66000.00')).toBeTruthy();
+    expect(queryByText('Balance adjusted from 62000.00 → 66000.00')).toBeNull();
+  });
+
   it('adds a label on submit and serialises with the delimiter', async () => {
     const onChangeText = jest.fn();
     const { getByTestId } = await renderInput({ value: 'work', onChangeText });

--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -170,17 +170,34 @@ describe('OperationListItem', () => {
           {...baseProps}
           operation={{
             ...baseOperation,
-            description: '[MoneyOK] | Account: Cash | groceries | Category: Food | Category group: Expenses',
+            description: '[MoneyOK] | Account: Cash | groceries | Category: Food | Category group: Expenses | Date: 2025.11.03 | Amount: 1172300 AMD',
           }}
         />,
       );
       // Ordinary labels and the [MoneyOK] marker remain visible...
       expect(getByText('groceries')).toBeTruthy();
       expect(getByText('[MoneyOK]')).toBeTruthy();
-      // ...but the Account:/Category:/Category group: metadata labels are hidden.
+      // ...but the imported metadata labels are hidden.
       expect(queryByText('Account: Cash')).toBeNull();
       expect(queryByText('Category: Food')).toBeNull();
       expect(queryByText('Category group: Expenses')).toBeNull();
+      expect(queryByText('Date: 2025.11.03')).toBeNull();
+      expect(queryByText('Amount: 1172300 AMD')).toBeNull();
+    });
+
+    it('shows Note: labels with the prefix stripped', async () => {
+      const { getByText, queryByText } = await render(
+        <OperationListItem
+          {...baseProps}
+          operation={{
+            ...baseOperation,
+            description: 'Note: За очки | groceries',
+          }}
+        />,
+      );
+      expect(getByText('За очки')).toBeTruthy();
+      expect(queryByText('Note: За очки')).toBeNull();
+      expect(getByText('groceries')).toBeTruthy();
     });
 
     it('summarises overflow labels as +N', async () => {

--- a/__tests__/services/AccountsDB.test.js
+++ b/__tests__/services/AccountsDB.test.js
@@ -828,6 +828,15 @@ describe('AccountsDB', () => {
         expect.stringContaining('INSERT INTO operations'),
         expect.arrayContaining(['income', '50.00', 'acc-1', 'shadow-income']),
       );
+
+      // Description carries the amount chain only — no "Balance adjusted from" prefix.
+      const insertCall = mockDb.runAsync.mock.calls.find(
+        c => String(c[0]).includes('INSERT INTO operations'),
+      );
+      const insertedDescription = insertCall[1][7];
+      expect(insertedDescription).not.toContain('Balance adjusted from');
+      expect(insertedDescription).toContain('100.00 → 150.00');
+      expect(insertedDescription).toContain('Test adjustment');
     });
 
     it('creates new adjustment operation when decreasing balance', async () => {

--- a/__tests__/services/OperationsDB.labels.test.js
+++ b/__tests__/services/OperationsDB.labels.test.js
@@ -72,7 +72,7 @@ describe('OperationsDB.getDistinctLabels', () => {
 
   it('excludes imported metadata labels and the [MoneyOK] marker from suggestions', async () => {
     queryAll.mockResolvedValue([
-      { description: '[MoneyOK] | Account: Cash | Category: Food | Category group: Expenses | groceries', category_id: 'c1', cnt: 5 },
+      { description: '[MoneyOK] | Account: Cash | Category: Food | Category group: Expenses | Date: 2025.11.03 | Amount: 1172300 AMD | groceries', category_id: 'c1', cnt: 5 },
     ]);
     const labels = await getDistinctLabels(10);
     expect(labels).toEqual(['groceries']);

--- a/__tests__/services/OperationsDB.labels.test.js
+++ b/__tests__/services/OperationsDB.labels.test.js
@@ -60,12 +60,21 @@ describe('OperationsDB.getDistinctLabels', () => {
     expect(await getDistinctLabels(10)).toEqual([]);
   });
 
-  it('parses legacy [MoneyOK] descriptions into their delimited labels', async () => {
+  it('parses real labels out of legacy [MoneyOK] descriptions but hides the marker', async () => {
     queryAll.mockResolvedValue([
       { description: '[MoneyOK] | groceries', category_id: 'c1', cnt: 5 },
       { description: 'real', category_id: 'c1', cnt: 1 },
     ]);
     const labels = await getDistinctLabels(10);
-    expect(labels).toEqual(expect.arrayContaining(['[MoneyOK]', 'groceries', 'real']));
+    expect(labels).toEqual(expect.arrayContaining(['groceries', 'real']));
+    expect(labels).not.toContain('[MoneyOK]');
+  });
+
+  it('excludes imported metadata labels and the [MoneyOK] marker from suggestions', async () => {
+    queryAll.mockResolvedValue([
+      { description: '[MoneyOK] | Account: Cash | Category: Food | Category group: Expenses | groceries', category_id: 'c1', cnt: 5 },
+    ]);
+    const labels = await getDistinctLabels(10);
+    expect(labels).toEqual(['groceries']);
   });
 });

--- a/__tests__/utils/labelUtils.test.js
+++ b/__tests__/utils/labelUtils.test.js
@@ -15,6 +15,7 @@ import {
   isHiddenLabel,
   visibleListLabels,
   isProtectedOperation,
+  displayLabel,
 } from '../../app/utils/labelUtils';
 
 describe('labelUtils', () => {
@@ -217,11 +218,14 @@ describe('labelUtils', () => {
   });
 
   describe('isSystemLabel', () => {
-    it('flags Account:/Category:/Category group: labels (case-insensitive)', () => {
+    it('flags Account:/Category:/Category group:/Date:/Amount: labels (case-insensitive)', () => {
       expect(isSystemLabel('Account: Cash')).toBe(true);
       expect(isSystemLabel('Category: Food')).toBe(true);
       expect(isSystemLabel('Category group: Expenses')).toBe(true);
+      expect(isSystemLabel('Date: 2025.11.03')).toBe(true);
+      expect(isSystemLabel('Amount: 1172300 AMD')).toBe(true);
       expect(isSystemLabel('account: cash')).toBe(true);
+      expect(isSystemLabel('  date:  2025.11.03 ')).toBe(true);
       expect(isSystemLabel('  Category group:  Income ')).toBe(true);
     });
 
@@ -230,6 +234,7 @@ describe('labelUtils', () => {
       expect(isSystemLabel('[MoneyOK]')).toBe(false);
       expect(isSystemLabel('Accountant')).toBe(false);
       expect(isSystemLabel('My Category')).toBe(false);
+      expect(isSystemLabel('Note: paid in cash')).toBe(false);
     });
 
     it('returns false for empty or non-string input', () => {
@@ -237,6 +242,26 @@ describe('labelUtils', () => {
       expect(isSystemLabel(null)).toBe(false);
       expect(isSystemLabel(undefined)).toBe(false);
       expect(isSystemLabel(42)).toBe(false);
+    });
+  });
+
+  describe('displayLabel', () => {
+    it('strips the Note: prefix and shows the free-text after it', () => {
+      expect(displayLabel('Note: Отпускные (октябрь)')).toBe('Отпускные (октябрь)');
+      expect(displayLabel('Note: За очки')).toBe('За очки');
+      expect(displayLabel('note:  paid in cash ')).toBe('paid in cash');
+    });
+
+    it('returns ordinary labels unchanged', () => {
+      expect(displayLabel('groceries')).toBe('groceries');
+      expect(displayLabel('[MoneyOK]')).toBe('[MoneyOK]');
+      expect(displayLabel('Notepad')).toBe('Notepad');
+    });
+
+    it('returns empty string for unusable input', () => {
+      expect(displayLabel('')).toBe('');
+      expect(displayLabel(null)).toBe('');
+      expect(displayLabel(undefined)).toBe('');
     });
   });
 
@@ -259,7 +284,7 @@ describe('labelUtils', () => {
 
   describe('visibleListLabels', () => {
     it('drops system labels but keeps ordinary ones and [MoneyOK]', () => {
-      const labels = parseLabels('[MoneyOK] | Account: Cash | groceries | Category: Food | Category group: Expenses');
+      const labels = parseLabels('[MoneyOK] | Account: Cash | groceries | Category: Food | Category group: Expenses | Date: 2025.11.03 | Amount: 1172300 AMD');
       expect(visibleListLabels(labels)).toEqual(['[MoneyOK]', 'groceries']);
     });
 
@@ -285,6 +310,8 @@ describe('labelUtils', () => {
       expect(isProtectedOperation('Account: Cash | groceries')).toBe(true);
       expect(isProtectedOperation('Category: Food')).toBe(true);
       expect(isProtectedOperation('Category group: Expenses | rent')).toBe(true);
+      expect(isProtectedOperation('Date: 2025.11.03 | salary')).toBe(true);
+      expect(isProtectedOperation('Amount: 1172300 AMD | salary')).toBe(true);
     });
 
     it('protects operations carrying the [MoneyOK] marker', () => {

--- a/__tests__/utils/labelUtils.test.js
+++ b/__tests__/utils/labelUtils.test.js
@@ -252,10 +252,16 @@ describe('labelUtils', () => {
       expect(displayLabel('note:  paid in cash ')).toBe('paid in cash');
     });
 
+    it('strips the "Balance adjusted from" prefix, leaving the amount chain', () => {
+      expect(displayLabel('Balance adjusted from 62000.00 → 66000.00')).toBe('62000.00 → 66000.00');
+      expect(displayLabel('balance adjusted from 80.00 → 100.00 → 120.00')).toBe('80.00 → 100.00 → 120.00');
+    });
+
     it('returns ordinary labels unchanged', () => {
       expect(displayLabel('groceries')).toBe('groceries');
       expect(displayLabel('[MoneyOK]')).toBe('[MoneyOK]');
       expect(displayLabel('Notepad')).toBe('Notepad');
+      expect(displayLabel('62000.00 → 66000.00')).toBe('62000.00 → 66000.00');
     });
 
     it('returns empty string for unusable input', () => {

--- a/__tests__/utils/labelUtils.test.js
+++ b/__tests__/utils/labelUtils.test.js
@@ -12,6 +12,7 @@ import {
   removeLabel,
   matchesAllLabels,
   isSystemLabel,
+  isHiddenLabel,
   visibleListLabels,
   isProtectedOperation,
 } from '../../app/utils/labelUtils';
@@ -236,6 +237,23 @@ describe('labelUtils', () => {
       expect(isSystemLabel(null)).toBe(false);
       expect(isSystemLabel(undefined)).toBe(false);
       expect(isSystemLabel(42)).toBe(false);
+    });
+  });
+
+  describe('isHiddenLabel', () => {
+    it('hides system labels and the [MoneyOK] marker (case-insensitive)', () => {
+      expect(isHiddenLabel('Account: Cash')).toBe(true);
+      expect(isHiddenLabel('Category: Food')).toBe(true);
+      expect(isHiddenLabel('Category group: Expenses')).toBe(true);
+      expect(isHiddenLabel('[MoneyOK]')).toBe(true);
+      expect(isHiddenLabel('[moneyok]')).toBe(true);
+    });
+
+    it('does not hide ordinary labels', () => {
+      expect(isHiddenLabel('groceries')).toBe(false);
+      expect(isHiddenLabel('Ваган')).toBe(false);
+      expect(isHiddenLabel('')).toBe(false);
+      expect(isHiddenLabel(null)).toBe(false);
     });
   });
 

--- a/app/components/operations/LabelInput.js
+++ b/app/components/operations/LabelInput.js
@@ -11,7 +11,7 @@ import {
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../../styles/designTokens';
-import { parseLabels, serializeLabels, addLabel, removeLabel, hasLabel } from '../../utils/labelUtils';
+import { parseLabels, serializeLabels, addLabel, removeLabel, hasLabel, displayLabel } from '../../utils/labelUtils';
 
 const MAX_SUGGESTION_CHIPS = 8;
 
@@ -178,7 +178,7 @@ const LabelInput = forwardRef(({
             style={[styles.chip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
             testID={`label-chip-${label}`}
           >
-            <Text style={[styles.chipText, { color: colors.text }]} numberOfLines={1}>{label}</Text>
+            <Text style={[styles.chipText, { color: colors.text }]} numberOfLines={1}>{displayLabel(label)}</Text>
             {editable && (
               <TouchableOpacity
                 onPress={() => handleRemove(label)}

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -4,7 +4,7 @@ import { TouchableRipple } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
-import { parseLabels, visibleListLabels } from '../../utils/labelUtils';
+import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
@@ -96,7 +96,7 @@ const OperationListItem = ({
   const typeLabel = isExpense ? t('expense_label') : isIncome ? t('income_label') : t('transfer_label');
   let accessibilityLabel = `${typeLabel}, ${title}, ${displayAmount}`;
   if (labels.length > 0) {
-    accessibilityLabel += `, ${t('labels')}: ${labels.join(', ')}`;
+    accessibilityLabel += `, ${t('labels')}: ${labels.map(displayLabel).join(', ')}`;
   }
 
   return (
@@ -128,7 +128,7 @@ const OperationListItem = ({
                   testID={`op-label-${label}`}
                 >
                   <Text style={[styles.labelChipText, { color: colors.mutedText }]} numberOfLines={1}>
-                    {label}
+                    {displayLabel(label)}
                   </Text>
                 </View>
               ))}

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -532,9 +532,12 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
       // Build description with adjustment history
       const historyString = adjustmentHistory.join(' → ');
       const originalFormatted = Currency.formatAmount(originalBalanceStr);
+      // Description carries only the balance chain (original → … → target). The
+      // original balance is also stored in its own column and the chain is parsed
+      // back from the "→" separators, so no prefix text is needed.
       const fullDescription = description
-        ? `${description}\nBalance adjusted from ${originalFormatted} → ${historyString}`
-        : `Balance adjusted from ${originalFormatted} → ${historyString}`;
+        ? `${description}\n${originalFormatted} → ${historyString}`
+        : `${originalFormatted} → ${historyString}`;
 
       if (existingOperation) {
         // Check if total delta is 0 - if so, delete the operation

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1,6 +1,6 @@
 import { executeQuery, queryAll, queryFirst, executeTransaction, isSearchNormAvailable } from './db';
 import { normalizeSearchText } from './searchNormalize';
-import { parseLabels } from '../utils/labelUtils';
+import { parseLabels, isHiddenLabel } from '../utils/labelUtils';
 
 // Returns 'SEARCH_NORM' when the custom function was registered successfully (full
 // Cyrillic case-folding + ё/е equivalence), otherwise falls back to SQLite's built-in
@@ -2009,6 +2009,9 @@ export const getDistinctLabels = async (limit = 50, categoryId = null) => {
     for (const row of (rows || [])) {
       const labels = parseLabels(row.description);
       for (const label of labels) {
+        // Imported metadata (Account:/Category:/Category group:) and the [MoneyOK]
+        // marker are never offered as suggestions.
+        if (isHiddenLabel(label)) continue;
         const key = label.toLowerCase();
         let entry = byLabel.get(key);
         if (!entry) {

--- a/app/utils/labelUtils.js
+++ b/app/utils/labelUtils.js
@@ -174,6 +174,19 @@ export const visibleListLabels = (labels) => {
 };
 
 /**
+ * Whether a single label should be kept out of autocomplete suggestions: imported
+ * metadata (a system label) or the [MoneyOK] import marker. Offering these as
+ * suggestions would let the user re-introduce the clutter / mark an operation as a
+ * protected import. Matching is case-insensitive.
+ * @param {*} label
+ * @returns {boolean}
+ */
+export const isHiddenLabel = (label) => {
+  if (isSystemLabel(label)) return true;
+  return normalizeLabel(label).toLowerCase() === MONEYOK_LABEL.toLowerCase();
+};
+
+/**
  * Whether an operation's description marks it as a protected import — it carries
  * either a system label (Account:/Category:/Category group:) or the [MoneyOK]
  * marker. Protected operations are non-deletable.

--- a/app/utils/labelUtils.js
+++ b/app/utils/labelUtils.js
@@ -26,10 +26,15 @@ export const MAX_LABEL_LENGTH = 60;
 // Prefixes that mark a label as imported metadata (e.g. from a MoneyOK export).
 // These clutter the operation list, so they are hidden there while still shown
 // when the operation is opened for editing. Matching is case-insensitive.
-export const SYSTEM_LABEL_PREFIXES = ['Account:', 'Category:', 'Category group:'];
+export const SYSTEM_LABEL_PREFIXES = ['Account:', 'Category:', 'Category group:', 'Date:', 'Amount:'];
 
 // Marker tag identifying an operation imported from MoneyOK.
 export const MONEYOK_LABEL = '[MoneyOK]';
+
+// Imported "Note:" labels carry free-text the user wrote in the source app. The
+// "Note:" prefix is just an import artefact, so it is stripped for display while
+// the underlying label value is left untouched.
+export const NOTE_LABEL_PREFIX = 'Note:';
 
 /**
  * Normalise a single label WITHOUT enforcing the length cap: drop the delimiter,
@@ -82,6 +87,21 @@ export const parseLabels = (description) => {
     if (result.length >= MAX_LABELS) break;
   }
   return result;
+};
+
+/**
+ * Map a label to its user-facing text. Imported "Note:" labels are shown as just
+ * the free-text after the prefix (e.g. "Note: За очки" -> "За очки"); all other
+ * labels are returned unchanged. Matching is case-insensitive. Never mutates state.
+ * @param {*} label
+ * @returns {string}
+ */
+export const displayLabel = (label) => {
+  const clean = normalizeLabel(label);
+  if (clean.toLowerCase().startsWith(NOTE_LABEL_PREFIX.toLowerCase())) {
+    return clean.slice(NOTE_LABEL_PREFIX.length).trim();
+  }
+  return clean;
 };
 
 /**

--- a/app/utils/labelUtils.js
+++ b/app/utils/labelUtils.js
@@ -36,6 +36,15 @@ export const MONEYOK_LABEL = '[MoneyOK]';
 // the underlying label value is left untouched.
 export const NOTE_LABEL_PREFIX = 'Note:';
 
+// Balance-adjustment operations historically stored their label as
+// "Balance adjusted from <orig> → <target>". The prefix is noise — only the
+// amount chain matters — so it is stripped for display. (New adjustments no
+// longer write the prefix; this keeps older records tidy too.)
+export const BALANCE_ADJUST_PREFIX = 'Balance adjusted from';
+
+// Prefixes stripped from a label purely for display (value is left untouched).
+const DISPLAY_STRIP_PREFIXES = [NOTE_LABEL_PREFIX, BALANCE_ADJUST_PREFIX];
+
 /**
  * Normalise a single label WITHOUT enforcing the length cap: drop the delimiter,
  * collapse internal whitespace, and trim. Returns '' for anything unusable.
@@ -90,16 +99,21 @@ export const parseLabels = (description) => {
 };
 
 /**
- * Map a label to its user-facing text. Imported "Note:" labels are shown as just
- * the free-text after the prefix (e.g. "Note: За очки" -> "За очки"); all other
- * labels are returned unchanged. Matching is case-insensitive. Never mutates state.
+ * Map a label to its user-facing text. Display-only prefixes are stripped:
+ * imported "Note:" labels show just the free-text after the prefix
+ * (e.g. "Note: За очки" -> "За очки"), and legacy "Balance adjusted from <a> → <b>"
+ * labels show just the amount chain ("<a> → <b>"). All other labels are returned
+ * unchanged. Matching is case-insensitive. Never mutates state.
  * @param {*} label
  * @returns {string}
  */
 export const displayLabel = (label) => {
   const clean = normalizeLabel(label);
-  if (clean.toLowerCase().startsWith(NOTE_LABEL_PREFIX.toLowerCase())) {
-    return clean.slice(NOTE_LABEL_PREFIX.length).trim();
+  const lower = clean.toLowerCase();
+  for (const prefix of DISPLAY_STRIP_PREFIXES) {
+    if (lower.startsWith(prefix.toLowerCase())) {
+      return clean.slice(prefix.length).trim();
+    }
   }
   return clean;
 };


### PR DESCRIPTION
## Summary

Follow-up to #1036, refining how operation labels (stored in an operation's `description`) are presented in the list, the operation modal, and autocomplete.

This PR:

1. **Keeps metadata labels out of autocomplete suggestions.** `Account:`/`Category:`/`Category group:`/`Date:`/`Amount:` labels and the `[MoneyOK]` marker were leaking into the label autocomplete; the user should never be offered these to apply manually.
2. **Treats `Date:` and `Amount:` like the other metadata prefixes** — hidden from the operations list, excluded from suggestions, and marking the operation as a protected (non-deletable) import.
3. **Shows `Note:` labels stripped.** Imported `Note:` labels carry free text from the source app; they now render as just the text after the prefix (e.g. `Note: За очки` → `За очки`).
4. **Shows balance-adjustment labels as the amount chain only.** Balance-adjustment (shadow) operations stored their label as `Balance adjusted from <orig> → <target>`; the prefix is now stripped at display, and **future adjustments no longer write it** — the description carries just the amount chain (`<orig> → … → <target>`).

## Implementation

In `app/utils/labelUtils.js`:
- `SYSTEM_LABEL_PREFIXES` now includes `Date:` and `Amount:`.
- `isHiddenLabel(label)` — true for a system label or `[MoneyOK]`; used to filter suggestions.
- `displayLabel(label)` — strips display-only prefixes (`Note:`, `Balance adjusted from`); other labels unchanged.

Wiring:
- `getDistinctLabels` (`OperationsDB.js`) skips hidden labels when aggregating suggestions.
- `OperationListItem.js` and `LabelInput.js` render chip text (and accessibility labels) through `displayLabel`, covering both the list and the operation modal.
- `AccountsDB.adjustAccountBalance` no longer writes the `Balance adjusted from` prefix. The original balance is still persisted in its own column and the chain is parsed back from the `→` separators, so history reconstruction is unaffected.

System-label hiding and protected/non-deletable behaviour flow through the existing `isSystemLabel` / `visibleListLabels` / `isProtectedOperation` helpers from #1036.

## Testing

- `labelUtils.test.js`: `displayLabel` (Note + balance-adjustment), `isHiddenLabel`, and `Date:`/`Amount:` coverage.
- `OperationListItem.test.js` / `LabelInput.test.js`: metadata hidden, `Note:` and balance-adjustment labels shown stripped.
- `OperationsDB.labels.test.js`: metadata excluded from suggestions.
- `AccountsDB.test.js`: new adjustment description omits the prefix and carries the amount chain.
- Full suite: **3715 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)