### PR TITLE
feat(planned): add mark-as-executed action and fix swipe row transparency

### DIFF
--- a/__tests__/contexts/PlannedOperationsContext.test.js
+++ b/__tests__/contexts/PlannedOperationsContext.test.js
@@ -59,6 +59,7 @@ describe('PlannedOperationsContext', () => {
     PlannedOperationsDB.updatePlannedOperation.mockResolvedValue(undefined);
     PlannedOperationsDB.deletePlannedOperation.mockResolvedValue(undefined);
     PlannedOperationsDB.markExecuted.mockResolvedValue(undefined);
+    PlannedOperationsDB.markExecutedOnly.mockResolvedValue(undefined);
     PlannedOperationsDB.executeAndMark.mockResolvedValue({ id: 100, type: 'expense' });
     PlannedOperationsDB.validatePlannedOperation.mockReturnValue(null);
   });
@@ -280,6 +281,79 @@ describe('PlannedOperationsContext', () => {
       });
 
       expect(PlannedOperationsDB.executeAndMark).toHaveBeenCalled();
+    });
+  });
+
+  describe('Mark Planned Operation Executed', () => {
+    it('calls markExecutedOnly and updates state for recurring without creating an operation', async () => {
+      const plannedOp = {
+        id: '1',
+        name: 'Rent',
+        type: 'expense',
+        amount: '500',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: true,
+        lastExecutedMonth: null,
+      };
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+
+      const { result } = await renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.markPlannedOperationExecuted(plannedOp);
+      });
+
+      expect(PlannedOperationsDB.markExecutedOnly).toHaveBeenCalledWith(
+        plannedOp,
+        expect.stringMatching(/^\d{4}-\d{2}$/),
+      );
+      expect(PlannedOperationsDB.executeAndMark).not.toHaveBeenCalled();
+
+      expect(result.current.plannedOperations).toHaveLength(1);
+      expect(result.current.plannedOperations[0].lastExecutedMonth).toMatch(/^\d{4}-\d{2}$/);
+    });
+
+    it('removes one-time planned operation from state after marking executed', async () => {
+      const plannedOp = {
+        id: '2',
+        name: 'One-time',
+        type: 'expense',
+        amount: '100',
+        accountId: 1,
+        categoryId: 'cat1',
+        isRecurring: false,
+        lastExecutedMonth: null,
+      };
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+
+      const { result } = await renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.markPlannedOperationExecuted(plannedOp);
+      });
+
+      expect(result.current.plannedOperations).toHaveLength(0);
+    });
+
+    it('shows dialog and re-throws when markExecutedOnly fails', async () => {
+      const plannedOp = {
+        id: '1', name: 'Rent', type: 'expense', amount: '500',
+        accountId: 1, categoryId: 'cat1', isRecurring: true, lastExecutedMonth: null,
+      };
+      PlannedOperationsDB.getAllPlannedOperations.mockResolvedValue([plannedOp]);
+      PlannedOperationsDB.markExecutedOnly.mockRejectedValue(new Error('write failed'));
+
+      const { result } = await renderHook(() => usePlannedOperations(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await expect(result.current.markPlannedOperationExecuted(plannedOp)).rejects.toThrow('write failed');
+      });
+
+      expect(mockShowDialog).toHaveBeenCalled();
     });
   });
 

--- a/__tests__/screens/PlannedOperationsScreen.test.js
+++ b/__tests__/screens/PlannedOperationsScreen.test.js
@@ -31,6 +31,7 @@ jest.mock('../../app/contexts/DialogContext', () => ({
 }));
 
 const mockExecute = jest.fn();
+const mockMarkExecuted = jest.fn();
 const mockDelete = jest.fn();
 const mockIsExecuted = jest.fn();
 
@@ -43,6 +44,7 @@ jest.mock('../../app/contexts/PlannedOperationsContext', () => ({
     ],
     loading: false,
     executePlannedOperation: mockExecute,
+    markPlannedOperationExecuted: mockMarkExecuted,
     deletePlannedOperation: mockDelete,
     isExecutedThisMonth: mockIsExecuted,
   }),
@@ -171,6 +173,25 @@ describe('PlannedOperationsScreen', () => {
       mockIsExecuted.mockReturnValue(true);
       const { queryByTestId } = await renderScreen();
       expect(queryByTestId('execute-action-r1')).toBeNull();
+    });
+  });
+
+  describe('Mark as executed action', () => {
+    it('calls markPlannedOperationExecuted when mark-executed swipe action is pressed', async () => {
+      mockIsExecuted.mockReturnValue(false);
+      const { getByTestId } = await renderScreen();
+      await fireEvent.press(getByTestId('mark-executed-action-r1'));
+      await waitFor(() => {
+        expect(mockMarkExecuted).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'r1' }),
+        );
+      });
+    });
+
+    it('does not render mark-executed action for executed items', async () => {
+      mockIsExecuted.mockReturnValue(true);
+      const { queryByTestId } = await renderScreen();
+      expect(queryByTestId('mark-executed-action-r1')).toBeNull();
     });
   });
 });

--- a/__tests__/services/PlannedOperationsDB.test.js
+++ b/__tests__/services/PlannedOperationsDB.test.js
@@ -375,4 +375,65 @@ describe('PlannedOperationsDB Service', () => {
       expect(markCalls).toHaveLength(0);
     });
   });
+
+  describe('markExecutedOnly (mark executed without creating an operation)', () => {
+    const recurringOp = {
+      id: 'plan-1',
+      isRecurring: true,
+    };
+
+    const oneTimeOp = {
+      id: 'plan-2',
+      isRecurring: false,
+    };
+
+    it('runs everything in a single transaction', async () => {
+      await PlannedOperationsDB.markExecutedOnly(recurringOp, '2026-05');
+
+      expect(executeTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT create a real operation', async () => {
+      await PlannedOperationsDB.markExecutedOnly(recurringOp, '2026-05');
+
+      expect(createOperationInTx).not.toHaveBeenCalled();
+    });
+
+    it('updates last_executed_month for recurring planned operation', async () => {
+      await PlannedOperationsDB.markExecutedOnly(recurringOp, '2026-05');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE planned_operations SET last_executed_month'),
+        expect.arrayContaining(['2026-05', 'plan-1']),
+      );
+    });
+
+    it('does NOT delete a recurring planned operation', async () => {
+      await PlannedOperationsDB.markExecutedOnly(recurringOp, '2026-05');
+
+      const deleteCalls = mockDb.runAsync.mock.calls.filter(
+        ([sql]) => sql.includes('DELETE FROM planned_operations'),
+      );
+      expect(deleteCalls).toHaveLength(0);
+    });
+
+    it('deletes a one-time planned operation after marking executed', async () => {
+      await PlannedOperationsDB.markExecutedOnly(oneTimeOp, '2026-05');
+
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM planned_operations WHERE id = ?'),
+        ['plan-2'],
+      );
+    });
+
+    it('propagates errors and rolls back (no partial state)', async () => {
+      executeTransaction.mockImplementation(async () => {
+        throw new Error('write failed');
+      });
+
+      await expect(
+        PlannedOperationsDB.markExecutedOnly(recurringOp, '2026-05'),
+      ).rejects.toThrow('write failed');
+    });
+  });
 });

--- a/app/contexts/PlannedOperationsContext.js
+++ b/app/contexts/PlannedOperationsContext.js
@@ -181,6 +181,32 @@ export const PlannedOperationsProvider = ({ children }) => {
   }, [showDialog, t]);
 
   /**
+   * Mark a planned operation as executed without creating a real operation
+   * (for cases where the user already added the operation manually).
+   */
+  const markPlannedOperationExecuted = useCallback(async (plannedOp) => {
+    try {
+      const currentMonth = getCurrentMonth();
+
+      await PlannedOperationsDB.markExecutedOnly(plannedOp, currentMonth);
+
+      if (plannedOp.isRecurring) {
+        setPlannedOperations(prev =>
+          prev.map(op => op.id === plannedOp.id
+            ? { ...op, lastExecutedMonth: currentMonth }
+            : op),
+        );
+      } else {
+        setPlannedOperations(prev => prev.filter(op => op.id !== plannedOp.id));
+      }
+    } catch (error) {
+      console.error('Failed to mark planned operation as executed:', error);
+      showDialog(t('error'), error.message, [{ text: t('ok') }]);
+      throw error;
+    }
+  }, [showDialog, t]);
+
+  /**
    * Check if a planned operation has been executed this month
    */
   const isExecutedThisMonth = useCallback((plannedOp) => {
@@ -195,6 +221,7 @@ export const PlannedOperationsProvider = ({ children }) => {
     updatePlannedOperation,
     deletePlannedOperation,
     executePlannedOperation,
+    markPlannedOperationExecuted,
     isExecutedThisMonth,
     reloadPlannedOperations,
   }), [
@@ -205,6 +232,7 @@ export const PlannedOperationsProvider = ({ children }) => {
     updatePlannedOperation,
     deletePlannedOperation,
     executePlannedOperation,
+    markPlannedOperationExecuted,
     isExecutedThisMonth,
     reloadPlannedOperations,
   ]);

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -37,6 +37,7 @@ export default function PlannedOperationsScreen() {
     plannedOperations,
     loading,
     executePlannedOperation,
+    markPlannedOperationExecuted,
     deletePlannedOperation,
     isExecutedThisMonth,
   } = usePlannedOperations();
@@ -216,6 +217,16 @@ export default function PlannedOperationsScreen() {
     }
   }, [executePlannedOperation, t]);
 
+  const handleMarkExecuted = useCallback(async (op) => {
+    try {
+      await markPlannedOperationExecuted(op);
+      setSnackbarMessage(t('marked_as_executed'));
+      setSnackbarVisible(true);
+    } catch (error) {
+      // Error handled by context
+    }
+  }, [markPlannedOperationExecuted, t]);
+
   const handleLongPress = useCallback((op) => {
     showDialog(
       t('select_action'),
@@ -249,17 +260,29 @@ export default function PlannedOperationsScreen() {
   }, [showDialog, t, handleEdit, deletePlannedOperation]);
 
   const renderRightActions = useCallback((item) => (
-    <Pressable
-      testID={`execute-action-${item.id}`}
-      style={[styles.swipeExecute, { backgroundColor: colors.primary }]}
-      onPress={() => handleExecute(item)}
-      accessibilityRole="button"
-      accessibilityLabel={t('execute')}
-    >
-      <Icon name="play" size={20} color="white" />
-      <Text style={styles.swipeExecuteText}>{t('execute')}</Text>
-    </Pressable>
-  ), [colors.primary, handleExecute, t]);
+    <View style={styles.swipeActionsContainer}>
+      <Pressable
+        testID={`execute-action-${item.id}`}
+        style={[styles.swipeExecute, { backgroundColor: colors.primary }]}
+        onPress={() => handleExecute(item)}
+        accessibilityRole="button"
+        accessibilityLabel={t('execute')}
+      >
+        <Icon name="play" size={20} color="white" />
+        <Text style={styles.swipeExecuteText}>{t('execute')}</Text>
+      </Pressable>
+      <Pressable
+        testID={`mark-executed-action-${item.id}`}
+        style={[styles.swipeExecute, { backgroundColor: colors.income }]}
+        onPress={() => handleMarkExecuted(item)}
+        accessibilityRole="button"
+        accessibilityLabel={t('mark_as_executed')}
+      >
+        <Icon name="check-bold" size={20} color="white" />
+        <Text style={styles.swipeExecuteText}>{t('done')}</Text>
+      </Pressable>
+    </View>
+  ), [colors.primary, colors.income, handleExecute, handleMarkExecuted, t]);
 
   const renderSectionHeader = useCallback(({ section }) => {
     const label = section.key === 'recurring' ? `🔁 ${t('recurring')}` : `1️⃣ ${t('one_time')}`;
@@ -346,7 +369,10 @@ export default function PlannedOperationsScreen() {
         friction={2}
         rightThreshold={60}
       >
-        <View testID={`item-opacity-${item.id}`}>
+        <View
+          testID={`item-opacity-${item.id}`}
+          style={[styles.swipeRowCover, { backgroundColor: colors.background }]}
+        >
           {rowContent}
         </View>
       </Swipeable>
@@ -535,6 +561,10 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.md,
     fontWeight: '700',
   },
+  swipeActionsContainer: {
+    flexDirection: 'row',
+    gap: SPACING.xs,
+  },
   swipeExecute: {
     alignItems: 'center',
     borderRadius: BORDER_RADIUS.md,
@@ -548,5 +578,8 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.xs,
     fontWeight: '600',
     marginTop: 2,
+  },
+  swipeRowCover: {
+    borderRadius: BORDER_RADIUS.md,
   },
 });

--- a/app/services/PlannedOperationsDB.js
+++ b/app/services/PlannedOperationsDB.js
@@ -263,6 +263,30 @@ export const markExecuted = async (id, monthStr) => {
 };
 
 /**
+ * Mark a planned operation as executed without creating a real operation
+ * (e.g. it was already added to operations manually). Runs the executed-flag
+ * update and the one-time delete in a single transaction, mirroring
+ * executeAndMark's atomicity guarantees.
+ */
+export const markExecutedOnly = async (plannedOp, currentMonth) => {
+  try {
+    await executeTransaction(async (db) => {
+      await db.runAsync(
+        'UPDATE planned_operations SET last_executed_month = ?, updated_at = ? WHERE id = ?',
+        [currentMonth, new Date().toISOString(), plannedOp.id],
+      );
+
+      if (!plannedOp.isRecurring) {
+        await db.runAsync('DELETE FROM planned_operations WHERE id = ?', [plannedOp.id]);
+      }
+    });
+  } catch (error) {
+    console.error('Failed to mark planned operation as executed:', error);
+    throw error;
+  }
+};
+
+/**
  * Atomically execute a planned operation in a single SQLite transaction:
  * inserts the real operation, adjusts account balances, marks the planned
  * operation as executed, and (for one-time plans) deletes it.

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Zum Neuordnen ziehen",
   "error_loading_accounts": "Konten konnten nicht geladen werden",
   "execute": "Ausführen",
+  "mark_as_executed": "Als ausgeführt markieren",
+  "marked_as_executed": "Als ausgeführt markiert",
   "loading_accounts": "Konten werden geladen...",
   "loading_categories": "Kategorien werden geladen...",
   "none": "Keine",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Drag to reorder",
   "error_loading_accounts": "Failed to load accounts",
   "execute": "Execute",
+  "mark_as_executed": "Mark as executed",
+  "marked_as_executed": "Marked as executed",
   "loading_accounts": "Loading accounts...",
   "loading_categories": "Loading categories...",
   "none": "None",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Arrastra para reordenar",
   "error_loading_accounts": "Error al cargar las cuentas",
   "execute": "Ejecutar",
+  "mark_as_executed": "Marcar como ejecutada",
+  "marked_as_executed": "Marcada como ejecutada",
   "loading_accounts": "Cargando cuentas...",
   "loading_categories": "Cargando categorías...",
   "none": "Ninguno",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Glisser pour réorganiser",
   "error_loading_accounts": "Échec du chargement des comptes",
   "execute": "Exécuter",
+  "mark_as_executed": "Marquer comme exécutée",
+  "marked_as_executed": "Marquée comme exécutée",
   "loading_accounts": "Chargement des comptes...",
   "loading_categories": "Chargement des catégories...",
   "none": "Aucun",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Քաշեք՝ վերադասավորելու համար",
   "error_loading_accounts": "Չհաջողվեց բեռնել հաշիվները",
   "execute": "Կատարել",
+  "mark_as_executed": "Նշել որպես կատարված",
+  "marked_as_executed": "Նշված է որպես կատարված",
   "loading_accounts": "Հաշիվների բեռնում...",
   "loading_categories": "Կատեգորիաների բեռնում...",
   "none": "Չկա",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Trascina per riordinare",
   "error_loading_accounts": "Impossibile caricare i conti",
   "execute": "Esegui",
+  "mark_as_executed": "Segna come eseguita",
+  "marked_as_executed": "Segnata come eseguita",
   "loading_accounts": "Caricamento conti...",
   "loading_categories": "Caricamento categorie...",
   "none": "Nessuno",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "ドラッグして並べ替え",
   "error_loading_accounts": "アカウントの読み込みに失敗しました",
   "execute": "実行",
+  "mark_as_executed": "実行済みにする",
+  "marked_as_executed": "実行済みにしました",
   "loading_accounts": "アカウントを読み込み中...",
   "loading_categories": "カテゴリを読み込み中...",
   "none": "なし",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "드래그하여 순서 변경",
   "error_loading_accounts": "계정을 불러오지 못했습니다",
   "execute": "실행",
+  "mark_as_executed": "실행됨으로 표시",
+  "marked_as_executed": "실행됨으로 표시되었습니다",
   "loading_accounts": "계정 불러오는 중...",
   "loading_categories": "카테고리 불러오는 중...",
   "none": "없음",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Arraste para reordenar",
   "error_loading_accounts": "Falha ao carregar as contas",
   "execute": "Executar",
+  "mark_as_executed": "Marcar como executada",
+  "marked_as_executed": "Marcada como executada",
   "loading_accounts": "Carregando contas...",
   "loading_categories": "Carregando categorias...",
   "none": "Nenhum",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "Перетащите для изменения порядка",
   "error_loading_accounts": "Не удалось загрузить счета",
   "execute": "Выполнить",
+  "mark_as_executed": "Отметить как выполненную",
+  "marked_as_executed": "Отмечено как выполненное",
   "loading_accounts": "Загрузка счетов...",
   "loading_categories": "Загрузка категорий...",
   "none": "Нет",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -476,6 +476,8 @@
   "drag_to_reorder": "拖动以重新排序",
   "error_loading_accounts": "加载账户失败",
   "execute": "执行",
+  "mark_as_executed": "标记为已执行",
+  "marked_as_executed": "已标记为已执行",
   "loading_accounts": "正在加载账户...",
   "loading_categories": "正在加载分类...",
   "none": "无",


### PR DESCRIPTION
## Summary

Adds a "mark as executed" swipe action for planned operations (for the case where the user already added the operation manually), next to the existing "Execute" action. Also fixes the swipe row appearing transparent/out of sync during the swipe gesture — the row now has an opaque background so it fully covers the reveal actions until swiped.

## Changes

- **app/services/PlannedOperationsDB.js** — add `markExecutedOnly(plannedOp, currentMonth)`, an atomic transaction that updates `last_executed_month` and deletes one-time plans, without inserting a real operation.
- **app/contexts/PlannedOperationsContext.js** — add `markPlannedOperationExecuted`, exposed via context, calling `markExecutedOnly` and updating local state the same way `executePlannedOperation` does (minus the operation creation).
- **app/screens/PlannedOperationsScreen.js** — add a second swipe action button ("Mark as executed") beside "Execute"; give the swipeable row an opaque `colors.background` so it fully covers the right actions instead of showing them through a transparent row during swipe.
- **assets/i18n/*.json** (all 11 languages) — add `mark_as_executed` and `marked_as_executed` strings.
- **__tests__/...** — tests for the new DB function, context method, and screen swipe action.

## Testing

`npm test -- --silent` — 138 suites / 4115 tests pass.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files
- [ ] Linked the related issue with `Closes #NNN` below — n/a

Closes #


---
_Generated by [Claude Code](https://claude.ai/code/session_01CVwrDg56SV1pDZJhHCyrgP)_