### PR TITLE
style(search): float the search bar and match the type-button height

### DIFF
--- a/__tests__/components/search/SearchBar.test.js
+++ b/__tests__/components/search/SearchBar.test.js
@@ -184,32 +184,33 @@ describe('SearchBar', () => {
   });
 
   describe('SearchBar visual style', () => {
-    it('search input container has clean rounded style', async () => {
+    // The open search now lives inside the same translucent rounded "pill" as the
+    // collapsed state (matching the floating bottom menu), so the field itself no
+    // longer carries the underline/background — the pill does.
+    it('search pill has a rounded translucent container', async () => {
       const { getByTestId } = await render(<SearchBar {...defaultProps} />);
-      const container = getByTestId('search-input-container');
+      const pill = getByTestId('search-pill');
 
-      const containerStyle = StyleSheet.flatten(container.props.style);
-      expect(containerStyle.borderBottomWidth).toBe(1);
-      expect(containerStyle.borderWidth).toBeUndefined();
-      expect(containerStyle.borderRadius).toBe(4);
-      expect(containerStyle.height).toBe(44);
+      const pillStyle = StyleSheet.flatten(pill.props.style);
+      expect(pillStyle.borderRadius).toBe(24);
+      expect(pillStyle.borderWidth).toBe(1);
     });
 
-    it('search input container has subtle background for visibility', async () => {
+    it('search pill uses a translucent surface background', async () => {
       const { getByTestId } = await render(<SearchBar {...defaultProps} />);
-      const container = getByTestId('search-input-container');
+      const pill = getByTestId('search-pill');
 
-      const containerStyle = StyleSheet.flatten(container.props.style);
-      // Solid dark background for clear visual definition
-      expect(containerStyle.backgroundColor).toBe('#1f1f1f');
+      const pillStyle = StyleSheet.flatten(pill.props.style);
+      // surface (#FFFFFF) with an appended alpha channel (e.g. #FFFFFFde)
+      expect(pillStyle.backgroundColor).toMatch(/^#FFFFFF/i);
     });
 
-    it('search input container has proper padding', async () => {
+    it('search input region stretches and keeps comfortable spacing', async () => {
       const { getByTestId } = await render(<SearchBar {...defaultProps} />);
       const container = getByTestId('search-input-container');
 
       const containerStyle = StyleSheet.flatten(container.props.style);
-      expect(containerStyle.paddingHorizontal).toBe(12);
+      expect(containerStyle.flex).toBe(1);
       expect(containerStyle.gap).toBe(12);
     });
   });

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -66,6 +66,7 @@ const OperationsList = forwardRef(({
   onScrollToIndexFailed,
   onContentSizeChange,
   headerComponent,
+  topInset,
   pendingSuggestionId,
   pendingSuggestions,
   onApplySuggestion,
@@ -365,8 +366,16 @@ const OperationsList = forwardRef(({
       extraData={[accounts, categories, pendingSuggestionId]}
       getItemLayout={getItemLayout}
       ListHeaderComponent={
-        headerComponent
-          ? <View onLayout={handleListHeaderLayout}>{headerComponent}</View>
+        (topInset > 0 || headerComponent)
+          ? (
+            <View onLayout={handleListHeaderLayout}>
+              {/* Spacer so the first content sits below the floating search bar
+                  and scrolls up behind it. Measured as part of the header, so
+                  getItemLayout offsets stay correct. */}
+              {topInset > 0 ? <View style={{ height: topInset }} /> : null}
+              {headerComponent}
+            </View>
+          )
           : null
       }
       ListFooterComponent={renderFooter}
@@ -423,6 +432,7 @@ OperationsList.propTypes = {
   onScrollToIndexFailed: PropTypes.func,
   onContentSizeChange: PropTypes.func,
   headerComponent: PropTypes.element,
+  topInset: PropTypes.number,
   pendingSuggestionId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   pendingSuggestions: PropTypes.arrayOf(PropTypes.string),
   onApplySuggestion: PropTypes.func,
@@ -437,6 +447,7 @@ OperationsList.defaultProps = {
   onScrollToIndexFailed: () => {},
   onContentSizeChange: () => {},
   headerComponent: null,
+  topInset: 0,
   pendingSuggestionId: null,
   pendingSuggestions: [],
   onApplySuggestion: () => {},

--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { View, TextInput, TouchableOpacity, StyleSheet, Text, Keyboard, Platform } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
-import { HORIZONTAL_PADDING } from '../../styles/layout';
+import { HORIZONTAL_PADDING, SPACING } from '../../styles/layout';
 
 // Append an alpha channel to a 6-digit hex color (alpha 0..1).
 // Mirrors the helper used by the bottom tab bar so the collapsed search
@@ -77,7 +77,7 @@ const SearchBar = ({
   // soft border, elevation). Tapping it expands the full-width search bar.
   if (collapsed) {
     return (
-      <View testID="search-bar-container" style={styles.collapsedContainer}>
+      <View testID="search-bar-container" style={styles.collapsedContainer} pointerEvents="box-none">
         <TouchableOpacity
           testID="search-input-container"
           activeOpacity={0.6}
@@ -93,7 +93,7 @@ const SearchBar = ({
           ]}
         >
           <View style={styles.iconWrapper}>
-            <Icon name="magnify" size={20} color={colors.text} />
+            <Icon name="magnify" size={18} color={colors.text} />
             {filterCount > 0 && (
               <View testID="filter-count-badge-collapsed" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
                 <Text style={styles.filterBadgeText}>{filterCount}</Text>
@@ -108,67 +108,69 @@ const SearchBar = ({
     );
   }
 
+  // Open/active state: the search field, clear, filter, and close controls live
+  // inside the same translucent rounded pill as the collapsed state, so the
+  // floating look is preserved while typing.
   return (
-    <View
-      testID="search-bar-container"
-      style={[styles.container, { backgroundColor: colors.background }]}
-    >
-      <TouchableOpacity
-        testID="search-input-container"
-        activeOpacity={1}
+    <View testID="search-bar-container" style={styles.openContainer} pointerEvents="box-none">
+      <View
+        testID="search-pill"
         style={[
-          styles.searchInputContainer,
-          { backgroundColor: colors.background, borderBottomColor: colors.border },
+          styles.openPill,
+          {
+            backgroundColor: withAlpha(colors.surface, 0.87),
+            borderColor: withAlpha(colors.border, 0.5),
+          },
         ]}
       >
-        <View style={styles.iconWrapper}>
+        <View testID="search-input-container" style={styles.searchInputContainer}>
           <Icon name="magnify" size={20} color={colors.text} />
+          <TextInput
+            style={[styles.searchInput, { color: colors.text }]}
+            value={localText}
+            onChangeText={setLocalText}
+            placeholder={t('search_operations_placeholder')}
+            placeholderTextColor={colors.mutedText}
+            autoFocus
+            autoCorrect={false}
+            autoCapitalize="none"
+          />
+          {localText.length > 0 && (
+            <TouchableOpacity
+              testID="clear-search-button"
+              onPress={handleClear}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <Icon name="close-circle" size={20} color={colors.mutedText} />
+            </TouchableOpacity>
+          )}
         </View>
-        <TextInput
-          style={[styles.searchInput, { color: colors.text }]}
-          value={localText}
-          onChangeText={setLocalText}
-          placeholder={t('search_operations_placeholder')}
-          placeholderTextColor={colors.mutedText}
-          autoFocus
-          autoCorrect={false}
-          autoCapitalize="none"
-        />
-        {localText.length > 0 && (
+        <View style={styles.buttonContainer}>
           <TouchableOpacity
-            testID="clear-search-button"
-            onPress={handleClear}
+            testID="filters-toggle-button"
+            onPress={() => { Keyboard.dismiss(); onToggleFilters(); }}
+            style={[styles.iconButton, filterCount > 0 && { backgroundColor: `${colors.primary}15` }]}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            activeOpacity={0.7}
+          >
+            <View style={styles.filterButtonContent}>
+              <Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
+              {filterCount > 0 && (
+                <View testID="filter-count-badge" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
+                  <Text style={styles.filterBadgeText}>{filterCount}</Text>
+                </View>
+              )}
+            </View>
+          </TouchableOpacity>
+          <TouchableOpacity
+            testID="close-search-button"
+            onPress={onClose}
+            style={styles.iconButton}
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >
-            <Icon name="close-circle" size={20} color={colors.mutedText} />
+            <Icon name="close" size={22} color={colors.text} />
           </TouchableOpacity>
-        )}
-      </TouchableOpacity>
-      <View style={styles.buttonContainer}>
-        <TouchableOpacity
-          testID="filters-toggle-button"
-          onPress={() => { Keyboard.dismiss(); onToggleFilters(); }}
-          style={[styles.iconButton, filterCount > 0 && { backgroundColor: `${colors.primary}15` }]}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          activeOpacity={0.7}
-        >
-          <View style={styles.filterButtonContent}>
-            <Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
-            {filterCount > 0 && (
-              <View testID="filter-count-badge" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
-                <Text style={styles.filterBadgeText}>{filterCount}</Text>
-              </View>
-            )}
-          </View>
-        </TouchableOpacity>
-        <TouchableOpacity
-          testID="close-search-button"
-          onPress={onClose}
-          style={styles.iconButton}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-        >
-          <Icon name="close" size={22} color={colors.text} />
-        </TouchableOpacity>
+        </View>
       </View>
     </View>
   );
@@ -181,7 +183,6 @@ SearchBar.propTypes = {
   onClose: PropTypes.func.isRequired,
   filterCount: PropTypes.number,
   colors: PropTypes.shape({
-    background: PropTypes.string.isRequired,
     surface: PropTypes.string.isRequired,
     border: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
@@ -201,29 +202,31 @@ SearchBar.defaultProps = {
 
 const styles = StyleSheet.create({
   buttonContainer: {
+    alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     width: 96, // 44 + 44 + 8
   },
   collapsedContainer: {
     alignItems: 'center',
     paddingHorizontal: HORIZONTAL_PADDING,
-    paddingVertical: 6,
+    paddingVertical: SPACING.xs,
     width: '100%',
-    zIndex: 100,
   },
   collapsedLabel: {
-    fontSize: 16,
+    fontSize: 14,
   },
+  // Matches the Расход/Доход/Перевод type buttons: same vertical padding,
+  // border, icon (18) and text (14) so the resting search pill is the same height.
   collapsedPill: {
     alignItems: 'center',
-    borderRadius: 22,
+    borderRadius: 20,
     borderWidth: 1,
     flexDirection: 'row',
-    gap: 8,
-    height: 44,
+    gap: SPACING.sm,
     justifyContent: 'center',
-    paddingHorizontal: 16,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.sm,
     width: '70%',
     ...Platform.select({
       android: {
@@ -236,14 +239,6 @@ const styles = StyleSheet.create({
         shadowRadius: 12,
       },
     }),
-  },
-  container: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    paddingHorizontal: HORIZONTAL_PADDING,
-    paddingVertical: 2,
-    width: '100%',
-    zIndex: 100,
   },
   filterBadge: {
     alignItems: 'center',
@@ -274,6 +269,30 @@ const styles = StyleSheet.create({
   iconWrapper: {
     position: 'relative',
   },
+  openContainer: {
+    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingVertical: SPACING.xs,
+    width: '100%',
+  },
+  openPill: {
+    alignItems: 'center',
+    borderRadius: 24,
+    borderWidth: 1,
+    flexDirection: 'row',
+    paddingLeft: SPACING.lg,
+    paddingRight: SPACING.xs,
+    ...Platform.select({
+      android: {
+        elevation: 8,
+      },
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.15,
+        shadowRadius: 12,
+      },
+    }),
+  },
   searchInput: {
     flex: 1,
     fontSize: 16,
@@ -281,14 +300,10 @@ const styles = StyleSheet.create({
   },
   searchInputContainer: {
     alignItems: 'center',
-    borderBottomWidth: 1,
-    borderRadius: 4,
     flex: 1,
     flexDirection: 'row',
-    gap: 12,
-    height: 44,
-    marginRight: 12,
-    paddingHorizontal: 12,
+    gap: SPACING.md,
+    height: 48,
   },
 });
 

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -75,7 +75,9 @@ const OperationsScreen = () => {
   // having already been re-loaded into `operations` (which is async).
   const pendingOpDescRef = useRef('');
   const [filterPanelHeight, setFilterPanelHeight] = useState(0);
-  const [searchBarAreaHeight, setSearchBarAreaHeight] = useState(0);
+  // Seeded with an estimate of the collapsed search-pill area so the list's top
+  // inset is roughly right on first paint; the real value arrives via onLayout.
+  const [searchBarAreaHeight, setSearchBarAreaHeight] = useState(48);
   const [flashCategoryErrorCount, setFlashCategoryErrorCount] = useState(0);
 
   const { searchMode, filtersExpanded, openSearch, closeSearch, reopenSearch, toggleFilters } = useSearch();
@@ -833,29 +835,9 @@ const OperationsScreen = () => {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <View onLayout={handleSearchBarAreaLayout}>
-        <SearchBar
-          searchText={searchState?.text || ''}
-          onSearchTextChange={setSearchText}
-          onToggleFilters={handleToggleFilters}
-          onClose={handleCloseSearch}
-          filterCount={getSearchFilterCount ? getSearchFilterCount() : 0}
-          colors={colors}
-          t={t}
-          collapsed={!isSearchOpen}
-          onCollapsedPress={handleCollapsedPress}
-        />
-        {isSearchOpen && hasActiveSearch && (
-          <FilterChipStrip
-            searchState={searchState}
-            onClearGroup={handleClearFilterGroup}
-            colors={colors}
-            t={t}
-          />
-        )}
-      </View>
       <OperationsList
         ref={flatListRef}
+        topInset={searchBarAreaHeight}
         groupedOperations={groupedOperations}
         accounts={accounts}
         categories={categories}
@@ -876,6 +858,35 @@ const OperationsScreen = () => {
         onApplySuggestion={handleApplySuggestion}
         onDismissSuggestion={handleDismissSuggestion}
       />
+
+      {/* Floating search area — overlays the list so its content scrolls behind
+          it instead of being clipped by an opaque band. The matching topInset on
+          the list above keeps content from starting underneath the pill. */}
+      <View
+        style={styles.floatingSearchArea}
+        onLayout={handleSearchBarAreaLayout}
+        pointerEvents="box-none"
+      >
+        <SearchBar
+          searchText={searchState?.text || ''}
+          onSearchTextChange={setSearchText}
+          onToggleFilters={handleToggleFilters}
+          onClose={handleCloseSearch}
+          filterCount={getSearchFilterCount ? getSearchFilterCount() : 0}
+          colors={colors}
+          t={t}
+          collapsed={!isSearchOpen}
+          onCollapsedPress={handleCollapsedPress}
+        />
+        {isSearchOpen && hasActiveSearch && (
+          <FilterChipStrip
+            searchState={searchState}
+            onClearGroup={handleClearFilterGroup}
+            colors={colors}
+            t={t}
+          />
+        )}
+      </View>
 
       {/* Picker Modal for Account/Category selection */}
       <PickerModal
@@ -949,6 +960,13 @@ const OperationsScreen = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  floatingSearchArea: {
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 100,
   },
   scrollToTopButton: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary

Follow-up to #1080, addressing three pieces of design feedback on the Operations search area:

1. **Match the type-button height** — the resting "Search" pill is now the same height as the Расход/Доход/Перевод buttons.
2. **Style the open search the same way** — the active/typing search is now the same translucent rounded pill instead of the old full-width underlined bar.
3. **No black band; content slides through** — the search no longer sits in an opaque band. It floats over the list, and list content scrolls up behind it.

## What changed

**`app/components/search/SearchBar.js`**
- **Collapsed pill** now mirrors the type buttons exactly: `paddingVertical: SPACING.sm`, `borderWidth: 1`, 18px magnify icon, 14px label — identical metrics, so the heights match.
- **Open/active state** was rebuilt inside the same translucent pill (`withAlpha(colors.surface, 0.87)`, soft border, rounded, elevation). The field, clear button, filter, and close controls now live inside one floating pill rather than a full-width underlined bar. Filter/close keep their 44×44 touch targets.
- Both states use `pointerEvents="box-none"` so taps land on the pill while touches in the transparent margins pass through to the list.

**`app/screens/OperationsScreen.js`**
- The search area is now an absolutely-positioned, transparent floating overlay (`floatingSearchArea`, `top: 0`, `zIndex: 100`) rendered above the list — so the list shows through instead of an opaque background band.
- The list receives a matching `topInset` so its content starts just below the pill and scrolls behind it.

**`app/components/operations/OperationsList.js`**
- New `topInset` prop renders a spacer at the top of the list header. Because the spacer is part of the measured header, `getItemLayout` offsets stay exact (date-jump scrolling unaffected).

## Behavior notes
- At rest the pill floats over the screen background (seamless, no distinct band); as you scroll, the quick-add form and rows slide up behind the translucent pill.
- The collapsed pill stays centered at ~70% width; the open pill spans the row to fit the input + controls — both share the translucent/rounded/floating look.

## Testing
- `npm test` — **all 3778 tests pass** (123 suites), rebased on the latest `main`.
- `eslint` clean.
- Updated the `SearchBar` visual-style unit tests to assert the new pill (the previous tests pinned the old underline/background, which no longer applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMGSRBxr8GsqB3nBiVMVXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMGSRBxr8GsqB3nBiVMVXT)_