### PR TITLE
fix: prioritize label-chip scroll over screen swipes

### DIFF
--- a/__tests__/components/operations/DescriptionSuggestionRow.test.js
+++ b/__tests__/components/operations/DescriptionSuggestionRow.test.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
+import { Gesture } from 'react-native-gesture-handler';
 import { render, fireEvent } from '@testing-library/react-native';
 import DescriptionSuggestionRow from '../../../app/components/operations/DescriptionSuggestionRow';
+import { SwipeNavigationGestureProvider } from '../../../app/contexts/SwipeNavigationContext';
 
 const mockColors = {
   border: '#333',
@@ -69,5 +71,30 @@ describe('DescriptionSuggestionRow', () => {
     for (const chip of baseProps.chips) {
       expect(getByText(chip)).toBeTruthy();
     }
+  });
+
+  describe('Swipe priority', () => {
+    it('gives the chip scroll priority over the screen-swipe gesture', async () => {
+      const swipeGesture = { __id: 'swipe' };
+      Gesture.Native.mockClear();
+
+      await render(
+        <SwipeNavigationGestureProvider value={swipeGesture}>
+          <DescriptionSuggestionRow {...baseProps} />
+        </SwipeNavigationGestureProvider>,
+      );
+
+      // The chip's native scroll gesture must block the screen-swipe Pan so a
+      // horizontal drag scrolls the chips instead of switching screens.
+      expect(Gesture.Native).toHaveBeenCalled();
+      const nativeInstance = Gesture.Native.mock.results[0].value;
+      expect(nativeInstance.blocksExternalGesture).toHaveBeenCalledWith(swipeGesture);
+    });
+
+    it('renders without a swipe gesture provider (no blocking relation)', async () => {
+      const { getByText } = await render(<DescriptionSuggestionRow {...baseProps} />);
+      // Still renders normally when there is no swipe navigation in the tree.
+      expect(getByText('Monthly pass')).toBeTruthy();
+    });
   });
 });

--- a/app/components/operations/DescriptionSuggestionRow.js
+++ b/app/components/operations/DescriptionSuggestionRow.js
@@ -1,10 +1,21 @@
-import React, { memo, useEffect, useRef } from 'react';
+import React, { memo, useEffect, useMemo, useRef } from 'react';
 import { View, Text, TouchableOpacity, Animated, ScrollView, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import { SPACING, FONT_SIZE, BORDER_RADIUS, DURATION } from '../../styles/designTokens';
+import { useSwipeNavigationGesture } from '../../contexts/SwipeNavigationContext';
 
 const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
   const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  // Give horizontal scrolling over the chips priority over the screen-swipe
+  // gesture: the native scroll blocks the external Pan until it fails, so a
+  // sideways drag on the chips scrolls the strip instead of switching screens.
+  const swipeGesture = useSwipeNavigationGesture();
+  const scrollGesture = useMemo(() => {
+    const native = Gesture.Native();
+    return swipeGesture ? native.blocksExternalGesture(swipeGesture) : native;
+  }, [swipeGesture]);
 
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -29,25 +40,27 @@ const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
             <Text style={[styles.chipText, { color: colors.mutedText }]}>✕</Text>
           </TouchableOpacity>
         </View>
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          keyboardShouldPersistTaps="always"
-          contentContainerStyle={styles.chipRow}
-          style={styles.chipScroll}
-        >
-          {chips.map((chip) => (
-            <TouchableOpacity
-              key={chip}
-              onPress={() => onApply(chip)}
-              style={[styles.chip, { borderColor: colors.border, backgroundColor: colors.surface }]}
-              accessibilityRole="button"
-              accessibilityLabel={`label: ${chip}`}
-            >
-              <Text style={[styles.chipText, { color: colors.primary }]} numberOfLines={1}>{chip}</Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
+        <GestureDetector gesture={scrollGesture}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            keyboardShouldPersistTaps="always"
+            contentContainerStyle={styles.chipRow}
+            style={styles.chipScroll}
+          >
+            {chips.map((chip) => (
+              <TouchableOpacity
+                key={chip}
+                onPress={() => onApply(chip)}
+                style={[styles.chip, { borderColor: colors.border, backgroundColor: colors.surface }]}
+                accessibilityRole="button"
+                accessibilityLabel={`label: ${chip}`}
+              >
+                <Text style={[styles.chipText, { color: colors.primary }]} numberOfLines={1}>{chip}</Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </GestureDetector>
       </View>
     </Animated.View>
   );

--- a/app/contexts/SwipeNavigationContext.js
+++ b/app/contexts/SwipeNavigationContext.js
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+
+// Shares the screen-swipe Pan gesture (created in SimpleTabs) with descendants
+// so nested horizontal scrollables can declare priority over it via
+// `blocksExternalGesture`. Defaults to null when there is no swipe navigation
+// in the tree (e.g. in isolation tests).
+const SwipeNavigationGestureContext = createContext(null);
+
+export const SwipeNavigationGestureProvider = SwipeNavigationGestureContext.Provider;
+
+// Returns the active swipe-navigation Pan gesture, or null when unavailable.
+export const useSwipeNavigationGesture = () => useContext(SwipeNavigationGestureContext);
+
+export default SwipeNavigationGestureContext;

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -24,6 +24,7 @@ import PlannedOperationsScreen from '../screens/PlannedOperationsScreen';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
+import { SwipeNavigationGestureProvider } from '../contexts/SwipeNavigationContext';
 import Header from '../components/Header';
 import SettingsScreen from '../screens/SettingsScreen';
 
@@ -482,7 +483,12 @@ export default function SimpleTabs() {
       <View style={styles.content}>
         <GestureDetector gesture={panGesture}>
           <Animated.View style={[styles.screensContainer, animatedStyle]}>
-            {renderScreens()}
+            {/* Expose the swipe Pan gesture so nested horizontal scrollables
+                (e.g. label-suggestion chips) can take priority over screen
+                swipes via blocksExternalGesture. */}
+            <SwipeNavigationGestureProvider value={panGesture}>
+              {renderScreens()}
+            </SwipeNavigationGestureProvider>
           </Animated.View>
         </GestureDetector>
       </View>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -455,10 +455,11 @@ jest.mock('react-native-gesture-handler', () => {
 
   const PropTypes = require('prop-types');
 
-  const GestureDetector = ({ children }) => React.createElement(View, {}, children);
+  const { View: RNView } = require('react-native');
+
+  const GestureDetector = ({ children }) => React.createElement(RNView, {}, children);
   GestureDetector.propTypes = { children: PropTypes.node };
 
-  const { View: RNView } = require('react-native');
   const SwipeableMock = ({ children, renderRightActions }) => {
     const rightActions = renderRightActions ? renderRightActions() : null;
     return React.createElement(RNView, {}, children, rightActions);
@@ -480,6 +481,9 @@ jest.mock('react-native-gesture-handler', () => {
       minDistance: jest.fn().mockReturnThis(),
       minPointers: jest.fn().mockReturnThis(),
       maxPointers: jest.fn().mockReturnThis(),
+      blocksExternalGesture: jest.fn().mockReturnThis(),
+      simultaneousWithExternalGesture: jest.fn().mockReturnThis(),
+      requireExternalGestureToFail: jest.fn().mockReturnThis(),
     })),
     Tap: jest.fn(() => ({
       onStart: jest.fn().mockReturnThis(),
@@ -495,6 +499,12 @@ jest.mock('react-native-gesture-handler', () => {
       onFinalize: jest.fn().mockReturnThis(),
       enabled: jest.fn().mockReturnThis(),
       minDuration: jest.fn().mockReturnThis(),
+    })),
+    Native: jest.fn(() => ({
+      enabled: jest.fn().mockReturnThis(),
+      blocksExternalGesture: jest.fn().mockReturnThis(),
+      simultaneousWithExternalGesture: jest.fn().mockReturnThis(),
+      requireExternalGestureToFail: jest.fn().mockReturnThis(),
     })),
   };
 


### PR DESCRIPTION
## Problem

Dragging horizontally across the label-suggestion chips (the `Кофе | Jermots | Note: Mak | …` row under an operation) triggered the **screen-swipe navigation** between tabs instead of scrolling the chip strip. The parent `Pan` gesture in `SimpleTabs` won the gesture race, so the chips were effectively impossible to scroll.

## Fix

Give the chip scroll priority over the screen swipe using `react-native-gesture-handler`'s gesture-relation API:

- **`app/contexts/SwipeNavigationContext.js`** (new) — exposes the screen-swipe `Pan` gesture to descendants via context, with a `null` default for trees without swipe navigation.
- **`app/navigation/SimpleTabs.js`** — wraps the mounted screens in `SwipeNavigationGestureProvider` so descendants can reference the swipe gesture.
- **`app/components/operations/DescriptionSuggestionRow.js`** — wraps the chip `ScrollView` in a `GestureDetector` with `Gesture.Native().blocksExternalGesture(swipeGesture)`. The native scroll now blocks the screen-swipe `Pan` until it fails, so sideways drags scroll the chips while the rest of the screen still swipes between tabs. Falls back to a plain native gesture when no provider is present.

The approach was verified against current `react-native-gesture-handler` docs (the `Gesture.Native` + `blocksExternalGesture` "scrollable list child takes precedence" pattern).

## Test changes

- Fixed the global `GestureDetector` mock in `jest.setup.js` to render a valid host `View` (it previously used an internal View path that produced an invalid element type), and added `Gesture.Native` plus the `blocksExternalGesture` / `simultaneousWithExternalGesture` / `requireExternalGestureToFail` chainable methods.
- Added regression tests asserting the chip native gesture blocks the provided swipe gesture, and that the row still renders without a provider.

All 3752 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016KCmeeZvhcKDeJnsZuD4Sy)_