### PR TITLE
feat(operations): parse DEBIT ACCOUNT notifications without learning category rules

### DIFF
--- a/__tests__/services/notifications/parseBankNotification.test.js
+++ b/__tests__/services/notifications/parseBankNotification.test.js
@@ -225,6 +225,52 @@ describe('parseBankNotification', () => {
     });
   });
 
+  describe('DEBIT ACCOUNT template (direct debit via API gateway)', () => {
+    // The Ameria "ARCA transaction" DEBIT ACCOUNT notification from the design.
+    const AMERIA_DEBIT_ACCOUNT = {
+      title: 'АРКА транзакции',
+      text: 'DEBIT ACCOUNT | 7,500.00 AMD | 4083***7027, | AMERIABANK API GATE, AM | 01.07.2026 12:02 | BALANCE: 104,320.20 AMD',
+      packageName: 'com.banqr.ameriabank',
+      postTime: 1782000900000,
+    };
+    let result;
+    beforeEach(() => {
+      result = parseBankNotification(AMERIA_DEBIT_ACCOUNT);
+    });
+
+    it('recognizes DEBIT ACCOUNT as a transaction', () => {
+      expect(result).not.toBeNull();
+    });
+
+    it('maps DEBIT ACCOUNT to an expense operation', () => {
+      expect(result.kind).toBe('DEBIT ACCOUNT');
+      expect(result.type).toBe('expense');
+    });
+
+    it('extracts amount, currency, card mask, merchant, country, date and time', () => {
+      expect(result.amount).toBe('7500.00');
+      expect(result.currency).toBe('AMD');
+      expect(result.cardMask).toBe('4083***7027');
+      expect(result.merchant).toBe('AMERIABANK API GATE');
+      expect(result.country).toBe('AM');
+      expect(result.date).toBe('2026-07-01');
+      expect(result.time).toBe('12:02');
+    });
+
+    it('flags that the category must be chosen manually (no learned binding)', () => {
+      expect(result.requiresCategory).toBe(true);
+    });
+
+    it('recognizes the DEBIT ACCOUNT keyword case-insensitively', () => {
+      const lower = parseBankNotification({
+        ...AMERIA_DEBIT_ACCOUNT,
+        text: AMERIA_DEBIT_ACCOUNT.text.replace('DEBIT ACCOUNT', 'debit account'),
+      });
+      expect(lower.kind).toBe('DEBIT ACCOUNT');
+      expect(lower.requiresCategory).toBe(true);
+    });
+  });
+
   describe('PRE-PURCHASE (authorization hold) is ignored to avoid duplicates', () => {
     it('returns null for a PRE-PURCHASE notification', () => {
       expect(
@@ -246,6 +292,11 @@ describe('parseBankNotification', () => {
     it('is true for C2C (any case)', () => {
       expect(kindRequiresCategory('C2C')).toBe(true);
       expect(kindRequiresCategory('c2c')).toBe(true);
+    });
+
+    it('is true for DEBIT ACCOUNT (any case)', () => {
+      expect(kindRequiresCategory('DEBIT ACCOUNT')).toBe(true);
+      expect(kindRequiresCategory('debit account')).toBe(true);
     });
 
     it('is false for PURCHASE and unknown/empty kinds', () => {

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -597,5 +597,20 @@ describe('processBankNotifications', () => {
       // ...but the friend -> category rule is never remembered.
       expect(NotificationRulesDB.upsertMerchantRule).not.toHaveBeenCalled();
     });
+
+    it('does not learn a merchant rule for a DEBIT ACCOUNT debit, even with a category', async () => {
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        ...pending, kind: 'DEBIT ACCOUNT', merchant: 'AMERIABANK API GATE',
+      });
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-fees' });
+
+      // The operation is still created and the card still learned...
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: 7, categoryId: 'cat-fees' }),
+      );
+      expect(AccountsDB.setAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
+      // ...but the generic gateway -> category rule is never remembered.
+      expect(NotificationRulesDB.upsertMerchantRule).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/services/notifications/bankParsers/ameriabank.js
+++ b/app/services/notifications/bankParsers/ameriabank.js
@@ -2,12 +2,18 @@
  * Bank notification parser for the Ameriabank app (`com.banqr.ameriabank`).
  *
  * Ameria posts each card event as a single pipe-delimited "ARCA transaction"
- * line. Four kinds are recognized today:
+ * line. Five kinds are recognized today:
  *
  *   PURCHASE                | 3,900.00 AMD  | 4083***7027, | NAREK MEHRABYAN, AM | 28.06.2026 10:15 | BALANCE: 133,719.97 AMD
  *   E-POS PURCHASE          | 129.99 EUR    | 4083***7027, | Nike ES, ES         | 29.06.2026 15:14 | BALANCE: 27,608.20 AMD
  *   C2C                     | 19,200.00 AMD | 4083***7027, | TO: N. DORVANYAN | AMERIABANK API GATE, AM | 28.06.2026 16:23 | BALANCE: 106,819.97 AMD
  *   PRE-PURCHASE COMPLETION | 2,800.00 AMD  | 4083***7027, | YANDEX.GO, AM | 30.06.2026 13:51 | BALANCE: 19,095.20 AMD
+ *   DEBIT ACCOUNT           | 7,500.00 AMD  | 4083***7027, | AMERIABANK API GATE, AM | 01.07.2026 12:02 | BALANCE: 104,320.20 AMD
+ *
+ * DEBIT ACCOUNT is a direct debit routed through the bank's API gateway (its
+ * merchant segment is the generic "AMERIABANK API GATE"). Like C2C, that generic
+ * counterparty covers many unrelated debits, so its category can never be inferred
+ * or learned — it is always reviewed manually (see KINDS_REQUIRING_CATEGORY).
  *
  * PRE-PURCHASE (the initial authorization hold) is intentionally ignored —
  * PRE-PURCHASE COMPLETION is the actual settled charge, so recording both
@@ -57,6 +63,11 @@ const KIND_TO_TYPE = {
   // amount may differ from the hold (e.g. a taxi fare calculated after the ride).
   // PRE-PURCHASE itself is intentionally omitted to avoid duplicate entries.
   'PRE-PURCHASE COMPLETION': 'expense',
+  // Direct debit routed through the bank's API gateway. An expense whose
+  // counterparty ("AMERIABANK API GATE") is generic across many unrelated
+  // debits, so — like C2C — its category cannot be inferred or learned. See
+  // KINDS_REQUIRING_CATEGORY below.
+  'DEBIT ACCOUNT': 'expense',
 };
 
 const KNOWN_KINDS = Object.keys(KIND_TO_TYPE);
@@ -65,10 +76,12 @@ const KNOWN_KINDS = Object.keys(KIND_TO_TYPE);
  * Kinds whose category must always be chosen by the user instead of being
  * inferred from learned merchant rules. A client-to-client transfer goes to the
  * same counterparty (a friend) for many different reasons, so any single learned
- * category would be wrong as often as right. These always land in the review
- * queue with the category left blank.
+ * category would be wrong as often as right. A DEBIT ACCOUNT is a direct debit
+ * whose merchant is the generic "AMERIABANK API GATE" gateway, which likewise
+ * spans many unrelated debits. These always land in the review queue with the
+ * category left blank, and no merchant rule is ever learned for them.
  */
-const KINDS_REQUIRING_CATEGORY = new Set(['C2C']);
+const KINDS_REQUIRING_CATEGORY = new Set(['C2C', 'DEBIT ACCOUNT']);
 
 /**
  * Whether a notification kind must always have its category chosen manually.
@@ -190,7 +203,7 @@ const toIsoDate = (day, month, year) => {
  *   country: string|null,     // ISO alpha-2, e.g. 'AM'
  *   date: string|null,        // 'YYYY-MM-DD'
  *   time: string|null,        // 'HH:MM'
- *   requiresCategory: boolean,// true when the category must be chosen manually (C2C)
+ *   requiresCategory: boolean,// true when the category must be chosen manually (C2C, DEBIT ACCOUNT)
  *   packageName: string|null, // source app, passed through for rule scoping
  *   raw: string,              // the original text, kept for auditing/debugging
  * }}
@@ -288,7 +301,8 @@ export const parse = (notification) => {
     country,
     date,
     time,
-    // C2C transfers must always be reviewed so the user picks the category.
+    // C2C transfers and DEBIT ACCOUNT debits must always be reviewed so the user
+    // picks the category (their counterparty is too generic to learn a rule from).
     requiresCategory: kindRequiresCategory(kind),
     packageName: notification.packageName || null,
     raw: text,


### PR DESCRIPTION
## Summary

Ameriabank posts direct debits routed through its API gateway as a new `DEBIT ACCOUNT` "ARCA transaction" kind that the app previously did not recognize. Its merchant segment is the generic `AMERIABANK API GATE` gateway, which spans many unrelated debits — so, exactly like a C2C transfer, its category can never be inferred or learned. This adds the kind and routes it into the manual-review queue while ensuring no merchant → category binding is ever saved for it.

Example notification:

```
DEBIT ACCOUNT | 7,500.00 AMD | 4083***7027, | AMERIABANK API GATE, AM | 01.07.2026 12:02 | BALANCE: 104,320.20 AMD
```

## Changes

- **app/services/notifications/bankParsers/ameriabank.js** — add `DEBIT ACCOUNT` to `KIND_TO_TYPE` (maps to `expense`) and to `KINDS_REQUIRING_CATEGORY`, so the parser flags `requiresCategory: true`. This reuses the existing C2C path: the resolver never auto-assigns a category, the pipeline never auto-creates the operation, and `resolvePendingNotification` never calls `upsertMerchantRule` for it. Updated the module docs accordingly.
- **__tests__/services/notifications/parseBankNotification.test.js** — add a DEBIT ACCOUNT parsing block (fields, `requiresCategory`, case-insensitive keyword) and extend `kindRequiresCategory` coverage.
- **__tests__/services/notifications/processBankNotifications.test.js** — add a test asserting that resolving a DEBIT ACCOUNT pending notification creates the operation and learns the card mask but never saves a merchant → category rule.

## Testing

- `npm test` — 138 suites / 4065 tests pass.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no user-facing strings)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3s5AdUsZVVbgYJmCnhUei)_