### PR TITLE
feat: forward app logs to Sentry as redacted structured logs

### DIFF
--- a/__tests__/services/sentry.test.js
+++ b/__tests__/services/sentry.test.js
@@ -62,6 +62,17 @@ describe('services/sentry', () => {
       expect(options.sendDefaultPii).toBe(false);
     });
 
+    it('enables structured logs but never auto-captures the console', () => {
+      const { mod, Sentry } = loadWith({ dsn: DSN });
+      mod.initSentry();
+      const options = Sentry.init.mock.calls[0][0];
+      expect(options.enableLogs).toBe(true);
+      expect(options._experiments).toEqual({ enableLogs: true });
+      // Auto console capture would bypass our redaction; it must be off.
+      expect(options.enableAutoConsoleLogs).toBe(false);
+      expect(typeof options.beforeSendLog).toBe('function');
+    });
+
     it('initSentry is idempotent', () => {
       const { mod, Sentry } = loadWith({ dsn: DSN });
       expect(mod.initSentry()).toBe(true);
@@ -100,6 +111,100 @@ describe('services/sentry', () => {
         throw new Error('sentry down');
       });
       expect(() => mod.captureException(new Error('boom'))).not.toThrow();
+    });
+
+    it('captureLog forwards each level to the matching Sentry.logger method', () => {
+      const { mod, Sentry } = loadWith({ dsn: DSN });
+      mod.captureLog('info', 'hello');
+      mod.captureLog('warn', 'careful');
+      mod.captureLog('error', 'oops');
+      mod.captureLog('debug', 'details');
+      expect(Sentry.logger.info).toHaveBeenCalledWith('hello');
+      expect(Sentry.logger.warn).toHaveBeenCalledWith('careful');
+      expect(Sentry.logger.error).toHaveBeenCalledWith('oops');
+      expect(Sentry.logger.debug).toHaveBeenCalledWith('details');
+    });
+
+    it('captureLog falls back to info for unknown levels', () => {
+      const { mod, Sentry } = loadWith({ dsn: DSN });
+      mod.captureLog('verbose', 'mystery');
+      expect(Sentry.logger.info).toHaveBeenCalledWith('mystery');
+    });
+
+    it('captureLog never throws even if the logger throws', () => {
+      const { mod, Sentry } = loadWith({ dsn: DSN });
+      Sentry.logger.info.mockImplementation(() => {
+        throw new Error('logger down');
+      });
+      expect(() => mod.captureLog('info', 'boom')).not.toThrow();
+    });
+  });
+
+  describe('when no DSN is configured (logging)', () => {
+    it('captureLog is a no-op', () => {
+      const { mod, Sentry } = loadWith(null);
+      mod.captureLog('error', 'should not send');
+      expect(Sentry.logger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('redactText', () => {
+    it('scrubs monetary amounts', () => {
+      const { mod } = loadWith({ dsn: DSN });
+      expect(mod.redactText('Balance is 1,234.56 after sync')).toBe(
+        'Balance is [redacted] after sync',
+      );
+      expect(mod.redactText('delta -12.5')).toBe('delta [redacted]');
+    });
+
+    it('scrubs long digit runs (balances stored as cents / ids)', () => {
+      const { mod } = loadWith({ dsn: DSN });
+      expect(mod.redactText('cents=123456')).toBe('cents=[redacted]');
+    });
+
+    it('scrubs email / PII addresses', () => {
+      const { mod } = loadWith({ dsn: DSN });
+      expect(mod.redactText('user jane.doe@example.com failed')).toBe(
+        'user [redacted] failed',
+      );
+    });
+
+    it('leaves short numbers and plain text intact', () => {
+      const { mod } = loadWith({ dsn: DSN });
+      expect(mod.redactText('Failed to delete account: 3 ops')).toBe(
+        'Failed to delete account: 3 ops',
+      );
+    });
+
+    it('returns non-string input unchanged', () => {
+      const { mod } = loadWith({ dsn: DSN });
+      expect(mod.redactText(undefined)).toBeUndefined();
+      expect(mod.redactText(42)).toBe(42);
+    });
+  });
+
+  describe('beforeSendLog redaction hook', () => {
+    function getHook() {
+      const { mod, Sentry } = loadWith({ dsn: DSN });
+      mod.initSentry();
+      return Sentry.init.mock.calls[0][0].beforeSendLog;
+    }
+
+    it('redacts the log message before sending', () => {
+      const beforeSendLog = getHook();
+      const out = beforeSendLog({ level: 'info', message: 'paid 99.99 to acct 555000' });
+      expect(out.message).toBe('paid [redacted] to acct [redacted]');
+    });
+
+    it('redacts string attribute values', () => {
+      const beforeSendLog = getHook();
+      const out = beforeSendLog({
+        level: 'info',
+        message: 'x',
+        attributes: { note: 'amount 50.00', wrapped: { value: 'id 778899', type: 'string' } },
+      });
+      expect(out.attributes.note).toBe('amount [redacted]');
+      expect(out.attributes.wrapped.value).toBe('id [redacted]');
     });
   });
 });

--- a/app/services/LogService.js
+++ b/app/services/LogService.js
@@ -1,4 +1,5 @@
 import { writeTodayLogs, readAllLogs, pruneOldFiles, clearAllLogs } from './LogsFile';
+import { captureLog } from './sentry';
 
 const MAX_ENTRIES = 500;
 
@@ -110,6 +111,9 @@ class LogService {
 
     this._notify();
     this._scheduledFlush();
+    // Mirror the line to Sentry's structured logs (no-op unless a DSN is
+    // configured). Redaction happens centrally in sentry.js `beforeSendLog`.
+    captureLog(level, entry.message);
   }
 
   getEntries(filter) {

--- a/app/services/sentry.js
+++ b/app/services/sentry.js
@@ -11,11 +11,78 @@ import * as Sentry from '@sentry/react-native';
  * build where Sentry has not been set up.
  *
  * Privacy: `sendDefaultPii` is disabled so no IP addresses, cookies, or user
- * identifiers are attached. The app never sends financial data to Sentry — only
- * error/crash metadata and stack traces.
+ * identifiers are attached. The app never sends raw financial data to Sentry —
+ * only error/crash metadata, stack traces, and redacted log lines (see
+ * `redactText` / `beforeSendLog` below).
  */
 
 const isDev = typeof __DEV__ !== 'undefined' && __DEV__;
+
+/**
+ * Best-effort redaction applied to every log line before it leaves the device.
+ * Logs flow through `console.*` (patched by LogService) and may incidentally
+ * contain monetary amounts, balances, or addresses. We scrub anything that
+ * looks like a money amount, a long digit run (balances are stored as integer
+ * cents), or an email/PII address. Over-redaction is acceptable — leaking is
+ * not.
+ */
+const REDACTION_PATTERNS = [
+  // Emails / address-like tokens.
+  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+  // Decimal amounts: 1234.56, 1,234.56, -12.5
+  /-?\d[\d,]*\.\d+/g,
+  // Long integer runs — balances/cents and most numeric ids.
+  /\b\d{4,}\b/g,
+];
+
+/** Scrub financial / PII patterns from a string. Returns input unchanged if not a string. */
+export function redactText(text) {
+  if (typeof text !== 'string') return text;
+  let out = text;
+  for (const re of REDACTION_PATTERNS) {
+    out = out.replace(re, '[redacted]');
+  }
+  return out;
+}
+
+/**
+ * `beforeSendLog` hook: redact the log body and any string attributes in place.
+ * Fail-closed — if redaction throws for any reason we drop the log rather than
+ * risk shipping unredacted content.
+ */
+function redactLog(log) {
+  try {
+    if (log && typeof log.message === 'string') {
+      log.message = redactText(log.message);
+    }
+    // Some SDK versions carry the text under `body` instead of `message`.
+    if (log && typeof log.body === 'string') {
+      log.body = redactText(log.body);
+    }
+    if (log && log.attributes && typeof log.attributes === 'object') {
+      for (const key of Object.keys(log.attributes)) {
+        const value = log.attributes[key];
+        if (typeof value === 'string') {
+          log.attributes[key] = redactText(value);
+        } else if (value && typeof value === 'object' && typeof value.value === 'string') {
+          // Attributes may be wrapped as { value, type }.
+          value.value = redactText(value.value);
+        }
+      }
+    }
+    return log;
+  } catch {
+    return null;
+  }
+}
+
+// Maps LogService levels to Sentry structured-log methods.
+const LOGGER_METHOD = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+};
 
 function readConfig() {
   const extra =
@@ -56,6 +123,19 @@ export function initSentry() {
     sendDefaultPii: false,
     tracesSampleRate,
     attachStacktrace: true,
+    // Structured logs: forward the app's own log lines (captured by LogService)
+    // to Sentry. The flag is set both top-level and under `_experiments` so the
+    // feature works across the 7.x line, where it migrated from experimental to
+    // stable. See `captureLog` for how entries are forwarded.
+    enableLogs: true,
+    _experiments: { enableLogs: true },
+    // We forward LogService entries explicitly (already redacted via
+    // `beforeSendLog`). Disable the SDK's automatic `console.*` capture so logs
+    // are not double-sent, and so nothing bypasses our forwarding path.
+    enableAutoConsoleLogs: false,
+    // Privacy: every log line is scrubbed of money amounts / PII before send.
+    // Fail-closed (drops the log) if redaction errors.
+    beforeSendLog: redactLog,
     // Privacy: drop console breadcrumbs. The app patches console via LogService
     // and may log transaction/account details; we must never ship those to
     // Sentry. Other low-risk breadcrumbs (navigation, lifecycle) are kept.
@@ -81,6 +161,27 @@ export function captureException(error, context) {
     Sentry.captureException(error, context);
   } catch {
     // Intentionally silent — reporting failures must not surface to the user.
+  }
+}
+
+/**
+ * Forward a single app log line to Sentry's structured logs. No-op when Sentry
+ * is not configured. The message is redacted centrally in `beforeSendLog`, so
+ * callers may pass the raw line. Never throws — telemetry must not crash the
+ * app, and must never call `console.*` (LogService patches it, which would
+ * recurse).
+ */
+export function captureLog(level, message) {
+  if (!isSentryEnabled()) return;
+  try {
+    const logger = Sentry.logger;
+    if (!logger) return;
+    const method = LOGGER_METHOD[level] || 'info';
+    if (typeof logger[method] === 'function') {
+      logger[method](typeof message === 'string' ? message : String(message));
+    }
+  } catch {
+    // Intentionally silent.
   }
 }
 

--- a/docs/SENTRY_SETUP.md
+++ b/docs/SENTRY_SETUP.md
@@ -10,6 +10,7 @@ Penny uses [`@sentry/react-native`](https://docs.sentry.io/platforms/react-nativ
 | Metro | `metro.config.js` (`getSentryExpoConfig`) | Injects Debug IDs so uploaded source maps match captured events |
 | Init + wrap | `App.js` → `app/services/sentry.js` | `Sentry.init(...)` on startup, `Sentry.wrap(App)` as the root |
 | Error reporting | `app/components/ErrorBoundary.js` | Reports caught render errors via `captureException` |
+| Log forwarding | `app/services/LogService.js` → `captureLog` | Mirrors each captured log line to Sentry structured logs (redacted) |
 | Runtime config | `app.config.js` `extra.sentry` | DSN + environment, read at runtime via `expo-constants` |
 
 When no DSN is configured the entire integration is a **no-op**, so development and tests are unaffected.
@@ -53,8 +54,29 @@ eas env:create --name SENTRY_AUTH_TOKEN --value "sntrys_…" --environment produ
 
 - `enabled: !__DEV__` — events are sent **only from release builds**, never dev / Expo Go.
 - `sendDefaultPii: false` — no IP addresses, cookies, or user identifiers.
-- `beforeBreadcrumb` drops **console breadcrumbs** — the app patches `console` via `LogService` and may log transaction/account details; those are never shipped to Sentry.
+- `beforeBreadcrumb` drops **console breadcrumbs** — the app patches `console` via `LogService` and may log transaction/account details; those are never shipped to Sentry as breadcrumbs.
 - `tracesSampleRate: 0.2` — only a sample of performance traces is collected.
+
+## Log forwarding (structured logs)
+
+The app's own log lines (everything that flows through `console.*`, captured by
+`LogService`) are mirrored to Sentry's **structured logs** so they're viewable
+alongside crashes. This is done **without** weakening the privacy posture:
+
+- `enableLogs: true` (also under `_experiments` for cross-version compatibility)
+  turns on structured logs. The `Sentry.logger.*` API is used to forward entries.
+- `enableAutoConsoleLogs: false` — the SDK's *automatic* `console.*` capture is
+  **disabled**. Logs only reach Sentry through our explicit, redacted forwarding
+  path (`LogService._addEntry` → `captureLog`), never raw.
+- `beforeSendLog` runs `redactText` on every log body and string attribute,
+  scrubbing money amounts, long digit runs (balances are stored as integer
+  cents), and email/PII addresses. It is **fail-closed**: if redaction throws,
+  the log is dropped rather than sent.
+- Forwarding is release-only and DSN-gated — with no DSN, or in dev / Expo Go,
+  `captureLog` is a complete no-op (same as the rest of the integration).
+
+Redaction is intentionally aggressive (over-redaction is preferred to leaking),
+so some non-sensitive numbers in log lines may also appear as `[redacted]`.
 
 ## Verifying it works
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -163,6 +163,14 @@ jest.mock('@sentry/react-native', () => ({
   setUser: jest.fn(),
   setExtra: jest.fn(),
   setContext: jest.fn(),
+  logger: {
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    fatal: jest.fn(),
+  },
 }));
 
 // Mock expo-constants with no Sentry config by default, so Sentry is a no-op in


### PR DESCRIPTION
## Summary

Extends the Sentry integration so your **regular app logs** (everything captured by `LogService` via the `console.*` patch) are mirrored to Sentry's **structured logs**, viewable alongside crashes — without weakening the app's privacy posture.

Per the design decision made on this request: **manual/redacted forwarding, release-only**.

## How it works

- `enableLogs: true` (set both top-level and under `_experiments` for compatibility across the `@sentry/react-native` 7.x line) turns on structured logs.
- `enableAutoConsoleLogs: false` — the SDK's *automatic* `console.*` capture is **disabled**, so nothing is shipped raw. Logs reach Sentry only through an explicit forwarding path: `LogService._addEntry` → `captureLog` → `Sentry.logger.*`.
- A **fail-closed** `beforeSendLog` hook runs `redactText` on every log body and string attribute, scrubbing:
  - money amounts (`1,234.56`, `-12.5`)
  - long digit runs (balances are stored as integer cents) and most numeric ids
  - email / PII addresses
  
  If redaction ever throws, the log is **dropped** rather than sent.
- Forwarding stays **release-only and DSN-gated** — in dev / Expo Go and in tests, `captureLog` is a complete no-op, matching the rest of the integration.

Redaction is intentionally aggressive (over-redaction preferred to leaking), so some non-sensitive numbers may also show as `[redacted]`.

## Changes

- `app/services/sentry.js` — `redactText`, `beforeSendLog` hook, new init options, `captureLog` forwarder.
- `app/services/LogService.js` — `_addEntry` mirrors each entry via `captureLog`.
- `jest.setup.js` — add `logger` to the Sentry mock.
- `__tests__/services/sentry.test.js` — tests for init options, `captureLog`, `redactText`, and the `beforeSendLog` hook.
- `docs/SENTRY_SETUP.md` — documents the log-forwarding behavior.

## Testing

`npm test` — **all 123 suites / 3790 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nkx3PsvaquZRVWLAkxXMFg)_