### PR TITLE
feat(geo): auto-save location for quick-add and notification operations

### DIFF
--- a/__tests__/hooks/useQuickAddLocation.test.js
+++ b/__tests__/hooks/useQuickAddLocation.test.js
@@ -1,0 +1,72 @@
+/**
+ * Tests for useQuickAddLocation — the non-blocking, best-effort location capture
+ * for the quick-add form (issue #1091). operationLocation is mocked so we drive
+ * capture outcomes directly.
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import useQuickAddLocation from '../../app/hooks/useQuickAddLocation';
+import { captureLocationIfEnabled } from '../../app/services/operationLocation';
+
+jest.mock('../../app/services/operationLocation', () => ({
+  captureLocationIfEnabled: jest.fn(),
+}));
+
+const flush = () => act(async () => { await Promise.resolve(); });
+
+describe('useQuickAddLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    captureLocationIfEnabled.mockResolvedValue({ latitude: '40.1', longitude: '44.2' });
+  });
+
+  it('primes a fix when the feature turns on and exposes it via getLocation', async () => {
+    const { result } = await renderHook(() => useQuickAddLocation(true));
+    await waitFor(() => expect(captureLocationIfEnabled).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.getLocation()).toEqual({ latitude: '40.1', longitude: '44.2' }));
+  });
+
+  it('does not capture when disabled, and getLocation stays null', async () => {
+    const { result } = await renderHook(() => useQuickAddLocation(false));
+    await flush();
+    expect(captureLocationIfEnabled).not.toHaveBeenCalled();
+    expect(result.current.getLocation()).toBeNull();
+  });
+
+  it('prime() is a no-op while disabled', async () => {
+    const { result } = await renderHook(() => useQuickAddLocation(false));
+    await act(async () => { result.current.prime(); });
+    await flush();
+    expect(captureLocationIfEnabled).not.toHaveBeenCalled();
+    expect(result.current.getLocation()).toBeNull();
+  });
+
+  it('clears the stored fix when the feature is turned off', async () => {
+    const { result, rerender } = await renderHook(({ on }) => useQuickAddLocation(on), {
+      initialProps: { on: true },
+    });
+    await waitFor(() => expect(result.current.getLocation()).not.toBeNull());
+
+    await act(async () => { rerender({ on: false }); });
+    await flush();
+    expect(result.current.getLocation()).toBeNull();
+  });
+
+  it('a superseded (slower) capture never overwrites a newer fix', async () => {
+    // First prime resolves slowly with a stale fix; a second prime resolves fast
+    // with the fresh fix. Only the newest fix must win.
+    let resolveStale;
+    captureLocationIfEnabled
+      .mockImplementationOnce(() => new Promise((res) => { resolveStale = res; }))
+      .mockResolvedValueOnce({ latitude: '10', longitude: '20' });
+
+    const { result } = await renderHook(() => useQuickAddLocation(true));
+    // The mount effect fired the first (stale, pending) capture.
+    await act(async () => { result.current.prime(); }); // second capture — resolves immediately
+    await waitFor(() => expect(result.current.getLocation()).toEqual({ latitude: '10', longitude: '20' }));
+
+    // Now let the stale capture resolve late — it must be discarded.
+    await act(async () => { resolveStale({ latitude: '99', longitude: '99' }); await Promise.resolve(); });
+    expect(result.current.getLocation()).toEqual({ latitude: '10', longitude: '20' });
+  });
+});

--- a/__tests__/screens/OperationsScreen.test.js
+++ b/__tests__/screens/OperationsScreen.test.js
@@ -149,6 +149,17 @@ jest.mock('../../app/components/operations/PickerModal', () => {
 });
 /* eslint-enable react/prop-types */
 
+// Location wiring: default to the feature off / no fix so existing tests are
+// unaffected; the location-specific test overrides these.
+jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ attachLocation: false })),
+}));
+
+jest.mock('../../app/hooks/useQuickAddLocation', () => jest.fn(() => ({
+  getLocation: jest.fn(() => null),
+  prime: jest.fn(),
+})));
+
 jest.mock('../../app/hooks/useQuickAddForm', () => jest.fn(() => ({
   quickAddValues: {
     type: 'expense',
@@ -1110,6 +1121,134 @@ describe('OperationsScreen', () => {
 
       expect(mockResetForm).toHaveBeenCalled();
       expect(mockClosePicker).toHaveBeenCalled();
+    });
+  });
+
+  describe('Quick-add location', () => {
+    const { act } = require('@testing-library/react-native');
+
+    it('attaches the primed location to a quick-added operation', async () => {
+      const OperationsScreen = require('../../app/screens/OperationsScreen').default;
+      const { useOperationsData } = require('../../app/contexts/OperationsDataContext');
+      const { useOperationsActions } = require('../../app/contexts/OperationsActionsContext');
+      const { useAccountsData } = require('../../app/contexts/AccountsDataContext');
+      const useQuickAddForm = require('../../app/hooks/useQuickAddForm');
+      const useQuickAddLocation = require('../../app/hooks/useQuickAddLocation');
+      const useOperationPicker = require('../../app/hooks/useOperationPicker');
+
+      useOperationPicker.mockReturnValue({
+        pickerState: { visible: true, type: 'category', data: [] },
+        categoryNavigation: { currentFolderId: null, breadcrumb: [] },
+        openPicker: jest.fn(),
+        closePicker: jest.fn(),
+        navigateIntoFolder: jest.fn(),
+        navigateBack: jest.fn(),
+      });
+
+      useQuickAddLocation.mockReturnValue({
+        getLocation: jest.fn(() => ({ latitude: '40.1', longitude: '44.2' })),
+        prime: jest.fn(),
+      });
+
+      const mockAddOperation = jest.fn(() => Promise.resolve({ id: 'new-op' }));
+      useQuickAddForm.mockReturnValue({
+        quickAddValues: { type: 'expense', amount: '100', accountId: 'acc-1', categoryId: 'cat-1' },
+        setQuickAddValues: jest.fn(),
+        getAccountName: jest.fn(() => 'Cash'),
+        getAccountBalance: jest.fn(() => '$1000.00'),
+        getCategoryInfo: jest.fn(() => ({ name: 'Food', icon: 'food' })),
+        getCategoryName: jest.fn(() => 'Food'),
+        filteredCategories: [],
+        resetForm: jest.fn(),
+      });
+
+      useAccountsData.mockReturnValue({
+        accounts: [{ id: 'acc-1', currency: 'USD' }],
+        visibleAccounts: [{ id: 'acc-1', currency: 'USD' }],
+        loading: false,
+      });
+      useOperationsData.mockReturnValue({
+        operations: [], loading: false, loadingMore: false, hasMoreOperations: false,
+      });
+      useOperationsActions.mockReturnValue({
+        deleteOperation: jest.fn(),
+        addOperation: mockAddOperation,
+        validateOperation: jest.fn(() => null),
+        loadMoreOperations: jest.fn(),
+        jumpToDate: jest.fn(),
+      });
+
+      const { getByTestId } = await render(<OperationsScreen />);
+      // handleQuickAdd is reached through the picker's auto-add shortcut (the
+      // quick-add form itself is a mocked list header and not rendered here).
+      await act(async () => {
+        await getByTestId('picker-modal').props.onAutoAddWithCategory('cat-1');
+      });
+
+      expect(mockAddOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: '40.1', longitude: '44.2' }),
+      );
+    });
+
+    it('quick-adds without coordinates when no fix is available', async () => {
+      const OperationsScreen = require('../../app/screens/OperationsScreen').default;
+      const { useOperationsData } = require('../../app/contexts/OperationsDataContext');
+      const { useOperationsActions } = require('../../app/contexts/OperationsActionsContext');
+      const { useAccountsData } = require('../../app/contexts/AccountsDataContext');
+      const useQuickAddForm = require('../../app/hooks/useQuickAddForm');
+      const useQuickAddLocation = require('../../app/hooks/useQuickAddLocation');
+      const useOperationPicker = require('../../app/hooks/useOperationPicker');
+
+      useOperationPicker.mockReturnValue({
+        pickerState: { visible: true, type: 'category', data: [] },
+        categoryNavigation: { currentFolderId: null, breadcrumb: [] },
+        openPicker: jest.fn(),
+        closePicker: jest.fn(),
+        navigateIntoFolder: jest.fn(),
+        navigateBack: jest.fn(),
+      });
+
+      useQuickAddLocation.mockReturnValue({
+        getLocation: jest.fn(() => null),
+        prime: jest.fn(),
+      });
+
+      const mockAddOperation = jest.fn(() => Promise.resolve({ id: 'new-op' }));
+      useQuickAddForm.mockReturnValue({
+        quickAddValues: { type: 'expense', amount: '100', accountId: 'acc-1', categoryId: 'cat-1' },
+        setQuickAddValues: jest.fn(),
+        getAccountName: jest.fn(() => 'Cash'),
+        getAccountBalance: jest.fn(() => '$1000.00'),
+        getCategoryInfo: jest.fn(() => ({ name: 'Food', icon: 'food' })),
+        getCategoryName: jest.fn(() => 'Food'),
+        filteredCategories: [],
+        resetForm: jest.fn(),
+      });
+
+      useAccountsData.mockReturnValue({
+        accounts: [{ id: 'acc-1', currency: 'USD' }],
+        visibleAccounts: [{ id: 'acc-1', currency: 'USD' }],
+        loading: false,
+      });
+      useOperationsData.mockReturnValue({
+        operations: [], loading: false, loadingMore: false, hasMoreOperations: false,
+      });
+      useOperationsActions.mockReturnValue({
+        deleteOperation: jest.fn(),
+        addOperation: mockAddOperation,
+        validateOperation: jest.fn(() => null),
+        loadMoreOperations: jest.fn(),
+        jumpToDate: jest.fn(),
+      });
+
+      const { getByTestId } = await render(<OperationsScreen />);
+      await act(async () => {
+        await getByTestId('picker-modal').props.onAutoAddWithCategory('cat-1');
+      });
+
+      const arg = mockAddOperation.mock.calls[0][0];
+      expect(arg).not.toHaveProperty('latitude');
+      expect(arg).not.toHaveProperty('longitude');
     });
   });
 

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -40,6 +40,18 @@ jest.mock('../../../app/services/PreferencesDB', () => ({
 }));
 import * as PreferencesDB from '../../../app/services/PreferencesDB';
 
+// Location capture is preference-gated; mock it so we can drive "fix available"
+// vs "feature off / no fix" directly. operationLocationFields stays the real pure
+// function so the merge-into-createOperation behavior is exercised.
+jest.mock('../../../app/services/operationLocation', () => ({
+  captureLocationIfEnabled: jest.fn(),
+  operationLocationFields: (loc) =>
+    loc && loc.latitude != null && loc.longitude != null
+      ? { latitude: loc.latitude, longitude: loc.longitude }
+      : {},
+}));
+import * as OperationLocation from '../../../app/services/operationLocation';
+
 // Use the real currency math but stub the live-rate fetch so conversions are
 // deterministic and never hit the network.
 jest.mock('../../../app/services/currency', () => {
@@ -112,6 +124,8 @@ describe('processBankNotifications', () => {
     PreferencesDB.getNumberPreference.mockResolvedValue(null);
     PreferencesDB.setPreference.mockResolvedValue();
     Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: null, source: 'none' });
+    // Location feature off by default — no coordinates attached.
+    OperationLocation.captureLocationIfEnabled.mockResolvedValue(null);
   });
 
   it('does nothing when disabled', async () => {
@@ -138,6 +152,83 @@ describe('processBankNotifications', () => {
       }),
     );
     expect(emitSpy).toHaveBeenCalledWith(EVENTS.RELOAD_ALL);
+  });
+
+  describe('location capture', () => {
+    it('attaches the captured location to an auto-created operation when enabled', async () => {
+      OperationLocation.captureLocationIfEnabled.mockResolvedValue({ latitude: '40.1', longitude: '44.2' });
+      NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+
+      await pipeline.processBankNotifications();
+
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: '40.1', longitude: '44.2' }),
+      );
+    });
+
+    it('books an auto-created operation without coordinates when capture yields none', async () => {
+      OperationLocation.captureLocationIfEnabled.mockResolvedValue(null);
+      NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+
+      await pipeline.processBankNotifications();
+
+      const arg = OperationsDB.createOperation.mock.calls[0][0];
+      expect(arg).not.toHaveProperty('latitude');
+      expect(arg).not.toHaveProperty('longitude');
+    });
+
+    it('captures at most one fix per run even across multiple auto-created operations', async () => {
+      OperationLocation.captureLocationIfEnabled.mockResolvedValue({ latitude: '40.1', longitude: '44.2' });
+      const SECOND = { ...PURCHASE, text: PURCHASE.text.replace('NAREK MEHRABYAN', 'SECOND SHOP'), postTime: PURCHASE.postTime + 1000 };
+      NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE, SECOND]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+
+      const summary = await pipeline.processBankNotifications();
+
+      expect(summary.created).toBe(2);
+      expect(OperationLocation.captureLocationIfEnabled).toHaveBeenCalledTimes(1);
+      expect(OperationsDB.createOperation).toHaveBeenNthCalledWith(1,
+        expect.objectContaining({ latitude: '40.1', longitude: '44.2' }));
+      expect(OperationsDB.createOperation).toHaveBeenNthCalledWith(2,
+        expect.objectContaining({ latitude: '40.1', longitude: '44.2' }));
+    });
+
+    it('does not capture a location when nothing is auto-created (all queued)', async () => {
+      // Untrusted source → the notification is queued, not booked, so no fix.
+      NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [])(key));
+
+      const summary = await pipeline.processBankNotifications();
+
+      expect(summary).toEqual({ created: 0, pending: 1, skipped: 0 });
+      expect(OperationLocation.captureLocationIfEnabled).not.toHaveBeenCalled();
+    });
+
+    it('attaches the captured location when resolving a pending notification', async () => {
+      OperationLocation.captureLocationIfEnabled.mockResolvedValue({ latitude: '1.5', longitude: '2.5' });
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        id: 'p1', type: 'expense', amount: '3900.00', currency: 'AMD',
+        cardMask: '4083***7027', merchant: 'NAREK MEHRABYAN', date: '2026-06-28',
+        accountId: null, categoryId: null, packageName: PKG,
+        createdAt: '2026-06-28T10:15:00.000Z',
+      });
+
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-food' });
+
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: '1.5', longitude: '2.5' }),
+      );
+    });
   });
 
   it('uses a learned label override as the operation label on auto-create', async () => {

--- a/__tests__/services/operationLocation.test.js
+++ b/__tests__/services/operationLocation.test.js
@@ -1,0 +1,107 @@
+/**
+ * Tests for operationLocation — the preference-gated location capture shared by
+ * every operation-creating path (modal, quick-add, notification ingestion).
+ *
+ * The contract: capture only when the opt-in is on AND permission is granted,
+ * and degrade to null on every other path (off, denied, failed fix) so it can
+ * never block saving an operation (issue #1091).
+ */
+
+import {
+  isAttachLocationEnabled,
+  captureLocationIfEnabled,
+  operationLocationFields,
+} from '../../app/services/operationLocation';
+import { ensureLocationPermission, getCurrentLocation } from '../../app/services/LocationService';
+import { getPreference } from '../../app/services/PreferencesDB';
+
+jest.mock('../../app/services/LocationService');
+jest.mock('../../app/services/PreferencesDB', () => ({
+  PREF_KEYS: { ATTACH_LOCATION: 'attach_location' },
+  getPreference: jest.fn(),
+}));
+
+describe('operationLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getPreference.mockResolvedValue('true');
+    ensureLocationPermission.mockResolvedValue({ granted: true, canAskAgain: true });
+    getCurrentLocation.mockResolvedValue({ latitude: '40.1', longitude: '44.2' });
+  });
+
+  describe('isAttachLocationEnabled', () => {
+    it('is true only when the preference is exactly "true"', async () => {
+      getPreference.mockResolvedValue('true');
+      await expect(isAttachLocationEnabled()).resolves.toBe(true);
+    });
+
+    it('is false for any other stored value', async () => {
+      getPreference.mockResolvedValue('false');
+      await expect(isAttachLocationEnabled()).resolves.toBe(false);
+      getPreference.mockResolvedValue('1');
+      await expect(isAttachLocationEnabled()).resolves.toBe(false);
+    });
+
+    it('never throws — a rejected read resolves to false', async () => {
+      getPreference.mockRejectedValue(new Error('db down'));
+      await expect(isAttachLocationEnabled()).resolves.toBe(false);
+    });
+  });
+
+  describe('captureLocationIfEnabled', () => {
+    it('returns coordinates when enabled, permitted, and the fix succeeds', async () => {
+      const coords = await captureLocationIfEnabled();
+      expect(coords).toEqual({ latitude: '40.1', longitude: '44.2' });
+      expect(ensureLocationPermission).toHaveBeenCalledTimes(1);
+      expect(getCurrentLocation).toHaveBeenCalledTimes(1);
+    });
+
+    it('short-circuits to null when the feature is off — no permission prompt, no fix', async () => {
+      getPreference.mockResolvedValue('false');
+      const coords = await captureLocationIfEnabled();
+      expect(coords).toBeNull();
+      expect(ensureLocationPermission).not.toHaveBeenCalled();
+      expect(getCurrentLocation).not.toHaveBeenCalled();
+    });
+
+    it('returns null when permission is not granted — no fix attempted', async () => {
+      ensureLocationPermission.mockResolvedValue({ granted: false, canAskAgain: true });
+      const coords = await captureLocationIfEnabled();
+      expect(coords).toBeNull();
+      expect(getCurrentLocation).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the fix itself fails (timeout / unavailable)', async () => {
+      getCurrentLocation.mockResolvedValue(null);
+      await expect(captureLocationIfEnabled()).resolves.toBeNull();
+    });
+
+    it('forwards options to getCurrentLocation', async () => {
+      await captureLocationIfEnabled({ timeoutMs: 1234 });
+      expect(getCurrentLocation).toHaveBeenCalledWith({ timeoutMs: 1234 });
+    });
+  });
+
+  describe('operationLocationFields', () => {
+    it('returns lat/lng overrides for a valid fix', () => {
+      expect(operationLocationFields({ latitude: '1', longitude: '2' })).toEqual({
+        latitude: '1',
+        longitude: '2',
+      });
+    });
+
+    it('keeps a valid 0 coordinate', () => {
+      expect(operationLocationFields({ latitude: 0, longitude: 0 })).toEqual({
+        latitude: 0,
+        longitude: 0,
+      });
+    });
+
+    it('returns an empty object for null / partial input', () => {
+      expect(operationLocationFields(null)).toEqual({});
+      expect(operationLocationFields(undefined)).toEqual({});
+      expect(operationLocationFields({ latitude: '1' })).toEqual({});
+      expect(operationLocationFields({ longitude: '2' })).toEqual({});
+    });
+  });
+});

--- a/app/hooks/useQuickAddLocation.js
+++ b/app/hooks/useQuickAddLocation.js
@@ -1,0 +1,53 @@
+import { useRef, useCallback, useEffect } from 'react';
+import { captureLocationIfEnabled } from '../services/operationLocation';
+
+/**
+ * useQuickAddLocation — keeps a best-effort current-location fix ready for
+ * quick-add saves WITHOUT ever blocking the save.
+ *
+ * Unlike the operation modal (which has a discrete "open" event to capture on),
+ * the quick-add form is always mounted, so the fix is captured ahead of time and
+ * stashed in a ref: the caller `prime()`s it as the user starts entering an
+ * operation (and after each add) so a fresh fix is usually ready by the time they
+ * tap add, then reads the latest via `getLocation()` at save time and attaches
+ * whatever is available (possibly null — capture is best-effort, issue #1091).
+ *
+ * Concurrency: a slower fix from an earlier prime must never overwrite a newer
+ * one, so each prime bumps a monotonic token and only commits if it is still the
+ * latest. Turning the feature off cancels any in-flight capture and clears the
+ * stored fix so a stale coordinate can never attach after opt-out.
+ *
+ * @param {boolean} enabled - the `attachLocation` preference
+ * @returns {{ getLocation: () => ({latitude:string,longitude:string}|null), prime: () => void }}
+ */
+const useQuickAddLocation = (enabled) => {
+  const locationRef = useRef(null);
+  const runIdRef = useRef(0);
+
+  const prime = useCallback(() => {
+    if (!enabled) return;
+    const runId = ++runIdRef.current;
+    captureLocationIfEnabled()
+      .then((loc) => {
+        if (runId === runIdRef.current) locationRef.current = loc;
+      })
+      .catch(() => {});
+  }, [enabled]);
+
+  // Prime once when the feature turns on; clear the stored fix (and invalidate any
+  // in-flight capture) when it turns off.
+  useEffect(() => {
+    if (!enabled) {
+      runIdRef.current += 1;
+      locationRef.current = null;
+      return;
+    }
+    prime();
+  }, [enabled, prime]);
+
+  const getLocation = useCallback(() => locationRef.current, []);
+
+  return { getLocation, prime };
+};
+
+export default useQuickAddLocation;

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -30,7 +30,9 @@ import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
 import useMultiCurrencyTransfer from '../hooks/useMultiCurrencyTransfer';
 import useOperationPicker from '../hooks/useOperationPicker';
 import useQuickAddForm from '../hooks/useQuickAddForm';
+import useQuickAddLocation from '../hooks/useQuickAddLocation';
 import { useSearch } from '../contexts/SearchContext';
+import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
 
 // Note: dynamic createStyles removed to keep linting stable.
 
@@ -139,6 +141,17 @@ const OperationsScreen = () => {
     foreignRateSource,
     foreignExchangeRate,
   } = useQuickAddForm(visibleAccounts, accounts, categories, t);
+
+  // Opt-in geolocation for quick-add. Read defensively: the context has no default
+  // value, so a missing provider (e.g. in unit tests) yields undefined.
+  const displaySettings = useDisplaySettings();
+  const attachLocation = !!(displaySettings && displaySettings.attachLocation);
+  // Best-effort, non-blocking location capture primed as the user starts entering
+  // an operation; attached at save time (issue #1091).
+  const { getLocation: getQuickAddLocation, prime: primeQuickAddLocation } = useQuickAddLocation(attachLocation);
+  // Tracks whether the amount field is currently empty, so a fix is primed exactly
+  // on the empty → non-empty edge (start of entry) rather than on every keystroke.
+  const amountWasEmptyRef = useRef(true);
 
   const {
     pickerState,
@@ -545,6 +558,15 @@ const OperationsScreen = () => {
     // Strip operationCurrency — not a DB field
     delete operationData.operationCurrency;
 
+    // Attach the current best-effort location when the feature is enabled. The fix
+    // was primed as the user began entering; whatever is ready now is used (possibly
+    // none), and it never blocks saving.
+    const capturedLocation = getQuickAddLocation();
+    if (capturedLocation && capturedLocation.latitude != null && capturedLocation.longitude != null) {
+      operationData.latitude = capturedLocation.latitude;
+      operationData.longitude = capturedLocation.longitude;
+    }
+
     const error = validateOperation(operationData, t);
     if (error) {
       if (operationData.type !== 'transfer' && !operationData.categoryId) {
@@ -575,6 +597,8 @@ const OperationsScreen = () => {
 
       // Reset form but keep account and type
       resetForm();
+      // The amount is cleared; the next entry starts fresh and re-primes location.
+      amountWasEmptyRef.current = true;
 
       Keyboard.dismiss();
 
@@ -595,7 +619,7 @@ const OperationsScreen = () => {
       // Errors from addOperation are already shown via dialog.
       // Errors from getDistinctLabels are non-critical — suggestion row simply won't appear.
     }
-  }, [quickAddValues, validateOperation, addOperation, t, showDialog, accounts, resetForm, lastEditedField]);
+  }, [quickAddValues, validateOperation, addOperation, t, showDialog, accounts, resetForm, lastEditedField, getQuickAddLocation]);
 
   // Handler for auto-add with category (from picker)
   const handleAutoAddWithCategory = useCallback(async (categoryId) => {
@@ -714,9 +738,16 @@ const OperationsScreen = () => {
   }, []);
 
   const handleAmountChange = useCallback((text) => {
+    // Kick off a best-effort location fix the moment the user starts entering an
+    // amount (empty → non-empty), so it is usually ready — without ever blocking —
+    // by the time they tap add.
+    if (amountWasEmptyRef.current && text) {
+      primeQuickAddLocation();
+    }
+    amountWasEmptyRef.current = !text;
     setQuickAddValues(v => ({ ...v, amount: text }));
     setLastEditedField('amount');
-  }, []);
+  }, [primeQuickAddLocation]);
 
   // Handlers for picker modal selections
   const handleSelectAccount = useCallback((id) => {

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -18,8 +18,28 @@ import * as NotificationRulesDB from '../NotificationRulesDB';
 import * as PendingNotificationsDB from '../PendingNotificationsDB';
 import { serializeLabels, sanitizeLabel } from '../../utils/labelUtils';
 import { appEvents, EVENTS } from '../eventEmitter';
+import { captureLocationIfEnabled, operationLocationFields } from '../operationLocation';
 import { parseBankNotification, kindRequiresCategory } from './parseBankNotification';
 import { resolveNotification } from './resolveNotification';
+
+/**
+ * A per-run location provider. Captures the device location at most once (lazily,
+ * only when an operation is actually created) and reuses it for every operation
+ * booked in the same run, so a batch of notifications shares one best-effort fix
+ * instead of hammering GPS. Returns { latitude, longitude } or null; the feature
+ * being off / permission missing / a failed fix all resolve to null so location
+ * capture never blocks booking a notification (issue #1091).
+ * @returns {() => Promise<{latitude: string, longitude: string}|null>}
+ */
+const makeLocationProvider = () => {
+  let cached; // undefined until the first attempt
+  return async () => {
+    if (cached === undefined) {
+      cached = await captureLocationIfEnabled();
+    }
+    return cached;
+  };
+};
 
 // Cap on remembered signatures. The native side only ever keeps a handful of
 // notifications, so this is comfortably large while bounding storage.
@@ -276,8 +296,10 @@ const isAllowedSource = (packageName, allowed) =>
  * @param {string} date - resolved ISO date (never null)
  * @param {string[]} allowedPackages - trusted-source allowlist
  * @param {{ created: number, pending: number }} summary
+ * @param {() => Promise<Object|null>} [getLocation] - best-effort location provider
+ *   for auto-created operations; omitted callers book without coordinates.
  */
-const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages, summary) => {
+const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation) => {
   // Everything an auto-create needs except the currency match. Auto-create only
   // for trusted sources; kinds that require a manual category (C2C transfers,
   // DEBIT ACCOUNT) always wait in the queue.
@@ -320,6 +342,7 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
     // A learned label override (e.g. "ECOSENSE BYUZAND" -> "Ecosense") wins over
     // the raw merchant for the operation's label.
     const label = resolution.labelOverride || descriptor.merchant;
+    const location = getLocation ? await getLocation() : null;
     await OperationsDB.createOperation({
       type: descriptor.type,
       ...currencyFields,
@@ -327,6 +350,7 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
       categoryId: resolution.categoryId,
       date,
       description: label ? serializeLabels([label]) : null,
+      ...operationLocationFields(location),
     });
     summary.created += 1;
   } else {
@@ -355,8 +379,10 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
  * @param {string} date - resolved ISO date (never null)
  * @param {string[]} allowedPackages - trusted-source allowlist
  * @param {{ created: number, pending: number }} summary
+ * @param {() => Promise<Object|null>} [getLocation] - best-effort location provider
+ *   for auto-created transfers; omitted callers book without coordinates.
  */
-const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages, summary) => {
+const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation) => {
   const target = await resolveAtmTargetAccount();
   const eligibleForAutoCreate =
     resolution.matchedAccount &&
@@ -390,6 +416,7 @@ const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages
         ),
       };
     }
+    const location = getLocation ? await getLocation() : null;
     await OperationsDB.createOperation({
       type: 'transfer',
       ...transferFields,
@@ -397,6 +424,7 @@ const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages
       toAccountId: target.id,
       date,
       description: descriptor.merchant ? serializeLabels([descriptor.merchant]) : null,
+      ...operationLocationFields(location),
     });
     summary.created += 1;
   } else {
@@ -450,6 +478,9 @@ const runProcess = async () => {
   const allowedPackages = await getAllowedPackages();
   const newlySeen = [];
 
+  // One best-effort location fix, shared by every operation auto-created this run.
+  const getLocation = makeLocationProvider();
+
   // Oldest first so operations are created in chronological order.
   const ordered = [...notifications].sort(
     (a, b) => (a.postTime || 0) - (b.postTime || 0),
@@ -480,9 +511,9 @@ const runProcess = async () => {
       // accounts, so they resolve a *target* account (a bound "cash" account)
       // instead of a category. Everything else books as expense/income.
       if (descriptor.isTransfer) {
-        await bookTransferOrQueue(descriptor, resolution, date, allowedPackages, summary);
+        await bookTransferOrQueue(descriptor, resolution, date, allowedPackages, summary, getLocation);
       } else {
-        await bookExpenseOrQueue(descriptor, resolution, date, allowedPackages, summary);
+        await bookExpenseOrQueue(descriptor, resolution, date, allowedPackages, summary, getLocation);
       }
 
       seen.add(signature);
@@ -577,6 +608,9 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
     };
   }
 
+  // Best-effort location for this user-driven save (attached only when enabled).
+  const location = await captureLocationIfEnabled();
+
   const operation = await OperationsDB.createOperation({
     type: pending.type,
     ...currencyFields,
@@ -585,6 +619,7 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
     // operations.date is NOT NULL — fall back to the row's creation date / today.
     date: pending.date || (pending.createdAt ? pending.createdAt.slice(0, 10) : todayIso()),
     description: label ? serializeLabels([label]) : null,
+    ...operationLocationFields(location),
   });
 
   // Persist an override change only when the user actually changed it in the
@@ -708,6 +743,9 @@ const resolvePendingTransfer = async (pending, choices = {}) => {
   const typedLabel = sanitizeLabel(choices.labelOverride);
   const label = typedLabel || pending.merchant;
 
+  // Best-effort location for this user-driven save (attached only when enabled).
+  const location = await captureLocationIfEnabled();
+
   const operation = await OperationsDB.createOperation({
     type: 'transfer',
     ...transferFields,
@@ -716,6 +754,7 @@ const resolvePendingTransfer = async (pending, choices = {}) => {
     // operations.date is NOT NULL — fall back to the row's creation date / today.
     date: pending.date || (pending.createdAt ? pending.createdAt.slice(0, 10) : todayIso()),
     description: label ? serializeLabels([label]) : null,
+    ...operationLocationFields(location),
   });
 
   // Learn the card -> source-account binding (default on when a card is present).
@@ -778,11 +817,12 @@ export const reAddNotification = async (notification) => {
   // The user explicitly asked to re-add this, so treat its own source as trusted
   // for this booking regardless of the learn-on-trust allowlist.
   const trustedAllowlist = descriptor.packageName ? [descriptor.packageName] : [];
+  const getLocation = makeLocationProvider();
 
   if (descriptor.isTransfer) {
-    await bookTransferOrQueue(descriptor, resolution, date, trustedAllowlist, summary);
+    await bookTransferOrQueue(descriptor, resolution, date, trustedAllowlist, summary, getLocation);
   } else {
-    await bookExpenseOrQueue(descriptor, resolution, date, trustedAllowlist, summary);
+    await bookExpenseOrQueue(descriptor, resolution, date, trustedAllowlist, summary, getLocation);
   }
 
   if (summary.created > 0 || summary.pending > 0) {

--- a/app/services/operationLocation.js
+++ b/app/services/operationLocation.js
@@ -1,0 +1,63 @@
+/**
+ * operationLocation — the single "should I attach a location, and if so which?"
+ * decision, shared by every path that creates an operation (the operation modal,
+ * quick-add, and bank-notification ingestion).
+ *
+ * It layers the user preference on top of the pure expo-location wrapper
+ * (LocationService): read the opt-in flag, and only when it is on request a
+ * permission + a single fix. Like LocationService, every path is best-effort and
+ * degrades to null (feature off, permission missing, timeout, any error) so
+ * capturing a location can never block or fail saving an operation (issue #1091).
+ *
+ * Kept separate from LocationService so that module stays a dependency-free
+ * expo-location shim, and separate from the React contexts so non-UI callers
+ * (notification processing) share the exact same source of truth as the toggle.
+ */
+
+import { getPreference, PREF_KEYS } from './PreferencesDB';
+import { ensureLocationPermission, getCurrentLocation } from './LocationService';
+
+/**
+ * Whether the "attach location to new operations" opt-in is enabled. Reads the
+ * same preference the Settings toggle writes, so UI and background callers never
+ * diverge. Defaults off and never throws.
+ * @returns {Promise<boolean>}
+ */
+export const isAttachLocationEnabled = async () => {
+  try {
+    const value = await getPreference(PREF_KEYS.ATTACH_LOCATION, 'false');
+    return value === 'true';
+  } catch (error) {
+    console.warn('[operationLocation] Failed to read attach-location preference:', error?.message);
+    return false;
+  }
+};
+
+/**
+ * Capture the device location for a new operation, but only when the feature is
+ * enabled. Returns { latitude, longitude } on a successful fix, or null when the
+ * feature is off, permission is missing, or the fix fails/times out. Never
+ * prompts beyond the OS permission (already secured by the Settings toggle before
+ * the feature can be on) and never throws.
+ * @param {Object} [opts]
+ * @param {number} [opts.timeoutMs] - forwarded to getCurrentLocation
+ * @returns {Promise<{ latitude: string, longitude: string } | null>}
+ */
+export const captureLocationIfEnabled = async (opts = {}) => {
+  if (!(await isAttachLocationEnabled())) return null;
+  const { granted } = await ensureLocationPermission();
+  if (!granted) return null;
+  return getCurrentLocation(opts);
+};
+
+/**
+ * Normalize a captured fix into the operation-field overrides to persist, or an
+ * empty object when there is nothing to attach. Spread into a createOperation
+ * payload: `{ ...operationLocationFields(loc) }`.
+ * @param {{ latitude: *, longitude: * }|null|undefined} location
+ * @returns {{ latitude: *, longitude: * }|{}}
+ */
+export const operationLocationFields = (location) =>
+  location && location.latitude != null && location.longitude != null
+    ? { latitude: location.latitude, longitude: location.longitude }
+    : {};


### PR DESCRIPTION
## Summary

The opt-in "attach location to new operations" feature (issue #1091) only captured a fix in the full operation modal. This extends it to the remaining operation-creating paths — quick-add and bank-notification operations (both auto-created and manually resolved) — so location is saved automatically with no extra user input wherever the feature is enabled. Every path stays best-effort and never blocks saving.

## Changes

- **app/services/operationLocation.js** (new) — shared, preference-gated capture (`isAttachLocationEnabled`, `captureLocationIfEnabled`, `operationLocationFields`) layered over the pure `LocationService` expo-location wrapper, so UI and background callers use one source of truth. Degrades to `null` on feature-off / permission-missing / timeout / error.
- **app/hooks/useQuickAddLocation.js** (new) — owns the non-blocking capture lifecycle for the always-mounted quick-add form: primes a fix in the background, guards against stale fixes with a monotonic token, clears on opt-out, and exposes `getLocation()` for save time.
- **app/screens/OperationsScreen.js** — prime a fix when the user starts entering an amount (empty → non-empty edge) and after each add; attach whatever fix is ready in `handleQuickAdd` before saving. Reads `useDisplaySettings` defensively.
- **app/services/notifications/processBankNotifications.js** — attach location to auto-created operations (one shared best-effort fix per run/re-add, captured lazily only when something is booked) and to manual review-queue resolves (`resolvePendingNotification`, `resolvePendingTransfer`) and explicit re-adds (`reAddNotification`).
- **__tests__/services/operationLocation.test.js**, **__tests__/hooks/useQuickAddLocation.test.js** (new) and additions to **__tests__/services/notifications/processBankNotifications.test.js**, **__tests__/screens/OperationsScreen.test.js** — cover enabled/disabled/denied/no-fix paths, single-capture-per-run, and the quick-add + notification wiring.

## Testing

- `npm test` — 141 suites / 4151 tests pass.
- `npm run lint` on the changed files — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new strings)
- [x] Linked the related issue with `Closes #NNN` below — or n/a

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4ZQiLE19aQPPYCBTfT5dD

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4ZQiLE19aQPPYCBTfT5dD)_