### PR TITLE
feat: open SQLite backup files with the app to start import

### DIFF
--- a/__tests__/hooks/useSqliteFileImport.test.js
+++ b/__tests__/hooks/useSqliteFileImport.test.js
@@ -1,0 +1,241 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { Linking } from 'react-native';
+import {
+  useSqliteFileImport,
+  deriveImportFilename,
+  isOpenableFileUri,
+} from '../../app/hooks/useSqliteFileImport';
+import { importBackupFromFile, CancelledImportError } from '../../app/services/BackupRestore';
+
+// --- Mocks -----------------------------------------------------------------
+
+const mockShowDialog = jest.fn();
+const mockStartImport = jest.fn();
+const mockCompleteImport = jest.fn();
+const mockCancelImport = jest.fn();
+const mockCancelToken = { cancelled: false };
+
+jest.mock('../../app/contexts/DialogContext', () => ({
+  useDialog: () => ({ showDialog: mockShowDialog }),
+}));
+
+jest.mock('../../app/contexts/ImportProgressContext', () => ({
+  useImportProgress: () => ({
+    startImport: mockStartImport,
+    completeImport: mockCompleteImport,
+    cancelImport: mockCancelImport,
+    getCancelToken: () => mockCancelToken,
+  }),
+}));
+
+jest.mock('../../app/contexts/LocalizationContext', () => ({
+  useLocalization: () => ({ t: (key) => key }),
+}));
+
+jest.mock('../../app/services/BackupRestore', () => {
+  class CancelledImportError extends Error {}
+  return {
+    importBackupFromFile: jest.fn(() => Promise.resolve({})),
+    CancelledImportError,
+  };
+});
+
+// Flush queued microtasks (e.g. the resolved getInitialURL promise and any
+// chained state updates) so they settle inside an act() scope.
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+// Pull the confirm/cancel button handlers out of the most recent showDialog call.
+const getDialogButtons = () => {
+  const lastCall = mockShowDialog.mock.calls[mockShowDialog.mock.calls.length - 1];
+  return lastCall[2];
+};
+const pressButton = async (style) => {
+  const button = getDialogButtons().find((b) => b.style === style);
+  await act(async () => {
+    button.onPress();
+    await flushMicrotasks();
+  });
+};
+
+describe('useSqliteFileImport helpers', () => {
+  describe('isOpenableFileUri', () => {
+    it('accepts content and file URIs', () => {
+      expect(isOpenableFileUri('content://downloads/123')).toBe(true);
+      expect(isOpenableFileUri('file:///storage/backup.db')).toBe(true);
+    });
+
+    it('rejects custom-scheme, http, null and non-string inputs', () => {
+      expect(isOpenableFileUri('com.heywood8.monkeep://path')).toBe(false);
+      expect(isOpenableFileUri('https://example.com/x.db')).toBe(false);
+      expect(isOpenableFileUri(null)).toBe(false);
+      expect(isOpenableFileUri(undefined)).toBe(false);
+      expect(isOpenableFileUri(42)).toBe(false);
+    });
+  });
+
+  describe('deriveImportFilename', () => {
+    it('keeps recognized backup extensions from the URI', () => {
+      expect(deriveImportFilename('file:///x/penny.db')).toBe('penny.db');
+      expect(deriveImportFilename('file:///x/backup.sqlite')).toBe('backup.sqlite');
+      expect(deriveImportFilename('file:///x/data.sqlite3')).toBe('data.sqlite3');
+      expect(deriveImportFilename('file:///x/export.json')).toBe('export.json');
+      expect(deriveImportFilename('file:///x/export.csv')).toBe('export.csv');
+    });
+
+    it('decodes percent-encoded filenames', () => {
+      expect(deriveImportFilename('content://p/my%20backup.db')).toBe('my backup.db');
+    });
+
+    it('defaults to a .db name when no recognizable extension is present', () => {
+      expect(deriveImportFilename('content://providers/document/1234')).toBe('imported_backup.db');
+      expect(deriveImportFilename('file:///x/archive.bin')).toBe('imported_backup.db');
+    });
+  });
+});
+
+describe('useSqliteFileImport hook', () => {
+  let urlListener;
+  let activeUnmount;
+  const originalGetInitialURL = Linking.getInitialURL;
+  const originalAddEventListener = Linking.addEventListener;
+
+  // Render the hook and flush the async getInitialURL handling inside act() so
+  // the resolved promise (and any showDialog it triggers) doesn't leak past the
+  // test and cause overlapping act() warnings / cross-test contamination.
+  const mountHook = async (options) => {
+    let utils;
+    await act(async () => {
+      utils = renderHook(() => useSqliteFileImport(options));
+      await flushMicrotasks();
+    });
+    activeUnmount = utils.unmount;
+    return utils;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCancelToken.cancelled = false;
+    urlListener = null;
+    activeUnmount = null;
+    Linking.getInitialURL = jest.fn().mockResolvedValue(null);
+    Linking.addEventListener = jest.fn((event, cb) => {
+      if (event === 'url') urlListener = cb;
+      return { remove: jest.fn() };
+    });
+  });
+
+  afterEach(() => {
+    if (activeUnmount) {
+      act(() => activeUnmount());
+    }
+    Linking.getInitialURL = originalGetInitialURL;
+    Linking.addEventListener = originalAddEventListener;
+  });
+
+  it('does nothing when disabled', async () => {
+    Linking.getInitialURL.mockResolvedValue('file:///x/penny.db');
+    await mountHook({ enabled: false });
+    expect(Linking.getInitialURL).not.toHaveBeenCalled();
+    expect(mockShowDialog).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-file URIs from the initial URL', async () => {
+    Linking.getInitialURL.mockResolvedValue('https://example.com/penny.db');
+    await mountHook();
+    expect(mockShowDialog).not.toHaveBeenCalled();
+  });
+
+  it('shows a confirmation warning when launched by opening a file', async () => {
+    Linking.getInitialURL.mockResolvedValue('file:///x/penny.db');
+    await mountHook();
+
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+    const [title, message, buttons] = mockShowDialog.mock.calls[0];
+    expect(title).toBe('restore_database');
+    expect(message).toBe('restore_confirm');
+    expect(buttons.map((b) => b.style)).toEqual(['cancel', 'destructive']);
+    // No import starts until the user confirms.
+    expect(mockStartImport).not.toHaveBeenCalled();
+  });
+
+  it('starts the import with the derived filename when confirmed', async () => {
+    Linking.getInitialURL.mockResolvedValue('file:///x/penny.db');
+    await mountHook();
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+
+    await pressButton('destructive');
+
+    expect(mockStartImport).toHaveBeenCalledTimes(1);
+    expect(importBackupFromFile).toHaveBeenCalledWith(
+      { fileUri: 'file:///x/penny.db', filename: 'penny.db' },
+      mockCancelToken,
+    );
+    expect(mockCompleteImport).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not import when the warning is cancelled', async () => {
+    Linking.getInitialURL.mockResolvedValue('file:///x/penny.db');
+    await mountHook();
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+
+    await pressButton('cancel');
+
+    expect(mockStartImport).not.toHaveBeenCalled();
+    expect(importBackupFromFile).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error dialog when the import fails', async () => {
+    importBackupFromFile.mockRejectedValueOnce(new Error('bad file'));
+    Linking.getInitialURL.mockResolvedValue('content://providers/document/1');
+    await mountHook();
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+
+    await pressButton('destructive');
+
+    expect(mockCancelImport).toHaveBeenCalledTimes(1);
+    // First dialog = warning, second dialog = error.
+    expect(mockShowDialog).toHaveBeenCalledTimes(2);
+    expect(mockShowDialog.mock.calls[1][1]).toBe('bad file');
+    expect(mockCompleteImport).not.toHaveBeenCalled();
+  });
+
+  it('silently aborts when the import is cancelled mid-flight', async () => {
+    importBackupFromFile.mockRejectedValueOnce(new CancelledImportError('cancelled'));
+    Linking.getInitialURL.mockResolvedValue('file:///x/penny.db');
+    await mountHook();
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+
+    await pressButton('destructive');
+
+    expect(mockCancelImport).toHaveBeenCalledTimes(1);
+    // Only the original warning dialog - no error dialog for user cancellation.
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles files opened while the app is already running (warm start)', async () => {
+    await mountHook();
+    expect(mockShowDialog).not.toHaveBeenCalled();
+
+    await act(async () => {
+      urlListener({ url: 'file:///x/penny.db' });
+      await flushMicrotasks();
+    });
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not stack a second warning while one is already pending', async () => {
+    Linking.getInitialURL.mockResolvedValue('file:///x/penny.db');
+    await mountHook();
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      urlListener({ url: 'file:///x/another.db' });
+      await flushMicrotasks();
+    });
+    // Still only one dialog - the pending prompt blocks a second.
+    expect(mockShowDialog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/screens/AppInitializer.test.js
+++ b/__tests__/screens/AppInitializer.test.js
@@ -23,6 +23,12 @@ jest.mock('../../app/contexts/UpdateDownloadContext', () => ({
   })),
 }));
 
+// The opened-file import handler is covered by its own unit tests; stub it here
+// so AppInitializer doesn't require the ImportProgress/Dialog providers.
+jest.mock('../../app/hooks/useSqliteFileImport', () => ({
+  useSqliteFileImport: jest.fn(),
+}));
+
 jest.mock('../../app/services/AppUpdateService', () => ({
   checkForAppUpdate: jest.fn(async () => ({
     success: true,

--- a/app.config.js
+++ b/app.config.js
@@ -28,6 +28,35 @@ module.exports = {
       edgeToEdgeEnabled: true,
       package: 'com.heywood8.monkeep',
       permissions: ['android.permission.REQUEST_INSTALL_PACKAGES'],
+      // Register Penny as a handler for opening SQLite database backup files.
+      // When the user opens a .db/.sqlite file from a file manager, email
+      // attachment, etc., Android offers Penny as one of the apps, and the
+      // launching ACTION_VIEW intent's content/file URI is delivered to JS via
+      // expo/react-native Linking (see app/hooks/useSqliteFileImport.js).
+      //
+      // SQLite files on disk are usually typed as application/octet-stream by
+      // Android (there is no standard registered MIME type for the .db
+      // extension), so we match that alongside the SQLite-specific MIME types
+      // and an extension-based pathPattern fallback for the file:// scheme.
+      // Files that turn out not to be valid backups are rejected gracefully by
+      // the import flow after the confirmation warning.
+      intentFilters: [
+        {
+          action: 'VIEW',
+          category: ['DEFAULT', 'BROWSABLE'],
+          data: [
+            { scheme: 'content', mimeType: 'application/x-sqlite3' },
+            { scheme: 'content', mimeType: 'application/vnd.sqlite3' },
+            { scheme: 'content', mimeType: 'application/octet-stream' },
+            { scheme: 'file', mimeType: 'application/x-sqlite3' },
+            { scheme: 'file', mimeType: 'application/vnd.sqlite3' },
+            { scheme: 'file', mimeType: 'application/octet-stream' },
+            { scheme: 'file', mimeType: '*/*', pathPattern: '.*\\.db' },
+            { scheme: 'file', mimeType: '*/*', pathPattern: '.*\\.sqlite' },
+            { scheme: 'file', mimeType: '*/*', pathPattern: '.*\\.sqlite3' },
+          ],
+        },
+      ],
     },
     extra: {
       eas: {

--- a/app/hooks/useSqliteFileImport.js
+++ b/app/hooks/useSqliteFileImport.js
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from 'react';
+import { Linking } from 'react-native';
+import { useDialog } from '../contexts/DialogContext';
+import { useImportProgress } from '../contexts/ImportProgressContext';
+import { useLocalization } from '../contexts/LocalizationContext';
+import { importBackupFromFile, CancelledImportError } from '../services/BackupRestore';
+
+/**
+ * Recognized backup file extensions. When the opened file URI carries one of
+ * these extensions we respect it so format detection works for JSON/CSV/SQLite
+ * backups alike; otherwise we fall back to a `.db` filename since the intent
+ * filters that route a file here are SQLite-oriented.
+ */
+const RECOGNIZED_EXTENSION = /\.(db|sqlite|sqlite3|json|csv)$/i;
+
+/**
+ * Only file/content URIs represent an externally opened document. Our own
+ * custom-scheme deep links (com.heywood8.monkeep://...) and http(s) links must
+ * be ignored here.
+ */
+export const isOpenableFileUri = (url) =>
+  typeof url === 'string' && (url.startsWith('content://') || url.startsWith('file://'));
+
+/**
+ * Derive a filename (with extension) from an opened file URI so the import
+ * pipeline can detect the backup format. Content URIs frequently lack a usable
+ * filename, in which case we default to a `.db` name to force SQLite handling.
+ * @param {string} uri
+ * @returns {string}
+ */
+export const deriveImportFilename = (uri) => {
+  try {
+    const decoded = decodeURIComponent(uri);
+    const segment = decoded.split(/[/\\]/).pop() || '';
+    if (RECOGNIZED_EXTENSION.test(segment)) {
+      return segment;
+    }
+  } catch {
+    // Malformed URI encoding - fall through to the default name.
+  }
+  return 'imported_backup.db';
+};
+
+/**
+ * Listens for SQLite/backup files opened with the app (Android ACTION_VIEW
+ * intents) and starts the restore flow after a confirmation warning, mirroring
+ * the Google Drive / file import experience.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.enabled=true] - When false, opened files are ignored
+ *   (e.g. during first-launch language selection before the app is ready).
+ */
+export const useSqliteFileImport = ({ enabled = true } = {}) => {
+  const { showDialog } = useDialog();
+  const { startImport, completeImport, cancelImport, getCancelToken } = useImportProgress();
+  const { t } = useLocalization();
+
+  // Guards against showing a second confirmation while one is already pending.
+  const promptOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    let isMounted = true;
+
+    const runImport = async (fileUri, filename) => {
+      startImport();
+      const cancelToken = getCancelToken();
+      try {
+        await importBackupFromFile({ fileUri, filename }, cancelToken);
+        completeImport();
+      } catch (error) {
+        cancelImport();
+        if (error instanceof CancelledImportError) return;
+        console.error('[useSqliteFileImport] import error:', error);
+        showDialog(
+          t('error') || 'Error',
+          error.message || t('restore_error') || 'Failed to restore backup',
+          [{ text: t('ok') || 'OK' }],
+        );
+      }
+    };
+
+    const handleUrl = (url) => {
+      if (!isMounted || !isOpenableFileUri(url) || promptOpenRef.current) return;
+
+      promptOpenRef.current = true;
+      const filename = deriveImportFilename(url);
+
+      showDialog(
+        t('restore_database') || 'Restore Database',
+        t('restore_confirm') ||
+          'Are you sure you want to restore from backup? This will replace all current data.',
+        [
+          {
+            text: t('cancel') || 'Cancel',
+            style: 'cancel',
+            onPress: () => {
+              promptOpenRef.current = false;
+            },
+          },
+          {
+            text: t('restore_database') || 'Restore',
+            style: 'destructive',
+            onPress: () => {
+              promptOpenRef.current = false;
+              runImport(url, filename);
+            },
+          },
+        ],
+      );
+    };
+
+    // Cold start: the app was launched by opening a file.
+    Linking.getInitialURL()
+      .then((url) => handleUrl(url))
+      .catch((error) => console.warn('[useSqliteFileImport] getInitialURL failed:', error));
+
+    // Warm start: a file was opened while the app was already running.
+    const subscription = Linking.addEventListener('url', ({ url }) => handleUrl(url));
+
+    return () => {
+      isMounted = false;
+      subscription.remove();
+    };
+  }, [enabled, showDialog, startImport, completeImport, cancelImport, getCancelToken, t]);
+};

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -9,6 +9,7 @@ import { useDialog } from '../contexts/DialogContext';
 import { checkForAppUpdate } from '../services/AppUpdateService';
 import { getPreference, setPreference, PREF_KEYS } from '../services/PreferencesDB';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
+import { useSqliteFileImport } from '../hooks/useSqliteFileImport';
 import UpdateAvailableModal from '../modals/UpdateAvailableModal';
 
 const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -25,6 +26,11 @@ const AppInitializer = () => {
   const { startDownload } = useUpdateDownload();
   const [isInitializing, setIsInitializing] = useState(false);
   const [pendingUpdate, setPendingUpdate] = useState(null);
+
+  // Handle SQLite/backup files opened with the app (Android ACTION_VIEW).
+  // Disabled during first launch so the import warning doesn't appear before
+  // the user has finished initial language setup.
+  useSqliteFileImport({ enabled: !isFirstLaunch });
 
   // Run once on every app open (after first launch is complete)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Makes Penny appear as one of the apps offered when you open a SQLite backup file (`.db` / `.sqlite`) on Android — from a file manager, email attachment, etc. When Penny is chosen, the **restore flow starts after a confirmation warning**, exactly like the existing Google Drive / file import.

## How it works

1. **Intent filters** (`app.config.js`) register Penny as an `ACTION_VIEW` handler for SQLite files. SQLite files on disk are usually typed by Android as `application/octet-stream` (there's no standard MIME type for the `.db` extension), so we match that alongside the SQLite-specific MIME types, plus an extension-based `pathPattern` fallback for the `file://` scheme.
2. When a file is opened, Android launches/foregrounds the app and the content/file URI is delivered to JS via `Linking` (`getInitialURL` on cold start, the `url` event on warm start).
3. **`useSqliteFileImport`** hook shows the standard restore warning (`restore_confirm`) with **Cancel** / **Restore** buttons. On confirm it runs `importBackupFromFile`, reusing the existing import-progress modal and error handling. Invalid files are rejected gracefully after the warning.
4. The hook is wired into `AppInitializer` and disabled during first-launch language setup.

## Notes

- The intent filters only take effect in a native build (the `android/` folder is gitignored / managed workflow), so this can't be exercised in JS tests — but the URL-handling, warning, and import behaviour are covered by unit tests.
- No new i18n keys: the warning reuses the existing `restore_confirm` / `restore_database` / `cancel` strings, keeping it identical to the Google Drive import warning.

## Testing

- `npm test` — all 3720 tests pass (16 new tests for the hook + helpers).
- New: `__tests__/hooks/useSqliteFileImport.test.js` covers cold/warm start, non-file URI rejection, confirm/cancel, derived filenames, and error vs. user-cancellation paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLvUqqtBKe2zye8AzGCG9x)_