### PR TITLE
fix(search): fold Cyrillic + ё/е in SQL search fallback

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1314,6 +1314,28 @@ describe('OperationsDB Service', () => {
       expect(sqlCall).toContain('SEARCH_NORM(pc.name) LIKE ?');
     });
 
+    it('falls back to an inline LOWER()+REPLACE() Cyrillic-folding expression when SEARCH_NORM is unavailable', async () => {
+      // On a real device expo-sqlite has no custom-function API, so isSearchNormAvailable()
+      // is false. The SQL must still fold Cyrillic case + ё/е instead of bare SEARCH_NORM/LOWER.
+      isSearchNormAvailable.mockReturnValue(false);
+      queryAll.mockResolvedValue([]);
+
+      const filters = { searchText: 'Самолёт' };
+      await OperationsDB.getFilteredOperationsByDateRange('2025-01-01', '2025-12-31', filters);
+
+      const sqlCall = queryAll.mock.calls[0][0];
+      const params = queryAll.mock.calls[0][1];
+      // No custom function is referenced...
+      expect(sqlCall).not.toContain('SEARCH_NORM(');
+      // ...and the inline expression wraps each searchable column in LOWER()+REPLACE().
+      expect(sqlCall).toContain('LOWER(o.description)');
+      expect(sqlCall).toContain('LOWER(c.name)');
+      expect(sqlCall).toContain("REPLACE(");
+      expect(sqlCall).toContain("'Ё', 'е'");
+      // The query term is still normalized (ё → е) so both halves use the same alphabet.
+      expect(params).toContain('%самолет%');
+    });
+
     it('trims search text before searching', async () => {
       queryAll.mockResolvedValue([]);
 

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1330,7 +1330,7 @@ describe('OperationsDB Service', () => {
       // ...and the inline expression wraps each searchable column in LOWER()+REPLACE().
       expect(sqlCall).toContain('LOWER(o.description)');
       expect(sqlCall).toContain('LOWER(c.name)');
-      expect(sqlCall).toContain("REPLACE(");
+      expect(sqlCall).toContain('REPLACE(');
       expect(sqlCall).toContain("'Ё', 'е'");
       // The query term is still normalized (ё → е) so both halves use the same alphabet.
       expect(params).toContain('%самолет%');

--- a/__tests__/services/searchNormalize.test.js
+++ b/__tests__/services/searchNormalize.test.js
@@ -7,7 +7,7 @@
  * as "Самолёт" — both spellings have to normalize to the same string.
  */
 
-import { normalizeSearchText } from '../../app/services/searchNormalize';
+import { normalizeSearchText, buildSearchNormSql } from '../../app/services/searchNormalize';
 
 describe('normalizeSearchText', () => {
   describe('null/undefined handling', () => {
@@ -90,5 +90,63 @@ describe('normalizeSearchText', () => {
     it('coerces booleans to strings', async () => {
       expect(normalizeSearchText(true)).toBe('true');
     });
+  });
+});
+
+describe('buildSearchNormSql (SQL fallback for missing custom function)', () => {
+  it('wraps the column in LOWER() for ASCII folding', () => {
+    const sql = buildSearchNormSql('o.description');
+    expect(sql).toContain('LOWER(o.description)');
+  });
+
+  it('produces a single SQL expression with no surrounding whitespace', () => {
+    const sql = buildSearchNormSql('a.name');
+    expect(sql).toBe(sql.trim());
+    expect(sql.startsWith('REPLACE(')).toBe(true);
+  });
+
+  it('emits REPLACE() pairs that lower-case the Russian Cyrillic alphabet', () => {
+    const sql = buildSearchNormSql('o.description');
+    // A representative sample of uppercase → lowercase folds.
+    expect(sql).toContain("REPLACE(LOWER(o.description), 'А', 'а')");
+    expect(sql).toContain("'С', 'с'");
+    expect(sql).toContain("'Т', 'т'");
+    expect(sql).toContain("'Я', 'я'");
+  });
+
+  it('folds both ё and Ё straight to е', () => {
+    const sql = buildSearchNormSql('o.description');
+    expect(sql).toContain("'Ё', 'е'");
+    expect(sql).toContain("'ё', 'е'");
+    // It must never fold Ё to ё (which would defeat ё/е equivalence).
+    expect(sql).not.toContain("'Ё', 'ё'");
+  });
+
+  it('embeds the column reference verbatim so callers control the alias', () => {
+    expect(buildSearchNormSql('to_a.name')).toContain('LOWER(to_a.name)');
+    expect(buildSearchNormSql('pc.name')).toContain('LOWER(pc.name)');
+  });
+
+  it('mirrors normalizeSearchText for the Cyrillic case via a JS REPLACE simulation', () => {
+    // Apply the same LOWER()+REPLACE() chain that the SQL would, and confirm the
+    // result matches the JS normalizer for Cyrillic input (the case that LOWER()
+    // alone could not handle).
+    const pairs = [
+      ['А', 'а'], ['Б', 'б'], ['В', 'в'], ['Г', 'г'], ['Д', 'д'], ['Е', 'е'],
+      ['Ж', 'ж'], ['З', 'з'], ['И', 'и'], ['Й', 'й'], ['К', 'к'], ['Л', 'л'],
+      ['М', 'м'], ['Н', 'н'], ['О', 'о'], ['П', 'п'], ['Р', 'р'], ['С', 'с'],
+      ['Т', 'т'], ['У', 'у'], ['Ф', 'ф'], ['Х', 'х'], ['Ц', 'ц'], ['Ч', 'ч'],
+      ['Ш', 'ш'], ['Щ', 'щ'], ['Ъ', 'ъ'], ['Ы', 'ы'], ['Ь', 'ь'], ['Э', 'э'],
+      ['Ю', 'ю'], ['Я', 'я'], ['Ё', 'е'], ['ё', 'е'],
+    ];
+    const sqlSimulate = (value) => {
+      // LOWER() in SQLite only folds ASCII; emulate that, then apply the pairs.
+      let out = value.replace(/[A-Z]/g, (c) => c.toLowerCase());
+      for (const [u, l] of pairs) out = out.split(u).join(l);
+      return out;
+    };
+    for (const input of ['Самолёт', 'САМОЛЕТ', 'Транспорт', 'Ёлка', 'еда']) {
+      expect(sqlSimulate(input)).toBe(normalizeSearchText(input));
+    }
   });
 });

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1,14 +1,17 @@
 import { executeQuery, queryAll, queryFirst, executeTransaction, isSearchNormAvailable } from './db';
-import { normalizeSearchText } from './searchNormalize';
+import { normalizeSearchText, buildSearchNormSql } from './searchNormalize';
 import { parseLabels, isHiddenLabel } from '../utils/labelUtils';
 
-// Returns 'SEARCH_NORM' when the custom function was registered successfully (full
-// Cyrillic case-folding + ё/е equivalence), otherwise falls back to SQLite's built-in
-// LOWER() (ASCII-only but safe). The JS-side query passed in is normalized with the
-// matching function so both halves of the LIKE comparison use the same alphabet.
-const searchFn = () => (isSearchNormAvailable() ? 'SEARCH_NORM' : 'LOWER');
-const normalizeSearchQuery = (text) =>
-  isSearchNormAvailable() ? normalizeSearchText(text) : String(text).toLowerCase();
+// Build the SQL expression that normalizes a searchable column. When the
+// SEARCH_NORM custom function registered (full Cyrillic case-folding + ё/е
+// equivalence) use it; otherwise fall back to an inline LOWER()+REPLACE()
+// expression that still folds the Russian Cyrillic alphabet and ё/е. (expo-sqlite
+// exposes no custom-function API today, so the fallback is what runs on device —
+// see db.js.) Both halves of the LIKE comparison must use the same alphabet, so
+// the query side is always normalized with normalizeSearchText().
+const searchNormExpr = (columnExpr) =>
+  isSearchNormAvailable() ? `SEARCH_NORM(${columnExpr})` : buildSearchNormSql(columnExpr);
+const normalizeSearchQuery = (text) => normalizeSearchText(text);
 import * as Currency from './currency';
 import { formatDate, updateTodayBalance } from './BalanceHistoryDB';
 import * as AccountsDB from './AccountsDB';
@@ -263,15 +266,14 @@ export const getFilteredOperationsByDateRange = async (startDate, endDate, filte
 
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
-      const norm = searchFn();
       const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${norm}(o.description) LIKE ?
+        ${searchNormExpr('o.description')} LIKE ?
         OR o.amount LIKE ?
-        OR ${norm}(a.name) LIKE ?
-        OR ${norm}(to_a.name) LIKE ?
-        OR ${norm}(c.name) LIKE ?
-        OR ${norm}(pc.name) LIKE ?
+        OR ${searchNormExpr('a.name')} LIKE ?
+        OR ${searchNormExpr('to_a.name')} LIKE ?
+        OR ${searchNormExpr('c.name')} LIKE ?
+        OR ${searchNormExpr('pc.name')} LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -352,15 +354,14 @@ export const getFilteredOperationsAllDates = async (filters = {}) => {
     }
 
     if (filters.searchText && filters.searchText.trim()) {
-      const norm = searchFn();
       const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${norm}(o.description) LIKE ?
+        ${searchNormExpr('o.description')} LIKE ?
         OR o.amount LIKE ?
-        OR ${norm}(a.name) LIKE ?
-        OR ${norm}(to_a.name) LIKE ?
-        OR ${norm}(c.name) LIKE ?
-        OR ${norm}(pc.name) LIKE ?
+        OR ${searchNormExpr('a.name')} LIKE ?
+        OR ${searchNormExpr('to_a.name')} LIKE ?
+        OR ${searchNormExpr('c.name')} LIKE ?
+        OR ${searchNormExpr('pc.name')} LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1320,15 +1321,14 @@ export const getFilteredOperationsByWeekFromDate = async (endDate, filters = {})
 
     // Apply search text filter (searches across multiple fields)
     if (filters.searchText && filters.searchText.trim()) {
-      const norm = searchFn();
       const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${norm}(o.description) LIKE ?
+        ${searchNormExpr('o.description')} LIKE ?
         OR o.amount LIKE ?
-        OR ${norm}(a.name) LIKE ?
-        OR ${norm}(to_a.name) LIKE ?
-        OR ${norm}(c.name) LIKE ?
-        OR ${norm}(pc.name) LIKE ?
+        OR ${searchNormExpr('a.name')} LIKE ?
+        OR ${searchNormExpr('to_a.name')} LIKE ?
+        OR ${searchNormExpr('c.name')} LIKE ?
+        OR ${searchNormExpr('pc.name')} LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1416,15 +1416,14 @@ export const getNextOldestFilteredOperation = async (beforeDate, filters = {}) =
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const norm = searchFn();
       const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${norm}(o.description) LIKE ?
+        ${searchNormExpr('o.description')} LIKE ?
         OR o.amount LIKE ?
-        OR ${norm}(a.name) LIKE ?
-        OR ${norm}(to_a.name) LIKE ?
-        OR ${norm}(c.name) LIKE ?
-        OR ${norm}(pc.name) LIKE ?
+        OR ${searchNormExpr('a.name')} LIKE ?
+        OR ${searchNormExpr('to_a.name')} LIKE ?
+        OR ${searchNormExpr('c.name')} LIKE ?
+        OR ${searchNormExpr('pc.name')} LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1581,15 +1580,14 @@ export const getNextNewestFilteredOperation = async (afterDate, filters = {}) =>
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const norm = searchFn();
       const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${norm}(o.description) LIKE ?
+        ${searchNormExpr('o.description')} LIKE ?
         OR o.amount LIKE ?
-        OR ${norm}(a.name) LIKE ?
-        OR ${norm}(to_a.name) LIKE ?
-        OR ${norm}(c.name) LIKE ?
-        OR ${norm}(pc.name) LIKE ?
+        OR ${searchNormExpr('a.name')} LIKE ?
+        OR ${searchNormExpr('to_a.name')} LIKE ?
+        OR ${searchNormExpr('c.name')} LIKE ?
+        OR ${searchNormExpr('pc.name')} LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }
@@ -1689,15 +1687,14 @@ export const getFilteredOperationsByWeekToDate = async (startDate, filters = {})
 
     // Apply search text filter
     if (filters.searchText && filters.searchText.trim()) {
-      const norm = searchFn();
       const searchLower = `%${normalizeSearchQuery(filters.searchText.trim())}%`;
       sql += ` AND (
-        ${norm}(o.description) LIKE ?
+        ${searchNormExpr('o.description')} LIKE ?
         OR o.amount LIKE ?
-        OR ${norm}(a.name) LIKE ?
-        OR ${norm}(to_a.name) LIKE ?
-        OR ${norm}(c.name) LIKE ?
-        OR ${norm}(pc.name) LIKE ?
+        OR ${searchNormExpr('a.name')} LIKE ?
+        OR ${searchNormExpr('to_a.name')} LIKE ?
+        OR ${searchNormExpr('c.name')} LIKE ?
+        OR ${searchNormExpr('pc.name')} LIKE ?
       )`;
       params.push(searchLower, searchLower, searchLower, searchLower, searchLower, searchLower);
     }

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -39,11 +39,18 @@ export const getDatabase = async () => {
         throw new Error('Database instance is null after opening');
       }
 
-      // Register search-normalization function — SQLite's built-in LOWER() is ASCII-only,
+      // Register a search-normalization function — SQLite's built-in LOWER() is ASCII-only,
       // so Cyrillic case-folding (and Russian ё/е equivalence) has to be done in JS. The
       // callback delegates to normalizeSearchText() which is the same normalizer applied
       // to the query on the JS side, so SQL-side and in-memory results stay consistent.
-      // expo-sqlite 16.x uses createCustomFunctionAsync(name, callback, options).
+      // expo-sqlite 16.x would use createCustomFunctionAsync(name, callback, options).
+      //
+      // Current expo-sqlite (SDK 56) exposes no custom-function API, so this feature-detect
+      // falls through on a real device. That is expected and not an error: OperationsDB
+      // falls back to an inline LOWER()+REPLACE() expression (buildSearchNormSql) that still
+      // folds the Cyrillic alphabet and ё/е, so search keeps working. The detection is kept
+      // so a future expo-sqlite that adds the API is used automatically for full Unicode
+      // folding. Nothing is logged on the not-available path to avoid noise.
       try {
         if (typeof dbInstance.createCustomFunctionAsync === 'function') {
           await dbInstance.createCustomFunctionAsync('SEARCH_NORM', normalizeSearchText, { deterministic: true });
@@ -51,11 +58,10 @@ export const getDatabase = async () => {
         } else if (typeof dbInstance.createFunctionAsync === 'function') {
           await dbInstance.createFunctionAsync('SEARCH_NORM', normalizeSearchText, { deterministic: true });
           searchNormAvailable = true;
-        } else {
-          console.warn('SEARCH_NORM: no custom function API found, Cyrillic/yo search will use LOWER()');
         }
       } catch (fnError) {
-        console.warn('SEARCH_NORM registration failed, Cyrillic/yo search will use LOWER():', fnError.message);
+        // Registration unexpectedly threw — the inline fallback still handles Cyrillic search.
+        console.warn('SEARCH_NORM registration failed, using inline Cyrillic-folding fallback:', fnError.message);
       }
 
       drizzleInstance = drizzle(dbInstance, { schema });

--- a/app/services/searchNormalize.js
+++ b/app/services/searchNormalize.js
@@ -26,3 +26,49 @@ export const normalizeSearchText = (value) => {
   if (value == null) return null;
   return String(value).normalize('NFC').toLowerCase().replace(/ё/g, 'е');
 };
+
+/**
+ * Russian Cyrillic uppercase → lowercase pairs, plus ё/Ё → е folding. Used to
+ * build a SQL expression that mirrors normalizeSearchText() for the Cyrillic
+ * alphabet (see buildSearchNormSql).
+ */
+const CYRILLIC_FOLD_PAIRS = [
+  ['А', 'а'], ['Б', 'б'], ['В', 'в'], ['Г', 'г'], ['Д', 'д'], ['Е', 'е'],
+  ['Ж', 'ж'], ['З', 'з'], ['И', 'и'], ['Й', 'й'], ['К', 'к'], ['Л', 'л'],
+  ['М', 'м'], ['Н', 'н'], ['О', 'о'], ['П', 'п'], ['Р', 'р'], ['С', 'с'],
+  ['Т', 'т'], ['У', 'у'], ['Ф', 'ф'], ['Х', 'х'], ['Ц', 'ц'], ['Ч', 'ч'],
+  ['Ш', 'ш'], ['Щ', 'щ'], ['Ъ', 'ъ'], ['Ы', 'ы'], ['Ь', 'ь'], ['Э', 'э'],
+  ['Ю', 'ю'], ['Я', 'я'],
+  // ё/Ё fold straight to е (not ё) so search treats them as equivalent.
+  ['Ё', 'е'], ['ё', 'е'],
+];
+
+/**
+ * Build a SQLite expression that normalizes `columnExpr` the way
+ * normalizeSearchText() does in JS — as closely as plain SQL allows.
+ *
+ * Why this exists: expo-sqlite exposes no API to register a custom SQL
+ * function, so the SEARCH_NORM custom function never registers on a real
+ * device (see db.js). SQLite's built-in LOWER() only case-folds ASCII, so a
+ * Cyrillic query like "самолёт" would never match a stored "Самолёт". This
+ * builder wraps the column in LOWER() (ASCII folding) plus a chain of
+ * REPLACE() calls that lower-case the Russian Cyrillic alphabet and fold
+ * ё/Ё → е.
+ *
+ * Coverage is the Russian alphabet only; other non-ASCII scripts (accented
+ * Latin, Greek, Armenian, …) still fold only their ASCII portion and match
+ * case-sensitively — the same limitation the LOWER()-only fallback always
+ * had, but now without breaking Cyrillic search. Callers must normalize the
+ * query side with normalizeSearchText() so both halves of the LIKE comparison
+ * use the same alphabet.
+ *
+ * @param {string} columnExpr - A SQL column reference, e.g. 'o.description'.
+ * @returns {string} A SQL expression string (no surrounding whitespace).
+ */
+export const buildSearchNormSql = (columnExpr) => {
+  let expr = `LOWER(${columnExpr})`;
+  for (const [upper, lower] of CYRILLIC_FOLD_PAIRS) {
+    expr = `REPLACE(${expr}, '${upper}', '${lower}')`;
+  }
+  return expr;
+};


### PR DESCRIPTION
## Problem

Sentry surfaced this warning firing on every production launch:

> `SEARCH_NORM: no custom function API found, Cyrillic/yo search will use LOWER()`

**Root cause:** expo-sqlite (SDK 56) exposes **no API to register a custom SQL function** — verified against the SDK 56 `SQLiteDatabase` source and Context7 docs; neither `createCustomFunctionAsync` nor `createFunctionAsync` exists on the real native database. So the `SEARCH_NORM` custom function never registered on device, and the search SQL fell back to SQLite's built-in `LOWER()`, which **only case-folds ASCII**.

Consequences on device:
- Cyrillic search broke — e.g. typing `самолёт` would not match a stored `Самолёт` (case + ё/е mismatch).
- The warning was logged at `warn` level on every launch and forwarded to Sentry as noise.

The custom function only ever "worked" in the test suite, where the expo-sqlite mock defines those methods.

## Fix

Replace the `LOWER()`-only fallback with an inline SQL expression built by the new `buildSearchNormSql()`:

- Wraps the column in `LOWER()` (ASCII folding) **plus** a chain of `REPLACE()` pairs that lower-case the Russian Cyrillic alphabet and fold `ё/Ё → е`, mirroring `normalizeSearchText()`.
- The query side now **always** normalizes with `normalizeSearchText()` (NFC + Unicode lowercase + ё→е), so both halves of every `LIKE` use the same alphabet.
- All 6 paginated search query builders in `OperationsDB.js` switch from the `${norm}(col)` pattern to `searchNormExpr('col')`.

The `SEARCH_NORM` feature-detect is **kept** — if a future expo-sqlite adds the API it's used automatically for full-Unicode folding — but it no longer logs on the expected not-available path, silencing the Sentry noise.

### Known limitation (unchanged)
Coverage is the Russian alphabet only. Other non-ASCII scripts (accented Latin, Greek, Armenian, …) still fold only their ASCII portion and match case-sensitively — the same limitation the `LOWER()`-only fallback always had, but now **without breaking Cyrillic search**. The in-memory filter path (`OperationsDataContext`) already handled all scripts via JS and is unchanged.

## Tests

- New `buildSearchNormSql` unit tests, including a JS simulation of the `LOWER()+REPLACE()` chain asserting it matches `normalizeSearchText()` for Cyrillic input.
- New `OperationsDB` test for the fallback path (`isSearchNormAvailable() === false`): SQL contains the inline `LOWER()+REPLACE()` expression with no `SEARCH_NORM(`, and the query term is ё-folded (`%самолет%`).
- Existing `SEARCH_NORM` registration and SQL-shape tests stay green (mock still exposes the API).
- Full suite: **3797 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Px1aTHTztDoNzYu957eFKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Px1aTHTztDoNzYu957eFKU)_