### PR TITLE
feat: auto-refresh notification processing panel with animated new cards

### DIFF
--- a/__tests__/components/NotificationProcessingContentPanel.test.js
+++ b/__tests__/components/NotificationProcessingContentPanel.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import NotificationProcessingContentPanel from '../../app/components/NotificationProcessingContentPanel';
 import * as pipeline from '../../app/services/notifications/processBankNotifications';
 import * as PendingNotificationsDB from '../../app/services/PendingNotificationsDB';
@@ -254,6 +254,61 @@ describe('NotificationProcessingContentPanel', () => {
           'pt1', expect.objectContaining({ accountId: 1, toAccountId: 2 }),
         ),
       );
+    });
+  });
+
+  describe('auto-refresh', () => {
+    // Grab the 3-second tick the panel arms after its initial load. Spying on
+    // setInterval and invoking the callback directly sidesteps the fragile
+    // fake-timer/async-pipeline interaction while still asserting the contract.
+    const getAutoRefreshTick = (spy) => {
+      const call = spy.mock.calls.find(([, ms]) => ms === 3000);
+      expect(call).toBeTruthy();
+      return call[0];
+    };
+
+    it('arms a 3-second interval that re-runs the pipeline and reloads the lists', async () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      try {
+        const { getByText } = await render(<NotificationProcessingContentPanel />);
+        await waitFor(() => expect(getByText('NAREK MEHRABYAN')).toBeTruthy());
+
+        const tick = getAutoRefreshTick(setIntervalSpy);
+        const recentBefore = NotificationAccess.getRecentNotifications.mock.calls.length;
+        const processBefore = pipeline.processBankNotifications.mock.calls.length;
+        const pendingBefore = PendingNotificationsDB.getPendingNotifications.mock.calls.length;
+
+        await act(async () => { await tick(); });
+
+        expect(NotificationAccess.getRecentNotifications.mock.calls.length).toBe(recentBefore + 1);
+        expect(pipeline.processBankNotifications.mock.calls.length).toBe(processBefore + 1);
+        expect(PendingNotificationsDB.getPendingNotifications.mock.calls.length).toBe(pendingBefore + 1);
+      } finally {
+        setIntervalSpy.mockRestore();
+      }
+    });
+
+    it('surfaces a notification that only arrives on a later refresh', async () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      try {
+        const { getByText, queryByText } = await render(<NotificationProcessingContentPanel />);
+        await waitFor(() => expect(getByText('New message')).toBeTruthy());
+        // Not present yet — it hasn't been captured at mount time.
+        expect(queryByText('Fresh purchase')).toBeNull();
+
+        // The next fetch (fired by the interval tick) adds a fresh notification.
+        NotificationAccess.getRecentNotifications.mockResolvedValue([
+          { title: 'Chat', text: 'Fresh purchase', packageName: 'com.chat', postTime: 1718000200000 },
+          BANK_RAW,
+          CHAT_RAW,
+        ]);
+        const tick = getAutoRefreshTick(setIntervalSpy);
+        await act(async () => { await tick(); });
+
+        expect(getByText('Fresh purchase')).toBeTruthy();
+      } finally {
+        setIntervalSpy.mockRestore();
+      }
     });
   });
 

--- a/__tests__/components/NotificationsContentPanel.test.js
+++ b/__tests__/components/NotificationsContentPanel.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import NotificationsContentPanel from '../../app/components/NotificationsContentPanel';
+import NotificationsContentPanel, { NotificationCard } from '../../app/components/NotificationsContentPanel';
 
 jest.mock('../../app/contexts/LocalizationContext', () => ({
   useLocalization: () => ({ t: (key) => key }),
@@ -93,5 +93,35 @@ describe('NotificationsContentPanel', () => {
       <NotificationsContentPanel {...baseProps} notifications={notifications} />,
     );
     expect(getByText('notification_no_text')).toBeTruthy();
+  });
+
+  describe('NotificationCard entry animation', () => {
+    const colors = {
+      surface: '#f5f5f5', primary: '#6200ee', selected: '#e8f0ff',
+      text: '#000', mutedText: '#888', border: '#ddd',
+    };
+    const t = (key) => key;
+
+    it('renders its content when animating in', async () => {
+      const notification = {
+        title: 'Bank', text: 'You spent $5', packageName: 'com.bank', postTime: 1718000000000,
+      };
+      const { getByText } = await render(
+        <NotificationCard notification={notification} colors={colors} t={t} animateIn />,
+      );
+      // The fade/slide-in wrapper must not swallow the card's content.
+      expect(getByText('Bank')).toBeTruthy();
+      expect(getByText('You spent $5')).toBeTruthy();
+    });
+
+    it('renders its content at rest when not animating', async () => {
+      const notification = {
+        title: 'Chat', text: 'New message', packageName: 'com.chat', postTime: 1718000100000,
+      };
+      const { getByText } = await render(
+        <NotificationCard notification={notification} colors={colors} t={t} />,
+      );
+      expect(getByText('New message')).toBeTruthy();
+    });
   });
 });

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -32,6 +32,10 @@ import { getLabelForMerchant } from '../services/NotificationRulesDB';
 import { getRecentNotifications } from '../services/NotificationAccess';
 import * as Currency from '../services/currency';
 
+// How often the panel silently re-runs the pipeline and reloads its lists so
+// newly-arrived notifications surface on their own, without a manual pull.
+const AUTO_REFRESH_MS = 3000;
+
 /**
  * "Notification processing" settings subpanel — the main view.
  *
@@ -73,6 +77,12 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
   // whenever the user toggles between the main and filters views.
   const mountedRef = useRef(true);
   useEffect(() => () => { mountedRef.current = false; }, []);
+  // Keys of recent-feed cards already shown. New keys (notifications captured
+  // after the panel opened) animate in; the initial batch is seeded silently so
+  // opening the panel doesn't fire a flurry of animations. `null` until seeded.
+  const seenRecentKeys = useRef(null);
+  // Guards the auto-refresh timer so a slow run can't overlap the next tick.
+  const autoRefreshingRef = useRef(false);
 
   const accountItems = accounts.map((a) => ({
     label: a.name,
@@ -174,6 +184,31 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
     }
   }, [reloadPending, reloadRecent]);
 
+  // Silent variant of handleRefresh for the auto-refresh timer: same work, but no
+  // RefreshControl spinner and guarded against overlapping runs.
+  const runSilentRefresh = useCallback(async () => {
+    if (autoRefreshingRef.current) return;
+    autoRefreshingRef.current = true;
+    try {
+      if (await isBankNotificationsEnabled()) {
+        await processBankNotifications();
+      }
+      if (mountedRef.current) await Promise.all([reloadPending(), reloadRecent()]);
+    } catch (error) {
+      // Non-fatal; keep the last good data until the next tick.
+    } finally {
+      autoRefreshingRef.current = false;
+    }
+  }, [reloadPending, reloadRecent]);
+
+  // Auto-refresh every AUTO_REFRESH_MS once the initial load has finished, so
+  // notifications arriving while the panel is open surface without a manual pull.
+  useEffect(() => {
+    if (loading) return undefined;
+    const intervalId = setInterval(runSilentRefresh, AUTO_REFRESH_MS);
+    return () => clearInterval(intervalId);
+  }, [loading, runSilentRefresh]);
+
   const setChoice = useCallback((id, patch) => {
     setChoices((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
   }, []);
@@ -227,6 +262,32 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
     () => filterNotificationsByApp(recent, hidden),
     [recent, hidden],
   );
+
+  // Give each card a content-stable key (not the array index) so a card keeps
+  // its identity across refreshes even as newer notifications are prepended —
+  // only genuinely new cards mount, so only they animate. A per-render counter
+  // disambiguates the rare notifications that share every field.
+  const keyedRecent = useMemo(() => {
+    const counts = {};
+    return visibleRecent.map((notification) => {
+      const base = `${notification.postTime || 0}|${notification.packageName || ''}|${notification.title || ''}|${notification.text || ''}`;
+      counts[base] = (counts[base] || 0) + 1;
+      const key = counts[base] > 1 ? `${base}#${counts[base]}` : base;
+      return { notification, key };
+    });
+  }, [visibleRecent]);
+
+  // Track which keys have been shown. Runs after render, so the render below sees
+  // the pre-update set and can flag brand-new cards. The first feed load seeds the
+  // set without animating anything.
+  const previouslySeen = seenRecentKeys.current;
+  useEffect(() => {
+    if (seenRecentKeys.current === null) {
+      seenRecentKeys.current = new Set(keyedRecent.map((k) => k.key));
+      return;
+    }
+    keyedRecent.forEach((k) => seenRecentKeys.current.add(k.key));
+  }, [keyedRecent]);
 
   if (loading) {
     return (
@@ -430,10 +491,11 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
           </Text>
         </View>
       ) : (
-        visibleRecent.map((notification, index) => {
-          // Notifications carry no stable id; post time + index keeps keys unique
-          // even when two arrive at the same millisecond.
-          const key = `${notification.postTime || 0}-${index}`;
+        keyedRecent.map(({ notification, key }) => {
+          // A card is "new" (and animates in) when its key wasn't shown before.
+          // Before the first seed (`null`) nothing is new, so the initial batch
+          // renders at rest.
+          const isNew = previouslySeen != null && !previouslySeen.has(key);
           return (
             <NotificationCard
               key={key}
@@ -442,6 +504,7 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
               t={t}
               onReAdd={(n) => handleReAdd(n, key)}
               reAddState={reAddState[key]}
+              animateIn={isNew}
             />
           );
         })

--- a/app/components/NotificationsContentPanel.js
+++ b/app/components/NotificationsContentPanel.js
@@ -19,7 +19,7 @@ const formatPostTime = (postTime) => {
   return `${datePart} · ${timePart}`;
 };
 
-export function NotificationCard({ notification, colors, t, onReAdd, reAddState }) {
+export function NotificationCard({ notification, colors, t, onReAdd, reAddState, animateIn }) {
   const { title, text, packageName, postTime } = notification;
   const timeLabel = formatPostTime(postTime);
   // A notification that parses into a bank transaction is surfaced with an
@@ -29,8 +29,29 @@ export function NotificationCard({ notification, colors, t, onReAdd, reAddState 
   const cardColorStyle = isBank
     ? { backgroundColor: colors.selected, borderColor: colors.primary, borderLeftColor: colors.primary }
     : { backgroundColor: colors.surface, borderColor: colors.border, borderLeftColor: colors.border };
+  // Entry animation: a freshly-captured card fades and slides down into place.
+  // `animateIn` is read once at mount — the card only animates the first time it
+  // appears (its stable key keeps it mounted across auto-refreshes), so existing
+  // cards never re-animate. Non-animated callers get it at rest (value 1).
+  const enterAnim = useRef(new Animated.Value(animateIn ? 0 : 1)).current;
+  useEffect(() => {
+    if (!animateIn) return;
+    Animated.timing(enterAnim, {
+      toValue: 1,
+      duration: 320,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+    // Mount-only: capture the initial `animateIn`; later prop changes are ignored.
+  }, []);
+  const enterStyle = {
+    opacity: enterAnim,
+    transform: [
+      { translateY: enterAnim.interpolate({ inputRange: [0, 1], outputRange: [-12, 0] }) },
+    ],
+  };
   return (
-    <View style={[styles.card, isBank && styles.cardBank, cardColorStyle]}>
+    <Animated.View style={[styles.card, isBank && styles.cardBank, cardColorStyle, enterStyle]}>
       <View style={styles.cardHeader}>
         <View style={styles.cardHeaderLeft}>
           <Ionicons
@@ -102,7 +123,7 @@ export function NotificationCard({ notification, colors, t, onReAdd, reAddState 
           )}
         </View>
       ) : null}
-    </View>
+    </Animated.View>
   );
 }
 
@@ -119,11 +140,14 @@ NotificationCard.propTypes = {
   onReAdd: PropTypes.func,
   // Optional: 'loading' | 'created' | 'pending' feedback state for this card.
   reAddState: PropTypes.oneOf(['loading', 'created', 'pending']),
+  // Optional: when true, the card plays a fade + slide-in animation on mount.
+  animateIn: PropTypes.bool,
 };
 
 NotificationCard.defaultProps = {
   onReAdd: null,
   reAddState: undefined,
+  animateIn: false,
 };
 
 export default function NotificationsContentPanel({ isLoading, notifications, onRefresh, bottomInset }) {

--- a/docs/NOTIFICATION_PROCESSING.md
+++ b/docs/NOTIFICATION_PROCESSING.md
@@ -81,6 +81,17 @@ category:
   `destinationAmount` in target currency, `exchangeRate` source→target); a missing
   rate routes to review instead of booking a wrong amount.
 
+### Live auto-refresh
+
+While the processing panel is open it re-runs the pipeline and reloads both the
+review queue and the **Recent notifications** feed every 3 seconds
+(`NotificationProcessingContentPanel`), so notifications captured while the panel
+is visible surface on their own — no pull-to-refresh needed (that still works).
+The refresh is silent (no spinner) and guarded so a slow run can't overlap the
+next tick; pull-to-refresh keeps its own spinner. A newly-captured card fades and
+slides into the feed (content-stable keys mean only genuinely new cards animate;
+the initial batch appears at rest).
+
 ### Re-adding an already-processed notification
 
 Each already-processed notification stays visible in the **Recent notifications**


### PR DESCRIPTION
## Summary

The notification-processing panel is passive today — it processes once on mount and only updates on a manual pull-to-refresh. This makes it auto-refresh every 3 seconds while open, and gives newly-captured notifications a fade + slide-in entry animation so they visibly appear rather than popping in.

## Changes

- **app/components/NotificationProcessingContentPanel.js** — add a 3-second auto-refresh timer (`runSilentRefresh` + `setInterval`) that re-runs the pipeline and reloads the review queue and recent feed once the initial load finishes; silent (no `RefreshControl` spinner) and guarded so a slow run can't overlap the next tick. Switch the recent feed to content-stable keys (post time + package + title + text, with a per-render counter for duplicates) instead of array indexes, so a card keeps its identity as newer notifications are prepended and only genuinely new cards mount. Track shown keys in a ref and pass `animateIn` to brand-new cards; the initial batch is seeded silently.
- **app/components/NotificationsContentPanel.js** — `NotificationCard` gains an optional `animateIn` prop; when set it plays a mount-only fade + slide-down (`Animated.timing`, 320ms, `Easing.out(Easing.cubic)`, native driver). Default `false` leaves existing usage at rest.
- **docs/NOTIFICATION_PROCESSING.md** — document the live auto-refresh and entry-animation behavior.
- **__tests__/components/NotificationProcessingContentPanel.test.js** — cover that a 3-second interval is armed and re-runs the pipeline/reloads on tick, and that a notification arriving only on a later refresh surfaces.
- **__tests__/components/NotificationsContentPanel.test.js** — cover that `NotificationCard` renders its content both when animating in and at rest.

## Testing

- `npm test` — 139 suites / 4128 tests pass.
- `npx eslint` on the changed files — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new strings)
- [ ] Linked the related issue with `Closes #NNN` below — n/a


---
_Generated by [Claude Code](https://claude.ai/code/session_01MBvDsJhYWiFRJ1zSbsZAMG)_