### PR TITLE
fix: strip "Note:" prefix from quick-add suggestion chips

### DIFF
--- a/__tests__/components/operations/DescriptionSuggestionRow.test.js
+++ b/__tests__/components/operations/DescriptionSuggestionRow.test.js
@@ -73,6 +73,27 @@ describe('DescriptionSuggestionRow', () => {
     }
   });
 
+  it('strips the "Note:" prefix from chip text while applying the raw label', async () => {
+    const onApply = jest.fn();
+    const { getByText, queryByText } = await render(
+      <DescriptionSuggestionRow
+        {...baseProps}
+        chips={['Note: Денису', 'Groceries']}
+        onApply={onApply}
+      />,
+    );
+
+    // The prefix is stripped for display...
+    expect(getByText('Денису')).toBeTruthy();
+    expect(queryByText('Note: Денису')).toBeNull();
+    // ...but plain labels are untouched.
+    expect(getByText('Groceries')).toBeTruthy();
+
+    // Pressing the chip still applies the raw underlying label.
+    await fireEvent.press(getByText('Денису'));
+    expect(onApply).toHaveBeenCalledWith('Note: Денису');
+  });
+
   describe('Swipe priority', () => {
     it('gives the chip scroll priority over the screen-swipe gesture', async () => {
       const swipeGesture = { __id: 'swipe' };

--- a/app/components/operations/DescriptionSuggestionRow.js
+++ b/app/components/operations/DescriptionSuggestionRow.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import { SPACING, FONT_SIZE, BORDER_RADIUS, DURATION } from '../../styles/designTokens';
 import { useSwipeNavigationGesture } from '../../contexts/SwipeNavigationContext';
+import { displayLabel } from '../../utils/labelUtils';
 
 const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
   const fadeAnim = useRef(new Animated.Value(0)).current;
@@ -54,9 +55,9 @@ const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
                 onPress={() => onApply(chip)}
                 style={[styles.chip, { borderColor: colors.border, backgroundColor: colors.surface }]}
                 accessibilityRole="button"
-                accessibilityLabel={`label: ${chip}`}
+                accessibilityLabel={`label: ${displayLabel(chip)}`}
               >
-                <Text style={[styles.chipText, { color: colors.primary }]} numberOfLines={1}>{chip}</Text>
+                <Text style={[styles.chipText, { color: colors.primary }]} numberOfLines={1}>{displayLabel(chip)}</Text>
               </TouchableOpacity>
             ))}
           </ScrollView>


### PR DESCRIPTION
## Summary

The label suggestion chips that appear under a freshly-created operation in the operations list (`DescriptionSuggestionRow`) were rendering the **raw** label text. Imported `Note: <text>` labels therefore showed up with the `Note: ` import-artefact prefix (e.g. `Note: Денису`, `Note: Жвачка`), as seen in the screenshot.

PR #1051 already stripped this prefix for the `LabelInput` suggestion chips, but the quick-add `DescriptionSuggestionRow` was missed.

## Change

- `DescriptionSuggestionRow` now renders `displayLabel(chip)` for both the visible chip text and its accessibility label — identical to the established `LabelInput` pattern.
- The raw label is still used as the React `key` and as the value passed to `onApply`, so applying a suggestion keeps the same underlying behaviour; only the display is cleaned up.

## Testing

- Added a regression test asserting the `Note:` prefix is stripped from chip text while the raw label is still applied on press.
- Full suite green: **3755 passed, 122 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFMS1MJCSGKdntQdP7bTW5)_