### PR TITLE
fix(android): match the apply-block package list in MainApplication

### DIFF
--- a/__tests__/plugins/withNotificationListener.test.js
+++ b/__tests__/plugins/withNotificationListener.test.js
@@ -58,7 +58,24 @@ describe('withNotificationListener', () => {
     expect(() => manifestCb(config)).toThrow(/application/);
   });
 
-  it('registers the native package in MainApplication', () => {
+  it('registers the native package in a modern apply-block MainApplication', () => {
+    withNotificationListener({});
+    const config = {
+      modResults: {
+        language: 'kt',
+        contents: [
+          'override fun getPackages(): List<ReactPackage> =',
+          '    PackageList(this).packages.apply {',
+          '      // add(MyReactNativePackage())',
+          '    }',
+        ].join('\n'),
+      },
+    };
+    const out = mainAppCb(config);
+    expect(out.modResults.contents).toContain('add(PennyNotificationsPackage())');
+  });
+
+  it('registers the native package in an older val-based MainApplication', () => {
     withNotificationListener({});
     const config = {
       modResults: {

--- a/plugins/withNotificationListener.js
+++ b/plugins/withNotificationListener.js
@@ -279,11 +279,20 @@ const addPackageRegistration = (config) =>
       return config;
     }
 
-    const anchor = 'val packages = PackageList(this).packages';
-    if (contents.includes(anchor)) {
+    // Modern Expo/RN templates (SDK 50+, RN 0.73+) return
+    // `PackageList(this).packages.apply { … }`, so we add inside the apply
+    // block. Older templates assign to a `val packages` first; handle that too.
+    const applyAnchor = 'PackageList(this).packages.apply {';
+    const valAnchor = 'val packages = PackageList(this).packages';
+    if (contents.includes(applyAnchor)) {
       contents = contents.replace(
-        anchor,
-        `${anchor}\n            packages.add(${PACKAGE_CLASS}())`,
+        applyAnchor,
+        `${applyAnchor}\n            add(${PACKAGE_CLASS}())`,
+      );
+    } else if (contents.includes(valAnchor)) {
+      contents = contents.replace(
+        valAnchor,
+        `${valAnchor}\n            packages.add(${PACKAGE_CLASS}())`,
       );
     } else {
       throw new Error(


### PR DESCRIPTION
## Problem

After #1101 merged, the EAS Android build failed during **prebuild**:

```
Error: [android.mainApplication]: withAndroidMainApplicationBaseMod:
withNotificationListener: could not find the package list in MainApplication
```

The notification-access config plugin registered its `ReactPackage` by anchoring on `val packages = PackageList(this).packages`. That form doesn't exist in the Expo SDK 56 / RN 0.85 `MainApplication.kt` template, which instead returns:

```kotlin
override fun getPackages(): List<ReactPackage> =
    PackageList(this).packages.apply {
      // add(MyReactNativePackage())
    }
```

So the anchor was never found and the plugin threw, aborting prebuild. (The Jest plugin test used the old `val packages` form, so it passed and didn't catch this.)

## Fix

- Insert `add(PennyNotificationsPackage())` **inside the `.apply { }` block** when present, keeping the older `val packages` assignment as a fallback.
- Update tests to cover **both** MainApplication styles (modern apply-block + older val-based).

## Testing

- `npx jest withNotificationListener` — 7 passing (now includes the apply-block case).
- Full suite green: **126 suites / 3816 tests**.

> [!NOTE]
> The anchor itself is native prebuild glue that Jest can't exercise end-to-end — the real validation is the EAS Android build, which should now get past prebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFk4aRoNKyrryof2BpjGND)_