### PR TITLE
style: adjust suggestion row spacing in quick-add form

### DIFF
--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -781,7 +781,7 @@ const OperationFormFields = memo(({
       };
 
       return (
-        <View style={[styles.categoryRowsWrapper, compact && styles.categoryRowsWrapperCompact]}>
+        <View style={[styles.categoryRowsWrapper, styles.accountRows, compact && styles.categoryRowsWrapperCompact]}>
           {/* Row 1: "All accounts" button (if > 8 total) + first 3 or 4 shortcuts */}
           <View style={styles.categoryButtonsContainer}>
             {showAllAccountsButton && (
@@ -961,6 +961,9 @@ const styles = StyleSheet.create({
   accountBalanceText: {
     fontSize: 12,
   },
+  accountRows: {
+    gap: SPACING.sm,
+  },
   accountShortcutBalance: {
     fontSize: 10,
     textAlign: 'center',
@@ -1012,7 +1015,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   categoryRows: {
-    gap: SPACING.sm,
+    gap: SPACING.xs,
   },
   categoryRowsWrapper: {
     marginBottom: SPACING.md,


### PR DESCRIPTION
## Summary

Adjusts the vertical spacing between the two-row suggestion grids in the quick-add form (`OperationFormFields.js`) so they read with more balanced, intentional spacing:

- **Suggested category rows**: reduced the gap between the two rows from `SPACING.sm` (8px) to `SPACING.xs` (4px) — they were too far apart.
- **Suggested transfer account rows**: added a gap between the two rows (previously `0px`, now `SPACING.sm` / 8px) — they were nearly touching.

This matches the requested change: less space between suggested category rows, more space between suggested account rows.

## Changes
- `categoryRows` gap: `SPACING.sm` → `SPACING.xs`
- New `accountRows` style with `gap: SPACING.sm`, applied to the transfer-account suggestion wrapper

## Testing
- `__tests__/components/OperationFormFields.test.js` — 36 passed
- `__tests__/components/operations/OperationsList.test.js` — 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnTjuWm6sASe332Gyf78T5)_