### PR TITLE
fix: prevent welcome screen flash on app open

### DIFF
--- a/__tests__/screens/AppInitializer.test.js
+++ b/__tests__/screens/AppInitializer.test.js
@@ -85,6 +85,7 @@ jest.mock('../../app/navigation/SimpleTabs', () => {
 // Create a mock LocalizationContext for controlled testing
 const mockLocalizationContext = {
   isFirstLaunch: false,
+  isLoading: false,
   setFirstLaunchComplete: jest.fn(),
   language: 'en',
 };
@@ -120,6 +121,7 @@ describe('AppInitializer', () => {
     jest.clearAllMocks();
     // Reset to default state
     mockLocalizationContext.isFirstLaunch = false;
+    mockLocalizationContext.isLoading = false;
     mockLocalizationContext.language = 'en';
     mockLocalizationContext.setFirstLaunchComplete = jest.fn();
   });
@@ -262,6 +264,30 @@ describe('AppInitializer', () => {
   });
 
   describe('Regression Tests', () => {
+    it('renders nothing while the language preference is still loading', async () => {
+      // Guards against briefly flashing the welcome/language screen on app open:
+      // isFirstLaunch defaults to true until the stored preference is read, so
+      // AppInitializer must render nothing (keeping the splash up) while loading.
+      mockLocalizationContext.isLoading = true;
+      mockLocalizationContext.isFirstLaunch = true;
+
+      const { queryByTestId, toJSON } = await render(<AppInitializer />);
+
+      expect(queryByTestId('language-selection-screen')).toBeNull();
+      expect(queryByTestId('simple-tabs')).toBeNull();
+      expect(toJSON()).toBeNull();
+    });
+
+    it('shows main app once loading completes for an initialized app', async () => {
+      mockLocalizationContext.isLoading = false;
+      mockLocalizationContext.isFirstLaunch = false;
+
+      const { getByTestId, queryByTestId } = await render(<AppInitializer />);
+
+      expect(getByTestId('simple-tabs')).toBeTruthy();
+      expect(queryByTestId('language-selection-screen')).toBeNull();
+    });
+
     it('does not show loading indicator when not initializing', async () => {
       mockLocalizationContext.isFirstLaunch = false;
 

--- a/app/contexts/LocalizationContext.js
+++ b/app/contexts/LocalizationContext.js
@@ -39,6 +39,7 @@ const LocalizationContext = createContext({
   setLanguage: () => {},
   availableLanguages: Object.keys(i18nData),
   isFirstLaunch: false,
+  isLoading: true,
   setFirstLaunchComplete: () => {},
 });
 
@@ -128,8 +129,9 @@ export function LocalizationProvider({ children }) {
     setLanguage,
     availableLanguages: Object.keys(i18nData),
     isFirstLaunch,
+    isLoading,
     setFirstLaunchComplete,
-  }), [t, language, setLanguage, isFirstLaunch, setFirstLaunchComplete]);
+  }), [t, language, setLanguage, isFirstLaunch, isLoading, setFirstLaunchComplete]);
 
   return (
     <LocalizationContext.Provider value={value}>

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -20,7 +20,7 @@ const UPDATE_REMINDER_DELAY_DAYS = 3;
  * Shows language selection screen on first launch, then initializes categories
  */
 const AppInitializer = () => {
-  const { isFirstLaunch, setFirstLaunchComplete, t } = useLocalization();
+  const { isFirstLaunch, isLoading, setFirstLaunchComplete, t } = useLocalization();
   const { colors } = useThemeColors();
   const { showDialog } = useDialog();
   const { startDownload } = useUpdateDownload();
@@ -120,6 +120,14 @@ const AppInitializer = () => {
       setIsInitializing(false);
     }
   };
+
+  // While the stored language preference is still loading, render nothing so the
+  // native splash screen stays up. This avoids briefly flashing the language
+  // selection (welcome) screen before we know whether this is truly a first
+  // launch — isFirstLaunch defaults to true until the preference is read.
+  if (isLoading) {
+    return null;
+  }
 
   // If showing language selection or initializing, don't show main app yet
   if (isFirstLaunch) {


### PR DESCRIPTION
## Problem

On every app open — even for an already-initialized app — the language selection ("welcome") screen briefly flashed before the main app appeared.

## Root cause

`AppInitializer` decided what to render based solely on `isFirstLaunch`, which defaults to `true` in `LocalizationContext` until the stored language preference is read from the database. The native splash screen is hidden once `isLoading` becomes `false`, but `AppInitializer` ignored `isLoading`. Without guaranteed batching of the `setIsFirstLaunch(false)` / `setIsLoading(false)` updates in the async load callback, the splash could hide for a frame while `isFirstLaunch` was still stale-`true`, rendering `LanguageSelectionScreen` momentarily.

## Fix

- Expose `isLoading` from `LocalizationContext`.
- In `AppInitializer`, render `null` while `isLoading` is `true`, keeping the native splash up until we definitively know whether this is a first launch. The splash hides exactly when the correct screen is ready.

## Testing

- Added regression tests in `AppInitializer.test.js` covering the loading gate (renders nothing while loading; shows main app once loading completes for an initialized app).
- `AppInitializer` + `LocalizationContext` suites: 40/40 passing.
- Full suite: all tests related to this change pass. (One unrelated, pre-existing flaky failure in `OperationModal.test.js` under parallel execution — passes in isolation both before and after this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019koNXVaUMa56NWZZDtwfbZ)_