### PR TITLE
style(search): make collapsed search bar a floating pill like the bottom menu

### DIFF
--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -1,8 +1,16 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { View, TextInput, TouchableOpacity, StyleSheet, Text, Keyboard } from 'react-native';
+import { View, TextInput, TouchableOpacity, StyleSheet, Text, Keyboard, Platform } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import { HORIZONTAL_PADDING } from '../../styles/layout';
+
+// Append an alpha channel to a 6-digit hex color (alpha 0..1).
+// Mirrors the helper used by the bottom tab bar so the collapsed search
+// pill picks up the same translucent surface treatment.
+const withAlpha = (hex, alpha) => {
+  const a = Math.round(alpha * 255).toString(16).padStart(2, '0');
+  return hex + a;
+};
 
 const SearchBar = ({
   searchText,
@@ -64,6 +72,42 @@ const SearchBar = ({
     onSearchTextChange('');
   }, [onSearchTextChange]);
 
+  // Collapsed resting state: a centered, semi-transparent, rounded floating
+  // pill that mirrors the bottom tab bar (~70% width, translucent surface,
+  // soft border, elevation). Tapping it expands the full-width search bar.
+  if (collapsed) {
+    return (
+      <View testID="search-bar-container" style={styles.collapsedContainer}>
+        <TouchableOpacity
+          testID="search-input-container"
+          activeOpacity={0.6}
+          onPress={onCollapsedPress}
+          accessibilityRole="button"
+          accessibilityLabel={t('search')}
+          style={[
+            styles.collapsedPill,
+            {
+              backgroundColor: withAlpha(colors.surface, 0.87),
+              borderColor: withAlpha(colors.border, 0.5),
+            },
+          ]}
+        >
+          <View style={styles.iconWrapper}>
+            <Icon name="magnify" size={20} color={colors.text} />
+            {filterCount > 0 && (
+              <View testID="filter-count-badge-collapsed" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
+                <Text style={styles.filterBadgeText}>{filterCount}</Text>
+              </View>
+            )}
+          </View>
+          <Text style={[styles.collapsedLabel, { color: colors.mutedText }]} numberOfLines={1}>
+            {t('search')}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
   return (
     <View
       testID="search-bar-container"
@@ -71,76 +115,61 @@ const SearchBar = ({
     >
       <TouchableOpacity
         testID="search-input-container"
-        activeOpacity={collapsed ? 0.6 : 1}
-        onPress={collapsed ? onCollapsedPress : undefined}
-        accessibilityRole={collapsed ? 'button' : undefined}
-        accessibilityLabel={collapsed ? t('search') : undefined}
+        activeOpacity={1}
         style={[
           styles.searchInputContainer,
           { backgroundColor: colors.background, borderBottomColor: colors.border },
-          collapsed && styles.searchInputContainerCollapsed,
         ]}
       >
         <View style={styles.iconWrapper}>
           <Icon name="magnify" size={20} color={colors.text} />
-          {collapsed && filterCount > 0 && (
-            <View testID="filter-count-badge-collapsed" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
-              <Text style={styles.filterBadgeText}>{filterCount}</Text>
-            </View>
-          )}
         </View>
-        {!collapsed && (
-          <>
-            <TextInput
-              style={[styles.searchInput, { color: colors.text }]}
-              value={localText}
-              onChangeText={setLocalText}
-              placeholder={t('search_operations_placeholder')}
-              placeholderTextColor={colors.mutedText}
-              autoFocus
-              autoCorrect={false}
-              autoCapitalize="none"
-            />
-            {localText.length > 0 && (
-              <TouchableOpacity
-                testID="clear-search-button"
-                onPress={handleClear}
-                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-              >
-                <Icon name="close-circle" size={20} color={colors.mutedText} />
-              </TouchableOpacity>
-            )}
-          </>
+        <TextInput
+          style={[styles.searchInput, { color: colors.text }]}
+          value={localText}
+          onChangeText={setLocalText}
+          placeholder={t('search_operations_placeholder')}
+          placeholderTextColor={colors.mutedText}
+          autoFocus
+          autoCorrect={false}
+          autoCapitalize="none"
+        />
+        {localText.length > 0 && (
+          <TouchableOpacity
+            testID="clear-search-button"
+            onPress={handleClear}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <Icon name="close-circle" size={20} color={colors.mutedText} />
+          </TouchableOpacity>
         )}
       </TouchableOpacity>
-      {!collapsed && (
-        <View style={styles.buttonContainer}>
-          <TouchableOpacity
-            testID="filters-toggle-button"
-            onPress={() => { Keyboard.dismiss(); onToggleFilters(); }}
-            style={[styles.iconButton, filterCount > 0 && { backgroundColor: `${colors.primary}15` }]}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            activeOpacity={0.7}
-          >
-            <View style={styles.filterButtonContent}>
-              <Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
-              {filterCount > 0 && (
-                <View testID="filter-count-badge" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
-                  <Text style={styles.filterBadgeText}>{filterCount}</Text>
-                </View>
-              )}
-            </View>
-          </TouchableOpacity>
-          <TouchableOpacity
-            testID="close-search-button"
-            onPress={onClose}
-            style={styles.iconButton}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          >
-            <Icon name="close" size={22} color={colors.text} />
-          </TouchableOpacity>
-        </View>
-      )}
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity
+          testID="filters-toggle-button"
+          onPress={() => { Keyboard.dismiss(); onToggleFilters(); }}
+          style={[styles.iconButton, filterCount > 0 && { backgroundColor: `${colors.primary}15` }]}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          activeOpacity={0.7}
+        >
+          <View style={styles.filterButtonContent}>
+            <Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
+            {filterCount > 0 && (
+              <View testID="filter-count-badge" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
+                <Text style={styles.filterBadgeText}>{filterCount}</Text>
+              </View>
+            )}
+          </View>
+        </TouchableOpacity>
+        <TouchableOpacity
+          testID="close-search-button"
+          onPress={onClose}
+          style={styles.iconButton}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        >
+          <Icon name="close" size={22} color={colors.text} />
+        </TouchableOpacity>
+      </View>
     </View>
   );
 };
@@ -153,6 +182,7 @@ SearchBar.propTypes = {
   filterCount: PropTypes.number,
   colors: PropTypes.shape({
     background: PropTypes.string.isRequired,
+    surface: PropTypes.string.isRequired,
     border: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
     mutedText: PropTypes.string.isRequired,
@@ -174,6 +204,38 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     gap: 8,
     width: 96, // 44 + 44 + 8
+  },
+  collapsedContainer: {
+    alignItems: 'center',
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: 6,
+    width: '100%',
+    zIndex: 100,
+  },
+  collapsedLabel: {
+    fontSize: 16,
+  },
+  collapsedPill: {
+    alignItems: 'center',
+    borderRadius: 22,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 8,
+    height: 44,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    width: '70%',
+    ...Platform.select({
+      android: {
+        elevation: 8,
+      },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.15,
+        shadowRadius: 12,
+      },
+    }),
   },
   container: {
     alignItems: 'center',
@@ -227,12 +289,6 @@ const styles = StyleSheet.create({
     height: 44,
     marginRight: 12,
     paddingHorizontal: 12,
-  },
-  searchInputContainerCollapsed: {
-    borderBottomWidth: 0,
-    flex: 0,
-    height: 32,
-    marginRight: 0,
   },
 });
 


### PR DESCRIPTION
## Summary

Restyles the **top search area** on the Operations screen so its resting (collapsed) state mirrors the bottom tab bar / "screens menu": a centered, semi-transparent, rounded, ~70%-width floating pill.

Before, the collapsed search was a small magnify-icon box pinned to the top-left. Now it visually echoes the bottom floating bar.

## What changed

`app/components/search/SearchBar.js` — the **collapsed** branch only:

- **Semi-transparent** surface background using the same `withAlpha(colors.surface, 0.87)` treatment as the bottom tab bar, plus a soft translucent border (`withAlpha(colors.border, 0.5)`).
- **Round** — fully rounded pill (`borderRadius: 22`, `height: 44`).
- **~70% width**, centered (`alignSelf` via centered container).
- **Elevation/shadow** matching the bottom bar (`elevation: 8` on Android, soft shadow on iOS).
- The magnify icon now pairs with a **"Search"** label (`t('search')`) so the wider pill reads as a real search field. The collapsed filter-count badge is preserved.

The **open/active** search state is intentionally unchanged — it stays full-width with the text input, filter, and close controls so typing and filtering remain comfortable. The render was refactored into an early return for the collapsed branch, which let the inline `collapsed ? …` conditionals be dropped from the open-state JSX (no behavioral change there).

## Design alignment

Matches the bottom tab bar in `app/navigation/SimpleTabs.js` (`floatingBar`: 70% width, `withAlpha(colors.surface, 0.87)`, rounded, elevated) for a consistent floating-pill aesthetic at the top and bottom of the screen.

## Testing

- `npm test` — **all 3768 tests pass** (122 suites), including the full `SearchBar` / search integration suites.
- `eslint` clean on the changed file.

All existing `SearchBar` tests exercise the open/active state, which is unchanged, so they remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMGSRBxr8GsqB3nBiVMVXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGSRBxr8GsqB3nBiVMVXT)_