### PR TITLE
fix(settings): size subpanel overlay in explicit pixels so it actually opens

### DIFF
--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -82,6 +82,11 @@ export default function SettingsScreen({ setSubPanelActive }) {
   const { startDownload, isDownloading, downloadProgress, downloadPhase } = useUpdateDownload();
   const { visibleAccounts } = useAccountsData();
   const [activeSubPanel, setActiveSubPanel] = useState(null);
+  // Measured size of the settings container. The subpanel overlay is sized in
+  // explicit pixels from this rather than relying on `absoluteFillObject`'s
+  // top+bottom inset stretch, which collapses to zero height under Reanimated 4 /
+  // RN 0.85's Yoga (leaving the panel invisible / seemingly not opening).
+  const [containerSize, setContainerSize] = useState(null);
   const [pinnedAccountId, setPinnedAccountId] = useState(null);
   const [logFilter, setLogFilter] = useState('all');
   const [storedBackups, setStoredBackups] = useState([]);
@@ -227,6 +232,14 @@ export default function SettingsScreen({ setSubPanelActive }) {
   const handleEmbeddedBackStateChange = useCallback((goBack) => {
     embeddedBackRef.current = typeof goBack === 'function' ? goBack : null;
     setEmbeddedCanGoBack(!!goBack);
+  }, []);
+
+  // Capture the container's pixel size so the subpanel overlay can be sized
+  // explicitly (see containerSize above). Only update on real changes to avoid
+  // an extra render loop.
+  const handleContainerLayout = useCallback((event) => {
+    const { width, height } = event.nativeEvent.layout;
+    setContainerSize(prev => (prev && prev.width === width && prev.height === height ? prev : { width, height }));
   }, []);
 
   // Whether a completed swipe (or hardware-back) should step one level up rather
@@ -908,7 +921,10 @@ export default function SettingsScreen({ setSubPanelActive }) {
     // dropped — the panel collapses to its header height and falls into normal
     // flow below the list. The inner Animated.View instead fills this concretely
     // sized parent with flex:1 and carries only the swipe transform + background.
-    <View style={styles.subPanelOverlay}>
+    <View style={[
+      styles.subPanelOverlay,
+      containerSize && { width: containerSize.width, height: containerSize.height },
+    ]}>
       <GestureDetector gesture={swipeGesture}>
         <Animated.View
           style={[styles.subPanelFill, { backgroundColor: colors.background }, swipeStyle]}
@@ -1425,6 +1441,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
   return (
     <View
       style={[styles.container, { backgroundColor: colors.background }]}
+      onLayout={handleContainerLayout}
     >
       <ScrollView contentContainerStyle={styles.settingsContent}>
         <TouchableRipple onPress={() => openSubPanel('language')} style={styles.settingsRow} testID="settings-language-row">
@@ -1916,14 +1933,18 @@ const styles = StyleSheet.create({
   },
   subPanelOverlay: {
     // Plain, transparent positioning + stacking layer covering the settings list
-    // while a subpanel is open. Both elevation and zIndex lift it above the base
-    // ScrollView: under the New Architecture (Fabric, RN 0.85+) Android stacking
-    // follows the CSS model, where paint order among positioned siblings is
-    // governed by zIndex while elevation only drives the native shadow. Without
-    // zIndex the overlay paints behind the ScrollView and renders below the main
-    // settings list instead of over it.
-    ...StyleSheet.absoluteFillObject,
+    // while a subpanel is open. Anchored top-left and sized in explicit pixels
+    // (from the measured container) rather than `absoluteFillObject`'s top+bottom
+    // inset stretch, which collapses to zero size under Reanimated 4 / RN 0.85's
+    // Yoga — that left the panel invisible / seemingly not opening. Both elevation
+    // and zIndex lift it above the base ScrollView: under the New Architecture
+    // (Fabric) Android stacking follows the CSS model, where paint order among
+    // positioned siblings is governed by zIndex while elevation only drives the
+    // native shadow.
     elevation: 8,
+    left: 0,
+    position: 'absolute',
+    top: 0,
     zIndex: 10,
   },
   subPanelTitle: {


### PR DESCRIPTION
## Third (and root-cause) fix — follow-up to #1073 and #1075

The earlier attempts treated symptoms:
- **#1073** added `zIndex` (fixed stacking order, but panel still collapsed to its header at the bottom).
- **#1075** moved `absoluteFillObject` onto a plain wrapper with a `flex: 1` child — which made it **worse**: the panel became invisible / appeared not to open at all.

## Actual root cause

The overlay was sized purely by an **inset stretch** (`StyleSheet.absoluteFillObject` = `top:0 + bottom:0 + left:0 + right:0`, no explicit dimensions). Under **Reanimated 4 / RN 0.85's New Architecture Yoga**, that full top+bottom stretch resolves to **zero height** in this layout — so:
- with the stretch directly on the animated view → it collapsed to its content (just the header), in normal flow at the bottom;
- after #1075 moved the stretch to the wrapper → the wrapper was zero-height, so the `flex: 1` child had nothing to fill → nothing visible.

Verified against the Reanimated v4 docs (context7): static layout styles on `Animated.View` are honored and animated styles only override the keys they define (the swipe style animates `transform` only), so this is **not** a style-merge problem — it's the inset-stretch sizing path. The app's other overlays avoid it because they anchor with a single inset plus content/explicit height (e.g. `SearchOverlay` uses `top:0` + content height), never a full top+bottom stretch.

## Fix

Measure the settings container with `onLayout` and size the overlay in **explicit pixels** (`width`/`height`), anchored at `top:0 / left:0`. Explicit dimensions never go through the inset-stretch path, so the overlay reliably fills the container. The inner `Animated.View` keeps `flex: 1` + the swipe `transform`; `elevation`/`zIndex` keep it above the list.

## Testing

- `npm test` — 122 suites / 3768 tests pass; `eslint` clean.
- ⚠️ This is a native Fabric/Yoga layout bug that **cannot be reproduced in Jest**. I can't run the Android New Architecture build in this environment, so this needs a manual check: pull the branch and tap any settings row (Language, Accounts, Export…) — the subpanel should slide in and fill the screen, and swipe-to-dismiss should still reveal the list behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDEvK3yV6vtngYfSeTpsr7)_