### PR TITLE
fix: resolve 24 functionality bugs across budgets, backup, dates, and multi-currency flows

### DIFF
--- a/__tests__/contexts/OperationsDataContext-search.test.js
+++ b/__tests__/contexts/OperationsDataContext-search.test.js
@@ -551,6 +551,47 @@ describe('OperationsDataContext - Search API', () => {
           expect(result.current.data.operations).toHaveLength(5);
         });
       });
+
+      it('includes incoming transfers when filtering by the destination account (regression)', async () => {
+        // op-4 is a transfer acc-1 → acc-2. Filtering by acc-2 must show it —
+        // the SQL layer matches account_id OR to_account_id, and the in-memory
+        // filter used to drop incoming transfers silently.
+        const result = await setupWithOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(5);
+        });
+
+        await act(async () => {
+          result.current.actions.updateSearchFilters({ accountIds: ['acc-2'] });
+        });
+
+        await waitFor(() => {
+          const filtered = result.current.data.operations;
+          expect(filtered.map(op => op.id).sort()).toEqual(['op-2', 'op-4', 'op-5']);
+        });
+      });
+    });
+
+    describe('destination account text search (regression)', () => {
+      it('finds transfers by the destination account name', async () => {
+        // "Bank Account" is acc-2's name; op-4 transfers INTO acc-2 and its
+        // description ("Transfer to bank") does not contain the full phrase.
+        const result = await setupWithOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(5);
+        });
+
+        await act(async () => {
+          result.current.actions.updateSearchFilters({ text: 'Bank Account' });
+        });
+
+        await waitFor(() => {
+          const ids = result.current.data.operations.map(op => op.id);
+          expect(ids).toContain('op-4');
+        });
+      });
     });
 
     describe('category filtering', () => {

--- a/__tests__/hooks/useExpenseData.test.js
+++ b/__tests__/hooks/useExpenseData.test.js
@@ -539,6 +539,38 @@ describe('useExpenseData', () => {
       expect(result.current.chartData[0].amount).toBe(150);
     });
 
+    it('should include spending recorded directly on the selected parent category (regression)', async () => {
+      // $50 logged directly on Food itself plus $30 on its child Groceries.
+      // Drilling into Food must show both (total 80, matching Food's slice in
+      // the "all" view) — direct-on-parent spending used to be dropped.
+      const deepCategories = [
+        { id: 'cat-1', name: 'Food', parentId: null, icon: 'food', categoryType: 'expense', isShadow: false },
+        { id: 'cat-2', name: 'Groceries', parentId: 'cat-1', icon: 'cart', categoryType: 'expense', isShadow: false },
+      ];
+      const mockSpending = [
+        { category_id: 'cat-1', total: '50' }, // directly on the selected parent
+        { category_id: 'cat-2', total: '30' }, // on the child
+      ];
+      OperationsDB.getSpendingByCategoryAndCurrency.mockResolvedValue(mockSpending);
+
+      const { result } = await renderHook(() =>
+        useExpenseData(mockYear, mockMonth, mockCurrency, 'cat-1', deepCategories, mockColors, mockT),
+      );
+
+      await act(async () => {
+        await result.current.loadExpenseData();
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.chartData).toHaveLength(2);
+      const foodItem = result.current.chartData.find(item => item.name === 'Food');
+      const groceriesItem = result.current.chartData.find(item => item.name === 'Groceries');
+      expect(foodItem.amount).toBe(50);
+      expect(groceriesItem.amount).toBe(30);
+      expect(result.current.totalExpenses).toBe(80);
+    });
+
     it('should skip item in subfolder view when no ancestor matches selected category', async () => {
       // 'Transport' is in a completely different tree from 'cat-1' (Food)
       const mockSpending = [

--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -1155,6 +1155,114 @@ op-2,income,20,acc-1,cat-1`;
     });
   });
 
+  describe('Regression — soft-delete and adjustment metadata survive restore', () => {
+    const makeMockDbInstance = () => {
+      let insertCount = 0;
+      return {
+        runAsync: jest.fn().mockImplementation(() => {
+          insertCount++;
+          return Promise.resolve({ lastInsertRowId: insertCount });
+        }),
+        getAllAsync: jest.fn().mockResolvedValue([]),
+        getFirstAsync: jest.fn().mockResolvedValue({ 1: 1 }),
+      };
+    };
+
+    it('restores accounts with their deleted_at flag (soft-deleted accounts must not resurrect)', async () => {
+      const mockDbInstance = makeMockDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(mockDbInstance);
+      });
+
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [
+            { id: 1, name: 'Live', balance: '100', currency: 'USD', deleted_at: null },
+            { id: 2, name: 'Deleted', balance: '0', currency: 'USD', deleted_at: '2024-01-02T00:00:00.000Z' },
+          ],
+          categories: [],
+          operations: [],
+          app_metadata: [],
+        },
+      };
+
+      await BackupRestore.restoreBackup(backup);
+
+      const accountInserts = mockDbInstance.runAsync.mock.calls.filter(call =>
+        call[0].startsWith('INSERT INTO accounts'),
+      );
+      expect(accountInserts).toHaveLength(2);
+      accountInserts.forEach(call => expect(call[0]).toContain('deleted_at'));
+
+      const deletedInsert = accountInserts.find(call => call[1].includes('Deleted'));
+      expect(deletedInsert[1]).toContain('2024-01-02T00:00:00.000Z');
+    });
+
+    it('restores operations with their original_balance column', async () => {
+      const mockDbInstance = makeMockDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(mockDbInstance);
+      });
+
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [{ id: 1, name: 'Main', balance: '150', currency: 'USD' }],
+          categories: [],
+          operations: [
+            {
+              id: 10,
+              type: 'income',
+              amount: '50',
+              account_id: 1,
+              date: '2024-01-01',
+              original_balance: '100',
+            },
+          ],
+          app_metadata: [],
+        },
+      };
+
+      await BackupRestore.restoreBackup(backup);
+
+      const operationInserts = mockDbInstance.runAsync.mock.calls.filter(call =>
+        call[0].startsWith('INSERT INTO operations'),
+      );
+      expect(operationInserts).toHaveLength(1);
+      expect(operationInserts[0][0]).toContain('original_balance');
+      expect(operationInserts[0][1]).toContain('100');
+    });
+
+    it('aborts before touching data when a transfer references a missing destination account', async () => {
+      const mockDbInstance = makeMockDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (callback) => {
+        await callback(mockDbInstance);
+      });
+
+      const backup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [{ id: 1, name: 'Main', balance: '100', currency: 'USD' }],
+          categories: [],
+          operations: [
+            { id: 10, type: 'transfer', amount: '50', account_id: 1, to_account_id: 99, date: '2024-01-01' },
+          ],
+          app_metadata: [],
+        },
+      };
+
+      await expect(BackupRestore.restoreBackup(backup)).rejects.toThrow(/account IDs not found/);
+      expect(mockDbInstance.runAsync).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Edge Cases and Regression Tests', () => {
     it('handles large backup data sets', async () => {
       const largeAccounts = Array.from({ length: 1000 }, (_, i) => ({

--- a/__tests__/services/BudgetsDB.test.js
+++ b/__tests__/services/BudgetsDB.test.js
@@ -803,6 +803,43 @@ describe('BudgetsDB Service', () => {
           BudgetsDB.getCurrentPeriodDates('invalid');
         }).toThrow('Invalid period type: invalid');
       });
+
+      describe('Regression Tests', () => {
+        it('weekly period spans exactly 7 days when the week starts in the previous month', async () => {
+          // Thu Jul 2 2026: Monday of that week is Jun 29. The end must be
+          // Sun Jul 5 — the old code applied start's day-of-month (29+6=35)
+          // to a July-based date, producing Aug 4 (a ~5 week "week").
+          const referenceDate = new Date(2026, 6, 2);
+          const { start, end } = BudgetsDB.getCurrentPeriodDates('weekly', referenceDate);
+
+          expect(start.getFullYear()).toBe(2026);
+          expect(start.getMonth()).toBe(5); // June
+          expect(start.getDate()).toBe(29);
+          expect(end.getFullYear()).toBe(2026);
+          expect(end.getMonth()).toBe(6); // July
+          expect(end.getDate()).toBe(5);
+        });
+
+        it('monthly period ends in the same month when the reference day does not exist in the next month', async () => {
+          // Jan 31: setMonth(+1) on the 31st used to roll to Mar 3, then
+          // setDate(0) yielded Feb 28 — a two-month "monthly" period.
+          const referenceDate = new Date(2026, 0, 31);
+          const { start, end } = BudgetsDB.getCurrentPeriodDates('monthly', referenceDate);
+
+          expect(start.getMonth()).toBe(0); // January
+          expect(start.getDate()).toBe(1);
+          expect(end.getMonth()).toBe(0); // January
+          expect(end.getDate()).toBe(31);
+        });
+
+        it('monthly period is correct on the 31st of months preceding 30-day months', async () => {
+          const referenceDate = new Date(2026, 2, 31); // Mar 31
+          const { start, end } = BudgetsDB.getCurrentPeriodDates('monthly', referenceDate);
+
+          expect(end.getMonth()).toBe(2); // March
+          expect(end.getDate()).toBe(31);
+        });
+      });
     });
 
     describe('getNextPeriodDates', () => {

--- a/__tests__/services/CategoriesDB.test.js
+++ b/__tests__/services/CategoriesDB.test.js
@@ -504,6 +504,39 @@ describe('CategoriesDB', () => {
       expect(params).toContain(null);
     });
 
+    it('allows re-parenting to an unrelated category', async () => {
+      mockDb.executeQuery.mockResolvedValue();
+      mockDb.queryAll.mockResolvedValue([]); // no descendants
+
+      await CategoriesDB.updateCategory('cat-1', { parentId: 'cat-9' });
+
+      const [query, params] = mockDb.executeQuery.mock.calls[0];
+      expect(query).toContain('parent_id = ?');
+      expect(params).toContain('cat-9');
+    });
+
+    it('rejects setting a category as its own parent (regression: parent cycle)', async () => {
+      await expect(
+        CategoriesDB.updateCategory('cat-1', { parentId: 'cat-1' }),
+      ).rejects.toThrow(/own parent/);
+      expect(mockDb.executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('rejects re-parenting onto a descendant (regression: parent cycle)', async () => {
+      // cat-2 is a child of cat-1; moving cat-1 under cat-2 would create a cycle
+      mockDb.queryAll.mockImplementation((query, params) => {
+        if (params && params[0] === 'cat-1') {
+          return Promise.resolve([{ id: 'cat-2', name: 'Child', parent_id: 'cat-1' }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      await expect(
+        CategoriesDB.updateCategory('cat-1', { parentId: 'cat-2' }),
+      ).rejects.toThrow(/subcategories/);
+      expect(mockDb.executeQuery).not.toHaveBeenCalled();
+    });
+
     it('always updates updated_at timestamp', async () => {
       mockDb.executeQuery.mockResolvedValue();
 

--- a/app/components/Calculator.js
+++ b/app/components/Calculator.js
@@ -4,6 +4,7 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import { BORDER_RADIUS, SPACING, HEIGHTS } from '../styles/designTokens';
 import { hasOperation as checkHasOperation, evaluateExpression as evalExpr } from '../utils/calculatorUtils';
+import { getDecimalPlaces } from '../services/currency';
 
 /**
  * Calculator button component - Memoized for performance
@@ -213,8 +214,10 @@ export default function Calculator({ value, onValueChange, colors, placeholder =
       if (key === 'backspace') {
         newExpression = prevExpression.slice(0, -1);
       } else if (key === '=') {
-        // Evaluate the expression
-        const result = evalExpr(prevExpression);
+        // Evaluate with the active currency's decimal places so pressing '='
+        // yields the same amount the save path would compute (e.g. 3 decimals
+        // for BHD/KWD, 0 for JPY) instead of the default 2.
+        const result = evalExpr(prevExpression, getDecimalPlaces(currencyCode));
         if (result !== null) {
           newExpression = result;
         }
@@ -242,7 +245,7 @@ export default function Calculator({ value, onValueChange, colors, placeholder =
 
       return newExpression;
     });
-  }, [getLastNumber]);
+  }, [getLastNumber, currencyCode]);
 
   // Handle equals button press - Wrapped with useCallback
   const handleEqualsPress = useCallback(() => {

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -73,9 +73,12 @@ const OperationsList = forwardRef(({
   onDismissSuggestion,
 }, ref) => {
 
-  // Format date label for the separator header
+  // Format date label for the separator header.
+  // Append T00:00:00 so the bare YYYY-MM-DD string parses as LOCAL midnight —
+  // bare date strings parse as UTC, which shifts the day west of Greenwich
+  // (today's section would read "Yesterday" in UTC-negative timezones).
   const formatDate = useCallback((dateString) => {
-    const date = new Date(dateString);
+    const date = new Date(`${dateString}T00:00:00`);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -7,6 +7,7 @@ import { appEvents, EVENTS } from '../services/eventEmitter';
 import { useDialog } from './DialogContext';
 import { setJsonPreference, PREF_KEYS } from '../services/PreferencesDB';
 import { useOperationsData } from './OperationsDataContext';
+import { formatDate as formatLocalDate } from '../services/BalanceHistoryDB';
 
 /**
  * OperationsActionsContext provides stable action functions for operations.
@@ -221,7 +222,8 @@ export const OperationsActionsProvider = ({ children }) => {
         const currentFilters = activeFiltersRef.current;
         const isFiltered = _hasActiveFilters(currentFilters);
 
-        const todayStr = new Date().toISOString().split('T')[0];
+        // Local date — operation dates are stored as local YYYY-MM-DD strings
+        const todayStr = formatLocalDate(new Date());
         let nextOp;
         if (!_oldestLoadedDate) {
           nextOp = isFiltered
@@ -579,10 +581,11 @@ export const OperationsActionsProvider = ({ children }) => {
       const currentFilters = activeFiltersRef.current;
       const isFiltered = _hasActiveFilters(currentFilters);
 
-      // Calculate today's date in YYYY-MM-DD format
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      const todayStr = today.toISOString().split('T')[0];
+      // Calculate today's date in YYYY-MM-DD format using the LOCAL calendar day.
+      // toISOString would yield yesterday's date for UTC+ timezones, silently
+      // excluding today's operations from the loaded range (and hasNewerOperations
+      // is set false below, so they could never be paged back in).
+      const todayStr = formatLocalDate(new Date());
 
       // Load all operations from the selected date to today
       const operationsData = isFiltered

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -160,9 +160,14 @@ export const OperationsDataProvider = ({ children }) => {
           }
         }
 
-        // match account name
+        // match account name (source and transfer destination — SQL search matches
+        // both a.name and to_a.name, so the in-memory pass must agree)
         const accountName = accountNameById.get(op.accountId);
         if (accountName && normalizeSearchText(accountName).includes(searchLower)) {
+          return true;
+        }
+        const toAccountName = op.toAccountId ? accountNameById.get(op.toAccountId) : null;
+        if (toAccountName && normalizeSearchText(toAccountName).includes(searchLower)) {
           return true;
         }
 
@@ -190,9 +195,14 @@ export const OperationsDataProvider = ({ children }) => {
       result = result.filter(op => searchState.types.includes(op.type));
     }
 
-    // account filter
+    // account filter — a transfer belongs to both its source and destination
+    // account (the SQL filters match account_id OR to_account_id; incoming
+    // transfers must not disappear when filtering by the receiving account)
     if (searchState.accountIds.length > 0) {
-      result = result.filter(op => searchState.accountIds.includes(op.accountId));
+      result = result.filter(op =>
+        searchState.accountIds.includes(op.accountId) ||
+        (op.toAccountId != null && searchState.accountIds.includes(op.toAccountId)),
+      );
     }
 
     // category filter

--- a/app/hooks/useBalanceHistory.js
+++ b/app/hooks/useBalanceHistory.js
@@ -69,19 +69,23 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
       const prevHistory = await getBalanceHistory(selectedAccount, prevStartDateStr, prevEndDateStr);
       const prevMonthTotalExpenses = await getTotalExpenses(selectedAccount, prevStartDateStr, prevEndDateStr);
 
-      // Get current month's total expenses for the selected account (used for spending prediction)
-      const currentMonthTotalExpenses = await getTotalExpenses(selectedAccount, startDateStr, endDateStr);
+      // Get current day of month
+      const now = new Date();
+      const isCurrentMonth = selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
+      const currentDay = isCurrentMonth ? now.getDate() : endDate.getDate();
+
+      // Get current month's total expenses for the selected account (used for
+      // spending prediction). For the current month, cap the window at today —
+      // the prediction divides by elapsed days, so future-dated operations
+      // (e.g. scheduled rent later this month) must not inflate the average.
+      const expenseEndStr = isCurrentMonth ? formatDate(now) : endDateStr;
+      const currentMonthTotalExpenses = await getTotalExpenses(selectedAccount, startDateStr, expenseEndStr);
 
       // Transform history data for chart
       const dataPoints = history.map(item => ({
         date: item.date,
         balance: parseFloat(item.balance),
       }));
-
-      // Get current day of month
-      const now = new Date();
-      const isCurrentMonth = selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
-      const currentDay = isCurrentMonth ? now.getDate() : endDate.getDate();
 
       // Generate all days in month for x-axis
       const daysInMonth = endDate.getDate();

--- a/app/hooks/useCategoryMonthlySpending.js
+++ b/app/hooks/useCategoryMonthlySpending.js
@@ -16,8 +16,11 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(false);
 
-  // Generate the last 12 months as YYYY-MM strings
-  const last12Months = useMemo(() => {
+  // Generate the last 12 months as YYYY-MM strings. Computed per call (not
+  // memoized at mount) so the window follows a month rollover during a
+  // long-lived session — the DB query recomputes its window from "now" too,
+  // and the two must agree or the newest month's spending maps to nothing.
+  const getLast12Months = () => {
     const months = [];
     const now = new Date();
     for (let i = 11; i >= 0; i--) {
@@ -30,7 +33,7 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
       });
     }
     return months;
-  }, []);
+  };
 
   // Load monthly spending data
   const loadData = useCallback(async () => {
@@ -62,7 +65,7 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
       // Build array of 12 months (fill 0 for missing months)
       // totals arrive as Decimal-safe strings from the DB layer; convert to float here
       // since chart components need numeric values for bar height arithmetic.
-      const fullYearData = last12Months.map(monthInfo => ({
+      const fullYearData = getLast12Months().map(monthInfo => ({
         yearMonth: monthInfo.yearMonth,
         year: monthInfo.year,
         month: monthInfo.month,
@@ -76,7 +79,7 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
     } finally {
       setLoading(false);
     }
-  }, [selectedCurrency, selectedCategoryId, last12Months]);
+  }, [selectedCurrency, selectedCategoryId]);
 
   // Calculate total yearly spending using Decimal-safe addition before the final float conversion
   const totalYearlySpending = useMemo(() => {

--- a/app/hooks/useExpenseData.js
+++ b/app/hooks/useExpenseData.js
@@ -98,7 +98,15 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
         const category = categoryMap.get(item.category_id);
         if (!category) return;
 
-        if (category.parentId === selectedCategory) {
+        // Spending recorded directly on the selected category itself must not be
+        // dropped — without its own bucket the drill-down total shrinks below the
+        // parent's slice in the "all" view.
+        if (category.id === selectedCategory) {
+          if (!aggregatedSpending[category.id]) {
+            aggregatedSpending[category.id] = { category, total: '0' };
+          }
+          aggregatedSpending[category.id].total = Currency.add(aggregatedSpending[category.id].total, item.total);
+        } else if (category.parentId === selectedCategory) {
           if (!aggregatedSpending[category.id]) {
             aggregatedSpending[category.id] = { category, total: '0' };
           }

--- a/app/hooks/useIncomeData.js
+++ b/app/hooks/useIncomeData.js
@@ -83,7 +83,15 @@ const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIn
         const category = categoryMap.get(item.category_id);
         if (!category) return;
 
-        if (category.parentId === selectedIncomeCategory) {
+        // Income recorded directly on the selected category itself must not be
+        // dropped — without its own bucket the drill-down total shrinks below the
+        // parent's slice in the "all" view.
+        if (category.id === selectedIncomeCategory) {
+          if (!aggregatedIncome[category.id]) {
+            aggregatedIncome[category.id] = { category, total: '0' };
+          }
+          aggregatedIncome[category.id].total = Currency.add(aggregatedIncome[category.id].total, item.total);
+        } else if (category.parentId === selectedIncomeCategory) {
           if (!aggregatedIncome[category.id]) {
             aggregatedIncome[category.id] = { category, total: '0' };
           }

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -70,11 +70,12 @@ const useOperationForm = ({
     return category?.isShadow || false;
   }, [operation, categories]);
 
-  // Check if operation date is today (for shadow operations)
+  // Check if operation date is today (for shadow operations).
+  // Compare against the LOCAL date — operation dates are stored as local
+  // YYYY-MM-DD strings, so the UTC date would mismatch near midnight.
   const isOperationToday = useMemo(() => {
     if (!operation) return false;
-    const today = new Date().toISOString().split('T')[0];
-    return operation.date === today;
+    return operation.date === formatDate(new Date());
   }, [operation]);
 
   // Imported MoneyOK operations carry protected metadata labels (Account:/Category:/
@@ -112,6 +113,34 @@ const useOperationForm = ({
     if (!values.operationCurrency || !sourceAccount) return false;
     return values.operationCurrency !== sourceAccount.currency;
   }, [values.type, values.operationCurrency, sourceAccount]);
+
+  // Clear a stale exchange rate when the currency PAIR changes — e.g. the user
+  // switches a transfer's destination from a EUR account to an AMD account. The
+  // auto-populate effect below only fires when exchangeRate is empty, so without
+  // this reset the old pair's rate would silently be applied to the new pair
+  // (crediting the destination a wildly wrong amount).
+  const ratePairRef = useRef(null);
+  useEffect(() => {
+    if (!visible) {
+      ratePairRef.current = null;
+      return;
+    }
+    const forTransfer = isMultiCurrencyTransfer && sourceAccount && destinationAccount;
+    const forForeignOp = isForeignCurrencyOp && sourceAccount && values.operationCurrency;
+    if (!forTransfer && !forForeignOp) {
+      ratePairRef.current = null;
+      return;
+    }
+    const fromCurrency = forForeignOp ? values.operationCurrency : sourceAccount.currency;
+    const toCurrency = forForeignOp ? sourceAccount.currency : destinationAccount?.currency;
+    if (!fromCurrency || !toCurrency) return;
+    const pair = `${fromCurrency}:${toCurrency}`;
+    if (ratePairRef.current && ratePairRef.current !== pair && values.exchangeRate) {
+      setValues(v => ({ ...v, exchangeRate: '', destinationAmount: '' }));
+      setLastEditedField(null);
+    }
+    ratePairRef.current = pair;
+  }, [visible, isMultiCurrencyTransfer, isForeignCurrencyOp, sourceAccount, destinationAccount, values.operationCurrency, values.exchangeRate]);
 
   // Auto-populate exchange rate when a multicurrency pair is detected and no rate is set yet.
   // Handles both multicurrency transfers and foreign currency expense/income ops.
@@ -472,7 +501,13 @@ const useOperationForm = ({
     // Automatically evaluate any pending math operation before saving
     let finalAmount = values.amount;
     if (hasOperation(values.amount)) {
-      const evaluated = evaluateExpression(values.amount, Currency.getDecimalPlaces(sourceAccount?.currency));
+      // The calculator amount is entered in the operation currency when a foreign
+      // currency is selected — evaluate with THAT currency's decimal places, not
+      // the account's (e.g. a USD amount on a JPY account must keep its cents).
+      const amountCurrency = (isForeignCurrencyOp && values.operationCurrency)
+        ? values.operationCurrency
+        : sourceAccount?.currency;
+      const evaluated = evaluateExpression(values.amount, Currency.getDecimalPlaces(amountCurrency));
       if (evaluated !== null) {
         finalAmount = evaluated;
       }
@@ -508,7 +543,7 @@ const useOperationForm = ({
     }
 
     onClose();
-  }, [values, validateFields, prepareOperationData, isNew, addOperation, updateOperation, operation, onClose, validateOperation, showDialog, t]);
+  }, [values, validateFields, prepareOperationData, isNew, addOperation, updateOperation, operation, onClose, validateOperation, showDialog, t, isForeignCurrencyOp, sourceAccount]);
 
   // Close modal
   const handleClose = useCallback(() => {
@@ -547,9 +582,10 @@ const useOperationForm = ({
     return displayName || t('select_category');
   }, [categories, t]);
 
-  // Helper: Format date for display
+  // Helper: Format date for display. Bare YYYY-MM-DD parses as UTC midnight,
+  // which is the previous local day west of Greenwich — anchor to local time.
   const formatDateForDisplay = useCallback((isoDate) => {
-    const date = new Date(isoDate);
+    const date = new Date(isoDate.includes('T') ? isoDate : `${isoDate}T00:00:00`);
     return date.toLocaleDateString(undefined, {
       year: 'numeric',
       month: 'long',

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -247,8 +247,13 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   );
 
   // Determine if split button should be shown
-  // Only for editing expense/income (not transfers, not shadow operations, not new)
-  const canSplit = !isNew && !isShadowOperation && values.type !== 'transfer' && parseFloat(values.amount) > 0;
+  // Only for editing expense/income (not transfers, not shadow operations, not new).
+  // Foreign-currency ops are excluded: the form model holds swapped amount/rate
+  // fields (foreign amount in `amount`), and handleSplit persists form values
+  // verbatim — splitting one would write the foreign nominal as the account
+  // amount, corrupting the row and the account balance.
+  const canSplit = !isNew && !isShadowOperation && values.type !== 'transfer'
+    && !isForeignCurrencyOp && parseFloat(values.amount) > 0;
 
   // Handle split confirmation
   const handleSplitConfirm = useCallback(async (splitAmount, categoryId) => {
@@ -270,10 +275,12 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     }
   }, [isShadowOperation, setValues, setLastEditedField]);
 
-  // Handler for exchange rate changes
+  // Handler for exchange rate changes. Decimal commas from locale decimal-pad
+  // keyboards are normalized to dots — Decimal parsing coerces comma strings to 0.
   const handleExchangeRateChange = useCallback((text) => {
     if (!isShadowOperation) {
-      setValues(v => ({ ...v, exchangeRate: text }));
+      const normalized = text.replace(',', '.');
+      setValues(v => ({ ...v, exchangeRate: normalized }));
       setLastEditedField('exchangeRate');
       setRateSource('manual');
     }
@@ -282,7 +289,8 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   // Handler for destination amount changes
   const handleDestinationAmountChange = useCallback((text) => {
     if (!isShadowOperation) {
-      setValues(v => ({ ...v, destinationAmount: text }));
+      const normalized = text.replace(',', '.');
+      setValues(v => ({ ...v, destinationAmount: normalized }));
       setLastEditedField('destinationAmount');
       setRateSource('manual');
     }
@@ -361,8 +369,12 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
     setValues(v => ({ ...v, categoryId: category.id, amount: finalAmount }));
     closePicker();
 
-    // Only auto-add for new operations, not when editing
-    if (isNew) {
+    // Only auto-add for new operations, not when editing.
+    // Foreign-currency ops are excluded: this fast path stores the raw form
+    // amount without the convert/swap logic of prepareOperationData, which
+    // would record the foreign nominal (e.g. 30 TRY) as the account-currency
+    // amount. The user completes those with the Save button instead.
+    if (isNew && !isForeignCurrencyOp) {
       // Check if amount is valid and auto-save
       const hasValidAmount = finalAmount &&
         !isNaN(parseFloat(finalAmount)) &&
@@ -396,7 +408,7 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
         }
       }
     }
-  }, [values, setValues, closePicker, isNew, addOperation, onClose, hasOperation, evaluateExpression, attachLocation, location]);
+  }, [values, setValues, closePicker, isNew, isForeignCurrencyOp, addOperation, onClose, hasOperation, evaluateExpression, attachLocation, location]);
 
   // FlatList key extractor
   const keyExtractor = useCallback((item) => {
@@ -646,10 +658,12 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
         t={t}
       />
 
-      {/* Date Picker */}
+      {/* Date Picker — anchor the bare YYYY-MM-DD date to local midnight; parsing
+          it bare (UTC) pre-selects the previous day west of Greenwich, and
+          confirming would silently move the operation back one day */}
       {showDatePicker && (
         <DateTimePicker
-          value={new Date(values.date)}
+          value={new Date(values.date?.includes('T') ? values.date : `${values.date}T00:00:00`)}
           mode="date"
           display="default"
           onChange={handleDateChange}

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -277,8 +277,10 @@ const NetWorthCard = memo(({ accounts, operations, colors, t }) => {
   // Calculate this month's change (only for accounts with matching currency)
   const monthlyChange = useMemo(() => {
     const now = new Date();
-    const currentMonth = now.getMonth();
-    const currentYear = now.getFullYear();
+    // Compare the YYYY-MM prefix of the stored local date string directly.
+    // Parsing "YYYY-MM-DD" with new Date() yields UTC midnight, which shifts
+    // ops dated the 1st into the previous month in UTC-negative timezones.
+    const currentMonthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 
     return operations.reduce((sum, op) => {
       // Only count operations from accounts with matching currency
@@ -286,8 +288,7 @@ const NetWorthCard = memo(({ accounts, operations, colors, t }) => {
         return sum;
       }
 
-      const opDate = new Date(op.date);
-      if (opDate.getMonth() === currentMonth && opDate.getFullYear() === currentYear) {
+      if (typeof op.date === 'string' && op.date.startsWith(currentMonthPrefix)) {
         const amount = parseFloat(op.amount || '0');
         if (op.type === 'income') {
           return sum + amount;

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -161,9 +161,26 @@ const CategoriesScreen = ({ onBackStateChange }) => {
   }, [pickerSlideAnim]);
 
   const potentialParents = useMemo(() => {
+    // Exclude the edited category AND all of its descendants — picking a
+    // descendant as parent creates a cycle, which detaches the subtree from the
+    // root grid and hangs every descendant walk (getAllDescendants, category paths).
+    const excludedIds = new Set();
+    if (formEditingCategory?.id) {
+      excludedIds.add(formEditingCategory.id);
+      const queue = [formEditingCategory.id];
+      while (queue.length > 0) {
+        const parentId = queue.shift();
+        categories.forEach(c => {
+          if (c.parentId === parentId && !excludedIds.has(c.id)) {
+            excludedIds.add(c.id);
+            queue.push(c.id);
+          }
+        });
+      }
+    }
     return categories.filter(c => {
       const catType = c.category_type || c.categoryType;
-      return catType === formValues.category_type && c.id !== formEditingCategory?.id && !c.isShadow;
+      return catType === formValues.category_type && !excludedIds.has(c.id) && !c.isShadow;
     });
   }, [categories, formValues.category_type, formEditingCategory]);
 

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -323,6 +323,17 @@ const GraphsScreen = () => {
       });
     });
 
+    // The picker defaults to the current month, so it must always be present —
+    // early in a new month (no operations yet) the wheel would otherwise display
+    // one period while the charts query another.
+    const currentPeriodValue = `${now.getFullYear()}-${now.getMonth()}`;
+    if (!items.some(item => item.value === currentPeriodValue)) {
+      items.unshift({
+        label: `${t(monthKeys[now.getMonth()])} ${now.getFullYear()}`,
+        value: currentPeriodValue,
+      });
+    }
+
     return items;
   }, [availableYears, availableMonths, t, monthKeys]);
 
@@ -359,11 +370,12 @@ const GraphsScreen = () => {
     // Calculate days in the selected month
     const daysInMonth = new Date(selectedYear, selectedMonth + 1, 0).getDate();
 
-    // Calculate days elapsed (from 1st to today, excluding current day)
+    // Days elapsed includes today: the expense total feeding this prediction
+    // covers the 1st through today, so the denominator must span the same days
+    // (dividing by currentDay - 1 would inflate the average every day).
     const currentDay = now.getDate();
-    const daysElapsed = currentDay - 1;
+    const daysElapsed = currentDay;
 
-    // If it's the first day, we can't make a good prediction yet
     if (daysElapsed < 1) {
       return null;
     }

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -258,6 +258,24 @@ const OperationsScreen = () => {
     }
   }, [pendingScroll, scrollToDateString, operationsLoading, groupedOperations]);
 
+  // Clear a stale exchange rate when the transfer's currency PAIR changes (e.g.
+  // destination switched from a EUR account to an AMD account). The auto-populate
+  // effect below only fires when exchangeRate is empty, so without this reset the
+  // old pair's rate would be applied to the new pair.
+  const ratePairRef = useRef(null);
+  useEffect(() => {
+    if (!isMultiCurrencyTransfer || !sourceAccount || !destinationAccount) {
+      ratePairRef.current = null;
+      return;
+    }
+    const pair = `${sourceAccount.currency}:${destinationAccount.currency}`;
+    if (ratePairRef.current && ratePairRef.current !== pair && quickAddValues.exchangeRate) {
+      setQuickAddValues(v => ({ ...v, exchangeRate: '', destinationAmount: '' }));
+      setLastEditedField(null);
+    }
+    ratePairRef.current = pair;
+  }, [isMultiCurrencyTransfer, sourceAccount, destinationAccount, quickAddValues.exchangeRate]);
+
   // Auto-populate exchange rate when multi-currency transfer accounts change (async with live rate)
   useEffect(() => {
     if (!isMultiCurrencyTransfer || !sourceAccount || !destinationAccount || quickAddValues.exchangeRate) {
@@ -318,9 +336,11 @@ const OperationsScreen = () => {
         }
       }
     }
-    // If user edited amount or rate, calculate destination amount
+    // If user edited amount or rate, calculate destination amount.
+    // Skip while the amount holds an unevaluated calculator expression ("10+5"):
+    // convertAmount would coerce it to 0 and persist destinationAmount "0.00".
     else if (lastEditedField === 'amount' || lastEditedField === 'exchangeRate') {
-      if (quickAddValues.amount && quickAddValues.exchangeRate) {
+      if (quickAddValues.amount && quickAddValues.exchangeRate && !hasOperation(quickAddValues.amount)) {
         const converted = Currency.convertAmount(
           quickAddValues.amount,
           sourceAccount.currency,
@@ -357,8 +377,10 @@ const OperationsScreen = () => {
   }, [t, showDialog, deleteOperation]);
 
   const handleDateSeparatorPress = useCallback((dateString) => {
-    // Parse the date and set it as the selected date
-    const date = new Date(dateString);
+    // Parse the date and set it as the selected date (T00:00:00 anchors the bare
+    // YYYY-MM-DD string to local midnight; bare strings parse as UTC and open the
+    // picker on the previous day west of Greenwich)
+    const date = new Date(`${dateString}T00:00:00`);
     setSelectedDate(date);
     setShowDatePicker(true);
   }, []);
@@ -447,8 +469,11 @@ const OperationsScreen = () => {
         }
       }
 
-      // Calculate destination amount if we have a rate but no destination amount
-      if (operationData.exchangeRate && !operationData.destinationAmount) {
+      // Calculate destination amount from the (already expression-evaluated) amount.
+      // Recompute unless the user explicitly typed the destination amount — the form
+      // state may hold a destination derived from a partial expression (e.g. "10+"
+      // coerced to "0.00"), which must not be trusted at save time.
+      if (operationData.exchangeRate && (!operationData.destinationAmount || lastEditedField !== 'destinationAmount')) {
         const converted = Currency.convertAmount(
           operationData.amount,
           effectiveSourceAccount.currency,
@@ -558,7 +583,7 @@ const OperationsScreen = () => {
       // Errors from addOperation are already shown via dialog.
       // Errors from getDistinctLabels are non-critical — suggestion row simply won't appear.
     }
-  }, [quickAddValues, validateOperation, addOperation, t, showDialog, accounts, resetForm]);
+  }, [quickAddValues, validateOperation, addOperation, t, showDialog, accounts, resetForm, lastEditedField]);
 
   // Handler for auto-add with category (from picker)
   const handleAutoAddWithCategory = useCallback(async (categoryId) => {
@@ -638,15 +663,19 @@ const OperationsScreen = () => {
     { key: 'transfer', label: t('transfer'), icon: 'swap-horizontal' },
   ], [t]);
 
-  // Callbacks for multi-currency fields
+  // Callbacks for multi-currency fields. Normalize a locale decimal comma to a
+  // dot — Android decimal-pad keyboards emit "," in many locales, and downstream
+  // Decimal parsing coerces comma strings to 0 (silently crediting nothing).
   const handleExchangeRateChange = useCallback((text) => {
-    setQuickAddValues(v => ({ ...v, exchangeRate: text }));
+    const normalized = text.replace(',', '.');
+    setQuickAddValues(v => ({ ...v, exchangeRate: normalized }));
     setLastEditedField('exchangeRate');
     setRateSource('manual');
   }, [setRateSource]);
 
   const handleDestinationAmountChange = useCallback((text) => {
-    setQuickAddValues(v => ({ ...v, destinationAmount: text }));
+    const normalized = text.replace(',', '.');
+    setQuickAddValues(v => ({ ...v, destinationAmount: normalized }));
     setLastEditedField('destinationAmount');
     setRateSource('manual');
   }, [setRateSource]);

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -519,8 +519,11 @@ export const adjustAccountBalance = async (accountId, newBalance, description = 
       const currentBalanceStr = account.balance || '0';
       const targetBalanceStr = String(newBalance) || '0';
 
-      // Check if there's already an adjustment operation for today
-      const today = new Date().toISOString().split('T')[0];
+      // Check if there's already an adjustment operation for today.
+      // Use the LOCAL date — operations and balance history both use local
+      // YYYY-MM-DD strings, so the UTC date would file the adjustment under
+      // yesterday (and break same-day merging) between local and UTC midnight.
+      const today = BalanceHistoryDB.formatDate(new Date());
       const existingOperation = await db.getFirstAsync(
         `SELECT o.*, c.category_type FROM operations o
          JOIN categories c ON o.category_id = c.id

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -79,7 +79,7 @@ export const createBackup = async () => {
 // Explicit column orderings per table — guards against sparse rows where
 // Object.keys(data[0]) would silently omit columns present only on later rows.
 const TABLE_FIELDS = {
-  accounts:           ['id', 'name', 'balance', 'currency', 'display_order', 'hidden', 'monthly_target', 'card_mask', 'auto_txn_rounding', 'created_at', 'updated_at'],
+  accounts:           ['id', 'name', 'balance', 'currency', 'display_order', 'hidden', 'monthly_target', 'card_mask', 'auto_txn_rounding', 'deleted_at', 'created_at', 'updated_at'],
   categories:         ['id', 'name', 'type', 'category_type', 'parent_id', 'icon', 'color', 'is_shadow', 'created_at', 'updated_at'],
   operations:         ['id', 'type', 'amount', 'account_id', 'category_id', 'to_account_id', 'date', 'created_at', 'description', 'exchange_rate', 'destination_amount', 'source_currency', 'destination_currency', 'original_balance', 'latitude', 'longitude'],
   budgets:            ['id', 'category_id', 'amount', 'currency', 'period_type', 'start_date', 'end_date', 'is_recurring', 'rollover_enabled', 'created_at', 'updated_at'],
@@ -402,9 +402,21 @@ export const restoreBackup = async (backup, cancelToken) => {
 
     const unmappedAccountIds = [];
     for (const operation of backup.data.operations) {
-      if (operation.account_id == null) continue;
-      if (!accountIdsInBackup.has(operation.account_id)) {
+      if (operation.account_id != null && !accountIdsInBackup.has(operation.account_id)) {
         unmappedAccountIds.push(operation.account_id);
+      }
+      // Transfers reference a second account — validate it too, or the restore
+      // dies mid-transaction with a raw FK error instead of this friendly abort.
+      if (operation.to_account_id != null && !accountIdsInBackup.has(operation.to_account_id)) {
+        unmappedAccountIds.push(operation.to_account_id);
+      }
+    }
+    for (const planned of backup.data.planned_operations || []) {
+      if (planned.account_id != null && !accountIdsInBackup.has(planned.account_id)) {
+        unmappedAccountIds.push(planned.account_id);
+      }
+      if (planned.to_account_id != null && !accountIdsInBackup.has(planned.to_account_id)) {
+        unmappedAccountIds.push(planned.to_account_id);
       }
     }
 
@@ -498,7 +510,7 @@ export const restoreBackup = async (backup, cancelToken) => {
         if (isIntegerId) {
           // Preserve the original integer ID
           result = await db.runAsync(
-            'INSERT INTO accounts (id, name, balance, currency, display_order, hidden, monthly_target, card_mask, auto_txn_rounding, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO accounts (id, name, balance, currency, display_order, hidden, monthly_target, card_mask, auto_txn_rounding, deleted_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
               Number(account.id),
               account.name,
@@ -509,6 +521,8 @@ export const restoreBackup = async (backup, cancelToken) => {
               account.monthly_target ?? null,
               account.card_mask ?? null,
               account.auto_txn_rounding ?? null,
+              // Preserve soft-delete state — omitting it resurrects deleted accounts on restore
+              account.deleted_at ?? null,
               account.created_at || new Date().toISOString(),
               account.updated_at || new Date().toISOString(),
             ],
@@ -520,7 +534,7 @@ export const restoreBackup = async (backup, cancelToken) => {
         } else {
           // UUID or no ID - let SQLite auto-generate integer ID
           result = await db.runAsync(
-            'INSERT INTO accounts (name, balance, currency, display_order, hidden, monthly_target, card_mask, auto_txn_rounding, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO accounts (name, balance, currency, display_order, hidden, monthly_target, card_mask, auto_txn_rounding, deleted_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
               account.name,
               account.balance || '0',
@@ -530,6 +544,7 @@ export const restoreBackup = async (backup, cancelToken) => {
               account.monthly_target ?? null,
               account.card_mask ?? null,
               account.auto_txn_rounding ?? null,
+              account.deleted_at ?? null,
               account.created_at || new Date().toISOString(),
               account.updated_at || new Date().toISOString(),
             ],
@@ -625,7 +640,7 @@ export const restoreBackup = async (backup, cancelToken) => {
         // value falls through to null (?? null) rather than failing the insert.
         const opType = VALID_OPERATION_TYPES.includes(operation.type) ? operation.type : 'expense';
         await db.runAsync(
-          'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, original_balance, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
           [
             opType,
             operation.amount || '0',
@@ -639,6 +654,7 @@ export const restoreBackup = async (backup, cancelToken) => {
             operation.destination_amount || null,
             operation.source_currency || null,
             operation.destination_currency || null,
+            operation.original_balance ?? null,
             operation.latitude ?? null,
             operation.longitude ?? null,
           ],
@@ -1179,6 +1195,15 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
       console.warn('No planned_operations table in imported database (older format)');
     }
 
+    // Merchant rules table may not exist in older backups. Without this extraction
+    // restoreBackup clears the live table and re-inserts nothing, wiping learned rules.
+    let merchantRules = [];
+    try {
+      merchantRules = await tempDb.getAllAsync('SELECT * FROM notification_merchant_rules ORDER BY created_at ASC');
+    } catch (e) {
+      console.warn('No notification_merchant_rules table in imported database (older format)');
+    }
+
     // Create backup object
     const backup = {
       version: BACKUP_VERSION,
@@ -1192,6 +1217,7 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
         app_metadata: appMetadata || [],
         balance_history: balanceHistory || [],
         planned_operations: plannedOperations || [],
+        notification_merchant_rules: merchantRules || [],
       },
     };
 

--- a/app/services/BalanceHistoryDB.js
+++ b/app/services/BalanceHistoryDB.js
@@ -132,8 +132,9 @@ export const populateCurrentMonthHistory = async (providedDb = null) => {
 
     // Define the population logic
     const populateLogic = async (db) => {
-      // Get all accounts (use db parameter directly)
-      const accounts = await db.getAllAsync('SELECT * FROM accounts ORDER BY display_order ASC, created_at DESC');
+      // Get all live accounts (soft-deleted ones must not get new history rows —
+      // their operations were reassigned, so reconstructed balances are meaningless)
+      const accounts = await db.getAllAsync('SELECT * FROM accounts WHERE deleted_at IS NULL ORDER BY display_order ASC, created_at DESC');
 
       for (const account of accounts) {
         // Get account creation date

--- a/app/services/BudgetsDB.js
+++ b/app/services/BudgetsDB.js
@@ -1,6 +1,7 @@
 import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
 import * as CategoriesDB from './CategoriesDB';
 import * as Currency from './currency';
+import { formatDate as formatLocalDate } from './BalanceHistoryDB';
 
 /**
  * Map database field names to camelCase for application use
@@ -291,7 +292,9 @@ export const deleteBudget = async (id) => {
  */
 export const getActiveBudgets = async (date = new Date()) => {
   try {
-    const dateStr = date.toISOString().split('T')[0];
+    // Local date string — operation/budget dates are stored as local YYYY-MM-DD,
+    // so a UTC string (toISOString) would shift the boundary in non-UTC timezones.
+    const dateStr = formatLocalDate(date);
 
     const budgets = await queryAll(
       `SELECT * FROM budgets
@@ -316,7 +319,7 @@ export const getActiveBudgets = async (date = new Date()) => {
  */
 export const hasActiveBudget = async (categoryId, date = new Date()) => {
   try {
-    const dateStr = date.toISOString().split('T')[0];
+    const dateStr = formatLocalDate(date);
 
     const result = await queryFirst(
       `SELECT 1 FROM budgets
@@ -470,13 +473,21 @@ export const getCurrentPeriodDates = (periodType, referenceDate = new Date(), lo
     const dayOfWeek = start.getDay(); // 0=Sun … 6=Sat
     const diff = (dayOfWeek - firstDayJS + 7) % 7;
     start.setDate(start.getDate() - diff);
-    end.setDate(start.getDate() + 6);
+    // Derive the end from the adjusted start, not from the reference date:
+    // when the week starts in the previous month, applying start's day-of-month
+    // to end (still holding the reference month) lands a month ahead.
+    end.setTime(start.getTime());
+    end.setDate(end.getDate() + 6);
     break;
   }
 
   case 'monthly': {
     // Month starts on 1st and ends on last day
     start.setDate(1);
+    // Pin the day before shifting the month: setMonth on a day-of-month that
+    // doesn't exist in the target month (e.g. Jan 31 → "Feb 31") rolls over an
+    // extra month, making the period end in the month after next.
+    end.setDate(1);
     end.setMonth(end.getMonth() + 1);
     end.setDate(0); // Last day of month
     break;
@@ -613,8 +624,11 @@ export const calculateBudgetStatus = async (budgetId, referenceDate = new Date()
 
     // Calculate current period dates
     const { start, end } = getCurrentPeriodDates(budget.periodType, referenceDate);
-    const startDateStr = start.toISOString().split('T')[0];
-    const endDateStr = end.toISOString().split('T')[0];
+    // Format with the local calendar date: start/end are local-midnight Dates, and
+    // operation dates are local YYYY-MM-DD strings. toISOString (UTC) would move
+    // the period boundary by a day for any non-UTC timezone.
+    const startDateStr = formatLocalDate(start);
+    const endDateStr = formatLocalDate(end);
 
     // Calculate spending
     const spent = await calculateSpendingForBudget(

--- a/app/services/CategoriesDB.js
+++ b/app/services/CategoriesDB.js
@@ -266,6 +266,17 @@ export const updateCategory = async (id, updates) => {
       values.push(updates.category_type || updates.categoryType);
     }
     if (updates.parentId !== undefined) {
+      // Guard against parent cycles: re-parenting onto itself or one of its own
+      // descendants would detach the subtree and hang every descendant walk.
+      if (updates.parentId) {
+        if (updates.parentId === id) {
+          throw new Error('Cannot set a category as its own parent');
+        }
+        const descendants = await getAllDescendants(id);
+        if (descendants.some(d => d.id === updates.parentId)) {
+          throw new Error('Cannot move a category into one of its own subcategories');
+        }
+      }
       fields.push('parent_id = ?');
       values.push(updates.parentId || null);
     }
@@ -410,12 +421,17 @@ export const getAllDescendants = async (id) => {
   try {
     const descendants = [];
     const queue = [id];
+    // Track visited ids so a corrupted parent cycle in existing data degrades
+    // to a bounded walk instead of an infinite loop.
+    const visited = new Set([id]);
 
     while (queue.length > 0) {
       const currentId = queue.shift();
       const children = await getChildCategories(currentId);
 
       for (const child of children) {
+        if (visited.has(child.id)) continue;
+        visited.add(child.id);
         descendants.push(child);
         queue.push(child.id);
       }

--- a/app/services/DailyBackupService.js
+++ b/app/services/DailyBackupService.js
@@ -34,10 +34,17 @@ const ensureBackupDir = async () => {
 };
 
 /**
- * Today's date as "YYYY-MM-DD".
+ * Today's date as "YYYY-MM-DD" in the user's local timezone — the "already
+ * backed up today" boundary must roll at local midnight, not UTC midnight
+ * (getISOWeekString below already uses local date components).
  * @returns {string}
  */
-export const getTodayDateString = () => new Date().toISOString().split('T')[0];
+export const getTodayDateString = () => {
+  const d = new Date();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${month}-${day}`;
+};
 
 /**
  * Current ISO 8601 week identifier as "YYYY-WNN".

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -940,9 +940,13 @@ export const deleteOperation = async (id) => {
  */
 export const getTotalExpenses = async (accountId, startDate, endDate) => {
   try {
+    // Shadow-category ops are balance adjustments, not real spending — exclude
+    // them so these totals agree with the pie charts, which filter shadows out.
     const results = await queryAll(
-      `SELECT amount FROM operations
-       WHERE account_id = ? AND type = 'expense' AND date >= ? AND date <= ?`,
+      `SELECT o.amount FROM operations o
+       LEFT JOIN categories c ON o.category_id = c.id
+       WHERE o.account_id = ? AND o.type = 'expense' AND o.date >= ? AND o.date <= ?
+         AND (c.is_shadow IS NULL OR c.is_shadow = 0)`,
       [accountId, startDate, endDate],
     );
     if (!results || results.length === 0) return '0';
@@ -963,8 +967,10 @@ export const getTotalExpenses = async (accountId, startDate, endDate) => {
 export const getTotalIncome = async (accountId, startDate, endDate) => {
   try {
     const results = await queryAll(
-      `SELECT amount FROM operations
-       WHERE account_id = ? AND type = 'income' AND date >= ? AND date <= ?`,
+      `SELECT o.amount FROM operations o
+       LEFT JOIN categories c ON o.category_id = c.id
+       WHERE o.account_id = ? AND o.type = 'income' AND o.date >= ? AND o.date <= ?
+         AND (c.is_shadow IS NULL OR c.is_shadow = 0)`,
       [accountId, startDate, endDate],
     );
     if (!results || results.length === 0) return '0';


### PR DESCRIPTION
## Summary

A systematic functionality-bug audit across all app areas (budgets, backup/restore, operations, accounts, multi-currency, graphs, search, categories) surfaced 24 confirmed bugs, all fixed here. The dominant root causes were (1) UTC/local timezone mixing — operation dates are stored as local `YYYY-MM-DD` strings but many code paths compared them against UTC-derived dates or parsed them as UTC midnight — and (2) multi-currency form state being trusted at save time when it held stale or unevaluated values.

## Changes

**Budget math**
- **app/services/BudgetsDB.js** — weekly period end is now derived from the adjusted week *start*, not the reference date (a week starting in the previous month used to span up to 5 weeks, e.g. Jun 29 → Aug 4); monthly period end pins the day before shifting the month (Jan 31 used to yield an end of Feb 28); period boundaries and active-budget checks now use local date strings instead of `toISOString()` (UTC), which shifted budget boundaries by a day in every non-UTC timezone.

**Backup / restore**
- **app/services/BackupRestore.js** — restore now preserves `accounts.deleted_at` (soft-deleted accounts used to resurrect with their old balances on every restore, including automatic daily backups) and `operations.original_balance` (cumulative same-day balance adjustments broke after a restore); SQLite import now extracts `notification_merchant_rules` (every SQLite restore used to wipe all learned merchant-categorization rules); pre-restore validation now also checks transfer `to_account_id` and planned-operation account references, so a bad backup aborts with the friendly "your data has not been changed" message instead of a raw FK error mid-transaction.
- **app/services/DailyBackupService.js** — the "already backed up today" boundary now rolls at local midnight instead of UTC midnight.

**Dates / timezones**
- **app/contexts/OperationsActionsContext.js** — `jumpToDate`/`loadMoreOperations` computed "today" in UTC; in UTC+ timezones a date jump permanently hid today's operations (the newer-operations flag was also cleared, so they could never be paged back in).
- **app/components/operations/OperationsList.js**, **app/hooks/useOperationForm.js**, **app/modals/OperationModal.js**, **app/screens/OperationsScreen.js** — bare `YYYY-MM-DD` strings were parsed as UTC midnight, so west of Greenwich the section headers labeled today "Yesterday", the edit modal displayed the previous day, and confirming the pre-selected date silently moved the operation back one day. All parse sites now anchor to local midnight (`T00:00:00`), and `isOperationToday` compares local dates (today's balance adjustments were un-deletable near midnight).
- **app/services/AccountsDB.js** — balance adjustments are now dated with the local day, fixing same-day adjustment merging and balance-history consistency for UTC+ users.
- **app/screens/AccountsScreen.js** — the net-worth monthly change now compares `YYYY-MM` string prefixes; ops dated the 1st were attributed to the previous month in UTC-negative timezones.

**Multi-currency**
- **app/screens/OperationsScreen.js** — quick-add transfers with a calculator expression (`10+5`) used to persist `destinationAmount: "0.00"` (source fully debited, destination credited nothing): the auto-convert effect now skips unevaluated expressions and the save path recomputes the destination from the evaluated amount; switching accounts now clears the previous currency pair's exchange rate (a USD→EUR rate used to silently apply to USD→AMD, crediting 92 AMD instead of ~38,700); rate/destination inputs normalize locale decimal commas.
- **app/hooks/useOperationForm.js** — same stale-rate clearing for the edit modal; calculator expressions for foreign-currency ops now evaluate with the operation currency's decimal places instead of the account's.
- **app/modals/OperationModal.js** — split is disabled for foreign-currency ops (splitting wrote the swapped form model verbatim to the DB, corrupting the row and account balance); the tap-category auto-add path no longer fires for foreign-currency ops (it skipped conversion and recorded the foreign nominal as the account-currency amount); comma normalization for rate/destination inputs.
- **app/components/Calculator.js** — `=` now rounds with the active currency's decimal places instead of always 2.

**Filters / graphs**
- **app/contexts/OperationsDataContext.js** — the in-memory account filter and text search now match `toAccountId` like the SQL layer does; incoming transfers used to vanish when filtering by the receiving account.
- **app/hooks/useExpenseData.js**, **app/hooks/useIncomeData.js** — drill-down pie charts no longer drop spending recorded directly on the selected parent category.
- **app/hooks/useBalanceHistory.js**, **app/screens/GraphsScreen.js** — spending prediction used a month-to-date-plus-future-ops numerator over an elapsed-days-minus-one denominator, inflating the forecast; the expense window is now capped at today and the denominator includes today. The period picker always contains the current month, so the wheel can't display one period while the charts query another.
- **app/hooks/useCategoryMonthlySpending.js** — the 12-month window was frozen at mount; after a month rollover in a long-lived session the new month's spending mapped to nothing.
- **app/services/OperationsDB.js** — `getTotalExpenses`/`getTotalIncome` exclude shadow balance-adjustment operations, matching the pie charts that feed the same screen.

**Categories**
- **app/screens/CategoriesScreen.js**, **app/services/CategoriesDB.js** — the parent picker excludes the edited category's descendants and the DB layer rejects cycle-creating re-parenting (setting a category's parent to its own child detached the subtree from the grid and hung every descendant walk); `getAllDescendants` is cycle-safe for already-corrupted data.

**Balance history**
- **app/services/BalanceHistoryDB.js** — `populateCurrentMonthHistory` skips soft-deleted accounts instead of recreating meaningless history rows for them.

### Found but not fixed (needs a product decision or larger change)

- **Google Sheets round-trip data loss** (`GoogleSheetsService.js`): export/import drops `card_mask`, `auto_txn_rounding`, `original_balance`, coordinates, and planned-op `last_executed_month` — a Sheets restore silently breaks bank-notification matching and re-executes recurring planned ops.
- **Daily-backup row-count guard lockout** (`DailyBackupService.js`): after a legitimate >50% data reduction, the rejected snapshot never becomes the new baseline, so automatic backups stop permanently; the baseline is also picked by lexicographic filename sort, which prefers old weeklies.
- **CSV section splitting** (`BackupRestore.js`): the `[SECTION]` regex isn't quote-aware, so a quoted value containing a newline followed by `[` truncates the section on import.
- **Planned cross-currency transfers** (`PlannedOperationsDB.js`): can be created but never executed (execution builds the op with no rate/destination amount and always throws).
- **Category deletion cascades** (`CategoriesDB.js`): deleting a category silently cascade-deletes its budgets and nulls planned-op categories with no warning.
- **Weekly budget locale week-start** (`BudgetsDB.js`): `calculateBudgetStatus` never passes the locale, so the Sunday-start table is dead code and weekly budgets are always Monday-based.
- **Deleting an account with operation transfer** (`AccountsDB.js`): reassigned operations change no balances, so the destination account's history/expense aggregations no longer reconcile.
- Minor: planned-ops summary sums amounts across currencies; net-worth monthly change ignores cross-currency transfer legs; balance-history manual edits aren't validated numerically; `parseInput` in `currency.js` mishandles comma decimals (currently dead code).

## Testing

- `npm test` — 138 suites / **4104 tests pass** (4092 baseline + 12 new regression tests).
- New regression tests: budget week/month boundary edge dates; restore preserving `deleted_at`/`original_balance` and aborting cleanly on dangling transfer refs; incoming-transfer account filtering and destination-name search; drill-down direct-on-parent spending; category parent-cycle rejection.
- `npx eslint` on all modified files — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new user-facing strings)
- [x] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFLPSZLPnkmpjW16JiDxLA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFLPSZLPnkmpjW16JiDxLA)_