### PR TITLE
feat(graphs): migrate balance-history chart to react-native-chart-kit v7 modern LineChart

### DIFF
--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -14,8 +14,8 @@ jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
   })),
 }));
 
-// Mock LineChart from react-native-chart-kit
-jest.mock('react-native-chart-kit', () => ({
+// Mock LineChart from the modern v2 charts subpath
+jest.mock('react-native-chart-kit/v2', () => ({
   LineChart: 'LineChart',
 }));
 
@@ -424,9 +424,9 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      expect(lineChart.props.data.labels).toEqual(['1', '5', '10', '15', '20', '25', '28']);
-      // Should have 4 datasets: actual + plain avg + prevMonth + zero baseline (no forecast when not current month)
-      expect(lineChart.props.data.datasets).toHaveLength(4);
+      expect(lineChart.props.data.map(d => d.day)).toEqual(['1', '5', '10', '15', '20', '25', '28']);
+      // Should have 4 series: actual + plain avg + prevMonth + zero baseline (no forecast when not current month)
+      expect(lineChart.props.series).toHaveLength(4);
     });
 
     it('includes actual dataset with correct styling', async () => {
@@ -454,9 +454,9 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
-      expect(actualDataset.data).toEqual(mockBalanceHistoryData.actualForChart);
-      expect(actualDataset.strokeWidth).toBe(3);
+      const actualSeries = lineChart.props.series.find(s => s.yKey === 'actual');
+      expect(lineChart.props.data.map(d => d.actual)).toEqual(mockBalanceHistoryData.actualForChart);
+      expect(actualSeries.strokeWidth).toBe(3);
     });
 
     it('includes plain avg dataset as second dataset', async () => {
@@ -486,11 +486,11 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const plainAvgDataset = lineChart.props.data.datasets[1];
-      expect(plainAvgDataset.withDots).toBe(false);
-      expect(plainAvgDataset.strokeWidth).toBe(2);
+      const plainAvgSeries = lineChart.props.series.find(s => s.yKey === 'plainAvg');
+      expect(plainAvgSeries.dot).toBe(false);
+      expect(plainAvgSeries.strokeWidth).toBe(2);
       // Plain avg should be gray color
-      expect(plainAvgDataset.color()).toBe('rgba(128, 128, 128, 0.4)');
+      expect(plainAvgSeries.color).toBe('rgba(128, 128, 128, 0.4)');
     });
 
     it('combines actual and forecast data when isCurrentMonth with spendingPrediction', async () => {
@@ -534,8 +534,9 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      // Should have 4 datasets: combined actual+forecast + plain avg + prevMonth + zero baseline
-      expect(lineChart.props.data.datasets).toHaveLength(4);
+      // 5 series: actual + forecast (split) + plain avg + prevMonth + zero baseline
+      expect(lineChart.props.series).toHaveLength(5);
+      expect(lineChart.props.series.find(s => s.yKey === 'forecast')).toBeTruthy();
 
       global.Date.mockRestore();
     });
@@ -567,10 +568,11 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      // Should have 4 datasets: actual + plain avg + prevMonth + zero baseline (no forecast)
-      expect(lineChart.props.data.datasets).toHaveLength(4);
-      const prevMonthDataset = lineChart.props.data.datasets[2];
-      expect(prevMonthDataset.withDots).toBe(false);
+      // 4 series: actual + plain avg + prevMonth + zero baseline (no forecast)
+      expect(lineChart.props.series).toHaveLength(4);
+      const prevMonthSeries = lineChart.props.series.find(s => s.yKey === 'prevMonth');
+      expect(prevMonthSeries).toBeTruthy();
+      expect(prevMonthSeries.dot).toBe(false);
     });
 
     it('excludes prevMonth dataset when not available', async () => {
@@ -603,8 +605,9 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      // Should have 3 datasets: actual + plain avg + zero baseline (no prevMonth)
-      expect(lineChart.props.data.datasets).toHaveLength(3);
+      // 3 series: actual + plain avg + zero baseline (no prevMonth)
+      expect(lineChart.props.series).toHaveLength(3);
+      expect(lineChart.props.series.find(s => s.yKey === 'prevMonth')).toBeFalsy();
     });
 
     it('excludes prevMonth dataset when all values are undefined', async () => {
@@ -637,8 +640,8 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      // Should have 3 datasets: actual + plain avg + zero baseline (no prevMonth since all undefined)
-      expect(lineChart.props.data.datasets).toHaveLength(3);
+      // 3 series: actual + plain avg + zero baseline (no prevMonth since all undefined)
+      expect(lineChart.props.series).toHaveLength(3);
     });
   });
 
@@ -1217,7 +1220,7 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
+      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
       expect(actualDataset.data).toEqual([1000, 1200]); // undefined should be filtered
     });
 
@@ -1516,7 +1519,7 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
+      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
       expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
 
@@ -1550,7 +1553,7 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
+      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
       expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
 
@@ -1584,7 +1587,7 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
+      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
       expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
 
@@ -1618,7 +1621,7 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
+      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
       // Labels are [1, 5, 10, 15, 20, 25, 31] — days 1, 5, 10 are <= 10
       expect(actualDataset.data).toEqual([500, 600, 700]);
     });
@@ -1653,7 +1656,7 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
+      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
       // Labels are [1, 5, 10, ...] — only day 1 is <= 3
       expect(actualDataset.data).toEqual([500]);
     });
@@ -1688,7 +1691,7 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
+      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
       // All labels [1, 5, 10, 15, 20, 25, 31] are <= 31
       expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
@@ -1733,12 +1736,13 @@ describe('BalanceHistoryCard', () => {
       );
 
       const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = lineChart.props.data.datasets[0];
-      // Days 1, 5, 10, 15 are <= 16 (actual data), days 20, 25, 31 get forecast values
-      // Actual: [500, 600, 700, 800] + forecast for days 20, 25, 31
-      expect(actualDataset.data.length).toBeGreaterThan(4);
-      // First 4 values should be the actual data
-      expect(actualDataset.data.slice(0, 4)).toEqual([500, 600, 700, 800]);
+      // Forecast now lives in its own dashed series (days after today), not appended to actual
+      const forecastValues = lineChart.props.data.map(d => d.forecast).filter(v => v !== null);
+      expect(forecastValues.length).toBeGreaterThan(0);
+      expect(lineChart.props.series.find(s => s.yKey === 'forecast')).toBeTruthy();
+      // Actual series stops at today: days 1, 5, 10, 15 (<= 16)
+      const actualValues = lineChart.props.data.map(d => d.actual).filter(v => v !== null);
+      expect(actualValues).toEqual([500, 600, 700, 800]);
     });
   });
 

--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -12,6 +12,10 @@ jest.mock('react-native-chart-kit', () => ({
   PieChart: () => 'PieChart',
 }));
 
+jest.mock('react-native-chart-kit/v2', () => ({
+  LineChart: () => 'LineChart',
+}));
+
 jest.mock('../../app/contexts/ThemeColorsContext', () => ({
   useThemeColors: jest.fn(() => ({
     colors: {

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -1,8 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
-import { LineChart } from 'react-native-chart-kit';
-import { Line, Text as SvgText, G } from 'react-native-svg';
+import { LineChart } from 'react-native-chart-kit/v2';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import SimplePicker from '../SimplePicker';
 import currencies from '../../../assets/currencies.json';
@@ -291,6 +290,63 @@ const BalanceHistoryCard = ({
     };
   }, [balanceHistoryData, spendingPrediction, isCurrentMonth, selectedYear, selectedMonth, selectedAccount]);
 
+  // v2 LineChart consumes an array of records (xKey + per-series yKeys) instead of
+  // the legacy parallel { labels, datasets } shape. The actual line is split into a
+  // solid "actual" series (up to today) and a dashed "forecast" series (today onward),
+  // which makes the "today" boundary self-evident — replacing the old hand-drawn
+  // vertical decorator line and its hardcoded chart geometry.
+  const chartData = useMemo(() => {
+    if (!chartComputed) return [];
+    const { combinedActualForecast, plainAvgData, currentDay, hasForecast } = chartComputed;
+    const prevMonth = balanceHistoryData.prevMonth || [];
+    const showForecast = isCurrentMonth && hasForecast;
+    return balanceHistoryData.labels.map((day, i) => {
+      const raw = combinedActualForecast[i];
+      const value = raw === undefined ? null : raw;
+      const isForecastDay = showForecast && day > currentDay;
+      const isBoundaryDay = showForecast && day === currentDay;
+      return {
+        day: String(day),
+        actual: isForecastDay ? null : value,
+        // include the boundary day in the forecast series too so the segments touch
+        forecast: (isForecastDay || isBoundaryDay) ? value : null,
+        plainAvg: plainAvgData[i] ?? null,
+        prevMonth: prevMonth[i] ?? null,
+        zero: 0,
+      };
+    });
+  }, [chartComputed, balanceHistoryData, isCurrentMonth]);
+
+  const chartSeries = useMemo(() => {
+    if (!chartComputed) return [];
+    const series = [
+      { yKey: 'actual', label: 'actual', color: colors.primary, strokeWidth: 3, dot: { radius: 2 } },
+    ];
+    if (isCurrentMonth && chartComputed.hasForecast) {
+      series.push({ yKey: 'forecast', label: 'forecast', color: colors.primary, strokeWidth: 3, strokeDasharray: [5, 5], dot: false });
+    }
+    series.push({ yKey: 'plainAvg', label: 'plainAvg', color: 'rgba(128, 128, 128, 0.4)', strokeWidth: 2, dot: false });
+    if (chartComputed.hasPrevMonthData) {
+      series.push({ yKey: 'prevMonth', label: 'prevMonth', color: 'rgba(156, 39, 176, 0.5)', strokeWidth: 2, dot: false });
+    }
+    series.push({ yKey: 'zero', label: 'zero', color: 'rgba(128, 128, 128, 0.5)', strokeWidth: 1, dot: false });
+    return series;
+  }, [chartComputed, colors.primary, isCurrentMonth]);
+
+  const chartTheme = useMemo(() => ({
+    background: colors.altRow,
+    plotBackground: colors.altRow,
+    grid: colors.border,
+    axis: colors.mutedText,
+    text: colors.mutedText,
+    tooltip: {
+      background: colors.surface,
+      border: colors.border,
+      text: colors.text,
+      mutedText: colors.mutedText,
+    },
+  }), [colors.altRow, colors.border, colors.mutedText, colors.surface, colors.text]);
+
   return (
     <View style={[styles.balanceHistoryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
       <View style={styles.balanceHistoryHeader}>
@@ -373,42 +429,15 @@ const BalanceHistoryCard = ({
               >
                 {chartComputed && (
                   <LineChart
-                    data={{
-                      labels: balanceHistoryData.labels.map(d => d.toString()),
-                      datasets: [
-                        {
-                          data: chartComputed.combinedActualForecast.filter(v => v !== undefined),
-                          color: () => colors.primary,
-                          strokeWidth: 3,
-                        },
-                        {
-                          data: chartComputed.plainAvgData,
-                          color: () => 'rgba(128, 128, 128, 0.4)',
-                          strokeWidth: 2,
-                          withDots: false,
-                        },
-                        ...(balanceHistoryData.prevMonth && balanceHistoryData.prevMonth.some(v => v !== undefined) ? [{
-                          data: balanceHistoryData.prevMonth.map(v => v ?? null),
-                          color: () => 'rgba(156, 39, 176, 0.5)',
-                          strokeWidth: 2,
-                          withDots: false,
-                        }] : []),
-                        {
-                          data: balanceHistoryData.labels.map(() => 0),
-                          color: () => 'rgba(128, 128, 128, 0.5)',
-                          strokeWidth: 1,
-                          withDots: false,
-                        },
-                      ],
-                    }}
+                    data={chartData}
+                    xKey="day"
+                    series={chartSeries}
                     width={screenWidth - 33}
                     height={220}
-                    paddingLeft="40"
-                    yAxisLabel=""
-                    yAxisSuffix=""
-                    yAxisInterval={chartComputed.niceInterval}
-                    segments={4}
-                    fromZero={!chartComputed.hasNegativeValues}
+                    theme={chartTheme}
+                    curve="monotone"
+                    connectNulls
+                    yDomain={chartComputed.hasNegativeValues || !chartComputed.niceMax ? 'auto' : [0, chartComputed.niceMax]}
                     formatYLabel={hideBalances ? () => '' : (value) => {
                       const numValue = parseFloat(value);
                       if (numValue === 0) return '';
@@ -432,76 +461,12 @@ const BalanceHistoryCard = ({
                       }
                       return '';
                     }}
-                    chartConfig={{
-                      backgroundColor: colors.altRow,
-                      backgroundGradientFrom: colors.altRow,
-                      backgroundGradientTo: colors.altRow,
-                      decimalPlaces: 0,
-                      color: (_opacity = 1) => colors.text,
-                      labelColor: (_opacity = 1) => colors.mutedText,
-                      style: {
-                        borderRadius: 16,
-                      },
-                      propsForDots: {
-                        r: '2',
-                        strokeWidth: '2',
-                      },
-                      propsForBackgroundLines: {
-                        strokeWidth: 1,
-                        stroke: colors.border,
-                        strokeDasharray: '0',
-                      },
-                    }}
-                    decorator={() => {
-                      // react-native-chart-kit places data using paddingRight (default 64) as
-                      // the left origin: x = paddingRight + i*(width-paddingRight)/n
-                      const chartWidth = screenWidth - 33; // must match width prop
-                      const chartPaddingRight = 64; // library default, acts as left margin
-                      const usableWidth = chartWidth - chartPaddingRight;
-                      const dataLength = balanceHistoryData.labels.length;
-                      const xStep = usableWidth / dataLength;
-                      const chartTop = 12;
-                      const chartBottom = 181;
-
-                      const elements = [];
-
-                      if (isCurrentMonth && chartComputed) {
-                        const todayIndex = chartComputed.currentDay - 1;
-                        const xPosition = chartPaddingRight + (todayIndex * xStep);
-                        elements.push(
-                          <Line
-                            key="today-line"
-                            x1={xPosition}
-                            y1={chartTop}
-                            x2={xPosition}
-                            y2={chartBottom}
-                            stroke={colors.primary}
-                            strokeWidth={1}
-                            strokeDasharray="4,4"
-                            opacity={0.6}
-                          />,
-                          <SvgText
-                            key="today-label"
-                            x={xPosition}
-                            y={10}
-                            fontSize={10}
-                            fill={colors.primary}
-                            textAnchor="middle"
-                            fontWeight="bold"
-                          >
-                            {chartComputed.currentDay}
-                          </SvgText>,
-                        );
-                      }
-
-                      return elements.length > 0 ? <G>{elements}</G> : null;
-                    }}
-                    bezier
-                    withInnerLines={true}
-                    withOuterLines={true}
-                    withVerticalLines={false}
-                    withHorizontalLines={true}
-                    withLegend={false}
+                    showHorizontalGridLines
+                    showVerticalGridLines={false}
+                    legend={false}
+                    crosshair
+                    tooltip={!hideBalances}
+                    accessibilityLabel={t('balance_history') || 'Balance history chart'}
                     style={styles.lineChartStyle}
                   />
                 )}

--- a/docs/BALANCE_HISTORY_CHARTKIT_V2_MIGRATION.md
+++ b/docs/BALANCE_HISTORY_CHARTKIT_V2_MIGRATION.md
@@ -1,199 +1,93 @@
-# Balance History → react-native-chart-kit v2 (modern) migration guide
+# Balance History → react-native-chart-kit v2 (modern) migration
 
-Status: **planned / not yet applied to the live chart.**
+Status: **applied — pending on-device visual verification.**
 
-This repo now depends on `react-native-chart-kit@^7.0.1` (bumped from v6). v7 keeps
-the **legacy root import** (`import { LineChart } from 'react-native-chart-kit'`)
-fully backward-compatible, so `BalanceHistoryCard.js` still renders unchanged on
-v7. This document describes how to move that one chart to the **modern v2**
-`LineChart` (`react-native-chart-kit/v2`) to gain a built-in crosshair, tooltips,
-and accessibility — and what does **not** map cleanly.
-
-> Why this is a guide and not a finished swap: the v2 `LineChart` is a ground-up
-> redesign (generic, data-accessor API). The balance-history chart is the app's
-> most complex (4 overlaid series, a bespoke nice-scale Y axis, a hand-drawn
-> "today" marker, hidden-balance mode). Two of those features have **no clean v2
-> equivalent** (see *Trade-offs*), so the swap needs to be tuned against a live
-> render on a device/emulator. Apply the steps below where you can actually see
-> the chart.
+`BalanceHistoryCard` now renders the modern **v2** `LineChart`
+(`react-native-chart-kit/v2`, v7+) instead of the legacy chart. This unlocks a
+built-in crosshair and tooltips and drops the fragile hand-drawn "today"
+decorator. All 138 Jest suites pass, but the test suite **mocks** the chart, so
+the rendered result still needs to be eyeballed on a device/emulator — see the
+checklist at the bottom and the *Known tuning items*.
 
 ---
 
-## 1. Prerequisite (done)
+## What changed
 
-`package.json` → `"react-native-chart-kit": "^7.0.1"`. Peer ranges that v7
-requires are already satisfied: `react >=19.1` (app: 19.2.3),
-`react-native >=0.81` (0.85.3), `react-native-svg >=15.12.1 <16` (15.15.4).
+- **Import:** `import { LineChart } from 'react-native-chart-kit/v2'` (was the
+  legacy root import). The `react-native-svg` `Line`/`Text`/`G` imports used by
+  the old decorator are gone.
+- **Data model:** the legacy parallel `{ labels, datasets: [{ data }] }` shape is
+  replaced by an **array of records** (`chartData`) + a per-series accessor
+  config (`chartSeries`). All of the existing `chartComputed` data prep is reused
+  unchanged; only the final shaping into records is new.
+- **Actual vs forecast split:** the old single combined line + a hand-drawn
+  vertical "today" line is replaced by two series — a solid `actual` series (up to
+  today) and a dashed `forecast` series (today onward). The solid→dashed boundary
+  *is* the "today" indicator, so the decorator (and its hardcoded `paddingRight`
+  geometry) is deleted.
+- **Theme:** app colors are mapped onto a `CartesianChartTheme` (`chartTheme`).
+- **Built-ins enabled:** `crosshair`, `tooltip` (suppressed when `hideBalances`),
+  `showHorizontalGridLines`, `legend={false}`, `curve="monotone"` (≈ the old
+  `bezier`), `connectNulls`.
 
-Run `npm install` after pulling so the `react-native-chart-kit/v2` subpath
-resolves.
+## Prop mapping (legacy → v2)
 
-## 2. Import change
-
-```diff
-- import { LineChart } from 'react-native-chart-kit';
-+ import { LineChart, getLineChartAccessibilitySummary } from 'react-native-chart-kit/v2';
-```
-
-The legacy `Line`, `Text as SvgText`, `G` imports from `react-native-svg` used by
-the old `decorator` can be removed (see *Trade-offs → today marker*).
-
-## 3. Data model change
-
-v6 took parallel arrays (`{ labels, datasets: [{ data }] }`). v2 takes an
-**array of records** plus a per-series accessor config:
-
-```js
-// Build once from the existing `chartComputed` memo — all the data prep is reused.
-const chartData = balanceHistoryData.labels.map((day, i) => {
-  const isForecastDay = isCurrentMonth && chartComputed.hasForecast && day > chartComputed.currentDay;
-  return {
-    day: String(day),
-    // Split the old combined line into actual (solid) vs forecast (dashed) so the
-    // "today" boundary is shown by the data itself — no manual vertical line needed.
-    actual:   isForecastDay ? null : (chartComputed.combinedActualForecast[i] ?? null),
-    forecast: isForecastDay ? (chartComputed.combinedActualForecast[i] ?? null) : null,
-    plainAvg: chartComputed.plainAvgData[i] ?? null,
-    prevMonth: balanceHistoryData.prevMonth?.[i] ?? null,
-    zero: 0,
-  };
-});
-// Bridge actual→forecast: also set forecast at the boundary day = actual value,
-// so the two segments visually touch at "today".
-```
-
-```js
-const series = [
-  { yKey: 'actual',   color: colors.primary, strokeWidth: 3, curve: 'monotone',
-    dot: { radius: 2 } },
-  { yKey: 'forecast', color: colors.primary, strokeWidth: 3, curve: 'monotone',
-    strokeDasharray: [5, 5], dot: false },
-  { yKey: 'plainAvg', color: 'rgba(128,128,128,0.4)', strokeWidth: 2, dot: false },
-  // prevMonth series added conditionally (same guard as today)
-  ...(chartComputed.hasPrevMonthData
-    ? [{ yKey: 'prevMonth', color: 'rgba(156,39,176,0.5)', strokeWidth: 2, dot: false }]
-    : []),
-  { yKey: 'zero', color: 'rgba(128,128,128,0.5)', strokeWidth: 1, dot: false },
-];
-```
-
-## 4. Prop mapping (v6 → v2)
-
-| v6 prop | v2 equivalent | Notes |
+| legacy prop | v2 equivalent | Notes |
 |---|---|---|
-| `data={{ labels, datasets }}` | `data={chartData}` + `xKey="day"` + `series={series}` | array-of-records model |
-| per-dataset `color` / `strokeWidth` | `series[].color` / `series[].strokeWidth` | static string, not a fn |
-| per-dataset `withDots: false` | `series[].dot: false` | or `dot: { radius }` |
-| `propsForDots={{ r: '2' }}` | `series[].dot: { radius: 2 }` | per-series now |
-| `bezier` | `series[].curve: 'monotone'` (or top-level `curve`) | `LineCurve = 'linear'\|'monotone'\|'step'` |
-| `fromZero` + `segments={4}` + `yAxisInterval` | `yDomain={[0, niceMax]}` | **no segment count** — see Trade-offs |
-| `formatYLabel={(s) => …}` | `formatYLabel={(n) => …}` | value is now a **number** (drop `parseFloat`) |
-| `formatXLabel={(s) => …}` | `formatXLabel={(value, index) => …}` | value is `ChartXValue` |
+| `data={{ labels, datasets }}` | `data={chartData}` + `xKey="day"` + `series={chartSeries}` | array-of-records model |
+| per-dataset `color` / `strokeWidth` (fns) | `series[].color` / `series[].strokeWidth` | static string, not a fn |
+| per-dataset `withDots: false` | `series[].dot: false` | `dot: { radius: 2 }` to size dots |
+| `bezier` | `curve="monotone"` | `LineCurve = 'linear' \| 'monotone' \| 'step'` |
+| `fromZero` + `segments={4}` + `yAxisInterval` | `yDomain={[0, niceMax]}` (else `'auto'`) | **no segment-count control** — see tuning |
+| `formatYLabel={(s)=>…}` | `formatYLabel={(n)=>…}` | value is a number now (`parseFloat` still tolerates both) |
+| `formatXLabel={(s)=>…}` | `formatXLabel={(value,index)=>…}` | value is `ChartXValue` |
 | `withVerticalLines={false}` | `showVerticalGridLines={false}` | |
-| `withHorizontalLines` / `withInnerLines` | `showHorizontalGridLines` | |
-| `withLegend={false}` | `legend={false}` | keep the custom legend table below the chart |
-| `chartConfig={{ backgroundColor, color, labelColor, … }}` | `theme={chartTheme}` | see *Theming* |
-| `decorator={() => <Line …/>}` (today marker) | removed | see *Trade-offs* |
-| `width` / `height` | `width` / `height` | unchanged |
+| `withHorizontalLines`/`withInnerLines` | `showHorizontalGridLines` | |
+| `withLegend={false}` | `legend={false}` | custom legend table kept below the chart |
+| `chartConfig={{ … }}` | `theme={chartTheme}` | `CartesianChartTheme` |
+| `decorator` (today line) | removed | replaced by the actual/forecast split |
 
-New, opt-in (the upside of migrating):
+## Known tuning items (verify/adjust on device)
 
-```jsx
-crosshair                                  // vertical inspector line on touch
-tooltip                                    // value bubble on touch
-defaultSelectedIndex={todayIndex}          // optional: open crosshair at "today" on mount
-accessibilityLabel={getLineChartAccessibilitySummary({
-  data: chartData, xKey: 'day', series, formatXLabel, formatYLabel,
-})}
-```
+1. **Today boundary when "today" isn't a labelled day.** The forecast series
+   includes the boundary day only when `currentDay` is present in
+   `balanceHistoryData.labels`. When it isn't, there can be a small visual gap
+   between the last `actual` point and the first `forecast` point. If that reads
+   poorly, extend `chartData` so the `forecast` series also carries the last
+   actual value (seed it at the last actual index).
+2. **Y-axis ladder.** v2 owns the axis model; `yDomain` pins the range but not the
+   1/2/5 "nice" segment count the old chart drew via `segments={4}`. Confirm the
+   gridlines/labels still read cleanly; adjust `yDomain` if needed.
+3. **Crosshair/tooltip provider.** A single chart manages its own selection state,
+   but if the crosshair/tooltip misbehave, wrap the chart in `ChartSelectionProvider`
+   (exported from `react-native-chart-kit/v2`).
+4. **Accessibility.** A static `accessibilityLabel` is used. The richer
+   `getLineChartAccessibilitySummary` helper is **not** re-exported from the
+   `/v2` barrel (only `LineChart` is), so it can't be imported from the public
+   subpath — don't try to wire it without a deeper import.
 
-## 5. Trade-offs (the parts that need a human eye)
+## Test/mock notes
 
-1. **Vertical "today" line.** v2 `referenceLines` are **horizontal (y-based) only** —
-   there is no vertical-at-x primitive. Recommended replacement: the
-   actual/forecast **series split** in §3 (solid up to today, dashed after) makes
-   the boundary self-evident. If you want an explicit on-rest vertical marker,
-   set `defaultSelectedIndex={todayIndex}` with `crosshair` enabled, or supply a
-   custom `renderCrosshair`. Verify which reads best on device.
+- The chart is mocked at `react-native-chart-kit/v2` in `jest.setup.js`,
+  `__tests__/components/BalanceHistoryCard.test.js`, and
+  `__tests__/screens/GraphsScreen.test.js`.
+- Component-test assertions read `lineChart.props.data` (records) and
+  `lineChart.props.series` (accessor config) instead of the old
+  `data.labels` / `data.datasets`.
 
-2. **Nice-scale Y axis.** v6 used `segments={4}` + `yAxisInterval` for the bespoke
-   1/2/5 "nice" ladder. v2 owns the axis model; you can pin the **range** via
-   `yDomain={[min, niceMax]}` but not the **segment count**. Gridline spacing will
-   be whatever v2 picks — eyeball that the labels still read cleanly (`K`/`M`
-   compaction via `formatYLabel` still applies).
+## Visual verification checklist (on device/emulator)
 
-## 6. Theming
-
-`CartesianChartTheme` maps directly onto the app palette (all keys optional):
-
-```js
-const chartTheme = {
-  background: colors.altRow,
-  plotBackground: colors.altRow,
-  grid: colors.border,
-  axis: colors.mutedText,
-  text: colors.mutedText,
-  series: [colors.primary], // fallback ramp; explicit series colors win
-  tooltip: {
-    background: colors.surface,
-    border: colors.border,
-    text: colors.text,
-    mutedText: colors.mutedText,
-  },
-};
-```
-
-Pass via `theme={chartTheme}`. (A `ChartKitProvider` wrapper also exists if you
-later theme multiple charts together.)
-
-## 7. Hidden-balance mode
-
-Still handled in `formatYLabel`: `formatYLabel={hideBalances ? () => '' : formatFn}`.
-The tooltip also surfaces values, so when `hideBalances` is on, also set
-`tooltip={false}` (and skip `accessibilityLabel`'s numeric summary) to avoid
-leaking amounts.
-
-## 8. Test + mock changes (required to keep the suite green)
-
-The current tests assert on the **v6 prop shape** and mock the **root** import.
-Both must change:
-
-- **`jest.setup.js`** — add a mock for the subpath (keep the existing root mock):
-  ```js
-  jest.mock('react-native-chart-kit/v2', () => ({
-    LineChart: () => 'LineChart',
-    getLineChartAccessibilitySummary: () => 'balance history chart',
-  }));
-  ```
-- **`__tests__/components/BalanceHistoryCard.test.js`** — switch the local
-  `jest.mock('react-native-chart-kit', …)` to `'react-native-chart-kit/v2'`, then
-  rewrite the data-shape assertions:
-  - `lineChart.props.data.labels` → the `day` field of `lineChart.props.data` records.
-  - `lineChart.props.data.datasets` (length/`[i].data`/`.strokeWidth`/`.withDots`/`.color()`)
-    → `lineChart.props.series` entries (`yKey`, `strokeWidth`, `dot`, `color` as a
-    plain string) and the per-key values inside `lineChart.props.data`.
-  - `formatYLabel('1500000')` → `formatYLabel(1500000)` (number arg) still returns `'2M'`.
-  - The legend-table assertions (`getByText('Actual')`, daily-avg regression cases,
-    etc.) are **unaffected** — they read the DOM, not chart props.
-- **`__tests__/screens/GraphsScreen.test.js`** — add the same `/v2` mock since the
-  screen renders `BalanceHistoryCard`.
-
-## 9. Visual verification checklist (on device/emulator)
-
-- [ ] Actual line solid; forecast continues dashed from **today**; segments meet.
-- [ ] Y-axis labels still compact (`K`/`M`) and gridlines read cleanly.
-- [ ] All series present with correct colors (primary / grey plain-avg / purple
-      prev-month / grey zero baseline).
+- [ ] Actual line solid; forecast continues dashed from today; segments meet (no jarring gap).
+- [ ] Y-axis labels compact (`K`/`M`) and gridlines read cleanly.
+- [ ] All series present with correct colors (primary / grey plain-avg / purple prev-month / grey zero baseline).
 - [ ] `hideBalances` blanks Y labels **and** suppresses tooltip values.
 - [ ] Sparse X labels (1, 5, 10, 15, 20, 25, last day) only.
-- [ ] Crosshair + tooltip appear on touch; today marker reads correctly.
+- [ ] Crosshair + tooltip appear on touch.
 - [ ] Light **and** dark themes.
 - [ ] Past month (no forecast) vs current month (with forecast) both correct.
 
 ## References
 
-- Modern props: `react-native-chart-kit/dist/v2/react-native/charts/line/types.d.ts`
+- Props: `react-native-chart-kit/dist/v2/react-native/charts/line/types.d.ts`
   (`LineChartProps`, `LineChartSeries`, reference/tooltip/crosshair configs).
 - Theme: `…/dist/v2/react-native/theme/presets.d.ts` (`CartesianChartTheme`).
-- Accessibility: `…/charts/line/accessibility.d.ts`
-  (`getLineChartAccessibilitySummary`, `getLineChartDataTable`).

--- a/docs/BALANCE_HISTORY_CHARTKIT_V2_MIGRATION.md
+++ b/docs/BALANCE_HISTORY_CHARTKIT_V2_MIGRATION.md
@@ -1,0 +1,199 @@
+# Balance History → react-native-chart-kit v2 (modern) migration guide
+
+Status: **planned / not yet applied to the live chart.**
+
+This repo now depends on `react-native-chart-kit@^7.0.1` (bumped from v6). v7 keeps
+the **legacy root import** (`import { LineChart } from 'react-native-chart-kit'`)
+fully backward-compatible, so `BalanceHistoryCard.js` still renders unchanged on
+v7. This document describes how to move that one chart to the **modern v2**
+`LineChart` (`react-native-chart-kit/v2`) to gain a built-in crosshair, tooltips,
+and accessibility — and what does **not** map cleanly.
+
+> Why this is a guide and not a finished swap: the v2 `LineChart` is a ground-up
+> redesign (generic, data-accessor API). The balance-history chart is the app's
+> most complex (4 overlaid series, a bespoke nice-scale Y axis, a hand-drawn
+> "today" marker, hidden-balance mode). Two of those features have **no clean v2
+> equivalent** (see *Trade-offs*), so the swap needs to be tuned against a live
+> render on a device/emulator. Apply the steps below where you can actually see
+> the chart.
+
+---
+
+## 1. Prerequisite (done)
+
+`package.json` → `"react-native-chart-kit": "^7.0.1"`. Peer ranges that v7
+requires are already satisfied: `react >=19.1` (app: 19.2.3),
+`react-native >=0.81` (0.85.3), `react-native-svg >=15.12.1 <16` (15.15.4).
+
+Run `npm install` after pulling so the `react-native-chart-kit/v2` subpath
+resolves.
+
+## 2. Import change
+
+```diff
+- import { LineChart } from 'react-native-chart-kit';
++ import { LineChart, getLineChartAccessibilitySummary } from 'react-native-chart-kit/v2';
+```
+
+The legacy `Line`, `Text as SvgText`, `G` imports from `react-native-svg` used by
+the old `decorator` can be removed (see *Trade-offs → today marker*).
+
+## 3. Data model change
+
+v6 took parallel arrays (`{ labels, datasets: [{ data }] }`). v2 takes an
+**array of records** plus a per-series accessor config:
+
+```js
+// Build once from the existing `chartComputed` memo — all the data prep is reused.
+const chartData = balanceHistoryData.labels.map((day, i) => {
+  const isForecastDay = isCurrentMonth && chartComputed.hasForecast && day > chartComputed.currentDay;
+  return {
+    day: String(day),
+    // Split the old combined line into actual (solid) vs forecast (dashed) so the
+    // "today" boundary is shown by the data itself — no manual vertical line needed.
+    actual:   isForecastDay ? null : (chartComputed.combinedActualForecast[i] ?? null),
+    forecast: isForecastDay ? (chartComputed.combinedActualForecast[i] ?? null) : null,
+    plainAvg: chartComputed.plainAvgData[i] ?? null,
+    prevMonth: balanceHistoryData.prevMonth?.[i] ?? null,
+    zero: 0,
+  };
+});
+// Bridge actual→forecast: also set forecast at the boundary day = actual value,
+// so the two segments visually touch at "today".
+```
+
+```js
+const series = [
+  { yKey: 'actual',   color: colors.primary, strokeWidth: 3, curve: 'monotone',
+    dot: { radius: 2 } },
+  { yKey: 'forecast', color: colors.primary, strokeWidth: 3, curve: 'monotone',
+    strokeDasharray: [5, 5], dot: false },
+  { yKey: 'plainAvg', color: 'rgba(128,128,128,0.4)', strokeWidth: 2, dot: false },
+  // prevMonth series added conditionally (same guard as today)
+  ...(chartComputed.hasPrevMonthData
+    ? [{ yKey: 'prevMonth', color: 'rgba(156,39,176,0.5)', strokeWidth: 2, dot: false }]
+    : []),
+  { yKey: 'zero', color: 'rgba(128,128,128,0.5)', strokeWidth: 1, dot: false },
+];
+```
+
+## 4. Prop mapping (v6 → v2)
+
+| v6 prop | v2 equivalent | Notes |
+|---|---|---|
+| `data={{ labels, datasets }}` | `data={chartData}` + `xKey="day"` + `series={series}` | array-of-records model |
+| per-dataset `color` / `strokeWidth` | `series[].color` / `series[].strokeWidth` | static string, not a fn |
+| per-dataset `withDots: false` | `series[].dot: false` | or `dot: { radius }` |
+| `propsForDots={{ r: '2' }}` | `series[].dot: { radius: 2 }` | per-series now |
+| `bezier` | `series[].curve: 'monotone'` (or top-level `curve`) | `LineCurve = 'linear'\|'monotone'\|'step'` |
+| `fromZero` + `segments={4}` + `yAxisInterval` | `yDomain={[0, niceMax]}` | **no segment count** — see Trade-offs |
+| `formatYLabel={(s) => …}` | `formatYLabel={(n) => …}` | value is now a **number** (drop `parseFloat`) |
+| `formatXLabel={(s) => …}` | `formatXLabel={(value, index) => …}` | value is `ChartXValue` |
+| `withVerticalLines={false}` | `showVerticalGridLines={false}` | |
+| `withHorizontalLines` / `withInnerLines` | `showHorizontalGridLines` | |
+| `withLegend={false}` | `legend={false}` | keep the custom legend table below the chart |
+| `chartConfig={{ backgroundColor, color, labelColor, … }}` | `theme={chartTheme}` | see *Theming* |
+| `decorator={() => <Line …/>}` (today marker) | removed | see *Trade-offs* |
+| `width` / `height` | `width` / `height` | unchanged |
+
+New, opt-in (the upside of migrating):
+
+```jsx
+crosshair                                  // vertical inspector line on touch
+tooltip                                    // value bubble on touch
+defaultSelectedIndex={todayIndex}          // optional: open crosshair at "today" on mount
+accessibilityLabel={getLineChartAccessibilitySummary({
+  data: chartData, xKey: 'day', series, formatXLabel, formatYLabel,
+})}
+```
+
+## 5. Trade-offs (the parts that need a human eye)
+
+1. **Vertical "today" line.** v2 `referenceLines` are **horizontal (y-based) only** —
+   there is no vertical-at-x primitive. Recommended replacement: the
+   actual/forecast **series split** in §3 (solid up to today, dashed after) makes
+   the boundary self-evident. If you want an explicit on-rest vertical marker,
+   set `defaultSelectedIndex={todayIndex}` with `crosshair` enabled, or supply a
+   custom `renderCrosshair`. Verify which reads best on device.
+
+2. **Nice-scale Y axis.** v6 used `segments={4}` + `yAxisInterval` for the bespoke
+   1/2/5 "nice" ladder. v2 owns the axis model; you can pin the **range** via
+   `yDomain={[min, niceMax]}` but not the **segment count**. Gridline spacing will
+   be whatever v2 picks — eyeball that the labels still read cleanly (`K`/`M`
+   compaction via `formatYLabel` still applies).
+
+## 6. Theming
+
+`CartesianChartTheme` maps directly onto the app palette (all keys optional):
+
+```js
+const chartTheme = {
+  background: colors.altRow,
+  plotBackground: colors.altRow,
+  grid: colors.border,
+  axis: colors.mutedText,
+  text: colors.mutedText,
+  series: [colors.primary], // fallback ramp; explicit series colors win
+  tooltip: {
+    background: colors.surface,
+    border: colors.border,
+    text: colors.text,
+    mutedText: colors.mutedText,
+  },
+};
+```
+
+Pass via `theme={chartTheme}`. (A `ChartKitProvider` wrapper also exists if you
+later theme multiple charts together.)
+
+## 7. Hidden-balance mode
+
+Still handled in `formatYLabel`: `formatYLabel={hideBalances ? () => '' : formatFn}`.
+The tooltip also surfaces values, so when `hideBalances` is on, also set
+`tooltip={false}` (and skip `accessibilityLabel`'s numeric summary) to avoid
+leaking amounts.
+
+## 8. Test + mock changes (required to keep the suite green)
+
+The current tests assert on the **v6 prop shape** and mock the **root** import.
+Both must change:
+
+- **`jest.setup.js`** — add a mock for the subpath (keep the existing root mock):
+  ```js
+  jest.mock('react-native-chart-kit/v2', () => ({
+    LineChart: () => 'LineChart',
+    getLineChartAccessibilitySummary: () => 'balance history chart',
+  }));
+  ```
+- **`__tests__/components/BalanceHistoryCard.test.js`** — switch the local
+  `jest.mock('react-native-chart-kit', …)` to `'react-native-chart-kit/v2'`, then
+  rewrite the data-shape assertions:
+  - `lineChart.props.data.labels` → the `day` field of `lineChart.props.data` records.
+  - `lineChart.props.data.datasets` (length/`[i].data`/`.strokeWidth`/`.withDots`/`.color()`)
+    → `lineChart.props.series` entries (`yKey`, `strokeWidth`, `dot`, `color` as a
+    plain string) and the per-key values inside `lineChart.props.data`.
+  - `formatYLabel('1500000')` → `formatYLabel(1500000)` (number arg) still returns `'2M'`.
+  - The legend-table assertions (`getByText('Actual')`, daily-avg regression cases,
+    etc.) are **unaffected** — they read the DOM, not chart props.
+- **`__tests__/screens/GraphsScreen.test.js`** — add the same `/v2` mock since the
+  screen renders `BalanceHistoryCard`.
+
+## 9. Visual verification checklist (on device/emulator)
+
+- [ ] Actual line solid; forecast continues dashed from **today**; segments meet.
+- [ ] Y-axis labels still compact (`K`/`M`) and gridlines read cleanly.
+- [ ] All series present with correct colors (primary / grey plain-avg / purple
+      prev-month / grey zero baseline).
+- [ ] `hideBalances` blanks Y labels **and** suppresses tooltip values.
+- [ ] Sparse X labels (1, 5, 10, 15, 20, 25, last day) only.
+- [ ] Crosshair + tooltip appear on touch; today marker reads correctly.
+- [ ] Light **and** dark themes.
+- [ ] Past month (no forecast) vs current month (with forecast) both correct.
+
+## References
+
+- Modern props: `react-native-chart-kit/dist/v2/react-native/charts/line/types.d.ts`
+  (`LineChartProps`, `LineChartSeries`, reference/tooltip/crosshair configs).
+- Theme: `…/dist/v2/react-native/theme/presets.d.ts` (`CartesianChartTheme`).
+- Accessibility: `…/charts/line/accessibility.d.ts`
+  (`getLineChartAccessibilitySummary`, `getLineChartDataTable`).

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -483,10 +483,14 @@ jest.mock('@react-native-community/datetimepicker', () => {
   };
 });
 
-// Mock react-native-chart-kit
+// Mock react-native-chart-kit (legacy root + modern v2 subpath)
 jest.mock('react-native-chart-kit', () => ({
   LineChart: () => 'LineChart',
   PieChart: () => 'PieChart',
+}));
+
+jest.mock('react-native-chart-kit/v2', () => ({
+  LineChart: () => 'LineChart',
 }));
 
 // Mock react-native-svg


### PR DESCRIPTION
## Summary

Bumps `react-native-chart-kit` to v7 and migrates the balance-history chart (`BalanceHistoryCard`) from the legacy chart to the modern **v2** `LineChart` (`react-native-chart-kit/v2`). This adds a built-in crosshair + tooltips and accessibility, and deletes the fragile hand-drawn "today" decorator (and its hardcoded chart geometry).

> ⚠️ **Needs on-device visual verification before merge.** The test suite *mocks* the chart and there's no emulator in CI, so green CI does **not** prove the chart renders correctly. Checklist + tuning notes are in `docs/BALANCE_HISTORY_CHARTKIT_V2_MIGRATION.md`.

## Changes

- **package.json** — `react-native-chart-kit` `^6.12.0` → `^7.0.1` (makes the `/v2` subpath available).
- **app/components/graphs/BalanceHistoryCard.js** — render the v2 `LineChart`: array-of-records `data` + per-series accessor `series`; the combined actual+forecast line + vertical decorator become a solid `actual` series (≤ today) and a dashed `forecast` series (≥ today), so the solid→dashed boundary *is* the today marker; `CartesianChartTheme` from app colors; `yDomain` instead of `fromZero`/`segments`; `curve="monotone"` instead of `bezier`; built-in `crosshair`/`tooltip` (tooltip off when `hideBalances`)/grid/`legend={false}`; static localized `accessibilityLabel`. All existing `chartComputed` data prep is reused.
- **jest.setup.js, __tests__/components/BalanceHistoryCard.test.js, __tests__/screens/GraphsScreen.test.js** — mock the `react-native-chart-kit/v2` subpath; component assertions now read `props.data` (records) and `props.series` instead of `data.labels`/`data.datasets`.
- **docs/BALANCE_HISTORY_CHARTKIT_V2_MIGRATION.md** — legacy→v2 prop mapping, on-device verification checklist, and known tuning items.

### Known tuning items (verify on device)
1. Today-boundary gap when "today" isn't a labelled day (forecast seeds the boundary only when `currentDay` is in `labels`).
2. v2 owns the Y-axis segment count (`yDomain` pins range, not the 1/2/5 ladder `segments={4}` drew).
3. If crosshair/tooltip misbehave, wrap in `ChartSelectionProvider` (exported from `/v2`).

### Dependency safety
Same maintainers as v6 (`hermanya` + `olegberman`); org moved `indiespirit` → `chart-kit`. No preinstall/install/postinstall scripts. Peer ranges satisfied: `react >=19.1` (19.2.3), `react-native >=0.81` (0.85.3), `react-native-svg >=15.12.1 <16` (15.15.4).

## Testing

- `npm test` (`jest --silent`) locally: **138 suites / 4043 tests pass.**
- `npx eslint` on all changed files: clean.
- ❌ **Not** visually verified — no device/emulator in this environment (the chart is mocked in tests). See the doc's checklist before merging.

## Checklist

- [x] Title follows Conventional Commits (`feat(graphs): …`)
- [x] `npm test` green (138 suites / 4043 tests, local + CI)
- [x] User-facing strings: reuses the existing `balance_history` key (present in all 11 `assets/i18n/*.json`); no new strings
- [x] Relates to Dependabot PR #1115

Relates to #1115
