### PR TITLE
feat(notifications): process E-POS purchases and convert foreign-currency charges

### DIFF
--- a/__tests__/services/currency.test.js
+++ b/__tests__/services/currency.test.js
@@ -502,6 +502,36 @@ describe('Currency Service', () => {
     });
   });
 
+  describe('invertRate', () => {
+    it('inverts a rate with decimal precision (default 6 places)', () => {
+      expect(Currency.invertRate('418.5')).toBe('0.002389');
+      expect(Currency.invertRate('0.92')).toBe('1.086957');
+      expect(Currency.invertRate('2')).toBe('0.500000');
+    });
+
+    it('honours a custom number of decimals', () => {
+      expect(Currency.invertRate('3', 4)).toBe('0.3333');
+      expect(Currency.invertRate('8', 2)).toBe('0.13');
+    });
+
+    it('accepts a numeric rate', () => {
+      expect(Currency.invertRate(4)).toBe('0.250000');
+    });
+
+    it('returns null for non-positive or invalid rates', () => {
+      expect(Currency.invertRate('0')).toBe(null);
+      expect(Currency.invertRate('-2')).toBe(null);
+      expect(Currency.invertRate(null)).toBe(null);
+      expect(Currency.invertRate('abc')).toBe(null);
+    });
+
+    it('round-trips: inverting twice returns approximately the original', () => {
+      const once = Currency.invertRate('418.5', 10);
+      const twice = Currency.invertRate(once, 4);
+      expect(twice).toBe('418.5000');
+    });
+  });
+
   describe('isReasonableRate', () => {
     it('returns true for reasonable rates within 50% of expected', async () => {
       // Expected USD->EUR rate is 0.92

--- a/__tests__/services/notifications/parseBankNotification.test.js
+++ b/__tests__/services/notifications/parseBankNotification.test.js
@@ -135,6 +135,50 @@ describe('parseBankNotification', () => {
     });
   });
 
+  describe('E-POS PURCHASE template (online point-of-sale, foreign currency)', () => {
+    // The Ameria "ARCA transaction" E-POS PURCHASE notification: a EUR charge on
+    // an AMD card account (note the balance segment is in AMD, the charge in EUR).
+    const AMERIA_EPOS = {
+      title: 'АРКА транзакции',
+      text: 'E-POS PURCHASE | 129.99 EUR | 4083***7027, | Nike ES, ES | 29.06.2026 15:14 | BALANCE: 27,608.20 AMD',
+      packageName: 'com.banqr.ameriabank',
+      postTime: 1782062040000,
+    };
+    let result;
+    beforeEach(() => {
+      result = parseBankNotification(AMERIA_EPOS);
+    });
+
+    it('recognizes E-POS PURCHASE as a transaction', () => {
+      expect(result).not.toBeNull();
+    });
+
+    it('maps E-POS PURCHASE to an expense operation', () => {
+      expect(result.kind).toBe('E-POS PURCHASE');
+      expect(result.type).toBe('expense');
+    });
+
+    it('reports the transaction currency as charged (EUR, not the AMD balance)', () => {
+      expect(result.amount).toBe('129.99');
+      expect(result.currency).toBe('EUR');
+    });
+
+    it('extracts the merchant and trailing country code', () => {
+      expect(result.merchant).toBe('Nike ES');
+      expect(result.country).toBe('ES');
+    });
+
+    it('does not require a manual category (merchant rules can resolve it)', () => {
+      expect(result.requiresCategory).toBe(false);
+    });
+
+    it('extracts the card mask, date and time', () => {
+      expect(result.cardMask).toBe('4083***7027');
+      expect(result.date).toBe('2026-06-29');
+      expect(result.time).toBe('15:14');
+    });
+  });
+
   describe('PURCHASE does not require a manual category', () => {
     it('marks a purchase as not requiring a category', () => {
       expect(parseBankNotification(AMERIA_PURCHASE).requiresCategory).toBe(false);

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -175,6 +175,34 @@ describe('processBankNotifications', () => {
     );
   });
 
+  it('does not fetch an exchange rate for a foreign-currency notification destined for the review queue', async () => {
+    // Account resolves (currency mismatch) but the merchant has no learned
+    // category, so the item will be queued — converting now would be wasted work
+    // (the result is discarded and recomputed at resolve time).
+    NotificationAccess.getRecentNotifications.mockResolvedValue([EPOS_EUR]); // EUR
+    AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+    NotificationRulesDB.getCategoryForMerchant.mockResolvedValue(null); // no category
+    PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+
+    const summary = await pipeline.processBankNotifications();
+
+    expect(summary).toEqual({ created: 0, pending: 1, skipped: 0 });
+    expect(Currency.fetchLiveExchangeRate).not.toHaveBeenCalled();
+    expect(OperationsDB.createOperation).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch an exchange rate for a foreign-currency notification from an untrusted source', async () => {
+    NotificationAccess.getRecentNotifications.mockResolvedValue([EPOS_EUR]); // EUR
+    AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+    NotificationRulesDB.getCategoryForMerchant.mockResolvedValue('cat-shopping');
+    // allowlist empty → not trusted → not eligible for auto-create
+
+    const summary = await pipeline.processBankNotifications();
+
+    expect(summary).toEqual({ created: 0, pending: 1, skipped: 0 });
+    expect(Currency.fetchLiveExchangeRate).not.toHaveBeenCalled();
+  });
+
   it('auto-creates an E-POS PURCHASE, converting the foreign amount to the account currency', async () => {
     NotificationAccess.getRecentNotifications.mockResolvedValue([EPOS_EUR]); // 129.99 EUR
     AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
@@ -344,6 +372,22 @@ describe('processBankNotifications', () => {
           sourceCurrency: 'EUR',
           destinationCurrency: 'AMD',
         }),
+      );
+    });
+
+    it('normalizes the amount to the account currency decimal places when currencies match', async () => {
+      // AMD has 0 decimal places: a '3900.00' charge should be stored as '3900',
+      // matching how a hand-entered AMD operation is formatted.
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        ...pending, amount: '3900.00', currency: 'AMD',
+      });
+      AccountsDB.getAccountById.mockResolvedValue({ id: 7, currency: 'AMD' });
+
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-food' });
+
+      expect(Currency.fetchLiveExchangeRate).not.toHaveBeenCalled();
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: '3900' }),
       );
     });
 

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -37,6 +37,14 @@ jest.mock('../../../app/services/PreferencesDB', () => ({
 }));
 import * as PreferencesDB from '../../../app/services/PreferencesDB';
 
+// Use the real currency math but stub the live-rate fetch so conversions are
+// deterministic and never hit the network.
+jest.mock('../../../app/services/currency', () => {
+  const actual = jest.requireActual('../../../app/services/currency');
+  return { ...actual, fetchLiveExchangeRate: jest.fn() };
+});
+import * as Currency from '../../../app/services/currency';
+
 const PKG = 'com.banqr.ameriabank';
 const PURCHASE = {
   title: 'АРКА транзакции',
@@ -49,6 +57,13 @@ const PURCHASE_NO_DATE = {
   text: 'PURCHASE | 3,900.00 AMD | 4083***7027 | NAREK MEHRABYAN, AM',
   packageName: PKG,
   postTime: 1782000900000,
+};
+// E-POS (online point-of-sale) purchase charged in EUR on an AMD card account.
+const EPOS_EUR = {
+  title: 'АРКА транзакции',
+  text: 'E-POS PURCHASE | 129.99 EUR | 4083***7027, | Nike ES, ES | 29.06.2026 15:14 | BALANCE: 27,608.20 AMD',
+  packageName: PKG,
+  postTime: 1782062040000,
 };
 const C2C = {
   title: 'АРКА транзакции',
@@ -78,6 +93,8 @@ describe('processBankNotifications', () => {
     NotificationRulesDB.getCategoryForMerchant.mockResolvedValue(null);
     OperationsDB.createOperation.mockResolvedValue({ id: 1 });
     PendingNotificationsDB.addPendingNotification.mockResolvedValue({ id: 'p1' });
+    AccountsDB.getAccountById.mockResolvedValue(null);
+    Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: null, source: 'none' });
   });
 
   it('does nothing when disabled', async () => {
@@ -117,18 +134,69 @@ describe('processBankNotifications', () => {
     expect(PendingNotificationsDB.addPendingNotification).toHaveBeenCalled();
   });
 
-  it('queues (does not auto-create) on a currency mismatch even if trusted', async () => {
+  it('auto-creates with a converted amount on a currency mismatch (trusted, fully matched)', async () => {
+    NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]); // 3,900 AMD
+    AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'USD' });
+    NotificationRulesDB.getCategoryForMerchant.mockResolvedValue('cat-food');
+    PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+    Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '0.0026', source: 'offline' });
+
+    const summary = await pipeline.processBankNotifications();
+
+    expect(summary).toEqual({ created: 1, pending: 0, skipped: 0 });
+    expect(Currency.fetchLiveExchangeRate).toHaveBeenCalledWith('AMD', 'USD');
+    expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'expense',
+        accountId: 7,
+        categoryId: 'cat-food',
+        amount: '10.14', // 3900 AMD * 0.0026 → USD
+        destinationAmount: '3900', // original foreign value (AMD, 0 decimals)
+        sourceCurrency: 'AMD',
+        destinationCurrency: 'USD',
+      }),
+    );
+  });
+
+  it('queues a foreign-currency purchase when no exchange rate is available', async () => {
     NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]); // AMD
     AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'USD' });
     NotificationRulesDB.getCategoryForMerchant.mockResolvedValue('cat-food');
     PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+    Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: null, source: 'none' });
 
     const summary = await pipeline.processBankNotifications();
 
     expect(summary).toEqual({ created: 0, pending: 1, skipped: 0 });
     expect(OperationsDB.createOperation).not.toHaveBeenCalled();
+    // Account + category are still suggested for the review queue.
     expect(PendingNotificationsDB.addPendingNotification).toHaveBeenCalledWith(
-      expect.objectContaining({ accountId: 7, categoryId: null }),
+      expect.objectContaining({ accountId: 7, categoryId: 'cat-food' }),
+    );
+  });
+
+  it('auto-creates an E-POS PURCHASE, converting the foreign amount to the account currency', async () => {
+    NotificationAccess.getRecentNotifications.mockResolvedValue([EPOS_EUR]); // 129.99 EUR
+    AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+    NotificationRulesDB.getCategoryForMerchant.mockResolvedValue('cat-shopping');
+    PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+    Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '418.5', source: 'offline' });
+
+    const summary = await pipeline.processBankNotifications();
+
+    expect(summary).toEqual({ created: 1, pending: 0, skipped: 0 });
+    expect(Currency.fetchLiveExchangeRate).toHaveBeenCalledWith('EUR', 'AMD');
+    expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'expense',
+        accountId: 7,
+        categoryId: 'cat-shopping',
+        amount: '54401', // 129.99 EUR * 418.5 → AMD (0 decimals)
+        destinationAmount: '129.99',
+        sourceCurrency: 'EUR',
+        destinationCurrency: 'AMD',
+        description: 'Nike ES',
+      }),
     );
   });
 
@@ -255,6 +323,41 @@ describe('processBankNotifications', () => {
         'bank_notifications_packages', [PKG],
       );
       expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledWith('p1');
+    });
+
+    it('converts the amount to the chosen account currency when they differ', async () => {
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        ...pending, amount: '129.99', currency: 'EUR', merchant: 'Nike ES',
+      });
+      AccountsDB.getAccountById.mockResolvedValue({ id: 7, currency: 'AMD' });
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '418.5', source: 'offline' });
+
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-shopping' });
+
+      expect(Currency.fetchLiveExchangeRate).toHaveBeenCalledWith('EUR', 'AMD');
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: 7,
+          categoryId: 'cat-shopping',
+          amount: '54401', // 129.99 EUR * 418.5 → AMD
+          destinationAmount: '129.99',
+          sourceCurrency: 'EUR',
+          destinationCurrency: 'AMD',
+        }),
+      );
+    });
+
+    it('throws (does not book a wrong amount) when no rate is available for a foreign purchase', async () => {
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        ...pending, amount: '129.99', currency: 'EUR',
+      });
+      AccountsDB.getAccountById.mockResolvedValue({ id: 7, currency: 'AMD' });
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: null, source: 'none' });
+
+      await expect(
+        pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-shopping' }),
+      ).rejects.toThrow(/exchange rate/);
+      expect(OperationsDB.createOperation).not.toHaveBeenCalled();
     });
 
     it('falls back to a valid date when the pending row has none', async () => {

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -24,6 +24,7 @@ import {
 } from '../services/notifications/notificationFilters';
 import { getPendingNotifications } from '../services/PendingNotificationsDB';
 import { getRecentNotifications } from '../services/NotificationAccess';
+import * as Currency from '../services/currency';
 
 /**
  * "Notification processing" settings subpanel — the main view.
@@ -191,6 +192,15 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
           const categoryRequired = kindRequiresCategory(item.kind, item.packageName);
           const canSave =
             choice.accountId != null && (!categoryRequired || choice.categoryId != null);
+          // Preview the converted amount when the chosen account's currency differs
+          // from the charge currency — the operation is booked in the account
+          // currency at save time, so show an estimate (offline rate) up front so
+          // the user can sanity-check it. The actual booking uses the live rate.
+          const chosenAccount = accounts.find((a) => a.id === choice.accountId);
+          const convertedPreview =
+            chosenAccount && item.currency && chosenAccount.currency !== item.currency
+              ? Currency.convertAmount(item.amount, item.currency, chosenAccount.currency)
+              : null;
           return (
             <View
               key={item.id}
@@ -207,6 +217,11 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
               <Text style={[styles.cardMeta, { color: colors.mutedText }]}>
                 {[item.date, item.cardMask].filter(Boolean).join(' · ')}
               </Text>
+              {convertedPreview && (
+                <Text style={[styles.cardConversion, { color: colors.mutedText }]}>
+                  ≈ {convertedPreview} {chosenAccount.currency}
+                </Text>
+              )}
 
               <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
                 {(t('account') || 'Account').toUpperCase()}
@@ -345,6 +360,11 @@ const styles = StyleSheet.create({
   cardAmount: {
     fontSize: 15,
     fontWeight: '700',
+  },
+  cardConversion: {
+    fontSize: 12,
+    fontStyle: 'italic',
+    marginTop: 2,
   },
   cardHeader: {
     alignItems: 'center',

--- a/app/services/currency.js
+++ b/app/services/currency.js
@@ -460,6 +460,32 @@ export const reverseConvert = (destinationAmount, fromCurrency, toCurrency, cust
 };
 
 /**
+ * Invert an exchange rate with decimal precision.
+ *
+ * Computing `1 / rate` in JavaScript floats loses precision (and violates the
+ * decimal.js arithmetic convention used everywhere else here). This does the
+ * division with Decimal so a foreign→account rate can be stored as the inverse
+ * account→foreign rate without float error.
+ *
+ * @param {string|number} rate - rate to invert
+ * @param {number} decimals - decimal places to keep (default 6, matching the
+ *   precision used elsewhere for stored exchange rates)
+ * @returns {string|null} the inverted rate as a string, or null when the input
+ *   is not a positive, finite number
+ */
+export const invertRate = (rate, decimals = 6) => {
+  try {
+    const rateDecimal = toDecimal(rate);
+    if (!rateDecimal.isFinite() || rateDecimal.lessThanOrEqualTo(0)) {
+      return null;
+    }
+    return new Decimal(1).dividedBy(rateDecimal).toFixed(decimals);
+  } catch (error) {
+    return null;
+  }
+};
+
+/**
  * Validate that an exchange rate is reasonable
  * @param {string|number} rate - Exchange rate to validate
  * @param {string} fromCurrency - Source currency code

--- a/app/services/notifications/bankParsers/ameriabank.js
+++ b/app/services/notifications/bankParsers/ameriabank.js
@@ -2,10 +2,15 @@
  * Bank notification parser for the Ameriabank app (`com.banqr.ameriabank`).
  *
  * Ameria posts each card event as a single pipe-delimited "ARCA transaction"
- * line. Two kinds are recognized today:
+ * line. Three kinds are recognized today:
  *
- *   PURCHASE | 3,900.00 AMD | 4083***7027, | NAREK MEHRABYAN, AM | 28.06.2026 10:15 | BALANCE: 133,719.97 AMD
- *   C2C      | 19,200.00 AMD | 4083***7027, | TO: N. DORVANYAN | AMERIABANK API GATE, AM | 28.06.2026 16:23 | BALANCE: 106,819.97 AMD
+ *   PURCHASE       | 3,900.00 AMD | 4083***7027, | NAREK MEHRABYAN, AM | 28.06.2026 10:15 | BALANCE: 133,719.97 AMD
+ *   E-POS PURCHASE | 129.99 EUR   | 4083***7027, | Nike ES, ES         | 29.06.2026 15:14 | BALANCE: 27,608.20 AMD
+ *   C2C            | 19,200.00 AMD | 4083***7027, | TO: N. DORVANYAN | AMERIABANK API GATE, AM | 28.06.2026 16:23 | BALANCE: 106,819.97 AMD
+ *
+ * Note the E-POS PURCHASE example: the transaction is charged in EUR while the
+ * card account is in AMD. The parser reports the transaction currency as-is
+ * (EUR); converting to the account currency is the ingestion layer's job.
  *
  * The `parse` function is *pure* (no side effects) so it can be exhaustively
  * unit-tested and reused regardless of how notifications are ingested (polling,
@@ -38,6 +43,10 @@ export const PACKAGE_NAMES = ['com.banqr.ameriabank'];
  */
 const KIND_TO_TYPE = {
   PURCHASE: 'expense',
+  // Card-not-present / online point-of-sale purchase (e.g. a webshop). Behaves
+  // exactly like an in-store PURCHASE: a merchant expense whose category can be
+  // inferred from learned rules. Often charged in a foreign currency.
+  'E-POS PURCHASE': 'expense',
   C2C: 'expense',
 };
 

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -120,7 +120,14 @@ const todayIso = () => new Date().toISOString().slice(0, 10);
  */
 export const buildOperationCurrencyFields = async (item, accountCurrency) => {
   if (!accountCurrency || !item.currency || item.currency === accountCurrency) {
-    return { amount: item.amount };
+    // Same currency (or unknown account): book as-is, but normalize to the
+    // account currency's decimal places when known, matching the manual-entry
+    // path (useOperationForm) so notification and hand-entered amounts agree.
+    return {
+      amount: accountCurrency
+        ? Currency.formatAmount(item.amount, accountCurrency)
+        : item.amount,
+    };
   }
 
   // foreign → account rate (e.g. EUR→AMD), at the current rate.
@@ -130,13 +137,14 @@ export const buildOperationCurrencyFields = async (item, accountCurrency) => {
   const convertedAmount = Currency.convertAmount(item.amount, item.currency, accountCurrency, rate);
   if (!convertedAmount) return null;
 
-  const foreignToAccount = Number(rate);
-  if (!Number.isFinite(foreignToAccount) || foreignToAccount <= 0) return null;
+  // Store the account→foreign rate, inverted with decimal precision.
+  const exchangeRate = Currency.invertRate(rate);
+  if (!exchangeRate) return null;
 
   return {
     amount: convertedAmount,                                              // account currency
     destinationAmount: Currency.formatAmount(item.amount, item.currency), // foreign currency
-    exchangeRate: (1 / foreignToAccount).toFixed(6),                      // account→foreign
+    exchangeRate,                                                         // account→foreign
     sourceCurrency: item.currency,                                        // foreign currency
     destinationCurrency: accountCurrency,                                 // account currency
   };
@@ -237,13 +245,24 @@ const runProcess = async () => {
     try {
       const resolution = await resolveNotification(descriptor);
 
+      // Everything an auto-create needs except the currency match. Computed first
+      // so a queue-bound notification never pays for the exchange-rate fetch
+      // below (whose result the pending branch would just discard and recompute
+      // at resolve time). Auto-create only for trusted sources; kinds that
+      // require a manual category (C2C transfers) always wait in the queue.
+      const eligibleForAutoCreate =
+        resolution.matchedAccount &&
+        resolution.matchedCategory &&
+        !descriptor.requiresCategory &&
+        isAllowedSource(descriptor.packageName, allowedPackages);
+
       // When the account currency differs from the notification currency, convert
       // the amount at the current exchange rate (same principle as a manually
       // entered foreign-currency operation). A failed conversion (no rate) means
       // we must not book a wrong amount — leave it for manual review.
       let currencyFields = { amount: descriptor.amount };
       let currencyResolved = resolution.currencyMatch;
-      if (resolution.accountId != null && !resolution.currencyMatch) {
+      if (eligibleForAutoCreate && !resolution.currencyMatch) {
         const built = await buildOperationCurrencyFields(descriptor, resolution.accountCurrency);
         if (built) {
           currencyFields = built;
@@ -251,15 +270,7 @@ const runProcess = async () => {
         }
       }
 
-      // Auto-create only for trusted sources; everything else is reviewed.
-      // Kinds that require a manual category (C2C transfers) are never
-      // auto-created — they always wait in the queue for the user's category.
-      const autoCreate =
-        resolution.matchedAccount &&
-        resolution.matchedCategory &&
-        currencyResolved &&
-        !descriptor.requiresCategory &&
-        isAllowedSource(descriptor.packageName, allowedPackages);
+      const autoCreate = eligibleForAutoCreate && currencyResolved;
 
       if (autoCreate) {
         await OperationsDB.createOperation({
@@ -327,7 +338,10 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
   }
 
   // Convert to the chosen account's currency at the current rate when they
-  // differ (e.g. a EUR purchase booked against an AMD account).
+  // differ (e.g. a EUR purchase booked against an AMD account). Unlike the
+  // auto-create path (which silently re-queues when no rate is available), this
+  // is a user-driven save with no further fallback — so a missing rate throws
+  // rather than booking a wrong amount, surfacing the failure to the caller.
   let currencyFields = { amount: pending.amount };
   if (pending.currency) {
     const account = await AccountsDB.getAccountById(accountId);

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -13,6 +13,7 @@ import { getRecentNotifications } from '../NotificationAccess';
 import * as PreferencesDB from '../PreferencesDB';
 import * as OperationsDB from '../OperationsDB';
 import * as AccountsDB from '../AccountsDB';
+import * as Currency from '../currency';
 import * as NotificationRulesDB from '../NotificationRulesDB';
 import * as PendingNotificationsDB from '../PendingNotificationsDB';
 import { serializeLabels } from '../../utils/labelUtils';
@@ -92,6 +93,54 @@ const isoDateFromPostTime = (postTime) => {
 
 /** Today's ISO date — the last-resort fallback for a missing date. */
 const todayIso = () => new Date().toISOString().slice(0, 10);
+
+/**
+ * Build the amount + multi-currency fields for booking a parsed notification
+ * against an account whose currency may differ from the notification's.
+ *
+ * A bank notification can be charged in a currency other than the card's account
+ * currency (e.g. a 129.99 EUR purchase on an AMD card). This mirrors how a
+ * manually-entered foreign-currency operation is stored so the balance is hit in
+ * the account currency while the original foreign value is preserved:
+ *   amount              = value in the account currency (what hits the balance)
+ *   destinationAmount   = original notification amount (foreign currency)
+ *   exchangeRate        = account→foreign rate
+ *   sourceCurrency      = foreign currency
+ *   destinationCurrency = account currency
+ *
+ * The conversion uses the *current* exchange rate (live, with offline fallback),
+ * the same source the operation form uses. When the currencies already match (or
+ * either is unknown) the amount is booked as-is.
+ *
+ * @param {{ amount: string, currency: string }} item - parsed descriptor / pending row
+ * @param {string|null|undefined} accountCurrency - currency of the booking account
+ * @returns {Promise<Object|null>} operation field overrides, or null when a
+ *   conversion is required but no exchange rate is available (caller must not
+ *   book a wrong amount — leave it for manual review).
+ */
+export const buildOperationCurrencyFields = async (item, accountCurrency) => {
+  if (!accountCurrency || !item.currency || item.currency === accountCurrency) {
+    return { amount: item.amount };
+  }
+
+  // foreign → account rate (e.g. EUR→AMD), at the current rate.
+  const { rate } = await Currency.fetchLiveExchangeRate(item.currency, accountCurrency);
+  if (!rate) return null;
+
+  const convertedAmount = Currency.convertAmount(item.amount, item.currency, accountCurrency, rate);
+  if (!convertedAmount) return null;
+
+  const foreignToAccount = Number(rate);
+  if (!Number.isFinite(foreignToAccount) || foreignToAccount <= 0) return null;
+
+  return {
+    amount: convertedAmount,                                              // account currency
+    destinationAmount: Currency.formatAmount(item.amount, item.currency), // foreign currency
+    exchangeRate: (1 / foreignToAccount).toFixed(6),                      // account→foreign
+    sourceCurrency: item.currency,                                        // foreign currency
+    destinationCurrency: accountCurrency,                                 // account currency
+  };
+};
 
 /**
  * Packages whose notifications are trusted to auto-create operations. A package
@@ -187,18 +236,35 @@ const runProcess = async () => {
 
     try {
       const resolution = await resolveNotification(descriptor);
+
+      // When the account currency differs from the notification currency, convert
+      // the amount at the current exchange rate (same principle as a manually
+      // entered foreign-currency operation). A failed conversion (no rate) means
+      // we must not book a wrong amount — leave it for manual review.
+      let currencyFields = { amount: descriptor.amount };
+      let currencyResolved = resolution.currencyMatch;
+      if (resolution.accountId != null && !resolution.currencyMatch) {
+        const built = await buildOperationCurrencyFields(descriptor, resolution.accountCurrency);
+        if (built) {
+          currencyFields = built;
+          currencyResolved = true;
+        }
+      }
+
       // Auto-create only for trusted sources; everything else is reviewed.
       // Kinds that require a manual category (C2C transfers) are never
       // auto-created — they always wait in the queue for the user's category.
       const autoCreate =
-        resolution.fullyMatched &&
+        resolution.matchedAccount &&
+        resolution.matchedCategory &&
+        currencyResolved &&
         !descriptor.requiresCategory &&
         isAllowedSource(descriptor.packageName, allowedPackages);
 
       if (autoCreate) {
         await OperationsDB.createOperation({
           type: descriptor.type,
-          amount: descriptor.amount,
+          ...currencyFields,
           accountId: resolution.accountId,
           categoryId: resolution.categoryId,
           date,
@@ -212,9 +278,10 @@ const runProcess = async () => {
           ...descriptor,
           date,
           accountId: resolution.accountId,
-          // Don't pre-fill a category whose currency we couldn't match — the
-          // user should confirm the account first.
-          categoryId: resolution.currencyMatch ? resolution.categoryId : null,
+          // Pre-fill the resolved category whenever we have an account to book
+          // against; a currency mismatch is no longer a blocker since it is
+          // resolved by conversion at save time.
+          categoryId: resolution.matchedAccount ? resolution.categoryId : null,
         });
         summary.pending += 1;
       }
@@ -259,9 +326,25 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
     throw new Error('Cannot resolve pending notification without an account');
   }
 
+  // Convert to the chosen account's currency at the current rate when they
+  // differ (e.g. a EUR purchase booked against an AMD account).
+  let currencyFields = { amount: pending.amount };
+  if (pending.currency) {
+    const account = await AccountsDB.getAccountById(accountId);
+    const accountCurrency = account ? account.currency : null;
+    const built = await buildOperationCurrencyFields(pending, accountCurrency);
+    if (built) {
+      currencyFields = built;
+    } else {
+      throw new Error(
+        `Cannot resolve pending notification ${pendingId}: no exchange rate for ${pending.currency}→${accountCurrency}`,
+      );
+    }
+  }
+
   const operation = await OperationsDB.createOperation({
     type: pending.type,
-    amount: pending.amount,
+    ...currencyFields,
     accountId,
     categoryId: categoryId || null,
     // operations.date is NOT NULL — fall back to the row's creation date / today.


### PR DESCRIPTION
## Summary

Ameriabank "E-POS PURCHASE" (online point-of-sale) notifications were not recognized, so charges like `E-POS PURCHASE | 129.99 EUR | … | Nike ES, ES | …` were silently skipped. They are now parsed as expenses. In addition, a notification charged in a currency different from the bound account's (e.g. 129.99 EUR on an AMD card) is now converted to the account currency at the current exchange rate — following the same principle and storage shape as a manually-entered foreign-currency operation — instead of always falling to the review queue or booking the wrong amount.

## Changes

- **app/services/notifications/bankParsers/ameriabank.js** — add `E-POS PURCHASE` to the kind→type map (expense, category inferable from learned merchant rules); document the foreign-currency example in the header comment. The parser still reports the transaction currency as charged (EUR), leaving conversion to the ingestion layer.
- **app/services/notifications/processBankNotifications.js**
  - New `buildOperationCurrencyFields(item, accountCurrency)` helper: when the account currency differs from the notification currency, it converts at the current rate (live with offline fallback) and returns `amount` (account currency), `destinationAmount` (foreign), `exchangeRate` (account→foreign), `sourceCurrency`, `destinationCurrency`. Returns `null` when no rate is available so a wrong amount is never booked.
  - Auto-create path: a foreign-currency charge with a resolvable rate now auto-creates (when source is trusted and account+category match) instead of being blocked by the currency mismatch; otherwise it falls to review.
  - `resolvePendingNotification`: converts to the chosen account's currency at save time; throws (rather than booking a wrong amount) when no rate is available.
  - Pending items now pre-fill the resolved category whenever an account is matched, since a currency mismatch is no longer a blocker.

## Testing

- `node_modules/.bin/jest __tests__/services/notifications/parseBankNotification.test.js __tests__/services/notifications/processBankNotifications.test.js` — 2 suites / 78 tests pass.
- `node_modules/.bin/jest` (full suite) — 137 suites / 4009 tests pass (one OperationModal render test intermittently times out under parallel load; passes in isolation and is unrelated to this change).
- Added parser tests for the E-POS EUR template and pipeline tests for auto-create-with-conversion, no-rate fallback to review, and resolve-time conversion (including the no-rate throw).

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new UI strings)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016NHvrjLMqSEefnMaVbXjjf)_