### PR TITLE
feat(updates): show release time and link version to GitHub release

### DIFF
--- a/__tests__/components/UpdateContentPanel.test.js
+++ b/__tests__/components/UpdateContentPanel.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Linking } from 'react-native';
 // fireEvent is used for update button press tests
-import UpdateContentPanel, { parseReleaseNotes } from '../../app/components/UpdateContentPanel';
+import UpdateContentPanel, { parseReleaseNotes, formatReleaseDateTime, releaseUrlFor } from '../../app/components/UpdateContentPanel';
 
 jest.mock('../../app/contexts/LocalizationContext', () => ({
   useLocalization: () => ({ t: (key) => key }),
@@ -41,6 +41,46 @@ describe('parseReleaseNotes', () => {
 
   it('handles empty notes gracefully', () => {
     expect(parseReleaseNotes('', '1.0.0')).toEqual({ date: null, body: '' });
+  });
+});
+
+describe('formatReleaseDateTime', () => {
+  it('renders both date and time from an ISO published_at timestamp', () => {
+    const label = formatReleaseDateTime('2026-06-17T14:30:00Z', '2026-06-17');
+    // Time component must be present (separated from the date by the middot).
+    expect(label).toContain(' · ');
+    // The numeric date and time pieces survive whatever the host locale produces.
+    expect(label).toMatch(/2026/);
+    expect(label).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it('falls back to the bare date string when no published_at is available', () => {
+    expect(formatReleaseDateTime(null, '2026-06-17')).toBe('2026-06-17');
+    expect(formatReleaseDateTime(undefined, '2026-06-17')).toBe('2026-06-17');
+  });
+
+  it('falls back to the date when published_at is unparseable', () => {
+    expect(formatReleaseDateTime('not-a-date', '2026-06-17')).toBe('2026-06-17');
+  });
+
+  it('returns null when neither a timestamp nor a fallback date exists', () => {
+    expect(formatReleaseDateTime(null, null)).toBeNull();
+  });
+});
+
+describe('releaseUrlFor', () => {
+  it('prefers the release html_url when present', () => {
+    expect(releaseUrlFor('https://github.com/o/r/releases/tag/penny-v1.2.0', 'https://github.com/o/r', '1.2.0'))
+      .toBe('https://github.com/o/r/releases/tag/penny-v1.2.0');
+  });
+
+  it('reconstructs the tag URL from the repo base when no html_url is given', () => {
+    expect(releaseUrlFor(null, 'https://github.com/o/r', '1.2.0'))
+      .toBe('https://github.com/o/r/releases/tag/penny-v1.2.0');
+  });
+
+  it('returns null when neither a url nor a repo base is available', () => {
+    expect(releaseUrlFor(null, null, '1.2.0')).toBeNull();
   });
 });
 
@@ -103,6 +143,76 @@ describe('UpdateContentPanel', () => {
         />,
       );
       expect(getByText('more_releases')).toBeTruthy();
+    });
+
+    it('shows the release date and time when published_at is present', async () => {
+      const { getByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            recentReleaseNotes: [
+              { version: '1.2.0', notes: '## 1.2.0 (2026-06-17)\n\nBug fix release', publishedAt: '2026-06-17T14:30:00Z' },
+            ],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      // The date label now carries a time component separated by a middot.
+      expect(getByText(/ · \d{1,2}:\d{2}/)).toBeTruthy();
+    });
+
+    it('opens the GitHub release page when the version is tapped', async () => {
+      const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue();
+      const { getByLabelText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            recentReleaseNotes: [
+              { version: '1.2.0', notes: 'Bug fix release', releaseUrl: 'https://github.com/o/r/releases/tag/penny-v1.2.0' },
+            ],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      const link = getByLabelText('View release 1.2.0 on GitHub');
+      fireEvent.press(link);
+      expect(openURL).toHaveBeenCalledWith('https://github.com/o/r/releases/tag/penny-v1.2.0');
+      openURL.mockRestore();
+    });
+
+    it('reconstructs the release URL from releasesUrl when the entry has no releaseUrl', async () => {
+      const openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue();
+      const { getByLabelText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            recentReleaseNotes: [{ version: '1.2.0', notes: 'Bug fix release' }],
+            releasesUrl: 'https://github.com/heywood8/money-tracker/releases',
+          }}
+        />,
+      );
+      fireEvent.press(getByLabelText('View release 1.2.0 on GitHub'));
+      expect(openURL).toHaveBeenCalledWith('https://github.com/heywood8/money-tracker/releases/tag/penny-v1.2.0');
+      openURL.mockRestore();
+    });
+
+    it('falls back to the heading date when published_at is absent', async () => {
+      const { getByText } = await render(
+        <UpdateContentPanel
+          {...baseProps}
+          updateResult={{
+            type: 'up_to_date',
+            recentReleaseNotes: [
+              { version: '1.2.0', notes: '## 1.2.0 (2026-06-17)\n\nBug fix release' },
+            ],
+            releasesUrl: null,
+          }}
+        />,
+      );
+      expect(getByText('2026-06-17')).toBeTruthy();
     });
 
     it('shows an inline install button on the release matching a downloaded APK', async () => {

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -340,6 +340,41 @@ describe('AppUpdateService', () => {
       expect(result.releasesUrl).toBe('https://github.com/heywood8/money-tracker/releases');
     });
 
+    it('propagates the release published_at timestamp into changelog entries', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ([
+          {
+            tag_name: 'v0.50.5',
+            assets: [{ name: 'penny-v0.50.5.apk', browser_download_url: 'https://example.com/penny-v0.50.5.apk' }],
+            html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v0.50.5',
+            body: 'New features in 0.50.5',
+            published_at: '2026-06-17T14:30:00Z',
+          },
+          {
+            tag_name: 'v0.50.3',
+            assets: [{ name: 'penny-v0.50.3.apk', browser_download_url: 'https://example.com/penny-v0.50.3.apk' }],
+            html_url: 'https://github.com/heywood8/money-tracker/releases/tag/v0.50.3',
+            body: 'Fixes in 0.50.3',
+            published_at: '2026-06-10T09:15:00Z',
+          },
+        ]),
+      });
+
+      const result = await checkForAppUpdate({
+        currentVersion: '0.50.3',
+        fetchImpl,
+      });
+
+      // The newer release surfaces its timestamp in both the update changelog and the recent list.
+      expect(result.releaseNotes[0].publishedAt).toBe('2026-06-17T14:30:00Z');
+      expect(result.recentReleaseNotes[0].publishedAt).toBe('2026-06-17T14:30:00Z');
+      expect(result.recentReleaseNotes[1].publishedAt).toBe('2026-06-10T09:15:00Z');
+      // The release page URL travels with the changelog entries so the version can deep-link to it.
+      expect(result.releaseNotes[0].releaseUrl).toBe('https://github.com/heywood8/money-tracker/releases/tag/v0.50.5');
+      expect(result.recentReleaseNotes[0].releaseUrl).toBe('https://github.com/heywood8/money-tracker/releases/tag/v0.50.5');
+    });
+
     it('handles GitHub rate limiting response gracefully', async () => {
       const fetchImpl = jest.fn().mockResolvedValue({
         ok: false,

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -65,6 +65,15 @@ const repoBaseFromReleasesUrl = (releasesUrl) => {
   return releasesUrl.replace(/\/releases\/?$/, '');
 };
 
+// Resolves the GitHub release page URL for a single release. Prefers the release's own
+// html_url from the API; when that is absent (older payloads) it reconstructs the tag URL
+// from the repository base, mirroring this repo's "penny-v<version>" tag convention.
+export const releaseUrlFor = (releaseUrl, repoBase, version) => {
+  if (releaseUrl) return releaseUrl;
+  if (repoBase && version) return `${repoBase}/releases/tag/penny-v${version}`;
+  return null;
+};
+
 // Renders release-note text, turning "#123" pull-request references into tappable links.
 const renderNotesWithLinks = (text, repoBase, linkColor) => {
   if (!text) return null;
@@ -103,13 +112,31 @@ const formatApkDate = (modificationTime) => {
   return new Date(modificationTime * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 };
 
+// Builds the "date · time" label shown beside a release version. GitHub's `published_at`
+// timestamp carries the time of day, so we prefer it and render both date and time. When it
+// is missing (older payloads, or the date was only lifted from the release-note heading) we
+// fall back to the bare date string, which has no time component.
+export const formatReleaseDateTime = (publishedAt, fallbackDate) => {
+  if (publishedAt) {
+    const parsed = new Date(publishedAt);
+    if (!Number.isNaN(parsed.getTime())) {
+      const datePart = parsed.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+      const timePart = parsed.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+      return `${datePart} · ${timePart}`;
+    }
+  }
+  return fallbackDate || null;
+};
+
 // Green used for the "installed / up to date" status, matching the checkmark elsewhere in this panel.
 const INSTALLED_GREEN = '#4caf50';
 // Amber used to warn that a corrupt cached download was discarded and is being re-downloaded.
 const WARNING_AMBER = '#f0a500';
 
-function ReleaseCard({ version, notes, badge, buildProgress, matchedApk, repoBase, onInstallApk, colors, t, isInstalled, isLatestInstalled, isUpdateCandidate }) {
+function ReleaseCard({ version, notes, publishedAt, releaseUrl, badge, buildProgress, matchedApk, repoBase, onInstallApk, colors, t, isInstalled, isLatestInstalled, isUpdateCandidate }) {
   const { date, body } = parseReleaseNotes(notes, version);
+  const dateLabel = formatReleaseDateTime(publishedAt, date);
+  const releasePageUrl = releaseUrlFor(releaseUrl, repoBase, version);
   const spinAnim = useRef(new Animated.Value(0)).current;
   useEffect(() => {
     if (!buildProgress) return undefined;
@@ -137,9 +164,20 @@ function ReleaseCard({ version, notes, badge, buildProgress, matchedApk, repoBas
     >
       <View style={styles.releaseHeader}>
         <View style={styles.releaseHeaderLeft}>
-          <Text style={[styles.releaseVersion, { color: colors.text }]}>v{version}</Text>
-          {date ? (
-            <Text style={[styles.releaseDate, { color: colors.mutedText }]}>{date}</Text>
+          {releasePageUrl ? (
+            <Text
+              style={[styles.releaseVersion, { color: colors.text }]}
+              onPress={() => Linking.openURL(releasePageUrl)}
+              accessibilityRole="link"
+              accessibilityLabel={`View release ${version} on GitHub`}
+            >
+              v{version}
+            </Text>
+          ) : (
+            <Text style={[styles.releaseVersion, { color: colors.text }]}>v{version}</Text>
+          )}
+          {dateLabel ? (
+            <Text style={[styles.releaseDate, { color: colors.mutedText }]}>{dateLabel}</Text>
           ) : null}
           {badge ? (
             <Text style={[styles.releaseBadge, { color: colors.mutedText, borderColor: colors.border }]}>
@@ -221,6 +259,8 @@ function ReleaseCard({ version, notes, badge, buildProgress, matchedApk, repoBas
 ReleaseCard.propTypes = {
   version: PropTypes.string,
   notes: PropTypes.string,
+  publishedAt: PropTypes.string,
+  releaseUrl: PropTypes.string,
   badge: PropTypes.string,
   buildProgress: PropTypes.shape({
     percent: PropTypes.number,
@@ -364,6 +404,8 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
         key={release.version}
         version={release.version}
         notes={release.notes}
+        publishedAt={release.publishedAt}
+        releaseUrl={release.releaseUrl}
         badge={release.badge}
         buildProgress={release.buildProgress}
         matchedApk={apkLookup.get(release.version)}
@@ -537,6 +579,8 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
           return {
             version: r.version,
             notes: r.notes,
+            publishedAt: r.publishedAt,
+            releaseUrl: r.releaseUrl,
             badge: !r.hasApk ? (t('no_apk_attached') || 'NO_APK_ATTACHED') : undefined,
             buildProgress,
           };
@@ -585,6 +629,8 @@ UpdateContentPanel.propTypes = {
     releaseNotes: PropTypes.arrayOf(PropTypes.shape({
       version: PropTypes.string,
       notes: PropTypes.string,
+      publishedAt: PropTypes.string,
+      releaseUrl: PropTypes.string,
       hasApk: PropTypes.bool,
       buildProgress: PropTypes.shape({
         percent: PropTypes.number,
@@ -593,6 +639,8 @@ UpdateContentPanel.propTypes = {
     recentReleaseNotes: PropTypes.arrayOf(PropTypes.shape({
       version: PropTypes.string,
       notes: PropTypes.string,
+      publishedAt: PropTypes.string,
+      releaseUrl: PropTypes.string,
     })),
     releasesUrl: PropTypes.string,
     alreadyDownloaded: PropTypes.bool,

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -291,14 +291,14 @@ export const checkForAppUpdate = async ({
 
       // Collect recent releases with APKs for changelog display regardless of version
       if (apkAsset && release.body && recentReleasesWithApk.length < MAX_CHANGELOG_ENTRIES) {
-        recentReleasesWithApk.push({ version: releaseVersion, notes: release.body });
+        recentReleasesWithApk.push({ version: releaseVersion, notes: release.body, publishedAt: release.published_at || null, releaseUrl: release.html_url || null });
       }
 
       if (compareVersions(releaseVersion, currentNormalized) <= 0) {
         continue; // not newer than current — skip
       }
 
-      newerReleases.push({ version: releaseVersion, notes: release.body || null, hasApk: !!apkAsset });
+      newerReleases.push({ version: releaseVersion, notes: release.body || null, hasApk: !!apkAsset, publishedAt: release.published_at || null, releaseUrl: release.html_url || null });
 
       if (apkAsset && (!bestRelease || compareVersions(releaseVersion, bestRelease.version) > 0)) {
         const checksumAsset = extractChecksumAsset(release.assets, apkAsset.name);
@@ -351,6 +351,8 @@ export const checkForAppUpdate = async ({
             version: r.version,
             notes: r.notes,
             hasApk: r.hasApk,
+            publishedAt: r.publishedAt || null,
+            releaseUrl: r.releaseUrl || null,
             buildProgress: !r.hasApk ? (progressByVersion[r.version] || null) : null,
           }));
         return {
@@ -374,7 +376,7 @@ export const checkForAppUpdate = async ({
 
     const releaseNotes = newerReleases
       .filter((r) => r.notes && r.hasApk)
-      .map((r) => ({ version: r.version, notes: r.notes }));
+      .map((r) => ({ version: r.version, notes: r.notes, publishedAt: r.publishedAt || null, releaseUrl: r.releaseUrl || null }));
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

The update-checking screen previously showed only the release **date** for each release (lifted from the release-note heading, e.g. `## 0.134.15 (2026-06-17)`, which has no time component). This PR surfaces the full release **timestamp** and makes each version label deep-link to its GitHub release page.

## Changes

**Show date + time**
- `AppUpdateService` now carries GitHub's `published_at` through every changelog entry (`releaseNotes` and `recentReleaseNotes`), not just the single best release.
- `UpdateContentPanel` renders `date · time` when a timestamp is available (via a new `formatReleaseDateTime` helper), falling back to the bare heading date when it isn't.

**Clickable version → GitHub release page**
- Each release's `html_url` now travels with its changelog entry.
- The version label (e.g. `v0.148.0`) is now a tappable link that opens the release page. Its text color is unchanged.
- A `releaseUrlFor` helper reconstructs the `…/releases/tag/penny-v<version>` URL from the repo base when an entry has no `html_url` (older payloads).

## Testing
- Added unit tests for `formatReleaseDateTime` and `releaseUrlFor`, component tests for the date/time rendering and the tappable version link, and a service test verifying `publishedAt` / `releaseUrl` propagation.
- Full suite green: **3749 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192SUWpxQUmLLo8c5kkHauk

---
_Generated by [Claude Code](https://claude.ai/code/session_0192SUWpxQUmLLo8c5kkHauk)_