### PR TITLE
feat(operations): add undo option for just-added operations

### DIFF
--- a/__tests__/components/operations/UndoSnackbar.test.js
+++ b/__tests__/components/operations/UndoSnackbar.test.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import { Animated } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import UndoSnackbar from '../../../app/components/operations/UndoSnackbar';
+
+const mockColors = {
+  surface: '#1e1e1e',
+  border: '#333',
+  primary: '#4C9EFF',
+  text: '#ffffff',
+};
+
+const flush = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('UndoSnackbar', () => {
+  const baseProps = {
+    operationId: 'op-123',
+    message: 'Operation added',
+    actionLabel: 'Undo',
+    duration: 5000,
+    colors: mockColors,
+    onUndo: jest.fn(),
+    onClosed: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Resolve the entry/exit slide animations synchronously so the close
+    // callbacks fire deterministically and no animation frames leak between
+    // tests. The auto-dismiss window itself is a real setTimeout.
+    jest.spyOn(Animated, 'timing').mockImplementation(() => ({
+      start: (cb) => { if (cb) cb({ finished: true }); },
+    }));
+  });
+
+  afterEach(() => {
+    Animated.timing.mockRestore();
+  });
+
+  it('renders the message and action label', async () => {
+    const { getByText } = await render(<UndoSnackbar {...baseProps} />);
+    expect(getByText('Operation added')).toBeTruthy();
+    expect(getByText('Undo')).toBeTruthy();
+  });
+
+  it('calls onUndo with the operation id when Undo is pressed', async () => {
+    const onUndo = jest.fn();
+    const { getByLabelText } = await render(
+      <UndoSnackbar {...baseProps} onUndo={onUndo} />,
+    );
+    await fireEvent.press(getByLabelText('Undo'));
+    expect(onUndo).toHaveBeenCalledWith('op-123');
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies the parent to close after Undo is pressed', async () => {
+    const onClosed = jest.fn();
+    const { getByLabelText } = await render(
+      <UndoSnackbar {...baseProps} onClosed={onClosed} />,
+    );
+    await fireEvent.press(getByLabelText('Undo'));
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not undo twice when Undo is pressed repeatedly', async () => {
+    const onUndo = jest.fn();
+    const { getByLabelText } = await render(
+      <UndoSnackbar {...baseProps} onUndo={onUndo} />,
+    );
+    const button = getByLabelText('Undo');
+    await fireEvent.press(button);
+    await fireEvent.press(button);
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-dismisses after the duration and calls onClosed without undoing', async () => {
+    const onUndo = jest.fn();
+    const onClosed = jest.fn();
+    await render(
+      <UndoSnackbar {...baseProps} duration={40} onUndo={onUndo} onClosed={onClosed} />,
+    );
+
+    await waitFor(() => expect(onClosed).toHaveBeenCalledTimes(1));
+    expect(onUndo).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-dismiss before the duration elapses', async () => {
+    const onClosed = jest.fn();
+    await render(
+      <UndoSnackbar {...baseProps} duration={10000} onClosed={onClosed} />,
+    );
+
+    // Well within the 10s window — the dismiss timer has not fired.
+    await flush(50);
+    expect(onClosed).not.toHaveBeenCalled();
+  });
+
+  it('clears its auto-dismiss timer on unmount', async () => {
+    const onClosed = jest.fn();
+    const { unmount } = await render(
+      <UndoSnackbar {...baseProps} duration={40} onClosed={onClosed} />,
+    );
+
+    unmount();
+    // Past the (short) duration — had the timer survived, it would have fired.
+    await flush(80);
+    expect(onClosed).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/operations/UndoSnackbar.js
+++ b/app/components/operations/UndoSnackbar.js
@@ -1,0 +1,217 @@
+import React, { memo, useEffect, useRef, useCallback } from 'react';
+import { View, Text, TouchableOpacity, Animated, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import {
+  SPACING,
+  FONT_SIZE,
+  BORDER_RADIUS,
+  DURATION,
+  ICON_SIZE,
+  ELEVATION,
+  Z_INDEX,
+} from '../../styles/designTokens';
+
+/**
+ * UndoSnackbar
+ *
+ * A transient "just-added" bar that floats above the tab bar and offers a brief
+ * window to undo the last created operation. A thin progress bar depletes over
+ * `duration`, giving the user a clear visual cue for how much time remains.
+ *
+ * Lifecycle is intentionally split so the exit animation always plays:
+ *  - `onUndo(operationId)` performs the undo (called before the slide-out).
+ *  - `onClosed()` tells the parent to unmount, and fires only after the exit
+ *    animation completes (whether dismissed by timeout or by the Undo tap).
+ *
+ * Mount this conditionally with a changing `key` (e.g. an incrementing token)
+ * so each new operation restarts the entry animation and countdown cleanly.
+ */
+const UndoSnackbar = ({
+  operationId,
+  message,
+  actionLabel,
+  duration,
+  colors,
+  bottomOffset,
+  onUndo,
+  onClosed,
+}) => {
+  // 0 = hidden (slid down + transparent), 1 = fully shown
+  const revealAnim = useRef(new Animated.Value(0)).current;
+  // 1 = full countdown bar, 0 = depleted
+  const progressAnim = useRef(new Animated.Value(1)).current;
+  // Guards against a double dismiss (e.g. timeout firing right as Undo is tapped)
+  const closingRef = useRef(false);
+
+  const animateOut = useCallback((beforeClosed) => {
+    if (closingRef.current) return;
+    closingRef.current = true;
+    if (beforeClosed) beforeClosed();
+    Animated.timing(revealAnim, {
+      toValue: 0,
+      duration: DURATION.fast,
+      useNativeDriver: true,
+    }).start(() => {
+      onClosed();
+    });
+  }, [revealAnim, onClosed]);
+
+  useEffect(() => {
+    // Entry: slide up + fade in.
+    Animated.timing(revealAnim, {
+      toValue: 1,
+      duration: DURATION.normal,
+      useNativeDriver: true,
+    }).start();
+
+    // Countdown: deplete the progress bar across the full visible window. Driven
+    // with a left-anchored scaleX so it can run on the native thread (see the
+    // `transformOrigin` in styles.progressFill) rather than churning JS state.
+    Animated.timing(progressAnim, {
+      toValue: 0,
+      duration,
+      useNativeDriver: true,
+    }).start();
+
+    // Auto-dismiss once the window elapses.
+    const timer = setTimeout(() => animateOut(), duration);
+    return () => clearTimeout(timer);
+    // Intentionally runs once per mount; a changing `key` handles new operations.
+  }, []);
+
+  const handleUndoPress = useCallback(() => {
+    // Perform the undo first (so it's immediate), then slide the bar away.
+    animateOut(() => onUndo(operationId));
+  }, [animateOut, onUndo, operationId]);
+
+  const translateY = revealAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [40, 0],
+  });
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={[styles.wrapper, { bottom: bottomOffset }]}
+    >
+      <Animated.View
+        style={[
+          styles.card,
+          {
+            backgroundColor: colors.surface,
+            borderColor: colors.border,
+            opacity: revealAnim,
+            transform: [{ translateY }],
+          },
+        ]}
+      >
+        <View style={styles.content}>
+          <Icon
+            name="check-circle"
+            size={ICON_SIZE.md}
+            color={colors.primary}
+          />
+          <Text style={[styles.message, { color: colors.text }]} numberOfLines={1}>
+            {message}
+          </Text>
+          <TouchableOpacity
+            onPress={handleUndoPress}
+            style={styles.actionButton}
+            accessibilityRole="button"
+            accessibilityLabel={actionLabel}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Icon name="undo-variant" size={ICON_SIZE.sm} color={colors.primary} />
+            <Text style={[styles.actionText, { color: colors.primary }]}>
+              {actionLabel}
+            </Text>
+          </TouchableOpacity>
+        </View>
+        <View style={[styles.progressTrack, { backgroundColor: colors.border }]}>
+          <Animated.View
+            style={[
+              styles.progressFill,
+              { backgroundColor: colors.primary, transform: [{ scaleX: progressAnim }] },
+            ]}
+          />
+        </View>
+      </Animated.View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  actionButton: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+  },
+  actionText: {
+    fontSize: FONT_SIZE.md,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  card: {
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    overflow: 'hidden',
+    width: '92%',
+    ...ELEVATION.high,
+  },
+  content: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    paddingVertical: SPACING.md,
+  },
+  message: {
+    flex: 1,
+    fontSize: FONT_SIZE.md,
+    fontWeight: '500',
+  },
+  progressFill: {
+    height: 3,
+    // Anchor the scaleX countdown to the left edge so it depletes rightward.
+    transformOrigin: 'left',
+    width: '100%',
+  },
+  progressTrack: {
+    height: 3,
+    width: '100%',
+  },
+  wrapper: {
+    alignItems: 'center',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    zIndex: Z_INDEX.toast,
+  },
+});
+
+UndoSnackbar.propTypes = {
+  operationId: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  actionLabel: PropTypes.string.isRequired,
+  duration: PropTypes.number,
+  colors: PropTypes.shape({
+    surface: PropTypes.string.isRequired,
+    border: PropTypes.string.isRequired,
+    primary: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }).isRequired,
+  bottomOffset: PropTypes.number,
+  onUndo: PropTypes.func.isRequired,
+  onClosed: PropTypes.func.isRequired,
+};
+
+UndoSnackbar.defaultProps = {
+  duration: 5000,
+  bottomOffset: 140,
+};
+
+export default memo(UndoSnackbar);

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -21,6 +21,7 @@ import ListCard from '../components/ListCard';
 import OperationsList from '../components/operations/OperationsList';
 import QuickAddForm from '../components/operations/QuickAddForm';
 import PickerModal from '../components/operations/PickerModal';
+import UndoSnackbar from '../components/operations/UndoSnackbar';
 import SearchOverlay from '../components/search/SearchOverlay';
 import SearchBar from '../components/search/SearchBar';
 import FilterChipStrip from '../components/search/FilterChipStrip';
@@ -74,6 +75,11 @@ const OperationsScreen = () => {
   // a ref so applying a label does not depend on the freshly-created operation
   // having already been re-loaded into `operations` (which is async).
   const pendingOpDescRef = useRef('');
+  // Undo bar for a just-added operation. `token` bumps on every add so the
+  // snackbar remounts (restarting its countdown/animation) when operations are
+  // added back-to-back within the 5-second window.
+  const [undoInfo, setUndoInfo] = useState(null); // null | { id, token }
+  const undoTokenRef = useRef(0);
   const [filterPanelHeight, setFilterPanelHeight] = useState(0);
   // Seeded with an estimate of the collapsed search-pill area so the list's top
   // inset is roughly right on first paint; the real value arrives via onLayout.
@@ -556,6 +562,12 @@ const OperationsScreen = () => {
 
       const createdOperation = await addOperation(operationData);
 
+      // Offer a brief window to undo the just-created operation.
+      if (createdOperation?.id) {
+        undoTokenRef.current += 1;
+        setUndoInfo({ id: createdOperation.id, token: undoTokenRef.current });
+      }
+
       // Save last accessed account
       if (quickAddValues.accountId) {
         setLastAccessedAccount(quickAddValues.accountId);
@@ -635,6 +647,23 @@ const OperationsScreen = () => {
   const handleDismissSuggestion = useCallback(() => {
     setPendingSuggestionId(null);
     setPendingSuggestions([]);
+  }, []);
+
+  // Undo a just-added operation: delete it and drop any label suggestions that
+  // targeted it (otherwise the suggestion row would point at a deleted op).
+  const handleUndoAdd = useCallback((operationId) => {
+    deleteOperation(operationId);
+    setPendingSuggestionId((prev) => {
+      if (prev === operationId) {
+        setPendingSuggestions([]);
+        return null;
+      }
+      return prev;
+    });
+  }, [deleteOperation]);
+
+  const handleUndoClosed = useCallback(() => {
+    setUndoInfo(null);
   }, []);
 
   // Keep the suggestion row in sync with the operation's current labels. When the
@@ -955,6 +984,20 @@ const OperationsScreen = () => {
         >
           <Icon name="chevron-up" size={24} color={colors.text} />
         </TouchableOpacity>
+      )}
+
+      {/* Undo bar for the most recently added operation (auto-hides after 5s) */}
+      {undoInfo && (
+        <UndoSnackbar
+          key={undoInfo.token}
+          operationId={undoInfo.id}
+          message={t('operation_added')}
+          actionLabel={t('undo')}
+          duration={5000}
+          colors={colors}
+          onUndo={handleUndoAdd}
+          onClosed={handleUndoClosed}
+        />
       )}
 
       <OperationModal

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Als ausgeführt markieren",
   "marked_as_executed": "Als ausgeführt markiert",
   "undo": "Rückgängig",
+  "operation_added": "Vorgang hinzugefügt",
   "marked_as_pending": "Als ausstehend markiert",
   "loading_accounts": "Konten werden geladen...",
   "loading_categories": "Kategorien werden geladen...",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Mark as executed",
   "marked_as_executed": "Marked as executed",
   "undo": "Undo",
+  "operation_added": "Operation added",
   "marked_as_pending": "Marked as pending",
   "loading_accounts": "Loading accounts...",
   "loading_categories": "Loading categories...",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Marcar como ejecutada",
   "marked_as_executed": "Marcada como ejecutada",
   "undo": "Deshacer",
+  "operation_added": "Operación añadida",
   "marked_as_pending": "Marcada como pendiente",
   "loading_accounts": "Cargando cuentas...",
   "loading_categories": "Cargando categorías...",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Marquer comme exécutée",
   "marked_as_executed": "Marquée comme exécutée",
   "undo": "Annuler",
+  "operation_added": "Opération ajoutée",
   "marked_as_pending": "Marquée comme en attente",
   "loading_accounts": "Chargement des comptes...",
   "loading_categories": "Chargement des catégories...",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Նշել որպես կատարված",
   "marked_as_executed": "Նշված է որպես կատարված",
   "undo": "Հետարկել",
+  "operation_added": "Գործարքն ավելացվեց",
   "marked_as_pending": "Նշված է որպես սպասվող",
   "loading_accounts": "Հաշիվների բեռնում...",
   "loading_categories": "Կատեգորիաների բեռնում...",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Segna come eseguita",
   "marked_as_executed": "Segnata come eseguita",
   "undo": "Annulla",
+  "operation_added": "Operazione aggiunta",
   "marked_as_pending": "Segnata come in sospeso",
   "loading_accounts": "Caricamento conti...",
   "loading_categories": "Caricamento categorie...",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "実行済みにする",
   "marked_as_executed": "実行済みにしました",
   "undo": "元に戻す",
+  "operation_added": "取引を追加しました",
   "marked_as_pending": "未実行にしました",
   "loading_accounts": "アカウントを読み込み中...",
   "loading_categories": "カテゴリを読み込み中...",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "실행됨으로 표시",
   "marked_as_executed": "실행됨으로 표시되었습니다",
   "undo": "실행 취소",
+  "operation_added": "거래가 추가되었습니다",
   "marked_as_pending": "대기 중으로 표시되었습니다",
   "loading_accounts": "계정 불러오는 중...",
   "loading_categories": "카테고리 불러오는 중...",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Marcar como executada",
   "marked_as_executed": "Marcada como executada",
   "undo": "Desfazer",
+  "operation_added": "Operação adicionada",
   "marked_as_pending": "Marcada como pendente",
   "loading_accounts": "Carregando contas...",
   "loading_categories": "Carregando categorias...",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "Отметить как выполненную",
   "marked_as_executed": "Отмечено как выполненное",
   "undo": "Отменить",
+  "operation_added": "Операция добавлена",
   "marked_as_pending": "Отмечено как ожидающее",
   "loading_accounts": "Загрузка счетов...",
   "loading_categories": "Загрузка категорий...",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -479,6 +479,7 @@
   "mark_as_executed": "标记为已执行",
   "marked_as_executed": "已标记为已执行",
   "undo": "撤销",
+  "operation_added": "已添加操作",
   "marked_as_pending": "已标记为待处理",
   "loading_accounts": "正在加载账户...",
   "loading_categories": "正在加载分类...",


### PR DESCRIPTION
## Summary

Just-added operations can now be cancelled. After a quick-add, a transient "Operation added" bar slides up above the tab bar with an **Undo** action and a depleting countdown progress bar. It stays visible for 5 seconds, giving the user a clear window (and visual cue of remaining time) to reverse the entry before it disappears.

## Changes

- **app/components/operations/UndoSnackbar.js** — new floating "just-added" bar: check icon + message + Undo action, with a slide-up/fade entry & exit and a native-driven `scaleX` countdown bar (left-anchored via `transformOrigin`). Auto-dismisses after the duration; a `closingRef` guard prevents a double dismiss when the timeout and the Undo tap race. Lifecycle is split so `onUndo` runs immediately on tap while `onClosed` fires only after the exit animation, keeping the animation intact.
- **app/screens/OperationsScreen.js** — capture the created operation on quick-add and show the bar; Undo deletes that operation (reversing balances) and clears any pending label suggestions that targeted it. An incrementing token used as the component `key` remounts the bar so the countdown/animation restart cleanly for back-to-back adds.
- **assets/i18n/*.json** — add `operation_added` string for all 11 languages.
- **__tests__/components/operations/UndoSnackbar.test.js** — cover render, Undo (id passed, single invocation, parent close), auto-dismiss without undoing, and timer cleanup on unmount.

## Testing

- `npm test` — 139 suites / 4124 tests pass.
- `npm run lint` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — or n/a
- [ ] Linked the related issue with `Closes #NNN` below — or n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dc2vrLthPio8uX6Lq8fpQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018dc2vrLthPio8uX6Lq8fpQ)_