### PR TITLE
fix(notifications): round amounts when resolving from the review queue

### DIFF
--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -524,6 +524,39 @@ describe('processBankNotifications', () => {
       );
     });
 
+    it('rounds the booked amount per the account rounding setting (regression)', async () => {
+      // A merchant charge of 7160 AMD resolved from the review queue against an
+      // account with rounding=100 must be stored as 7200 — matching the
+      // auto-create path, which previously rounded while this path did not.
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        ...pending, amount: '7160.00', currency: 'AMD',
+      });
+      AccountsDB.getAccountById.mockResolvedValue({ id: 7, currency: 'AMD', autoTxnRounding: 100 });
+
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-food' });
+
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: '7200' }),
+      );
+    });
+
+    it('rounds the converted amount on a currency mismatch, leaving the foreign value intact', async () => {
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        ...pending, amount: '129.99', currency: 'EUR', merchant: 'Nike ES',
+      });
+      AccountsDB.getAccountById.mockResolvedValue({ id: 7, currency: 'AMD', autoTxnRounding: 100 });
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '418.5', source: 'offline' });
+
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-shopping' });
+
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: '54400',           // 54401 AMD rounded to the nearest 100
+          destinationAmount: '129.99', // original foreign value preserved (unrounded)
+        }),
+      );
+    });
+
     it('throws (does not book a wrong amount) when no rate is available for a foreign purchase', async () => {
       PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
         ...pending, amount: '129.99', currency: 'EUR',
@@ -729,6 +762,36 @@ describe('processBankNotifications', () => {
         pipeline.resolvePendingNotification('pt1', { accountId: 7, toAccountId: 7 }),
       ).rejects.toThrow(/same source and target/);
       expect(OperationsDB.createOperation).not.toHaveBeenCalled();
+    });
+
+    it('rounds a same-currency transfer amount per the source account rounding (regression)', async () => {
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        ...pendingTransfer, amount: '200160.00',
+      });
+      AccountsDB.getAccountById.mockImplementation(async (id) =>
+        id === 7 ? { id: 7, currency: 'AMD', autoTxnRounding: 100 } : id === 9 ? { id: 9, currency: 'AMD' } : null);
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [])(key));
+
+      await pipeline.resolvePendingNotification('pt1', { accountId: 7, toAccountId: 9 });
+
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'transfer', amount: '200200' }),
+      );
+    });
+
+    it('does not round a cross-currency transfer amount (destination amount kept intact)', async () => {
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue(pendingTransfer);
+      AccountsDB.getAccountById.mockImplementation(async (id) =>
+        id === 7 ? { id: 7, currency: 'AMD', autoTxnRounding: 100 } : id === 9 ? { id: 9, currency: 'USD' } : null);
+      Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: '0.0026', source: 'offline' });
+
+      await pipeline.resolvePendingNotification('pt1', { accountId: 7, toAccountId: 9 });
+
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: '200000', destinationAmount: '520.00',
+        }),
+      );
     });
 
     it('books a cross-currency transfer with a destination amount and rate', async () => {

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -543,6 +543,11 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
   const chosenLabel = hasLabelChoice ? typedLabel : learnedLabel;
   const label = chosenLabel || pending.merchant;
 
+  // Fetch the chosen account once: its currency drives conversion and its
+  // rounding setting is applied to the booked amount below.
+  const account = await AccountsDB.getAccountById(accountId);
+  const accountCurrency = account ? account.currency : null;
+
   // Convert to the chosen account's currency at the current rate when they
   // differ (e.g. a EUR purchase booked against an AMD account). Unlike the
   // auto-create path (which silently re-queues when no rate is available), this
@@ -550,8 +555,6 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
   // rather than booking a wrong amount, surfacing the failure to the caller.
   let currencyFields = { amount: pending.amount };
   if (pending.currency) {
-    const account = await AccountsDB.getAccountById(accountId);
-    const accountCurrency = account ? account.currency : null;
     const built = await buildOperationCurrencyFields(pending, accountCurrency);
     if (built) {
       currencyFields = built;
@@ -560,6 +563,18 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
         `Cannot resolve pending notification ${pendingId}: no exchange rate for ${pending.currency}→${accountCurrency}`,
       );
     }
+  }
+
+  // Apply the account's automatic-transaction rounding (10/100/1000) to the
+  // amount that hits the balance, matching the auto-create path. Only the booked
+  // `amount` is rounded; any preserved foreign `destinationAmount` keeps the
+  // original charged value.
+  const accountRounding = account ? account.autoTxnRounding : null;
+  if (accountRounding) {
+    currencyFields = {
+      ...currencyFields,
+      amount: Currency.roundToNearest(currencyFields.amount, accountRounding, accountCurrency),
+    };
   }
 
   const operation = await OperationsDB.createOperation({
@@ -668,11 +683,23 @@ const resolvePendingTransfer = async (pending, choices = {}) => {
   // Unlike auto-create (which re-queues on a missing rate) this is a user-driven
   // save with no further fallback, so a missing rate throws rather than booking a
   // wrong amount.
-  const transferFields = await buildTransferCurrencyFields(pending, sourceCurrency, targetCurrency);
+  let transferFields = await buildTransferCurrencyFields(pending, sourceCurrency, targetCurrency);
   if (!transferFields) {
     throw new Error(
       `Cannot resolve pending transfer ${pending.id}: no exchange rate for ${pending.currency}→${sourceCurrency}→${targetCurrency}`,
     );
+  }
+
+  // Round the source-side amount only for a same-currency transfer, where the
+  // target receives the identical amount; a cross-currency transfer keeps its
+  // rate-derived destinationAmount intact so both sides stay consistent. Mirrors
+  // the auto-create transfer path.
+  const accountRounding = sourceAccount ? sourceAccount.autoTxnRounding : null;
+  if (accountRounding && !transferFields.destinationAmount) {
+    transferFields = {
+      ...transferFields,
+      amount: Currency.roundToNearest(transferFields.amount, accountRounding, sourceCurrency),
+    };
   }
 
   // An optional custom name typed in the review UI becomes the operation label;


### PR DESCRIPTION
## Summary

The account's **"Round automatic transactions"** setting was only applied on the auto-create path. When a bank notification landed in the review queue and the user resolved it manually (picking a category/account), the amount was booked **unrounded** — e.g. a 7160 AMD charge on the Ameria card (set to round to 100) was stored as `7160` instead of `7200`. Root cause: `resolvePendingNotification` / `resolvePendingTransfer` built the operation amount without ever calling `Currency.roundToNearest`, unlike `bookExpenseOrQueue` / `bookTransferOrQueue`.

## Changes

- **app/services/notifications/processBankNotifications.js** — apply the account's `autoTxnRounding` in `resolvePendingNotification` (fetch the account once up front, round the booked `amount` after any currency conversion) and in `resolvePendingTransfer` (round the source-side `amount` only for same-currency transfers). Mirrors the auto-create path: only the account-currency `amount` is rounded; a preserved foreign `destinationAmount` and cross-currency transfer amounts are left intact.
- **__tests__/services/notifications/processBankNotifications.test.js** — regression tests: same-currency rounding, converted-amount rounding with the foreign value preserved, same-currency transfer rounding, and cross-currency transfer left unrounded.

## Testing

- `npm test` — 138 suites / 4092 tests pass.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no user-facing strings)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwAjVbwUTZkeFfHYWaohVC)_