### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+  PR title = changelog entry. It MUST follow Conventional Commits — the
+  "PR Title Check" workflow enforces it, and release-please turns the squashed
+  title into the release notes. Pick one type:
+    feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+  Scope is optional. Common scopes: (search) (settings) (operations) (accounts)
+  (graphs) (android) (updates) (geo) (e2e).
+  Example:  fix(search): fold Cyrillic ё/е in the SQL fallback
+-->
+
+## Summary
+
+<!-- What changed and why, in 1–3 sentences.
+     Bug fix? Lead with the problem and its root cause. -->
+
+## Changes
+
+<!-- File-keyed bullets describing what you actually changed, e.g.
+- **app/screens/AccountsScreen.js** — show a ⭐ on the default-account row.
+- **assets/i18n/*.json** — add `default_account_hint` for all 11 languages. -->
+
+-
+
+## Testing
+
+<!-- Required. Paste the exact command(s) and the result, e.g.
+     `npm test` — 135 suites / 3955 tests pass.
+     Add any manual or on-device steps you ran. -->
+
+-
+
+## Checklist
+
+- [ ] Title follows Conventional Commits (`type(scope): subject`)
+- [ ] `npm test` is green (all suites pass)
+- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — or n/a
+- [ ] Linked the related issue with `Closes #NNN` below — or n/a
+
+Closes #
+
+<!-- Tips:
+     • UI change? Comment `/screenshots` on the PR to attach light & dark captures.
+     • Want a device smoke-test? Run `/verify-pr <number>` — it derives E2E
+       scenarios from this description, so be specific in Summary/Changes above. -->


### PR DESCRIPTION
## Summary

There's no PR template in the repo today, yet the last 50 non-release PRs already follow a remarkably consistent shape. This adds `.github/pull_request_template.md` that codifies that organic convention, so future PRs (human- or Claude-authored) start from the same skeleton — with light nudges toward the repo's real merge gates.

## Changes

- **`.github/pull_request_template.md`** (new) — default PR template with:
  - Conventional Commit **title guidance** up top (the `PR Title Check` workflow enforces it, and release-please turns the squashed title into the changelog entry).
  - `## Summary` / `## Changes` / `## Testing` — the three most-used headings across recent PRs; **Testing** prompts for the exact command + suite/test counts, matching the "all tests green" rule.
  - A 4-item **checklist** of the actual gates: conventional title, `npm test` green, i18n across all **11** `assets/i18n/*.json` files, and issue linking with `Closes #`.
  - Pointers to the existing **`/screenshots`** (auto light/dark captures) and **`/verify-pr`** (device E2E) automations instead of asking for manual screenshots — 0/50 recent PRs paste them.

## Testing

- Docs-only change (a Markdown template); no source, config, or test files touched, so `npm test` was not re-run.

## Checklist

- [x] Title follows Conventional Commits (`chore: add pull request template`)
- [x] `npm test` is green — n/a, no code changed
- [x] User-facing strings updated in all 11 `assets/i18n/*.json` files — n/a
- [x] Linked the related issue with `Closes #NNN` — n/a, no tracking issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPKC1QotgG7uGeTNkw2jLD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPKC1QotgG7uGeTNkw2jLD)_