### PR TITLE
feat: strip Note:/metadata prefixes from label suggestion chips

### DIFF
--- a/__tests__/components/operations/LabelInput.test.js
+++ b/__tests__/components/operations/LabelInput.test.js
@@ -110,6 +110,18 @@ describe('LabelInput', () => {
     expect(onChangeText).toHaveBeenCalledWith('food');
   });
 
+  it('shows Note: suggestion chips with the prefix stripped', async () => {
+    const { getByTestId, getByText, queryByText } = await renderInput({
+      value: '',
+      suggestions: ['Note: Mak'],
+    });
+    await fireEvent(getByTestId('label-input-field'), 'focus');
+    await waitFor(() => expect(getByTestId('label-suggestion-Note: Mak')).toBeTruthy());
+    // The chip text is the display form, not the raw "Note: Mak" label.
+    expect(getByText('Mak')).toBeTruthy();
+    expect(queryByText('Note: Mak')).toBeNull();
+  });
+
   it('hides the input and remove buttons when not editable', async () => {
     const { queryByTestId, getByText } = await renderInput({ value: 'work', editable: false });
     expect(queryByTestId('label-input-field')).toBeNull();

--- a/app/components/operations/LabelInput.js
+++ b/app/components/operations/LabelInput.js
@@ -230,11 +230,11 @@ const LabelInput = forwardRef(({
                 onPress={() => handleSuggestionPress(label)}
                 activeOpacity={0.65}
                 accessibilityRole="button"
-                accessibilityLabel={`label: ${label}`}
+                accessibilityLabel={`label: ${displayLabel(label)}`}
                 testID={`label-suggestion-${label}`}
               >
                 <Icon name="plus" size={12} color={colors.primary} />
-                <Text style={[styles.suggestionText, { color: colors.primary }]} numberOfLines={1}>{label}</Text>
+                <Text style={[styles.suggestionText, { color: colors.primary }]} numberOfLines={1}>{displayLabel(label)}</Text>
               </TouchableOpacity>
             ))}
           </ScrollView>


### PR DESCRIPTION
## Summary

Follow-up to #1039. Imported `Note:` labels are shown stripped (`Note: Mak` → `Mak`) in the operations list and in the operation's own label chips, but the **autocomplete suggestion chips** still rendered the raw label — so `Note: Mak` still appeared with the `Note:` prefix in the suggestion row.

This applies `displayLabel` to the suggestion chip text (and its accessibility label) so suggestions match how labels appear everywhere else.

## Implementation

- `LabelInput.js`: render each suggestion chip's text and `accessibilityLabel` through `displayLabel(label)`. The underlying value applied when a chip is tapped is unchanged (the raw label), so it continues to display stripped once added and no duplicate suggestions are introduced.

## Testing

- `LabelInput.test.js`: added a test asserting a `Note: Mak` suggestion renders as `Mak`.
- Full suite: **3716 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYJUGbc2JcDjdKwCwMXm2e)_