### PR TITLE
fix: equalize search bar spacing on Operations screen

### DIFF
--- a/app/components/operations/QuickAddForm.js
+++ b/app/components/operations/QuickAddForm.js
@@ -131,7 +131,10 @@ const styles = StyleSheet.create({
     gap: SPACING.sm,
     marginBottom: SPACING.xs,
     marginHorizontal: SPACING.sm,
-    marginTop: 0,
+    // Match the search pill → type-selector gap to the type-selector → account
+    // gap (SPACING.sm). The search bar contributes SPACING.xs of bottom padding,
+    // so add SPACING.xs here to reach SPACING.sm total above the form.
+    marginTop: SPACING.xs,
     paddingBottom: SPACING.xs,
     paddingHorizontal: SPACING.xs,
   },


### PR DESCRIPTION
## Summary

On the Operations screen the gap between the search pill and the Расход/Доход/Перевод (expense/income/transfer) type selector was smaller than the gap between the type selector and the account (счёт) row. This makes the two gaps equal.

- The search → type-selector gap came solely from the search bar's bottom padding (`SPACING.xs` = 4px).
- The type-selector → account gap is `SPACING.sm` = 8px (`typeSelectorCompact.marginBottom`).

Added `marginTop: SPACING.xs` (4px) to the quick-add form container so the search → type-selector gap totals `SPACING.sm` (8px), matching the type-selector → account gap.

## Changes

- `app/components/operations/QuickAddForm.js`: set the form container `marginTop` from `0` to `SPACING.xs`.

## Testing

- `npx jest` — 129 suites / 3865 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014FWiyf4p7BPjGiHPevf4s7)_