### PR TITLE
refactor: replace BudgetModal nested picker Modals with the subpanel pattern

### DIFF
--- a/__tests__/modals/BudgetModal.test.js
+++ b/__tests__/modals/BudgetModal.test.js
@@ -517,50 +517,47 @@ describe('BudgetModal', () => {
     });
   });
 
-  it('closes currency picker via close button (lines 504-506)', async () => {
-    const { getByText, queryByText } = await render(
+  it('closes currency picker via back arrow', async () => {
+    const { getByText, getByTestId, queryByText } = await render(
       <BudgetModal visible={true} onClose={mockOnClose} isNew={true} categoryId="c1" categoryName="Food" />,
     );
 
-    // Open currency picker
+    // Open currency subpanel
     const currencyBtn = getByText(/USD/);
     await fireEvent.press(currencyBtn);
 
-    // Modal should open
+    // Subpanel should slide in
     expect(getByText('select_currency')).toBeTruthy();
 
-    // Find and press close button
-    const closeBtn = getByText('close');
-    await fireEvent.press(closeBtn);
+    // Press the back arrow to close the subpanel
+    await fireEvent.press(getByTestId('budget-subpanel-back'));
 
     await waitFor(() => {
       expect(queryByText('select_currency')).toBeFalsy();
     });
   });
 
-  it('closes period picker via close button (lines 541)', async () => {
-    const { getByText, queryByText, getAllByText } = await render(
+  it('closes period picker via back arrow', async () => {
+    const { getByText, getByTestId, getAllByText } = await render(
       <BudgetModal visible={true} onClose={mockOnClose} isNew={true} categoryId="c1" categoryName="Food" />,
     );
 
-    // Open period picker
+    // Open period subpanel
     const periodBtn = getByText('monthly');
     await fireEvent.press(periodBtn);
 
-    // Modal should open with period_type title
+    // Subpanel should slide in with period_type title
     await waitFor(() => {
       const periodTitles = getAllByText('period_type');
-      expect(periodTitles.length).toBeGreaterThan(1); // One in main form, one in picker title
+      expect(periodTitles.length).toBeGreaterThan(1); // One in main form label, one as subpanel title
     });
 
-    // Find and press close button in the period picker
-    const closeBtns = getAllByText('close');
-    await fireEvent.press(closeBtns[closeBtns.length - 1]);
+    // Press the back arrow to close the subpanel
+    await fireEvent.press(getByTestId('budget-subpanel-back'));
 
-    // Picker should close - period picker has period_type as title
+    // After closing, only the form's period_type label remains
     await waitFor(() => {
-      // After closing, there should be only one period_type text (the label)
-      expect(getByText('period_type')).toBeTruthy();
+      expect(getAllByText('period_type').length).toBe(1);
     });
   });
 
@@ -951,52 +948,111 @@ describe('BudgetModal', () => {
       expect(getByText('save')).toBeTruthy();
     });
 
-    it('opens currency picker modal successfully', async () => {
-      const { getByText, queryByText } = await render(
+    it('opens currency picker subpanel successfully', async () => {
+      const { getByText, getByTestId, queryByText } = await render(
         <BudgetModal visible={true} onClose={mockOnClose} isNew={true} categoryId="c1" categoryName="Food" />,
       );
 
-      // Open currency picker
+      // Open currency subpanel
       const currencyBtn = getByText(/USD/);
       await fireEvent.press(currencyBtn);
 
-      // Modal should open with title
+      // Subpanel should slide in with title
       expect(getByText('select_currency')).toBeTruthy();
 
-      // Close via close button
-      const closeBtn = getByText('close');
-      await fireEvent.press(closeBtn);
+      // Close via back arrow
+      await fireEvent.press(getByTestId('budget-subpanel-back'));
 
       await waitFor(() => {
         expect(queryByText('select_currency')).toBeFalsy();
       });
     });
 
-    it('opens period picker modal successfully', async () => {
-      const { getByText, getAllByText, queryAllByText, getByPlaceholderText } = await render(
+    it('opens period picker subpanel successfully', async () => {
+      const { getByText, getByTestId, getAllByText, queryAllByText } = await render(
         <BudgetModal visible={true} onClose={mockOnClose} isNew={true} categoryId="c1" categoryName="Food" />,
       );
 
-      // Open period picker
+      // Open period subpanel
       const periodBtn = getByText('monthly');
       await fireEvent.press(periodBtn);
 
-      // Modal should open with title - now there should be 2 period_type elements
+      // Subpanel should slide in - now there should be 2 period_type elements
       await waitFor(() => {
         const periodLabels = getAllByText('period_type');
         expect(periodLabels.length).toBeGreaterThan(1);
       });
 
-      // Close via close button (last close button)
-      const closeBtns = getAllByText('close');
-      await fireEvent.press(closeBtns[closeBtns.length - 1]);
+      // Close via back arrow
+      await fireEvent.press(getByTestId('budget-subpanel-back'));
 
-      // Modal should close
+      // Subpanel should close
       await waitFor(() => {
-        // After closing, modal title should be gone (only the label remains)
+        // After closing, subpanel title should be gone (only the label remains)
         const remaining = queryAllByText('period_type');
         expect(remaining.length).toBe(1);
       });
+    });
+  });
+
+  describe('Subpanel pattern (no nested Modal)', () => {
+    it('renders the picker as a subpanel within the same modal (no nested Modal)', async () => {
+      const { getByText, getByTestId, getAllByTestId, queryByTestId } = await render(
+        <BudgetModal visible={true} onClose={mockOnClose} isNew={true} categoryId="c1" categoryName="Food" />,
+      );
+
+      // No subpanel up front
+      expect(queryByTestId('budget-subpanel')).toBeFalsy();
+
+      // Opening the currency picker mounts the subpanel inside the existing modal
+      await fireEvent.press(getByText(/USD/));
+      expect(getByTestId('budget-subpanel')).toBeTruthy();
+      expect(getByText('select_currency')).toBeTruthy();
+
+      // Still exactly one modal, and the main form header is still mounted behind it
+      expect(getAllByTestId('budget-modal').length).toBe(1);
+      expect(getByText('set_budget')).toBeTruthy();
+    });
+
+    it('hardware back closes the subpanel first, then the modal', async () => {
+      const { getByText, getByTestId, queryByText } = await render(
+        <BudgetModal visible={true} onClose={mockOnClose} isNew={true} categoryId="c1" categoryName="Food" />,
+      );
+
+      // Open the currency subpanel
+      await fireEvent.press(getByText(/USD/));
+      expect(getByText('select_currency')).toBeTruthy();
+
+      // First hardware-back (onRequestClose): closes the subpanel, not the modal
+      await fireEvent(getByTestId('budget-modal'), 'requestClose');
+      await waitFor(() => {
+        expect(queryByText('select_currency')).toBeFalsy();
+      });
+      expect(mockOnClose).not.toHaveBeenCalled();
+
+      // Second hardware-back: now closes the whole modal
+      await fireEvent(getByTestId('budget-modal'), 'requestClose');
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled();
+      });
+    });
+
+    it('back arrow on the subpanel does not close the modal', async () => {
+      const { getByText, getByTestId, queryByText } = await render(
+        <BudgetModal visible={true} onClose={mockOnClose} isNew={true} categoryId="c1" categoryName="Food" />,
+      );
+
+      await fireEvent.press(getByText('monthly'));
+      await waitFor(() => expect(getByText('weekly')).toBeTruthy());
+
+      await fireEvent.press(getByTestId('budget-subpanel-back'));
+
+      await waitFor(() => {
+        // weekly option gone (subpanel unmounted) but modal still open
+        expect(queryByText('weekly')).toBeFalsy();
+      });
+      expect(getByText('set_budget')).toBeTruthy();
+      expect(mockOnClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/modals/BudgetModal.js
+++ b/app/modals/BudgetModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -12,6 +12,9 @@ import {
   Platform,
   Keyboard,
   Switch,
+  Animated,
+  Easing,
+  Dimensions,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -56,8 +59,13 @@ export default function BudgetModal({ visible, onClose, budget, categoryId, cate
   const [errors, setErrors] = useState({});
   const [showStartDatePicker, setShowStartDatePicker] = useState(false);
   const [showEndDatePicker, setShowEndDatePicker] = useState(false);
-  const [currencyPickerVisible, setCurrencyPickerVisible] = useState(false);
-  const [periodPickerVisible, setPeriodPickerVisible] = useState(false);
+
+  // Sub-panel navigation (subpanel pattern — see CLAUDE.md). Secondary views
+  // (currency / period pickers) slide in over the form inside the same modal
+  // instead of opening a second, nested native Modal.
+  const [activeSubPanel, setActiveSubPanel] = useState(null); // null | 'currency' | 'period'
+  const mainAnim = useRef(new Animated.Value(0)).current; // 0 = form visible, 1 = form shifted/dimmed
+  const subPanelAnim = useRef(new Animated.Value(0)).current; // 0 = subpanel hidden, 1 = visible
 
   const PERIOD_TYPES = [
     { key: 'weekly', label: t('weekly') },
@@ -95,6 +103,55 @@ export default function BudgetModal({ visible, onClose, budget, categoryId, cate
     }
     setErrors({});
   }, [budget, isNew, visible, availableCurrencies]);
+
+  // Reset any open subpanel (and its animation values) whenever the modal is
+  // hidden, so reopening always starts on the form.
+  useEffect(() => {
+    if (!visible) {
+      setActiveSubPanel(null);
+      mainAnim.setValue(0);
+      subPanelAnim.setValue(0);
+    }
+  }, [visible, mainAnim, subPanelAnim]);
+
+  // Slide a secondary view in over the form. Asymmetric durations inside a
+  // single Animated.parallel produce the staggered feel without an
+  // Animated.delay node (which would break the native driver).
+  const openSubPanel = useCallback((panel) => {
+    Keyboard.dismiss();
+    setActiveSubPanel(panel);
+    Animated.parallel([
+      Animated.timing(mainAnim, {
+        toValue: 1,
+        duration: 200,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(subPanelAnim, {
+        toValue: 1,
+        duration: 260,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [mainAnim, subPanelAnim]);
+
+  const closeSubPanel = useCallback(() => {
+    Animated.parallel([
+      Animated.timing(subPanelAnim, {
+        toValue: 0,
+        duration: 180,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(mainAnim, {
+        toValue: 0,
+        duration: 240,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start(() => setActiveSubPanel(null));
+  }, [subPanelAnim, mainAnim]);
 
   const validateForm = useCallback(() => {
     const newErrors = {};
@@ -178,6 +235,16 @@ export default function BudgetModal({ visible, onClose, budget, categoryId, cate
     onClose();
   }, [onClose]);
 
+  // Android hardware back (and the outer Modal's onRequestClose): step out of an
+  // open subpanel first, otherwise close the whole modal.
+  const handleRequestClose = useCallback(() => {
+    if (activeSubPanel) {
+      closeSubPanel();
+    } else {
+      handleClose();
+    }
+  }, [activeSubPanel, closeSubPanel, handleClose]);
+
   const handleDelete = useCallback(() => {
     showDialog(
       t('delete_budget'),
@@ -220,6 +287,71 @@ export default function BudgetModal({ visible, onClose, budget, categoryId, cate
     return date.toLocaleDateString();
   }, [t]);
 
+  const handleSelectCurrency = useCallback((code) => {
+    setValues(v => ({ ...v, currency: code }));
+    closeSubPanel();
+  }, [closeSubPanel]);
+
+  const handleSelectPeriod = useCallback((key) => {
+    setValues(v => ({ ...v, periodType: key }));
+    closeSubPanel();
+  }, [closeSubPanel]);
+
+  // Subpanel slides in from the right edge of the card; the form shifts slightly
+  // left and fades as it goes. Transforms/opacity only — no layout impact.
+  const panelWidth = Dimensions.get('window').width;
+  const subPanelTranslateX = subPanelAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [panelWidth, 0],
+  });
+  const mainTranslateX = mainAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, -40],
+  });
+  const mainOpacity = mainAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [1, 0],
+  });
+
+  const renderCurrencyItem = useCallback(({ item }) => (
+    <Pressable
+      onPress={() => handleSelectCurrency(item.code)}
+      style={({ pressed }) => [
+        styles.pickerOption,
+        { borderColor: colors.border },
+        pressed && { backgroundColor: colors.selected },
+        values.currency === item.code && { backgroundColor: colors.selected },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`${item.code} ${item.name}`}
+    >
+      <View style={styles.currencyOption}>
+        <Text style={[styles.text18bold, { color: colors.text }]}>
+          {item.code}
+        </Text>
+        <Text style={[styles.text14muted, { color: colors.mutedText }]}>
+          {item.symbol} - {item.name}
+        </Text>
+      </View>
+    </Pressable>
+  ), [colors, values.currency, handleSelectCurrency]);
+
+  const renderPeriodItem = useCallback(({ item }) => (
+    <Pressable
+      onPress={() => handleSelectPeriod(item.key)}
+      style={({ pressed }) => [
+        styles.pickerOption,
+        { borderColor: colors.border },
+        pressed && { backgroundColor: colors.selected },
+        values.periodType === item.key && { backgroundColor: colors.selected },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={item.label}
+    >
+      <Text style={[styles.text18, { color: colors.text }]}>{item.label}</Text>
+    </Pressable>
+  ), [colors, values.periodType, handleSelectPeriod]);
+
   return (
     <>
       {visible && <ModalBlurOverlay />}
@@ -227,7 +359,8 @@ export default function BudgetModal({ visible, onClose, budget, categoryId, cate
         visible={visible}
         animationType="slide"
         transparent={true}
-        onRequestClose={handleClose}
+        onRequestClose={handleRequestClose}
+        testID="budget-modal"
       >
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -235,212 +368,271 @@ export default function BudgetModal({ visible, onClose, budget, categoryId, cate
         >
           <Pressable style={styles.modalOverlay} onPress={handleClose}>
             <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <ScrollView
-                style={styles.scrollView}
-                contentContainerStyle={styles.scrollContent}
-                keyboardShouldPersistTaps="handled"
+              <Animated.View
+                style={[
+                  styles.mainContent,
+                  { opacity: mainOpacity, transform: [{ translateX: mainTranslateX }] },
+                ]}
               >
-                <ModalHeader title={isNew ? t('set_budget') : t('edit_budget')} />
+                <ScrollView
+                  style={styles.scrollView}
+                  contentContainerStyle={styles.scrollContent}
+                  keyboardShouldPersistTaps="handled"
+                >
+                  <ModalHeader title={isNew ? t('set_budget') : t('edit_budget')} />
 
-                <Text style={[styles.categoryLabel, { color: colors.mutedText }]}>
-                  {t('budget_for_category')}: {categoryName}
-                </Text>
-
-                {/* Amount Input */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
-                    {t('budget_amount')}
+                  <Text style={[styles.categoryLabel, { color: colors.mutedText }]}>
+                    {t('budget_for_category')}: {categoryName}
                   </Text>
-                  <TextInput
-                    style={[
-                      styles.input,
-                      {
-                        color: colors.text,
-                        backgroundColor: colors.inputBackground,
-                        borderColor: errors.amount ? colors.error : colors.inputBorder,
-                      },
-                    ]}
-                    value={values.amount}
-                    onChangeText={text => setValues(v => ({ ...v, amount: text }))}
-                    placeholder="0.00"
-                    placeholderTextColor={colors.mutedText}
-                    keyboardType="decimal-pad"
-                    returnKeyType="done"
-                    onSubmitEditing={Keyboard.dismiss}
-                  />
-                  {errors.amount && (
-                    <Text style={[styles.error, { color: colors.error }]}>{errors.amount}</Text>
-                  )}
-                </View>
 
-                {/* Currency Picker */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
-                    {t('currency')}
-                  </Text>
-                  <Pressable
-                    style={[
-                      styles.pickerButton,
-                      { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                    ]}
-                    onPress={() => setCurrencyPickerVisible(true)}
-                  >
-                    <View style={styles.pickerValue}>
-                      <Text style={[styles.text16, { color: colors.text }]}> 
-                        {values.currency} {currencies[values.currency]?.symbol || ''}
-                      </Text>
-                      <Icon name="chevron-down" size={20} color={colors.text} />
-                    </View>
-                  </Pressable>
-                </View>
+                  {/* Amount Input */}
+                  <View style={styles.inputContainer}>
+                    <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
+                      {t('budget_amount')}
+                    </Text>
+                    <TextInput
+                      style={[
+                        styles.input,
+                        {
+                          color: colors.text,
+                          backgroundColor: colors.inputBackground,
+                          borderColor: errors.amount ? colors.error : colors.inputBorder,
+                        },
+                      ]}
+                      value={values.amount}
+                      onChangeText={text => setValues(v => ({ ...v, amount: text }))}
+                      placeholder="0.00"
+                      placeholderTextColor={colors.mutedText}
+                      keyboardType="decimal-pad"
+                      returnKeyType="done"
+                      onSubmitEditing={Keyboard.dismiss}
+                    />
+                    {errors.amount && (
+                      <Text style={[styles.error, { color: colors.error }]}>{errors.amount}</Text>
+                    )}
+                  </View>
 
-                {/* Period Type Picker */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
-                    {t('period_type')}
-                  </Text>
-                  <Pressable
-                    style={[
-                      styles.pickerButton,
-                      { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                    ]}
-                    onPress={() => setPeriodPickerVisible(true)}
-                  >
-                    <View style={styles.pickerValue}>
-                      <Text style={[styles.text16, { color: colors.text }]}> 
-                        {PERIOD_TYPES.find(p => p.key === values.periodType)?.label}
-                      </Text>
-                      <Icon name="chevron-down" size={20} color={colors.text} />
-                    </View>
-                  </Pressable>
-                </View>
-
-                {/* Start Date Picker */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
-                    {t('start_date')}
-                  </Text>
-                  <Pressable
-                    style={[
-                      styles.pickerButton,
-                      { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
-                    ]}
-                    onPress={() => setShowStartDatePicker(true)}
-                  >
-                    <View style={styles.pickerValue}>
-                      <Text style={[styles.text16, { color: colors.text }]}> 
-                        {formatDate(values.startDate)}
-                      </Text>
-                      <Icon name="calendar" size={20} color={colors.text} />
-                    </View>
-                  </Pressable>
-                </View>
-
-                {/* End Date Picker */}
-                <View style={styles.inputContainer}>
-                  <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
-                    {t('end_date')}
-                  </Text>
-                  <View style={styles.dateRow}>
+                  {/* Currency Picker */}
+                  <View style={styles.inputContainer}>
+                    <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
+                      {t('currency')}
+                    </Text>
                     <Pressable
                       style={[
                         styles.pickerButton,
-                        styles.flex1,
-                        {
-                          backgroundColor: colors.inputBackground,
-                          borderColor: colors.inputBorder,
-                        },
+                        { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
                       ]}
-                      onPress={() => setShowEndDatePicker(true)}
+                      onPress={() => openSubPanel('currency')}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('currency')}
                     >
                       <View style={styles.pickerValue}>
-                        <Text style={[styles.text16, { color: colors.text }]}> 
-                          {formatDate(values.endDate)}
+                        <Text style={[styles.text16, { color: colors.text }]}>
+                          {values.currency} {currencies[values.currency]?.symbol || ''}
+                        </Text>
+                        <Icon name="chevron-down" size={20} color={colors.text} />
+                      </View>
+                    </Pressable>
+                  </View>
+
+                  {/* Period Type Picker */}
+                  <View style={styles.inputContainer}>
+                    <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
+                      {t('period_type')}
+                    </Text>
+                    <Pressable
+                      style={[
+                        styles.pickerButton,
+                        { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                      ]}
+                      onPress={() => openSubPanel('period')}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('period_type')}
+                    >
+                      <View style={styles.pickerValue}>
+                        <Text style={[styles.text16, { color: colors.text }]}>
+                          {PERIOD_TYPES.find(p => p.key === values.periodType)?.label}
+                        </Text>
+                        <Icon name="chevron-down" size={20} color={colors.text} />
+                      </View>
+                    </Pressable>
+                  </View>
+
+                  {/* Start Date Picker */}
+                  <View style={styles.inputContainer}>
+                    <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
+                      {t('start_date')}
+                    </Text>
+                    <Pressable
+                      style={[
+                        styles.pickerButton,
+                        { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder },
+                      ]}
+                      onPress={() => setShowStartDatePicker(true)}
+                    >
+                      <View style={styles.pickerValue}>
+                        <Text style={[styles.text16, { color: colors.text }]}>
+                          {formatDate(values.startDate)}
                         </Text>
                         <Icon name="calendar" size={20} color={colors.text} />
                       </View>
                     </Pressable>
-                    {values.endDate && (
+                  </View>
+
+                  {/* End Date Picker */}
+                  <View style={styles.inputContainer}>
+                    <Text style={[styles.inputLabel, { color: colors.mutedText }]}>
+                      {t('end_date')}
+                    </Text>
+                    <View style={styles.dateRow}>
                       <Pressable
-                        style={[styles.clearButton, { backgroundColor: colors.secondary }]}
-                        onPress={() => setValues(v => ({ ...v, endDate: null }))}
+                        style={[
+                          styles.pickerButton,
+                          styles.flex1,
+                          {
+                            backgroundColor: colors.inputBackground,
+                            borderColor: colors.inputBorder,
+                          },
+                        ]}
+                        onPress={() => setShowEndDatePicker(true)}
                       >
-                        <Icon name="close" size={20} color={colors.text} />
+                        <View style={styles.pickerValue}>
+                          <Text style={[styles.text16, { color: colors.text }]}>
+                            {formatDate(values.endDate)}
+                          </Text>
+                          <Icon name="calendar" size={20} color={colors.text} />
+                        </View>
                       </Pressable>
-                    )}
-                  </View>
-                </View>
-
-                {/* Recurring Switch */}
-                <View style={styles.switchContainer}>
-                  <View style={styles.switchLabel}>
-                    <Icon name="sync" size={20} color={colors.text} style={styles.iconMarginRight} />
-                    <Text style={[styles.text16, { color: colors.text }]}>{t('recurring')}</Text>
-                  </View>
-                  <Switch
-                    value={values.isRecurring}
-                    onValueChange={(value) => setValues(v => ({ ...v, isRecurring: value }))}
-                    trackColor={{ false: colors.border, true: colors.primary }}
-                    thumbColor={colors.card}
-                  />
-                </View>
-
-                {/* Rollover Switch */}
-                <View style={styles.switchContainer}>
-                  <View style={styles.switchLabel}>
-                    <Icon name="arrow-right-thick" size={20} color={colors.text} style={styles.iconMarginRight} />
-                    <View style={styles.flex1}>
-                      <Text style={[styles.text16, { color: colors.text }]}>{t('rollover')}</Text>
-                      <Text style={[styles.text12, styles.smallTop, { color: colors.mutedText }]}> 
-                      Carry unused amount to next period
-                      </Text>
+                      {values.endDate && (
+                        <Pressable
+                          style={[styles.clearButton, { backgroundColor: colors.secondary }]}
+                          onPress={() => setValues(v => ({ ...v, endDate: null }))}
+                        >
+                          <Icon name="close" size={20} color={colors.text} />
+                        </Pressable>
+                      )}
                     </View>
                   </View>
-                  <Switch
-                    value={values.rolloverEnabled}
-                    onValueChange={(value) => setValues(v => ({ ...v, rolloverEnabled: value }))}
-                    trackColor={{ false: colors.border, true: colors.primary }}
-                    thumbColor={colors.card}
-                  />
-                </View>
 
-                {errors.general && (
-                  <Text style={[styles.error, { color: colors.error }]}>{errors.general}</Text>
-                )}
+                  {/* Recurring Switch */}
+                  <View style={styles.switchContainer}>
+                    <View style={styles.switchLabel}>
+                      <Icon name="sync" size={20} color={colors.text} style={styles.iconMarginRight} />
+                      <Text style={[styles.text16, { color: colors.text }]}>{t('recurring')}</Text>
+                    </View>
+                    <Switch
+                      value={values.isRecurring}
+                      onValueChange={(value) => setValues(v => ({ ...v, isRecurring: value }))}
+                      trackColor={{ false: colors.border, true: colors.primary }}
+                      thumbColor={colors.card}
+                    />
+                  </View>
 
-                {/* Delete Button (only for existing budgets) */}
-                {!isNew && (
+                  {/* Rollover Switch */}
+                  <View style={styles.switchContainer}>
+                    <View style={styles.switchLabel}>
+                      <Icon name="arrow-right-thick" size={20} color={colors.text} style={styles.iconMarginRight} />
+                      <View style={styles.flex1}>
+                        <Text style={[styles.text16, { color: colors.text }]}>{t('rollover')}</Text>
+                        <Text style={[styles.text12, styles.smallTop, { color: colors.mutedText }]}>
+                        Carry unused amount to next period
+                        </Text>
+                      </View>
+                    </View>
+                    <Switch
+                      value={values.rolloverEnabled}
+                      onValueChange={(value) => setValues(v => ({ ...v, rolloverEnabled: value }))}
+                      trackColor={{ false: colors.border, true: colors.primary }}
+                      thumbColor={colors.card}
+                    />
+                  </View>
+
+                  {errors.general && (
+                    <Text style={[styles.error, { color: colors.error }]}>{errors.general}</Text>
+                  )}
+
+                  {/* Delete Button (only for existing budgets) */}
+                  {!isNew && (
+                    <Pressable
+                      style={[styles.deleteButtonContainer, { borderTopColor: colors.border }]}
+                      onPress={handleDelete}
+                    >
+                      <Icon name="delete-outline" size={20} color={colors.delete} />
+                      <Text style={[styles.deleteButtonText, { color: colors.delete }]}>
+                        {t('delete_budget')}
+                      </Text>
+                    </Pressable>
+                  )}
+                </ScrollView>
+
+                {/* Action Buttons */}
+                <View style={[styles.modalButtonRow, { backgroundColor: colors.card }]}>
                   <Pressable
-                    style={[styles.deleteButtonContainer, { borderTopColor: colors.border }]}
-                    onPress={handleDelete}
+                    style={[styles.modalButton, { backgroundColor: colors.secondary }]}
+                    onPress={handleClose}
                   >
-                    <Icon name="delete-outline" size={20} color={colors.delete} />
-                    <Text style={[styles.deleteButtonText, { color: colors.delete }]}>
-                      {t('delete_budget')}
+                    <Text style={[styles.buttonText, { color: colors.text }]}>
+                      {t('cancel')}
                     </Text>
                   </Pressable>
-                )}
-              </ScrollView>
+                  <Pressable
+                    style={[styles.modalButton, { backgroundColor: colors.primary }]}
+                    onPress={handleSave}
+                  >
+                    <Text style={[styles.buttonText, { color: colors.text }]}>
+                      {t('save')}
+                    </Text>
+                  </Pressable>
+                </View>
+              </Animated.View>
 
-              {/* Action Buttons */}
-              <View style={[styles.modalButtonRow, { backgroundColor: colors.card }]}>
-                <Pressable
-                  style={[styles.modalButton, { backgroundColor: colors.secondary }]}
-                  onPress={handleClose}
+              {/* Secondary view (currency / period picker) — slides in over the
+                  form within the same modal. Mounted only while open so the
+                  entry animation always plays from the hidden state. */}
+              {activeSubPanel && (
+                <Animated.View
+                  testID="budget-subpanel"
+                  style={[
+                    styles.subPanel,
+                    { backgroundColor: colors.card },
+                    { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
+                  ]}
                 >
-                  <Text style={[styles.buttonText, { color: colors.text }]}>
-                    {t('cancel')}
-                  </Text>
-                </Pressable>
-                <Pressable
-                  style={[styles.modalButton, { backgroundColor: colors.primary }]}
-                  onPress={handleSave}
-                >
-                  <Text style={[styles.buttonText, { color: colors.text }]}>
-                    {t('save')}
-                  </Text>
-                </Pressable>
-              </View>
+                  <View style={styles.subPanelHeader}>
+                    <Pressable
+                      onPress={closeSubPanel}
+                      style={styles.subPanelBack}
+                      hitSlop={8}
+                      testID="budget-subpanel-back"
+                      accessibilityRole="button"
+                      accessibilityLabel={t('back')}
+                    >
+                      <Icon name="arrow-left" size={24} color={colors.text} />
+                    </Pressable>
+                    <Text style={[styles.subPanelTitle, { color: colors.text }]}>
+                      {activeSubPanel === 'currency' ? t('select_currency') : t('period_type')}
+                    </Text>
+                  </View>
+
+                  {activeSubPanel === 'currency' && (
+                    <FlatList
+                      data={availableCurrencies}
+                      keyExtractor={item => item.code}
+                      renderItem={renderCurrencyItem}
+                      keyboardShouldPersistTaps="handled"
+                    />
+                  )}
+
+                  {activeSubPanel === 'period' && (
+                    <FlatList
+                      data={PERIOD_TYPES}
+                      keyExtractor={item => item.key}
+                      renderItem={renderPeriodItem}
+                      keyboardShouldPersistTaps="handled"
+                    />
+                  )}
+                </Animated.View>
+              )}
             </Pressable>
           </Pressable>
         </KeyboardAvoidingView>
@@ -465,87 +657,6 @@ export default function BudgetModal({ visible, onClose, budget, categoryId, cate
             minimumDate={values.startDate ? new Date(values.startDate + 'T00:00:00') : undefined}
           />
         )}
-
-        {/* Currency Picker Modal */}
-        <Modal
-          visible={currencyPickerVisible}
-          animationType="slide"
-          transparent
-          onRequestClose={() => setCurrencyPickerVisible(false)}
-        >
-          <Pressable style={styles.modalOverlay} onPress={() => setCurrencyPickerVisible(false)}>
-            <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <Text style={[styles.pickerTitle, { color: colors.text }]}>{t('select_currency')}</Text>
-              <FlatList
-                data={availableCurrencies}
-                keyExtractor={item => item.code}
-                renderItem={({ item }) => (
-                  <Pressable
-                    onPress={() => {
-                      setValues(v => ({ ...v, currency: item.code }));
-                      setCurrencyPickerVisible(false);
-                    }}
-                    style={({ pressed }) => [
-                      styles.pickerOption,
-                      { borderColor: colors.border },
-                      pressed && { backgroundColor: colors.selected },
-                      values.currency === item.code && { backgroundColor: colors.selected },
-                    ]}
-                  >
-                    <View style={styles.currencyOption}>
-                      <Text style={[styles.text18bold, { color: colors.text }]}> 
-                        {item.code}
-                      </Text>
-                      <Text style={[styles.text14muted, { color: colors.mutedText }]}> 
-                        {item.symbol} - {item.name}
-                      </Text>
-                    </View>
-                  </Pressable>
-                )}
-              />
-              <Pressable style={styles.closeButton} onPress={() => setCurrencyPickerVisible(false)}>
-                <Text style={[styles.textPrimary, { color: colors.primary }]}>{t('close')}</Text>
-              </Pressable>
-            </Pressable>
-          </Pressable>
-        </Modal>
-
-        {/* Period Type Picker Modal */}
-        <Modal
-          visible={periodPickerVisible}
-          animationType="slide"
-          transparent
-          onRequestClose={() => setPeriodPickerVisible(false)}
-        >
-          <Pressable style={styles.modalOverlay} onPress={() => setPeriodPickerVisible(false)}>
-            <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <Text style={[styles.pickerTitle, { color: colors.text }]}>{t('period_type')}</Text>
-              <FlatList
-                data={PERIOD_TYPES}
-                keyExtractor={item => item.key}
-                renderItem={({ item }) => (
-                  <Pressable
-                    onPress={() => {
-                      setValues(v => ({ ...v, periodType: item.key }));
-                      setPeriodPickerVisible(false);
-                    }}
-                    style={({ pressed }) => [
-                      styles.pickerOption,
-                      { borderColor: colors.border },
-                      pressed && { backgroundColor: colors.selected },
-                      values.periodType === item.key && { backgroundColor: colors.selected },
-                    ]}
-                  >
-                    <Text style={[styles.text18, { color: colors.text }]}>{item.label}</Text>
-                  </Pressable>
-                )}
-              />
-              <Pressable style={styles.closeButton} onPress={() => setPeriodPickerVisible(false)}>
-                <Text style={[styles.textPrimary, { color: colors.primary }]}>{t('close')}</Text>
-              </Pressable>
-            </Pressable>
-          </Pressable>
-        </Modal>
       </Modal>
     </>
   );
@@ -593,11 +704,6 @@ const styles = StyleSheet.create({
     marginLeft: 8,
     padding: 12,
   },
-  closeButton: {
-    alignSelf: 'center',
-    marginTop: 8,
-    padding: 10,
-  },
   currencyOption: {
     alignItems: 'baseline',
     flexDirection: 'row',
@@ -642,6 +748,10 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginBottom: 6,
   },
+  mainContent: {
+    flexShrink: 1,
+    padding: 20,
+  },
   modalButton: {
     alignItems: 'center',
     borderRadius: 6,
@@ -660,7 +770,7 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     maxHeight: '85%',
     minHeight: '60%',
-    padding: 20,
+    overflow: 'hidden',
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.2,
@@ -677,22 +787,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     padding: 12,
   },
-  pickerModalContent: {
-    borderRadius: 12,
-    maxHeight: '60%',
-    padding: 12,
-    width: '90%',
-  },
   pickerOption: {
     borderBottomWidth: 1,
     paddingHorizontal: 8,
     paddingVertical: 12,
-  },
-  pickerTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 12,
-    textAlign: 'center',
   },
   pickerValue: {
     alignItems: 'center',
@@ -708,6 +806,23 @@ const styles = StyleSheet.create({
   },
   smallTop: {
     marginTop: 2,
+  },
+  subPanel: {
+    ...StyleSheet.absoluteFillObject,
+    padding: 20,
+  },
+  subPanelBack: {
+    marginRight: 8,
+    padding: 4,
+  },
+  subPanelHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  subPanelTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
   },
   switchContainer: {
     alignItems: 'center',
@@ -738,8 +853,5 @@ const styles = StyleSheet.create({
   text18bold: {
     fontSize: 18,
     fontWeight: '500',
-  },
-  textPrimary: {
-    fontSize: 16,
   },
 });


### PR DESCRIPTION
## What & why

Closes #917.

Tapping the **currency** or **period** row in `BudgetModal` opened a *second native `Modal` nested inside the main `Modal`* — the anti-pattern CLAUDE.md forbids ("never open a new modal for secondary views inside an existing modal"). On Android this produced a redundant slide animation over the already-rendered modal and a confusing two-step hardware-back (first press closed the inner picker, second closed the modal).

This PR replaces both nested `Modal`s with the documented **subpanel pattern**: a single, conditionally-mounted `Animated.View` that slides in over the form **within the same `Modal`**, using a back-arrow header instead of a separate "Close" button.

## Implementation notes

- **Subpanel state + animation** — `activeSubPanel` (`null | 'currency' | 'period'`) plus two `Animated.Value`s driven by `Animated.parallel` with the documented easing/durations (entry `Easing.out(Easing.cubic)` 260ms, main-list exit `Easing.in(Easing.quad)` 200ms; reverse on close). No `Animated.delay`/`sequence` nodes, so the native driver stays intact.
- **Adapted for the centered card** — the reference implementation (`SettingsScreen`) is full-screen (`absoluteFillObject`); `BudgetModal` is a centered card (90% width, 60–85% height). The card now uses `overflow: 'hidden'`, the subpanel is an `absoluteFill` layer inside it, and the form is wrapped so it keeps its original flex-shrink/scroll behaviour.
- **Back handling** — the `Modal`'s `onRequestClose` (Android hardware back) closes an open subpanel first, then the modal. Subpanel state resets whenever the modal is hidden.
- Selecting a currency/period sets the value and slides the panel away. Saved-budget output is unchanged.

## Acceptance criteria (from #917)

- [x] No nested `Modal` components remain in `BudgetModal`
- [x] Currency & period pickers slide in/out within the same modal
- [x] Hardware back closes subpanel → then modal, in that order
- [x] Selection behaviour unchanged (saved budget identical)
- [x] `npm test -- --silent` passes

## Note on the issue's test claim

The issue stated there were *no existing BudgetModal tests* — in fact `__tests__/modals/BudgetModal.test.js` had ~38 tests, several asserting the old picker `Close` button / nested-modal titles. Those are rewritten to drive the back arrow, and three tests were added (no-nested-`Modal` structure, hardware-back ordering, back-arrow doesn't close the modal).

## Testing

- `BudgetModal` suite: **41 passed** (38 updated + 3 new)
- Full suite: **122 suites / 3757 tests passed**
- `eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2v2T9JUqFy8Cfg6x48GsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2v2T9JUqFy8Cfg6x48GsJ)_