### PR TITLE
refactor: replace deprecated InteractionManager with requestIdleCallback

### DIFF
--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -1,6 +1,5 @@
 /* global __DEV__ */
 import React, { createContext, useContext, useCallback, useMemo, useEffect, useRef } from 'react';
-import { InteractionManager } from 'react-native';
 import PropTypes from 'prop-types';
 import * as OperationsDB from '../services/OperationsDB';
 import { useAccountsActions } from './AccountsActionsContext';
@@ -153,9 +152,10 @@ export const OperationsActionsProvider = ({ children }) => {
       _setHasMoreOperations(!allDatesLoaded);
       _setDataLoaded(true);
 
-      // Pre-warm cache after first non-text load so subsequent text searches are instant
+      // Pre-warm cache after first non-text load so subsequent text searches are instant.
+      // Deferred to idle time so it never competes with rendering the freshly loaded list.
       if (!hasTextSearch && !Array.isArray(allOpsCacheRef.current)) {
-        InteractionManager.runAfterInteractions(() => { _loadCache(); });
+        requestIdleCallback(() => { _loadCache(); });
       }
     } catch (error) {
       console.error('Failed to load initial operations:', error);

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { View, StyleSheet, FlatList, TouchableOpacity, TextInput, Pressable, Modal, Keyboard, InteractionManager, BackHandler } from 'react-native';
+import { View, StyleSheet, FlatList, TouchableOpacity, TextInput, Pressable, Modal, Keyboard, BackHandler } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -213,7 +213,7 @@ const OperationsScreen = () => {
   const handleContentSizeChange = useCallback((width, height) => {
     // scrollScheduledRef gates re-entrant calls: between the first scheduling and the
     // next React re-render (where pendingScroll becomes false), this callback can fire
-    // many times. Without the ref, each firing would queue another InteractionManager
+    // many times. Without the ref, each firing would queue another idle-callback
     // scroll and cause snap-back whenever the user tries to scroll away.
     if (scrollScheduledRef.current) return;
 
@@ -226,8 +226,9 @@ const OperationsScreen = () => {
         // Synchronously mark as handled before the async scroll so subsequent firings bail out
         scrollScheduledRef.current = true;
 
-        // Defer scroll until after interactions/layout have settled
-        InteractionManager.runAfterInteractions(() => {
+        // Defer scroll until the JS thread is idle (after interactions/layout
+        // have settled). The timeout guarantees it still fires under load.
+        requestIdleCallback(() => {
           try {
             // Use animated: false for instant, graceful jump to distant dates
             flatListRef.current?.scrollToIndex({
@@ -247,7 +248,7 @@ const OperationsScreen = () => {
             setScrollToDateString(null);
             setPendingScroll(false);
           }
-        });
+        }, { timeout: 500 });
       } else {
         setScrollToDateString(null);
         setPendingScroll(false);
@@ -778,16 +779,16 @@ const OperationsScreen = () => {
 
     if (wasExpanded && !filtersExpanded) {
       if (scrollOffsetRef.current <= filterPanelHeight) {
-        InteractionManager.runAfterInteractions(() => {
+        requestIdleCallback(() => {
           flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
-        });
+        }, { timeout: 500 });
       }
     }
   }, [filtersExpanded, filterPanelHeight]);
 
   // Auto-scroll to top when search closes (open → closed/collapsed).
   // The user is returning to the normal view and should land on the QuickAdd form.
-  // Deferred via InteractionManager so the scroll runs after the close animation settles.
+  // Deferred via requestAnimationFrame so the scroll runs after the close animation settles.
   useEffect(() => {
     const wasOpen = prevSearchModeRef.current === 'open';
     prevSearchModeRef.current = searchMode;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -34,6 +34,19 @@ if (typeof global.structuredClone === 'undefined') {
   global.structuredClone = (obj) => JSON.parse(JSON.stringify(obj));
 }
 
+// React Native provides requestIdleCallback/cancelIdleCallback globally, but the
+// jest-expo test environment does not. Polyfill them so code that schedules idle
+// work (replacing the deprecated InteractionManager) runs in tests.
+// setImmediate matches how the now-replaced InteractionManager.runAfterInteractions
+// scheduled its callbacks, so deferred work fires at the same point in the event loop.
+if (typeof global.requestIdleCallback === 'undefined') {
+  global.requestIdleCallback = (cb) =>
+    setImmediate(() => cb({ didTimeout: false, timeRemaining: () => 50 }));
+}
+if (typeof global.cancelIdleCallback === 'undefined') {
+  global.cancelIdleCallback = (id) => clearImmediate(id);
+}
+
 // Mock expo-clipboard
 jest.mock('expo-clipboard', () => ({
   setStringAsync: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Summary

React Native has deprecated `InteractionManager` (`InteractionManager has been deprecated and will be removed in a future release. Please refactor long tasks into smaller ones, and use 'requestIdleCallback' instead.`). This PR replaces all remaining `InteractionManager.runAfterInteractions` usages with the recommended `requestIdleCallback`.

I verified `requestIdleCallback` as the integrated, event-loop-aware replacement against current React Native docs via context7 before making the change.

## Changes

- **`app/contexts/OperationsActionsContext.js`** — defer the operations cache pre-warm to idle time via `requestIdleCallback`. This is the textbook deferrable background task, so it never competes with rendering the freshly loaded list. Removed the now-unused `InteractionManager` import.
- **`app/screens/OperationsScreen.js`** — replace the two scroll-deferral call sites (scroll-to-date after content-size change, and scroll-to-top after the filter panel closes) with `requestIdleCallback`, passing `{ timeout: 500 }` so the scroll still fires promptly under load. Removed the unused import and refreshed two stale comments (one had already drifted to reference `InteractionManager` for a `requestAnimationFrame`-based scroll).
- **`jest.setup.js`** — add a `requestIdleCallback`/`cancelIdleCallback` polyfill. The React Native runtime provides these globals, but the jest-expo test environment does not. The polyfill schedules via `setImmediate`, matching how `InteractionManager.runAfterInteractions` previously scheduled its callbacks, so existing test timing (e.g. the cache pre-warm path) is preserved exactly.

## Testing

- `npm test` — **123 suites, 3778 tests passing**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVZ4nVtDJdi9Pg7683vgYA)_