### PR TITLE
fix(settings): render subpanels over main list on New Architecture

### DIFF
--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -1902,9 +1902,15 @@ const styles = StyleSheet.create({
   },
   subPanelOverlay: {
     // Covers the settings list while open; the swipe slides it off to the right
-    // to reveal the list behind. Elevation lifts it above the base layer.
+    // to reveal the list behind. Both elevation and zIndex lift it above the
+    // base ScrollView: under the New Architecture (Fabric, RN 0.85+) Android
+    // stacking follows the CSS model, where paint order among positioned
+    // siblings is governed by zIndex while elevation only drives the native
+    // shadow. Without zIndex the absolutely-positioned overlay paints behind the
+    // ScrollView and renders below the main settings list instead of over it.
     ...StyleSheet.absoluteFillObject,
     elevation: 8,
+    zIndex: 10,
   },
   subPanelTitle: {
     fontWeight: '600',


### PR DESCRIPTION
## Problem

After the Expo SDK 54 → 56 upgrade (#1065 — RN 0.85, Reanimated 4.3, New Architecture/Fabric), the Settings screen subpanels (Language, Accounts, Export, Import, Logs, etc.) started rendering **below** the main settings list instead of sliding over it.

## Root cause

`subPanelOverlay` is an absolutely-positioned (`StyleSheet.absoluteFillObject`) sibling of the main settings `ScrollView`, relying solely on `elevation: 8` to sit above it.

Under the old architecture (Paper), Android `elevation` alone reliably lifted an absolutely-positioned sibling above the base view. Under the New Architecture (Fabric, RN 0.85+), Android Z-ordering follows the CSS model more closely: paint order among positioned siblings is governed by `zIndex`, while `elevation` mainly drives the native shadow layer. Without a `zIndex`, the overlay paints behind the `ScrollView` and ends up below the main settings list.

## Fix

Add `zIndex: 10` to `subPanelOverlay`, matching the `elevation` + `zIndex` convention already used by other overlays in the codebase (`OperationsScreen` scroll-to-top button, `SearchOverlay`). `zIndex` is scoped to siblings within the settings container, so the floating tab bar stacking (handled at the `SimpleTabs` level) is unaffected.

## Testing

- `npm test` — all 122 suites / 3768 tests pass, including the 50 SettingsScreen tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDEvK3yV6vtngYfSeTpsr7)_