### PR TITLE
fix(android): dedupe repeated notifications in the access subpanel

### DIFF
--- a/plugins/withNotificationListener.js
+++ b/plugins/withNotificationListener.js
@@ -51,7 +51,10 @@ class ${SERVICE_CLASS} : NotificationListenerService() {
         val title = extras.getCharSequence(Notification.EXTRA_TITLE)?.toString().orEmpty()
         val text = extras.getCharSequence(Notification.EXTRA_TEXT)?.toString().orEmpty()
         if (title.isBlank() && text.isBlank()) return
-        record(applicationContext, title, text, sbn.packageName ?: "", sbn.postTime)
+        // sbn.key is stable across updates of the same notification (e.g. a chat
+        // thread that re-posts as new messages arrive), so it lets us collapse
+        // repeats instead of stacking identical cards.
+        record(applicationContext, title, text, sbn.packageName ?: "", sbn.postTime, sbn.key ?: "")
     }
 
     companion object {
@@ -66,6 +69,7 @@ class ${SERVICE_CLASS} : NotificationListenerService() {
             text: String,
             packageName: String,
             postTime: Long,
+            key: String,
         ) {
             val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             val current = try {
@@ -78,13 +82,23 @@ class ${SERVICE_CLASS} : NotificationListenerService() {
                 put("text", text)
                 put("packageName", packageName)
                 put("postTime", postTime)
+                put("key", key)
             }
-            // Newest first, capped at MAX_STORED.
+            // Newest first, capped at MAX_STORED. Drop any earlier entry that is
+            // the same notification — matched by its stable key, or by identical
+            // package+title+text — so re-posts/updates don't appear as duplicates.
             val updated = JSONArray()
             updated.put(entry)
             var i = 0
             while (i < current.length() && updated.length() < MAX_STORED) {
-                updated.put(current.get(i))
+                val existing = current.getJSONObject(i)
+                val sameKey = key.isNotEmpty() && existing.optString("key") == key
+                val sameContent = existing.optString("packageName") == packageName &&
+                    existing.optString("title") == title &&
+                    existing.optString("text") == text
+                if (!sameKey && !sameContent) {
+                    updated.put(existing)
+                }
                 i++
             }
             prefs.edit().putString(KEY_RECENT, updated.toString()).apply()


### PR DESCRIPTION
## Problem

On-device, the new **Notification access** subpanel shows duplicate cards — e.g. two identical "Анюта 😊" entries from `org.telegram.messenger` at the same minute:

Messaging apps re-post the *same* conversation notification as new messages arrive, so `onNotificationPosted` fires repeatedly for what is effectively one notification. The listener recorded a fresh entry each time, stacking identical cards.

## Fix

When recording, capture the notification's stable `sbn.key` and drop any earlier stored entry that is the same notification — matched either by that key, or by identical `package` + `title` + `text`. Re-posts and updates now collapse into a single, newest card, and the window still holds up to 5 *distinct* notifications.

## Testing

- Full Jest suite green: **126 suites / 3816 tests**.

> [!NOTE]
> The dedupe runs in the native `NotificationListenerService` (generated at prebuild), which Jest can't exercise — this needs to be confirmed on-device in an EAS build. The screenshot that prompted this fix is the repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFk4aRoNKyrryof2BpjGND)_