### PR TITLE
fix: show bottom gradient fade over Settings subpanels

### DIFF
--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -597,6 +597,13 @@ const styles = StyleSheet.create({
   },
   tabGradientOverlay: {
     bottom: 0,
+    // Match the elevation of the floating bar and the Settings subpanel overlay
+    // so the gradient fade renders above an elevated subpanel (e.g. the Settings
+    // sub-screens) the same way it does over the operations list. With equal
+    // elevation, draw order falls back to document order: screen content <
+    // gradient < floating bar. The overlay has no backgroundColor, so this does
+    // not cast a shadow on Android — it only affects z-ordering.
+    elevation: 8,
     height: TAB_OVERLAY_HEIGHT,
     left: 0,
     position: 'absolute',


### PR DESCRIPTION
## Summary

On the operations list, the floating bottom tab bar has a translucent gradient fade behind it (the `TabGradientBlocker` overlay), so list content fades softly under the nav bar. On the Settings screen this fade was missing whenever a subpanel was open (e.g. "Check for updates", Export, Logs) — content ended abruptly above the bar with no transparency.

### Cause

The Settings subpanel renders an overlay with `elevation: 8`. On Android, `elevation` takes z-ordering precedence across the whole view tree for overlapping views, so the elevated subpanel was drawing *above* the global gradient overlay (which had elevation 0), hiding the fade. The floating tab bar (also elevation 8, rendered last) stayed on top.

### Fix

Give the `tabGradientOverlay` the same `elevation: 8` as the subpanel and floating bar. With equal elevation, draw order falls back to document order — screen content < gradient < floating bar — so the gradient fade renders above the Settings subpanel just like it does over the operations list. The overlay has no `backgroundColor`, so this only affects z-ordering and casts no shadow on Android.

One-line style change in `app/navigation/SimpleTabs.js`.

## Testing

- `npx jest` — all 121 suites / 3715 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0115duDK6LrgPe4vt76y7oAx)_