### PR TITLE
feat(notifications): handle PRE-PURCHASE and PRE-PURCHASE COMPLETION from Ameriabank

### DIFF
--- a/__tests__/services/notifications/parseBankNotification.test.js
+++ b/__tests__/services/notifications/parseBankNotification.test.js
@@ -179,6 +179,88 @@ describe('parseBankNotification', () => {
     });
   });
 
+  describe('PRE-PURCHASE template (authorization hold)', () => {
+    const AMERIA_PRE_PURCHASE = {
+      title: 'АРКА транзакции',
+      text: 'PRE-PURCHASE | 2,800.00 AMD | 4083***7027, | YANDEX.GO, AM | 30.06.2026 10:51 | BALANCE: 19,095.20 AMD',
+      packageName: 'com.banqr.ameriabank',
+      postTime: 1782000900000,
+    };
+    let result;
+    beforeEach(() => {
+      result = parseBankNotification(AMERIA_PRE_PURCHASE);
+    });
+
+    it('recognizes PRE-PURCHASE as a transaction', () => {
+      expect(result).not.toBeNull();
+    });
+
+    it('maps PRE-PURCHASE to an expense operation', () => {
+      expect(result.kind).toBe('PRE-PURCHASE');
+      expect(result.type).toBe('expense');
+    });
+
+    it('extracts amount, currency, card mask, merchant, country, date and time', () => {
+      expect(result.amount).toBe('2800.00');
+      expect(result.currency).toBe('AMD');
+      expect(result.cardMask).toBe('4083***7027');
+      expect(result.merchant).toBe('YANDEX.GO');
+      expect(result.country).toBe('AM');
+      expect(result.date).toBe('2026-06-30');
+      expect(result.time).toBe('10:51');
+    });
+
+    it('does not require a manual category', () => {
+      expect(result.requiresCategory).toBe(false);
+    });
+  });
+
+  describe('PRE-PURCHASE COMPLETION template (settlement of hold)', () => {
+    const AMERIA_PRE_PURCHASE_COMPLETION = {
+      title: 'АРКА транзакции',
+      text: 'PRE-PURCHASE COMPLETION | 2,800.00 AMD | 4083***7027, | YANDEX.GO, AM | 30.06.2026 13:51 | BALANCE: 19,095.20 AMD',
+      packageName: 'com.banqr.ameriabank',
+      postTime: 1782000900000,
+    };
+    let result;
+    beforeEach(() => {
+      result = parseBankNotification(AMERIA_PRE_PURCHASE_COMPLETION);
+    });
+
+    it('recognizes PRE-PURCHASE COMPLETION as a transaction', () => {
+      expect(result).not.toBeNull();
+    });
+
+    it('maps PRE-PURCHASE COMPLETION to an expense operation', () => {
+      expect(result.kind).toBe('PRE-PURCHASE COMPLETION');
+      expect(result.type).toBe('expense');
+    });
+
+    it('extracts amount, currency, card mask, merchant, country, date and time', () => {
+      expect(result.amount).toBe('2800.00');
+      expect(result.currency).toBe('AMD');
+      expect(result.cardMask).toBe('4083***7027');
+      expect(result.merchant).toBe('YANDEX.GO');
+      expect(result.country).toBe('AM');
+      expect(result.date).toBe('2026-06-30');
+      expect(result.time).toBe('13:51');
+    });
+
+    it('does not require a manual category', () => {
+      expect(result.requiresCategory).toBe(false);
+    });
+
+    it('handles a completion with a different amount than the original hold', () => {
+      const result = parseBankNotification({
+        text: 'PRE-PURCHASE COMPLETION | 2,500.00 AMD | 4083***7027, | YANDEX.GO, AM | 30.06.2026 13:03 | BALANCE: 19,095.20 AMD',
+        packageName: 'com.banqr.ameriabank',
+      });
+      expect(result).not.toBeNull();
+      expect(result.amount).toBe('2500.00');
+      expect(result.kind).toBe('PRE-PURCHASE COMPLETION');
+    });
+  });
+
   describe('PURCHASE does not require a manual category', () => {
     it('marks a purchase as not requiring a category', () => {
       expect(parseBankNotification(AMERIA_PURCHASE).requiresCategory).toBe(false);

--- a/app/services/notifications/bankParsers/ameriabank.js
+++ b/app/services/notifications/bankParsers/ameriabank.js
@@ -2,11 +2,13 @@
  * Bank notification parser for the Ameriabank app (`com.banqr.ameriabank`).
  *
  * Ameria posts each card event as a single pipe-delimited "ARCA transaction"
- * line. Three kinds are recognized today:
+ * line. Five kinds are recognized today:
  *
- *   PURCHASE       | 3,900.00 AMD | 4083***7027, | NAREK MEHRABYAN, AM | 28.06.2026 10:15 | BALANCE: 133,719.97 AMD
- *   E-POS PURCHASE | 129.99 EUR   | 4083***7027, | Nike ES, ES         | 29.06.2026 15:14 | BALANCE: 27,608.20 AMD
- *   C2C            | 19,200.00 AMD | 4083***7027, | TO: N. DORVANYAN | AMERIABANK API GATE, AM | 28.06.2026 16:23 | BALANCE: 106,819.97 AMD
+ *   PURCHASE                | 3,900.00 AMD  | 4083***7027, | NAREK MEHRABYAN, AM | 28.06.2026 10:15 | BALANCE: 133,719.97 AMD
+ *   E-POS PURCHASE          | 129.99 EUR    | 4083***7027, | Nike ES, ES         | 29.06.2026 15:14 | BALANCE: 27,608.20 AMD
+ *   C2C                     | 19,200.00 AMD | 4083***7027, | TO: N. DORVANYAN | AMERIABANK API GATE, AM | 28.06.2026 16:23 | BALANCE: 106,819.97 AMD
+ *   PRE-PURCHASE            | 2,800.00 AMD  | 4083***7027, | YANDEX.GO, AM | 30.06.2026 10:51 | BALANCE: 19,095.20 AMD
+ *   PRE-PURCHASE COMPLETION | 2,800.00 AMD  | 4083***7027, | YANDEX.GO, AM | 30.06.2026 13:51 | BALANCE: 19,095.20 AMD
  *
  * Note the E-POS PURCHASE example: the transaction is charged in EUR while the
  * card account is in AMD. The parser reports the transaction currency as-is
@@ -48,6 +50,12 @@ const KIND_TO_TYPE = {
   // inferred from learned rules. Often charged in a foreign currency.
   'E-POS PURCHASE': 'expense',
   C2C: 'expense',
+  // Temporary authorization hold placed before the final charge is settled.
+  // Processed as an expense so the user sees the pending amount immediately.
+  'PRE-PURCHASE': 'expense',
+  // Settlement of a prior PRE-PURCHASE hold. The final charged amount may differ
+  // from the original hold (e.g. a taxi fare calculated after the ride).
+  'PRE-PURCHASE COMPLETION': 'expense',
 };
 
 const KNOWN_KINDS = Object.keys(KIND_TO_TYPE);


### PR DESCRIPTION
## Summary

- Added `PRE-PURCHASE` and `PRE-PURCHASE COMPLETION` to the Ameriabank notification parser's `KIND_TO_TYPE` map, both mapped to `expense`
- `PRE-PURCHASE` is the initial authorization hold; `PRE-PURCHASE COMPLETION` is the final settled charge (amount may differ from the hold, e.g. a taxi fare calculated after the ride)
- Updated the file-level comment to document both new notification formats
- Added test cases for both kinds covering amount, currency, card mask, merchant, country, date/time extraction, `requiresCategory: false`, and the case where the completion amount differs from the hold amount

## Test plan

- [x] All 64 existing + new tests pass (`bun test parseBankNotification.test.js`)
- [x] PRE-PURCHASE recognized as expense, correct field extraction
- [x] PRE-PURCHASE COMPLETION recognized as expense, correct field extraction
- [x] Completion with different amount than the original hold parses correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_013QvnBysPqmhVP4StwHxLv7)_