### PR TITLE
feat(planned): add undo swipe action for executed operations

### DIFF
--- a/__tests__/screens/PlannedOperationsScreen.test.js
+++ b/__tests__/screens/PlannedOperationsScreen.test.js
@@ -32,6 +32,7 @@ jest.mock('../../app/contexts/DialogContext', () => ({
 
 const mockExecute = jest.fn();
 const mockMarkExecuted = jest.fn();
+const mockUpdate = jest.fn();
 const mockDelete = jest.fn();
 const mockIsExecuted = jest.fn();
 
@@ -45,6 +46,7 @@ jest.mock('../../app/contexts/PlannedOperationsContext', () => ({
     loading: false,
     executePlannedOperation: mockExecute,
     markPlannedOperationExecuted: mockMarkExecuted,
+    updatePlannedOperation: mockUpdate,
     deletePlannedOperation: mockDelete,
     isExecutedThisMonth: mockIsExecuted,
   }),
@@ -192,6 +194,23 @@ describe('PlannedOperationsScreen', () => {
       mockIsExecuted.mockReturnValue(true);
       const { queryByTestId } = await renderScreen();
       expect(queryByTestId('mark-executed-action-r1')).toBeNull();
+    });
+  });
+
+  describe('Undo action', () => {
+    it('calls updatePlannedOperation with a cleared lastExecutedMonth when undo swipe action is pressed', async () => {
+      mockIsExecuted.mockImplementation((op) => op.id === 'r1');
+      const { getByTestId } = await renderScreen();
+      await fireEvent.press(getByTestId('undo-action-r1'));
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith('r1', { lastExecutedMonth: null });
+      });
+    });
+
+    it('does not render undo action for un-executed items', async () => {
+      mockIsExecuted.mockReturnValue(false);
+      const { queryByTestId } = await renderScreen();
+      expect(queryByTestId('undo-action-r1')).toBeNull();
     });
   });
 });

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -38,6 +38,7 @@ export default function PlannedOperationsScreen() {
     loading,
     executePlannedOperation,
     markPlannedOperationExecuted,
+    updatePlannedOperation,
     deletePlannedOperation,
     isExecutedThisMonth,
   } = usePlannedOperations();
@@ -227,6 +228,16 @@ export default function PlannedOperationsScreen() {
     }
   }, [markPlannedOperationExecuted, t]);
 
+  const handleUndoExecuted = useCallback(async (op) => {
+    try {
+      await updatePlannedOperation(op.id, { lastExecutedMonth: null });
+      setSnackbarMessage(t('marked_as_pending'));
+      setSnackbarVisible(true);
+    } catch (error) {
+      // Error handled by context
+    }
+  }, [updatePlannedOperation, t]);
+
   const handleLongPress = useCallback((op) => {
     showDialog(
       t('select_action'),
@@ -283,6 +294,19 @@ export default function PlannedOperationsScreen() {
       </Pressable>
     </View>
   ), [colors.primary, colors.income, handleExecute, handleMarkExecuted, t]);
+
+  const renderUndoAction = useCallback((item) => (
+    <Pressable
+      testID={`undo-action-${item.id}`}
+      style={[styles.swipeExecute, { backgroundColor: colors.mutedText }]}
+      onPress={() => handleUndoExecuted(item)}
+      accessibilityRole="button"
+      accessibilityLabel={t('undo')}
+    >
+      <Icon name="undo" size={20} color="white" />
+      <Text style={styles.swipeExecuteText}>{t('undo')}</Text>
+    </Pressable>
+  ), [colors.mutedText, handleUndoExecuted, t]);
 
   const renderSectionHeader = useCallback(({ section }) => {
     const label = section.key === 'recurring' ? `🔁 ${t('recurring')}` : `1️⃣ ${t('one_time')}`;
@@ -357,7 +381,16 @@ export default function PlannedOperationsScreen() {
           testID={`item-opacity-${item.id}`}
           style={styles.executedWrapper}
         >
-          {rowContent}
+          <Swipeable
+            renderRightActions={() => renderUndoAction(item)}
+            overshootRight={false}
+            friction={2}
+            rightThreshold={60}
+          >
+            <View style={[styles.swipeRowCover, { backgroundColor: colors.background }]}>
+              {rowContent}
+            </View>
+          </Swipeable>
         </View>
       );
     }
@@ -378,7 +411,7 @@ export default function PlannedOperationsScreen() {
       </Swipeable>
     );
   }, [colors, isExecutedThisMonth, getCategoryInfo, getAccountName, getAccountCurrency,
-    getCurrencySymbol, handleEdit, handleLongPress, renderRightActions]);
+    getCurrencySymbol, handleEdit, handleLongPress, renderRightActions, renderUndoAction]);
 
   const renderEmpty = useCallback(() => {
     if (loading) {

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -478,6 +478,8 @@
   "execute": "Ausführen",
   "mark_as_executed": "Als ausgeführt markieren",
   "marked_as_executed": "Als ausgeführt markiert",
+  "undo": "Rückgängig",
+  "marked_as_pending": "Als ausstehend markiert",
   "loading_accounts": "Konten werden geladen...",
   "loading_categories": "Kategorien werden geladen...",
   "none": "Keine",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -478,6 +478,8 @@
   "execute": "Execute",
   "mark_as_executed": "Mark as executed",
   "marked_as_executed": "Marked as executed",
+  "undo": "Undo",
+  "marked_as_pending": "Marked as pending",
   "loading_accounts": "Loading accounts...",
   "loading_categories": "Loading categories...",
   "none": "None",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -478,6 +478,8 @@
   "execute": "Ejecutar",
   "mark_as_executed": "Marcar como ejecutada",
   "marked_as_executed": "Marcada como ejecutada",
+  "undo": "Deshacer",
+  "marked_as_pending": "Marcada como pendiente",
   "loading_accounts": "Cargando cuentas...",
   "loading_categories": "Cargando categorías...",
   "none": "Ninguno",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -478,6 +478,8 @@
   "execute": "Exécuter",
   "mark_as_executed": "Marquer comme exécutée",
   "marked_as_executed": "Marquée comme exécutée",
+  "undo": "Annuler",
+  "marked_as_pending": "Marquée comme en attente",
   "loading_accounts": "Chargement des comptes...",
   "loading_categories": "Chargement des catégories...",
   "none": "Aucun",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -478,6 +478,8 @@
   "execute": "Կատարել",
   "mark_as_executed": "Նշել որպես կատարված",
   "marked_as_executed": "Նշված է որպես կատարված",
+  "undo": "Հետարկել",
+  "marked_as_pending": "Նշված է որպես սպասվող",
   "loading_accounts": "Հաշիվների բեռնում...",
   "loading_categories": "Կատեգորիաների բեռնում...",
   "none": "Չկա",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -478,6 +478,8 @@
   "execute": "Esegui",
   "mark_as_executed": "Segna come eseguita",
   "marked_as_executed": "Segnata come eseguita",
+  "undo": "Annulla",
+  "marked_as_pending": "Segnata come in sospeso",
   "loading_accounts": "Caricamento conti...",
   "loading_categories": "Caricamento categorie...",
   "none": "Nessuno",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -478,6 +478,8 @@
   "execute": "実行",
   "mark_as_executed": "実行済みにする",
   "marked_as_executed": "実行済みにしました",
+  "undo": "元に戻す",
+  "marked_as_pending": "未実行にしました",
   "loading_accounts": "アカウントを読み込み中...",
   "loading_categories": "カテゴリを読み込み中...",
   "none": "なし",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -478,6 +478,8 @@
   "execute": "실행",
   "mark_as_executed": "실행됨으로 표시",
   "marked_as_executed": "실행됨으로 표시되었습니다",
+  "undo": "실행 취소",
+  "marked_as_pending": "대기 중으로 표시되었습니다",
   "loading_accounts": "계정 불러오는 중...",
   "loading_categories": "카테고리 불러오는 중...",
   "none": "없음",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -478,6 +478,8 @@
   "execute": "Executar",
   "mark_as_executed": "Marcar como executada",
   "marked_as_executed": "Marcada como executada",
+  "undo": "Desfazer",
+  "marked_as_pending": "Marcada como pendente",
   "loading_accounts": "Carregando contas...",
   "loading_categories": "Carregando categorias...",
   "none": "Nenhum",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -478,6 +478,8 @@
   "execute": "Выполнить",
   "mark_as_executed": "Отметить как выполненную",
   "marked_as_executed": "Отмечено как выполненное",
+  "undo": "Отменить",
+  "marked_as_pending": "Отмечено как ожидающее",
   "loading_accounts": "Загрузка счетов...",
   "loading_categories": "Загрузка категорий...",
   "none": "Нет",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -478,6 +478,8 @@
   "execute": "执行",
   "mark_as_executed": "标记为已执行",
   "marked_as_executed": "已标记为已执行",
+  "undo": "撤销",
+  "marked_as_pending": "已标记为待处理",
   "loading_accounts": "正在加载账户...",
   "loading_categories": "正在加载分类...",
   "none": "无",


### PR DESCRIPTION
## Summary

Adds an "Undo" swipe action for planned operations that are already marked as done this month (executed via Execute or Mark as executed), so a mistaken tap can be reversed.

## Changes

- **app/screens/PlannedOperationsScreen.js** — wrap executed items in a `Swipeable` with a single "Undo" right action; reuses the existing `updatePlannedOperation(id, { lastExecutedMonth: null })` context call to reset the executed state back to pending. The opaque swipe-row-cover background from the earlier fix is applied here too so the row fully covers the action during swipe.
- **assets/i18n/*.json** (all 11 languages) — add `undo` and `marked_as_pending` strings.
- **__tests__/screens/PlannedOperationsScreen.test.js** — tests for the new undo swipe action.

## Testing

`npm test -- --silent` — 138 suites / 4117 tests pass.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files
- [ ] Linked the related issue with `Closes #NNN` below — n/a

Closes #


---
_Generated by [Claude Code](https://claude.ai/code/session_01CVwrDg56SV1pDZJhHCyrgP)_