### PR TITLE
fix: let Settings subpanel content scroll behind the tab bar

### DIFF
--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -346,7 +346,7 @@ const unmatchedApksFor = (downloadedApks, releases) => {
   return downloadedApks.filter((apk) => !apk.version || !shown.has(apk.version));
 };
 
-export default function UpdateContentPanel({ isChecking, updateResult, downloadedApks, onUpdate, onInstallApk, onRefresh }) {
+export default function UpdateContentPanel({ isChecking, updateResult, downloadedApks, onUpdate, onInstallApk, onRefresh, bottomInset }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const contentAnim = useRef(new Animated.Value(0)).current;
@@ -458,7 +458,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
                 </Text>
               </View>
             ) : null}
-            <View style={styles.updateBottomRow}>
+            <View style={[styles.updateBottomRow, { paddingBottom: bottomInset }]}>
               {releaseNotes ? (
                 <UnmatchedApks apks={unmatched} onInstallApk={onInstallApk} colors={colors} t={t} compact />
               ) : (
@@ -504,6 +504,10 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
             // Only fall back to a standalone bottom status when that card is absent (the
             // installed version isn't among the listed releases).
             const latestShownOnCard = !!installedVersion && releases.some((r) => r.version === installedVersion);
+            // The release list is the bottom-most element only when no status row
+            // follows it; in that case it carries the bottom inset so its content
+            // can scroll clear of — and peek through — the floating tab bar.
+            const upToDateHasBottomRow = unmatched.length > 0 || !latestShownOnCard;
             return (
               <>
                 <Text style={[styles.changelogTitle, { color: colors.mutedText }]}>
@@ -512,6 +516,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
                 <ScrollView
                   style={styles.changelogScroll}
                   showsVerticalScrollIndicator={false}
+                  contentContainerStyle={upToDateHasBottomRow ? undefined : { paddingBottom: bottomInset }}
                   refreshControl={onRefresh ? <RefreshControl refreshing={false} onRefresh={onRefresh} /> : undefined}
                 >
                   {renderReleaseCards(releases)}
@@ -519,10 +524,10 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
                     <MoreReleasesLink url={updateResult.releasesUrl} colors={colors} t={t} />
                   )}
                 </ScrollView>
-                {(unmatched.length > 0 || !latestShownOnCard) && (
+                {upToDateHasBottomRow && (
                   <>
                     <Divider style={styles.updateDivider} />
-                    <View style={styles.updateBottomRow}>
+                    <View style={[styles.updateBottomRow, { paddingBottom: bottomInset }]}>
                       <UnmatchedApks apks={unmatched} onInstallApk={onInstallApk} colors={colors} t={t} compact />
                       {!latestShownOnCard ? (
                         <View style={styles.upToDateBottomRight}>
@@ -594,6 +599,7 @@ export default function UpdateContentPanel({ isChecking, updateResult, downloade
             <ScrollView
               style={styles.changelogScroll}
               showsVerticalScrollIndicator={false}
+              contentContainerStyle={{ paddingBottom: bottomInset }}
               refreshControl={onRefresh ? <RefreshControl refreshing={false} onRefresh={onRefresh} /> : undefined}
             >
               {renderReleaseCards(noApkReleases)}
@@ -655,6 +661,7 @@ UpdateContentPanel.propTypes = {
   onUpdate: PropTypes.func,
   onInstallApk: PropTypes.func,
   onRefresh: PropTypes.func,
+  bottomInset: PropTypes.number,
 };
 
 UpdateContentPanel.defaultProps = {
@@ -664,6 +671,7 @@ UpdateContentPanel.defaultProps = {
   onUpdate: () => {},
   onInstallApk: () => {},
   onRefresh: null,
+  bottomInset: 0,
 };
 
 const styles = StyleSheet.create({
@@ -867,7 +875,10 @@ const styles = StyleSheet.create({
   resultContainer: {
     flex: 1,
     paddingHorizontal: HORIZONTAL_PADDING,
-    paddingVertical: SPACING.lg,
+    // Only top padding: the bottom inset is applied per-section (scroll
+    // contentContainerStyle / bottom action row) so list content can scroll
+    // behind the floating tab bar instead of stopping short above it.
+    paddingTop: SPACING.lg,
   },
   upToDateBottomRight: {
     alignItems: 'center',

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -67,6 +67,11 @@ const BUILD_PROGRESS_POLL_MS = 5000;
 
 export default function SettingsScreen({ setSubPanelActive }) {
   const insets = useSafeAreaInsets();
+  // Bottom padding applied to each subpanel's scrollable content so the last
+  // items clear the floating tab bar while the scroll viewport itself still
+  // extends to the screen bottom — letting content scroll behind the
+  // translucent bar exactly like the operations list does.
+  const scrollBottomInset = insets.bottom + 80;
   const { colors } = useThemeColors();
   const { colorScheme, setTheme } = useThemeConfig();
   const { t, language, setLanguage, availableLanguages } = useLocalization();
@@ -919,11 +924,13 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
         <Divider />
 
-        {/* Subpanel body */}
+        {/* Subpanel body — fills to the screen bottom so list content can scroll
+            behind the translucent floating tab bar. The bottom padding that keeps
+            the last items reachable lives on each scrollable's contentContainerStyle
+            instead, mirroring the operations list. */}
         <View style={[
           styles.subPanelBody,
           (activeSubPanel === 'accounts' || activeSubPanel === 'categories') && styles.subPanelBodyFlush,
-          !(activeSubPanel === 'accounts' || activeSubPanel === 'categories') && { paddingBottom: insets.bottom + 80 },
         ]}>
           {activeSubPanel === 'accounts' && <AccountsScreen onBackStateChange={handleEmbeddedBackStateChange} />}
           {activeSubPanel === 'categories' && <CategoriesScreen onBackStateChange={handleEmbeddedBackStateChange} />}
@@ -931,6 +938,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
           {activeSubPanel === 'defaultAccount' && (
             <ScrollView
               style={styles.listContainer}
+              contentContainerStyle={{ paddingBottom: scrollBottomInset }}
               testID="settings-default-account-panel"
             >
               <TouchableRipple
@@ -964,7 +972,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
           )}
 
           {activeSubPanel === 'language' && (
-            <ScrollView style={styles.listContainer}>
+            <ScrollView style={styles.listContainer} contentContainerStyle={{ paddingBottom: scrollBottomInset }}>
               {availableLanguages.map(lng => (
                 <TouchableRipple
                   key={lng}
@@ -985,7 +993,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
           )}
 
           {activeSubPanel === 'export' && exportStep === 'list' && (
-            <ScrollView style={styles.listContainer}>
+            <ScrollView style={styles.listContainer} contentContainerStyle={{ paddingBottom: scrollBottomInset }}>
               <TouchableRipple
                 onPress={saveLocalBackupSuccess ? null : handleSaveLocalBackup}
                 style={styles.listItem}
@@ -1179,7 +1187,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
           )}
 
           {activeSubPanel === 'import' && importStep === 'source' && (
-            <ScrollView style={styles.listContainer}>
+            <ScrollView style={styles.listContainer} contentContainerStyle={{ paddingBottom: scrollBottomInset }}>
               <TouchableRipple onPress={() => handleImportSourceSelect('file')} style={styles.listItem}>
                 <View style={styles.listItemContent}>
                   <View style={styles.formatItemRow}>
@@ -1253,7 +1261,10 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 keyExtractor={(item) => item.uri}
                 renderItem={renderBackupItem}
                 style={styles.flexList}
-                contentContainerStyle={storedBackups.length === 0 && styles.emptyContainer}
+                contentContainerStyle={[
+                  storedBackups.length === 0 && styles.emptyContainer,
+                  { paddingBottom: scrollBottomInset },
+                ]}
                 ListEmptyComponent={
                   <Text style={[styles.emptyText, { color: colors.mutedText }]}>
                     {t('local_backups_empty') || 'No local backups yet'}
@@ -1361,7 +1372,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
               <Divider />
 
-              <View style={styles.logsActionBar}>
+              <View style={[styles.logsActionBar, { paddingBottom: scrollBottomInset }]}>
                 <TouchableOpacity onPress={handleShareLogs} style={styles.logsActionButton}>
                   <Ionicons name="share-outline" size={20} color={colors.primary} />
                   <Text style={[styles.logsActionText, { color: colors.primary }]}>
@@ -1387,6 +1398,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 onUpdate={handleUpdateFromSettings}
                 onInstallApk={handleInstallApk}
                 onRefresh={runUpdateCheck}
+                bottomInset={scrollBottomInset}
               />
             </View>
           )}


### PR DESCRIPTION
## Summary

Follow-up to #1042. That PR made the bottom gradient render *over* the Settings subpanels, but the subpanel content still stopped abruptly above the floating tab bar — leaving an opaque gap, as shown in the reported screenshot. The release notes / version history list didn't scroll behind the bar the way the operations list does.

### Cause

The subpanel body applied the bottom inset (`insets.bottom + 80`) to the **container** (`subPanelBody`). That shrank the scroll viewport so it ended *above* the bar, and the gap underneath rendered the opaque subpanel background — so nothing could show through the translucent bar.

### Fix

Move the bottom inset off the container and onto each scrollable's `contentContainerStyle`, so the scroll viewport itself extends to the screen bottom while the last items still clear the bar. Content now scrolls behind — and peeks through — the translucent tab bar, matching the operations list.

- `SettingsScreen.js`: drop the container `paddingBottom`; apply `scrollBottomInset` to the `contentContainerStyle` of the language / default-account / export / import-source ScrollViews and the local-backups FlatList. The logs action bar (a fixed bottom row) keeps its own bottom inset so it still clears the bar. The update panel receives the inset via a new `bottomInset` prop.
- `UpdateContentPanel.js`: thread `bottomInset` through. The release-notes ScrollView carries it in `contentContainerStyle` when it's the bottom-most element (so the list peeks through), while fixed bottom action rows (the "Update now" row, the up-to-date status row) carry it as padding so they stay above the bar.

## Testing

- `npx eslint` on the changed files — clean.
- `npx jest` — all 122 suites / 3749 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0115duDK6LrgPe4vt76y7oAx)_