### PR TITLE
fix(notifications): ignore PRE-PURCHASE hold, only process PRE-PURCHASE COMPLETION

### DIFF
--- a/__tests__/services/notifications/parseBankNotification.test.js
+++ b/__tests__/services/notifications/parseBankNotification.test.js
@@ -179,42 +179,6 @@ describe('parseBankNotification', () => {
     });
   });
 
-  describe('PRE-PURCHASE template (authorization hold)', () => {
-    const AMERIA_PRE_PURCHASE = {
-      title: 'АРКА транзакции',
-      text: 'PRE-PURCHASE | 2,800.00 AMD | 4083***7027, | YANDEX.GO, AM | 30.06.2026 10:51 | BALANCE: 19,095.20 AMD',
-      packageName: 'com.banqr.ameriabank',
-      postTime: 1782000900000,
-    };
-    let result;
-    beforeEach(() => {
-      result = parseBankNotification(AMERIA_PRE_PURCHASE);
-    });
-
-    it('recognizes PRE-PURCHASE as a transaction', () => {
-      expect(result).not.toBeNull();
-    });
-
-    it('maps PRE-PURCHASE to an expense operation', () => {
-      expect(result.kind).toBe('PRE-PURCHASE');
-      expect(result.type).toBe('expense');
-    });
-
-    it('extracts amount, currency, card mask, merchant, country, date and time', () => {
-      expect(result.amount).toBe('2800.00');
-      expect(result.currency).toBe('AMD');
-      expect(result.cardMask).toBe('4083***7027');
-      expect(result.merchant).toBe('YANDEX.GO');
-      expect(result.country).toBe('AM');
-      expect(result.date).toBe('2026-06-30');
-      expect(result.time).toBe('10:51');
-    });
-
-    it('does not require a manual category', () => {
-      expect(result.requiresCategory).toBe(false);
-    });
-  });
-
   describe('PRE-PURCHASE COMPLETION template (settlement of hold)', () => {
     const AMERIA_PRE_PURCHASE_COMPLETION = {
       title: 'АРКА транзакции',
@@ -258,6 +222,17 @@ describe('parseBankNotification', () => {
       expect(result).not.toBeNull();
       expect(result.amount).toBe('2500.00');
       expect(result.kind).toBe('PRE-PURCHASE COMPLETION');
+    });
+  });
+
+  describe('PRE-PURCHASE (authorization hold) is ignored to avoid duplicates', () => {
+    it('returns null for a PRE-PURCHASE notification', () => {
+      expect(
+        parseBankNotification({
+          text: 'PRE-PURCHASE | 2,800.00 AMD | 4083***7027, | YANDEX.GO, AM | 30.06.2026 10:51 | BALANCE: 19,095.20 AMD',
+          packageName: 'com.banqr.ameriabank',
+        }),
+      ).toBeNull();
     });
   });
 

--- a/app/services/notifications/bankParsers/ameriabank.js
+++ b/app/services/notifications/bankParsers/ameriabank.js
@@ -2,13 +2,16 @@
  * Bank notification parser for the Ameriabank app (`com.banqr.ameriabank`).
  *
  * Ameria posts each card event as a single pipe-delimited "ARCA transaction"
- * line. Five kinds are recognized today:
+ * line. Four kinds are recognized today:
  *
  *   PURCHASE                | 3,900.00 AMD  | 4083***7027, | NAREK MEHRABYAN, AM | 28.06.2026 10:15 | BALANCE: 133,719.97 AMD
  *   E-POS PURCHASE          | 129.99 EUR    | 4083***7027, | Nike ES, ES         | 29.06.2026 15:14 | BALANCE: 27,608.20 AMD
  *   C2C                     | 19,200.00 AMD | 4083***7027, | TO: N. DORVANYAN | AMERIABANK API GATE, AM | 28.06.2026 16:23 | BALANCE: 106,819.97 AMD
- *   PRE-PURCHASE            | 2,800.00 AMD  | 4083***7027, | YANDEX.GO, AM | 30.06.2026 10:51 | BALANCE: 19,095.20 AMD
  *   PRE-PURCHASE COMPLETION | 2,800.00 AMD  | 4083***7027, | YANDEX.GO, AM | 30.06.2026 13:51 | BALANCE: 19,095.20 AMD
+ *
+ * PRE-PURCHASE (the initial authorization hold) is intentionally ignored —
+ * PRE-PURCHASE COMPLETION is the actual settled charge, so recording both
+ * would create duplicate entries for the same transaction.
  *
  * Note the E-POS PURCHASE example: the transaction is charged in EUR while the
  * card account is in AMD. The parser reports the transaction currency as-is
@@ -50,11 +53,9 @@ const KIND_TO_TYPE = {
   // inferred from learned rules. Often charged in a foreign currency.
   'E-POS PURCHASE': 'expense',
   C2C: 'expense',
-  // Temporary authorization hold placed before the final charge is settled.
-  // Processed as an expense so the user sees the pending amount immediately.
-  'PRE-PURCHASE': 'expense',
-  // Settlement of a prior PRE-PURCHASE hold. The final charged amount may differ
-  // from the original hold (e.g. a taxi fare calculated after the ride).
+  // Settlement of a prior PRE-PURCHASE authorization hold. The final charged
+  // amount may differ from the hold (e.g. a taxi fare calculated after the ride).
+  // PRE-PURCHASE itself is intentionally omitted to avoid duplicate entries.
   'PRE-PURCHASE COMPLETION': 'expense',
 };
 


### PR DESCRIPTION
## Summary

- Removed `PRE-PURCHASE` from the Ameriabank parser's `KIND_TO_TYPE` map — it was incorrectly added in the previous PR alongside `PRE-PURCHASE COMPLETION`, causing duplicate expense entries for the same transaction
- `PRE-PURCHASE` is a temporary authorization hold; `PRE-PURCHASE COMPLETION` is the actual settled charge (and may carry a different amount, e.g. a taxi fare finalized after the ride)
- Only `PRE-PURCHASE COMPLETION` is now recorded as an expense
- Added a test asserting that `PRE-PURCHASE` returns `null` (is ignored by the parser)

## Test plan

- [x] All 61 tests pass
- [x] `PRE-PURCHASE COMPLETION` parsed correctly as expense
- [x] `PRE-PURCHASE` returns `null` and is not recorded

---
_Generated by [Claude Code](https://claude.ai/code/session_013QvnBysPqmhVP4StwHxLv7)_