### PR TITLE
perf(operations): add getItemLayout to OperationsList for instant date jumps

### DIFF
--- a/__tests__/components/operations/OperationsList.test.js
+++ b/__tests__/components/operations/OperationsList.test.js
@@ -10,6 +10,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react-native';
 import { ActivityIndicator } from 'react-native';
 import OperationsList from '../../../app/components/operations/OperationsList';
+import { HEIGHTS, BORDER_RADIUS, SPACING } from '../../../app/styles/designTokens';
 
 // Intercept SectionList to capture its props for direct callback testing.
 // RNTL v14 no longer exposes composite elements, so we capture props this way.
@@ -426,6 +427,79 @@ describe('OperationsList', () => {
       // should not throw for either index
       await render(sp.renderItem({ item: section.data[0], index: 0, section }));
       await render(sp.renderItem({ item: section.data[1], index: 1, section }));
+    });
+  });
+
+  // ── getItemLayout — exact offsets for instant date jumps ───────────────────
+  // No onLayout fires in the test renderer, so the measured-height refs keep
+  // their defaults: list header = 0, section header = SPACING.sm + 17 +
+  // SPACING.xs + BORDER_RADIUS.md = 37. Rows are HEIGHTS.listItem (48) with a
+  // 1px separator on every row except the last in a section; the section footer
+  // is BORDER_RADIUS.md + SPACING.xs = 12.
+  describe('getItemLayout', () => {
+    const ROW = HEIGHTS.listItem;                       // 48
+    const SEP = 1;
+    const FOOTER = BORDER_RADIUS.md + SPACING.xs;        // 12
+    const HEADER = SPACING.sm + 17 + SPACING.xs + BORDER_RADIUS.md; // 37
+
+    const makeOps = (prefix, count) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `${prefix}-${i}`, type: 'expense', amount: '1.00', accountId: 'acc-usd', categoryId: 'cat-1',
+      }));
+
+    it('is provided to the SectionList', async () => {
+      const { sp } = await getSectionListProps({ groupedOperations: [makeGroup(TODAY, makeOps('a', 1))] });
+      expect(typeof sp.getItemLayout).toBe('function');
+    });
+
+    it('computes exact header / row / footer offsets across sections', async () => {
+      // Section A: 2 rows, Section B: 1 row.
+      const groups = [makeGroup(TODAY, makeOps('a', 2)), makeGroup(OLD_DATE, makeOps('b', 1))];
+      const { sp } = await getSectionListProps({ groupedOperations: groups });
+      const layout = (i) => sp.getItemLayout(sp.sections, i);
+
+      // Section A — flattened [header, rowA0, rowA1, footerA]
+      expect(layout(0)).toEqual({ length: HEADER, offset: 0, index: 0 });            // header A
+      expect(layout(1)).toEqual({ length: ROW + SEP, offset: HEADER, index: 1 });    // row 0 (not last)
+      expect(layout(2)).toEqual({ length: ROW, offset: HEADER + ROW + SEP, index: 2 }); // row 1 (last, no sep)
+      const aItemsHeight = 2 * ROW + 1 * SEP; // 97
+      expect(layout(3)).toEqual({ length: FOOTER, offset: HEADER + aItemsHeight, index: 3 }); // footer A
+
+      // Section B starts after A's full height (header + rows + footer).
+      const sectionAHeight = HEADER + aItemsHeight + FOOTER;
+      expect(layout(4)).toEqual({ length: HEADER, offset: sectionAHeight, index: 4 }); // header B
+      expect(layout(5)).toEqual({ length: ROW, offset: sectionAHeight + HEADER, index: 5 }); // row 0 (last)
+      expect(layout(6)).toEqual({ length: FOOTER, offset: sectionAHeight + HEADER + ROW, index: 6 }); // footer B
+    });
+
+    it('produces contiguous offsets (offset[i+1] === offset[i] + length[i])', async () => {
+      const groups = [
+        makeGroup(TODAY, makeOps('a', 3)),
+        makeGroup(YESTERDAY, makeOps('b', 1)),
+        makeGroup(OLD_DATE, makeOps('c', 2)),
+      ];
+      const { sp } = await getSectionListProps({ groupedOperations: groups });
+      const totalCells = groups.reduce((sum, g) => sum + g.operations.length + 2, 0);
+      let expectedOffset = 0;
+      for (let i = 0; i < totalCells; i++) {
+        const frame = sp.getItemLayout(sp.sections, i);
+        expect(frame.index).toBe(i);
+        expect(frame.offset).toBe(expectedOffset);
+        expect(frame.length).toBeGreaterThan(0);
+        expectedOffset += frame.length;
+      }
+    });
+
+    it('returns a zero-length frame for out-of-range indices', async () => {
+      const { sp } = await getSectionListProps({ groupedOperations: [makeGroup(TODAY, makeOps('a', 1))] });
+      // Section has 1 row → flattened cells 0..2; index 3 is past the end.
+      expect(sp.getItemLayout(sp.sections, 3)).toEqual({ length: 0, offset: 0, index: 3 });
+      expect(sp.getItemLayout(sp.sections, -1)).toEqual({ length: 0, offset: 0, index: -1 });
+    });
+
+    it('handles an empty list without throwing', async () => {
+      const { sp } = await getSectionListProps({ groupedOperations: [] });
+      expect(sp.getItemLayout([], 0)).toEqual({ length: 0, offset: 0, index: 0 });
     });
   });
 });

--- a/__tests__/components/operations/OperationsList.test.js
+++ b/__tests__/components/operations/OperationsList.test.js
@@ -501,5 +501,72 @@ describe('OperationsList', () => {
       const { sp } = await getSectionListProps({ groupedOperations: [] });
       expect(sp.getItemLayout([], 0)).toEqual({ length: 0, offset: 0, index: 0 });
     });
+
+    // ── runtime height measurement feeding getItemLayout ─────────────────────
+    // onLayout never fires in the test renderer, so we drive the captured
+    // handlers directly and confirm getItemLayout picks up the measured heights.
+    describe('runtime height measurement', () => {
+      const fireLayout = (element, height) => {
+        element.props.onLayout({ nativeEvent: { layout: { height } } });
+      };
+
+      it('uses a measured section-header height for every section offset', async () => {
+        const groups = [makeGroup(TODAY, makeOps('a', 1)), makeGroup(OLD_DATE, makeOps('b', 1))];
+        const { sp } = await getSectionListProps({ groupedOperations: groups });
+        const section = toSection(groups[0]);
+        const aData = 1 * ROW + FOOTER; // section A's rows + footer = dataBefore[B]
+
+        // Fallback height until the DateSeparator card reports a real one.
+        expect(sp.getItemLayout(sp.sections, 0).length).toBe(HEADER);
+        expect(sp.getItemLayout(sp.sections, 3).offset).toBe(aData + HEADER); // section B header
+
+        // The section-header card reports its real height.
+        await act(async () => { fireLayout(sp.renderSectionHeader({ section }), 44); });
+
+        // Both the header length and every later section's offset reflect it.
+        expect(sp.getItemLayout(sp.sections, 0).length).toBe(44);
+        expect(sp.getItemLayout(sp.sections, 3)).toEqual({ length: 44, offset: aData + 44, index: 3 });
+      });
+
+      it('keeps the first measurement, then the tallest, and ignores non-positive heights', async () => {
+        const groups = [makeGroup(TODAY, makeOps('a', 1))];
+        const { sp } = await getSectionListProps({ groupedOperations: groups });
+        const section = toSection(groups[0]);
+        const headerLength = () => sp.getItemLayout(sp.sections, 0).length;
+
+        // First real measurement replaces the fallback even when it is shorter.
+        await act(async () => { fireLayout(sp.renderSectionHeader({ section }), 30); });
+        expect(headerLength()).toBe(30);
+
+        // A shorter later measurement is ignored (keep the tallest seen)...
+        await act(async () => { fireLayout(sp.renderSectionHeader({ section }), 25); });
+        expect(headerLength()).toBe(30);
+
+        // ...a taller one wins...
+        await act(async () => { fireLayout(sp.renderSectionHeader({ section }), 50); });
+        expect(headerLength()).toBe(50);
+
+        // ...and a zero/garbage layout never regresses it.
+        await act(async () => { fireLayout(sp.renderSectionHeader({ section }), 0); });
+        expect(headerLength()).toBe(50);
+      });
+
+      it('shifts all offsets down by the measured list-header (QuickAdd form) height', async () => {
+        const React = require('react');
+        const headerComponent = React.createElement('View', { testID: 'qa-form' });
+        const { sp } = await getSectionListProps({
+          groupedOperations: [makeGroup(TODAY, makeOps('a', 1))],
+          headerComponent,
+        });
+
+        // List header starts at 0 until its wrapper reports a height.
+        expect(sp.getItemLayout(sp.sections, 0).offset).toBe(0);
+
+        await act(async () => { fireLayout(sp.ListHeaderComponent, 120); });
+
+        // First section header now begins right after the measured list header.
+        expect(sp.getItemLayout(sp.sections, 0)).toEqual({ length: HEADER, offset: 120, index: 0 });
+      });
+    });
   });
 });

--- a/__tests__/screens/OperationsScreen.test.js
+++ b/__tests__/screens/OperationsScreen.test.js
@@ -1196,13 +1196,15 @@ describe('OperationsScreen', () => {
       expect(scrollToTopButton).toBeNull();
     });
 
-    it('handleScrollToIndexFailed handles scroll index errors gracefully', async () => {
+    it('handleScrollToIndexFailed falls back gracefully without warnings or retries', async () => {
       const OperationsScreen = require('../../app/screens/OperationsScreen').default;
       const { useOperationsData } = require('../../app/contexts/OperationsDataContext');
       const { useOperationsActions } = require('../../app/contexts/OperationsActionsContext');
 
-      // Spy on console.warn to verify the handler is called
+      // The list now ships getItemLayout, so the failure path is a quiet safety
+      // net: no console.warn, no 100ms setTimeout retry dance.
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const timeoutSpy = jest.spyOn(global, 'setTimeout');
 
       useOperationsData.mockReturnValue({
         operations: [],
@@ -1227,19 +1229,19 @@ describe('OperationsScreen', () => {
       const { getByTestId } = await render(<OperationsScreen />);
       const operationsList = getByTestId('operations-list');
 
-      // Invoke onScrollToIndexFailed
+      // Ignore any timers scheduled during render; only watch the handler itself.
+      timeoutSpy.mockClear();
+
+      // Invoke onScrollToIndexFailed — must not throw and must stay quiet
       await act(async () => {
-        operationsList.props.onScrollToIndexFailed({ index: 10 });
+        operationsList.props.onScrollToIndexFailed({ index: 10, averageItemLength: 56 });
       });
 
-      // Should log the error
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'scrollToIndex failed for index:',
-        10,
-        'Using offset fallback',
-      );
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(timeoutSpy).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
+      timeoutSpy.mockRestore();
     });
 
     it('handleContentSizeChange is passed to OperationsList', async () => {

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -6,7 +6,7 @@ import DateSeparator from './DateSeparator';
 import OperationListItem from './OperationListItem';
 import OperationsListPlaceholder from './OperationsListPlaceholder';
 import currencies from '../../../assets/currencies.json';
-import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
+import { SPACING, BORDER_RADIUS, HEIGHTS } from '../../styles/designTokens';
 
 /**
  * Get currency symbol from currency code
@@ -16,6 +16,31 @@ const getCurrencySymbol = (currencyCode) => {
   const currency = currencies[currencyCode];
   return currency ? currency.symbol : currencyCode;
 };
+
+// ── getItemLayout constants ────────────────────────────────────────────────
+// The SectionList flattens to [sectionHeader, ...rows, sectionFooter] per
+// section. getItemLayout lets scrollToLocation compute a target offset directly
+// instead of measuring every cell on the way (which is slow and trips the
+// onScrollToIndexFailed fallback). These cover the fixed-height pieces:
+//
+//   • Row height: OperationListItem's row uses minHeight HEIGHTS.listItem and
+//     single-line content, so a row is exactly this tall in the common case.
+//   • Separator: the 1px divider rendered INSIDE OperationListItem for every
+//     row except the last in a section (see styles.separator there).
+//   • Section footer: the cardBottom cap (height BORDER_RADIUS.md) plus its
+//     marginBottom (SPACING.xs); the margin is folded in so the following
+//     section header lands at the correct offset.
+//
+// The section header (DateSeparator + cardTop) contains text whose exact line
+// height is font/platform dependent, and the list header (the QuickAdd form) is
+// dynamic, so both are measured at runtime via onLayout rather than hardcoded.
+const ITEM_ROW_HEIGHT = HEIGHTS.listItem;
+const ITEM_SEPARATOR_HEIGHT = 1;
+const SECTION_FOOTER_HEIGHT = BORDER_RADIUS.md + SPACING.xs;
+// Used only until the first DateSeparator card reports its real height:
+// paddingTop (SPACING.sm) + ~17px text line + paddingBottom (SPACING.xs) for the
+// DateSeparator, plus the cardTop cap (BORDER_RADIUS.md).
+const SECTION_HEADER_HEIGHT_FALLBACK = SPACING.sm + 17 + SPACING.xs + BORDER_RADIUS.md;
 
 /**
  * OperationsList Component
@@ -142,6 +167,31 @@ const OperationsList = forwardRef(({
     );
   }, [loadingMore, colors, t]);
 
+  // ── Runtime-measured heights for getItemLayout ────────────────────────────
+  // Read lazily inside getItemLayout (which RN calls fresh each time), so these
+  // are plain refs — updating them needs no re-render and never churns mid-scroll.
+  const listHeaderHeightRef = useRef(0);
+  const sectionHeaderHeightRef = useRef(SECTION_HEADER_HEIGHT_FALLBACK);
+  const sectionHeaderMeasuredRef = useRef(false);
+
+  // The QuickAdd form (list header) grows/shrinks, so always track its latest height.
+  const handleListHeaderLayout = useCallback((e) => {
+    listHeaderHeightRef.current = e.nativeEvent.layout.height;
+  }, []);
+
+  // Section headers are uniform; capture the first real measurement, then keep the
+  // tallest seen (expense days show a spending total, income-only days do not).
+  const handleSectionHeaderLayout = useCallback((e) => {
+    const h = e.nativeEvent.layout.height;
+    if (h <= 0) return;
+    if (!sectionHeaderMeasuredRef.current) {
+      sectionHeaderHeightRef.current = h;
+      sectionHeaderMeasuredRef.current = true;
+    } else if (h > sectionHeaderHeightRef.current) {
+      sectionHeaderHeightRef.current = h;
+    }
+  }, []);
+
   // Convert groupedOperations array into SectionList sections
   const sections = useMemo(() => groupedOperations.map(group => ({
     title: group.date,
@@ -149,9 +199,73 @@ const OperationsList = forwardRef(({
     data: group.operations,
   })), [groupedOperations]);
 
+  // Cumulative geometry per section, recomputed only when the sections change.
+  // Keeps getItemLayout to an O(log n) binary search instead of an O(items) walk.
+  // Stores the parts that don't depend on the measured header heights; those are
+  // added at lookup time so a header-height change never invalidates this cache.
+  const layoutCache = useMemo(() => {
+    const flatStarts = new Array(sections.length); // flattened index where each section starts
+    const dataBefore = new Array(sections.length); // Σ(rows + footer) of all earlier sections
+    const counts = new Array(sections.length);     // rows in each section
+    const itemsHeights = new Array(sections.length); // total row height of each section
+    let flat = 0;
+    let data = 0;
+    for (let s = 0; s < sections.length; s++) {
+      const n = sections[s].data.length;
+      flatStarts[s] = flat;
+      dataBefore[s] = data;
+      counts[s] = n;
+      const itemsH = n > 0
+        ? n * ITEM_ROW_HEIGHT + (n - 1) * ITEM_SEPARATOR_HEIGHT
+        : 0;
+      itemsHeights[s] = itemsH;
+      flat += n + 2; // section header + rows + section footer
+      data += itemsH + SECTION_FOOTER_HEIGHT;
+    }
+    return { flatStarts, dataBefore, counts, itemsHeights, totalCount: flat };
+  }, [sections]);
+
+  // Exact offsets for the SectionList's flattened cells. Section header and list
+  // header heights come from the measured refs; rows/separators/footers are fixed.
+  const getItemLayout = useCallback((_data, index) => {
+    const { flatStarts, dataBefore, counts, itemsHeights, totalCount } = layoutCache;
+    const headerH = sectionHeaderHeightRef.current;
+    const listHeaderH = listHeaderHeightRef.current;
+
+    if (totalCount === 0 || index < 0 || index >= totalCount) {
+      return { length: 0, offset: listHeaderH, index };
+    }
+
+    // Largest section s whose flattened start is <= index.
+    let lo = 0;
+    let hi = flatStarts.length - 1;
+    let s = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (flatStarts[mid] <= index) { s = mid; lo = mid + 1; } else { hi = mid - 1; }
+    }
+
+    // Offset of section s's header: list header + earlier rows/footers + earlier headers.
+    const base = listHeaderH + dataBefore[s] + s * headerH;
+    const local = index - flatStarts[s];
+    const n = counts[s];
+
+    if (local === 0) {
+      return { length: headerH, offset: base, index }; // section header
+    }
+    if (local <= n) {
+      const j = local - 1; // row index within the section
+      const offset = base + headerH + j * (ITEM_ROW_HEIGHT + ITEM_SEPARATOR_HEIGHT);
+      const isLast = j === n - 1; // last row has no trailing separator
+      return { length: ITEM_ROW_HEIGHT + (isLast ? 0 : ITEM_SEPARATOR_HEIGHT), offset, index };
+    }
+    // section footer
+    return { length: SECTION_FOOTER_HEIGHT, offset: base + headerH + itemsHeights[s], index };
+  }, [layoutCache]);
+
   // Render the date separator as a section header
   const renderSectionHeader = useCallback(({ section }) => (
-    <View style={styles.groupContainer}>
+    <View style={styles.groupContainer} onLayout={handleSectionHeaderLayout}>
       <DateSeparator
         date={section.title}
         spendingSums={section.spendingSums}
@@ -170,7 +284,7 @@ const OperationsList = forwardRef(({
         ]}
       />
     </View>
-  ), [formatDate, colors, onDateSeparatorPress]);
+  ), [formatDate, colors, onDateSeparatorPress, handleSectionHeaderLayout]);
 
   // Render a closing cap at the bottom of each section's card
   const renderSectionFooter = useCallback(({ section }) => (
@@ -249,7 +363,12 @@ const OperationsList = forwardRef(({
       renderSectionFooter={renderSectionFooter}
       keyExtractor={keyExtractor}
       extraData={[accounts, categories, pendingSuggestionId]}
-      ListHeaderComponent={headerComponent}
+      getItemLayout={getItemLayout}
+      ListHeaderComponent={
+        headerComponent
+          ? <View onLayout={handleListHeaderLayout}>{headerComponent}</View>
+          : null
+      }
       ListFooterComponent={renderFooter}
       ListEmptyComponent={
         initialLoading ? (

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -4,7 +4,7 @@ import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from '
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS, HEIGHTS } from '../styles/layout';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useOperationsData } from '../contexts/OperationsDataContext';
@@ -815,31 +815,16 @@ const OperationsScreen = () => {
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
   }, []);
 
-  // Handle scroll to index failures (when item is not rendered yet)
+  // Safety net for scrollToIndex failures. The list now provides getItemLayout,
+  // so scrollToLocation resolves offsets directly and this should not fire in
+  // practice. If it ever does, jump straight to an estimated offset — no retry,
+  // no timeout dance (RN supplies averageItemLength from its measured cells).
   const handleScrollToIndexFailed = useCallback((info) => {
-    console.warn('scrollToIndex failed for index:', info.index, 'Using offset fallback');
-
-    // Scroll to approximate position using offset
-    const estimatedItemHeight = 75;
-    const estimatedOffset = info.index * estimatedItemHeight;
-
+    const averageItemHeight = info?.averageItemLength || HEIGHTS.listItem;
     flatListRef.current?.scrollToOffset({
-      offset: estimatedOffset,
+      offset: averageItemHeight * (info?.index || 0),
       animated: false,
     });
-
-    // Try scrollToIndex again after a delay for precise positioning
-    setTimeout(() => {
-      try {
-        flatListRef.current?.scrollToIndex({
-          index: info.index,
-          animated: false,
-          viewPosition: 0,
-        });
-      } catch (error) {
-        console.warn('Second scrollToIndex attempt failed');
-      }
-    }, 100);
   }, []);
 
   const handleSearchBarAreaLayout = useCallback((event) => {


### PR DESCRIPTION
Closes #920

## Problem

Jumping to a date in the operations list was slow and sometimes landed wrong. Without `getItemLayout`, `SectionList.scrollToLocation` has to render/measure every cell on the way to the target, frequently hitting `onScrollToIndexFailed`, which retried with a hardcoded `estimatedItemHeight = 75` after a 100 ms `setTimeout` — visible delay plus occasional mis-positioning.

## What changed

**`app/components/operations/OperationsList.js`**
- Added `getItemLayout` to the `SectionList`. `scrollToLocation` now resolves the target offset directly instead of measuring along the way.
- The flattened SectionList geometry — `[sectionHeader, ...rows, sectionFooter]` per section — is cached in a `useMemo` keyed on `sections`; lookup is an **O(log n) binary search** over cumulative per-section offsets (not an O(items) walk).
- **Fixed heights** come from design tokens: row = `HEIGHTS.listItem`, the 1px divider (which lives *inside* `OperationListItem`, so only non-last rows carry it), and the section footer = `BORDER_RADIUS.md + SPACING.xs` (the card-bottom cap + its margin, folded in so the next header lands correctly).
- **Dynamic / text-dependent heights are measured at runtime** via `onLayout` and read lazily from refs:
  - the **list header** (the QuickAdd form) grows/shrinks, so its latest height is tracked;
  - the **section header** (`DateSeparator` + card-top) contains text whose exact line height is font/platform dependent, so the first real measurement is captured (then the tallest, since expense days show a spending total and income-only days don't).
  - Reading from refs means a height change never forces a re-render or churns offsets mid-scroll.

**`app/screens/OperationsScreen.js`**
- With `getItemLayout` present, `onScrollToIndexFailed` no longer fires (RN only routes there when there is *no* `getItemLayout`). `handleScrollToIndexFailed` is reduced to a quiet single-shot offset fallback — **no `console.warn`, no 100 ms retry dance**.

## Why measure instead of hardcode

I verified against the bundled RN 0.81 source that `ListMetricsAggregator.getCellMetrics` returns `getItemLayout`'s `offset` **verbatim** — there is no automatic `_headerLength` adjustment — so the offset must include the (dynamic) list-header height. Measuring at runtime is more robust than baking in estimates and keeps the rendered output byte-for-byte identical (only `onLayout` handlers and a transparent wrapper `View` around the header were added).

## Caveat (issue point 5)

Rows are constant height in the common case (single line). `OperationListItem`'s title has no `numberOfLines` and label chips wrap, so a long/label-heavy row can grow to two lines. `getItemLayout` uses the single-line height for rows; a wrapped row introduces small error that RN's own cell measurement self-corrects as cells render — and it is still far closer than the previous flat 75 px estimate. Making rows strictly constant would require truncating titles/labels (a visible regression), so it was intentionally avoided.

## Acceptance criteria

- [x] Date jump scrolls immediately to the correct section with no retry delay
- [x] No `scrollToIndex failed` warnings during heavy scrolling/jumping (`getItemLayout` prevents the failure path entirely)
- [x] Normal scrolling, section headers, and footers render identically (only `onLayout` + a transparent wrapper added)
- [x] `npm test -- --silent` passes — **3763 tests, 122 suites, all green**; lint clean

## Tests

Added a `getItemLayout` suite in `__tests__/components/operations/OperationsList.test.js` covering exact header/row/footer offsets across sections, the contiguity invariant (`offset[i+1] === offset[i] + length[i]`), the last-row-has-no-separator rule, and out-of-range / empty-list handling. Updated the `OperationsScreen` fallback test to assert the new quiet behavior (no warn, no `setTimeout`).

> [!NOTE]
> Verified via tests and source analysis. Not exercised on a device/emulator in this environment, so a quick manual check of a long-distance date jump (and a label-heavy list) is worthwhile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSLr9b7Uj56RFLYBHhfDi1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSLr9b7Uj56RFLYBHhfDi1)_