### PR TITLE
feat(updates): prompt for updates every minute and fix empty update dialog

### DIFF
--- a/__tests__/modals/UpdateAvailableModal.test.js
+++ b/__tests__/modals/UpdateAvailableModal.test.js
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import * as RN from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import UpdateAvailableModal from '../../app/modals/UpdateAvailableModal';
 
@@ -57,6 +58,21 @@ describe('UpdateAvailableModal', () => {
         <UpdateAvailableModal {...baseProps} updateData={baseUpdateData} />,
       );
       expect(getByText('v2.0.0')).toBeTruthy();
+    });
+
+    it('gives the dialog a bounded absolute height so its content is not empty', async () => {
+      // Regression guard: paper's Modal wraps children in an auto-height Surface, so a
+      // percentage height never resolves and the shared panel's flex:1 ScrollView
+      // collapses to zero height — an empty dialog. The container must carry a concrete
+      // numeric height (windowHeight * 0.8 = 640 here).
+      const { getByTestId } = await render(
+        <UpdateAvailableModal {...baseProps} updateData={baseUpdateData} />,
+      );
+      const flat = RN.StyleSheet.flatten(getByTestId('update-modal-container').props.style);
+      // A concrete pixel height (not a percentage or undefined) is what keeps the shared
+      // panel's flex:1 ScrollView from collapsing; the exact value tracks the window height.
+      expect(typeof flat.height).toBe('number');
+      expect(flat.height).toBeGreaterThan(0);
     });
 
     it('renders dismiss button and calls onDismiss when pressed', async () => {

--- a/__tests__/screens/AppInitializer.test.js
+++ b/__tests__/screens/AppInitializer.test.js
@@ -5,9 +5,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render, waitFor } from '@testing-library/react-native';
+import { render, waitFor, act, fireEvent } from '@testing-library/react-native';
 import AppInitializer from '../../app/screens/AppInitializer';
 import { LocalizationProvider, useLocalization } from '../../app/contexts/LocalizationContext';
+import { checkForAppUpdate } from '../../app/services/AppUpdateService';
+import { useUpdateDownload } from '../../app/contexts/UpdateDownloadContext';
 
 jest.mock('../../app/contexts/DialogContext', () => ({
   useDialog: jest.fn(() => ({
@@ -34,6 +36,48 @@ jest.mock('../../app/services/AppUpdateService', () => ({
     success: true,
     isUpdateAvailable: false,
   })),
+}));
+
+// Render the update dialog as a lightweight testable stand-in so these tests focus on
+// AppInitializer's polling/dismissal logic rather than the modal's internals.
+jest.mock('../../app/modals/UpdateAvailableModal', () => {
+  const React = require('react');
+  const PropTypes = require('prop-types');
+  const { View, Text, TouchableOpacity } = require('react-native');
+  function MockUpdateAvailableModal({ visible, onDismiss, onUpdate, updateData }) {
+    if (!visible || !updateData) return null;
+    return (
+      <View testID="update-available-modal">
+        <Text testID="update-modal-version">{updateData.latestVersion}</Text>
+        <TouchableOpacity testID="update-modal-dismiss" onPress={onDismiss}>
+          <Text>Later</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          testID="update-modal-now"
+          onPress={() => onUpdate(updateData.downloadUrl)}
+        >
+          <Text>Update now</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+  MockUpdateAvailableModal.propTypes = {
+    visible: PropTypes.bool,
+    onDismiss: PropTypes.func,
+    onUpdate: PropTypes.func,
+    updateData: PropTypes.object,
+  };
+  return MockUpdateAvailableModal;
+});
+
+// Side-effecting services fired from AppInitializer's open effects; stub to no-ops so
+// they don't leak async work into the update-check timing tests.
+jest.mock('../../app/services/DailyBackupService', () => ({
+  performDailyBackupIfNeeded: jest.fn(async () => undefined),
+}));
+
+jest.mock('../../app/services/notifications/processBankNotifications', () => ({
+  processBankNotifications: jest.fn(async () => undefined),
 }));
 
 jest.mock('../../app/services/PreferencesDB', () => ({
@@ -88,6 +132,7 @@ const mockLocalizationContext = {
   isLoading: false,
   setFirstLaunchComplete: jest.fn(),
   language: 'en',
+  t: (key) => key,
 };
 
 jest.mock('../../app/contexts/LocalizationContext', () => {
@@ -124,6 +169,16 @@ describe('AppInitializer', () => {
     mockLocalizationContext.isLoading = false;
     mockLocalizationContext.language = 'en';
     mockLocalizationContext.setFirstLaunchComplete = jest.fn();
+    mockLocalizationContext.t = (key) => key;
+    // Default: app is up to date and idle so no dialog appears unless a test opts in.
+    // clearAllMocks wipes call history but not implementations, so re-assert the defaults
+    // here to avoid cross-test leakage of a previously-set update result.
+    checkForAppUpdate.mockResolvedValue({ success: true, isUpdateAvailable: false });
+    useUpdateDownload.mockReturnValue({
+      isDownloading: false,
+      downloadProgress: null,
+      startDownload: jest.fn(),
+    });
   });
 
   describe('Initialization', () => {
@@ -341,6 +396,147 @@ describe('AppInitializer', () => {
 
       // Language selection should be accessible
       expect(getByTestId('language-selection-screen')).toBeTruthy();
+    });
+  });
+
+  describe('Automatic update checking', () => {
+    const AVAILABLE_UPDATE = {
+      success: true,
+      isUpdateAvailable: true,
+      latestVersion: '2.0.0',
+      currentVersion: '1.0.0',
+      downloadUrl: 'https://example.com/penny-2.0.0.apk',
+      checksumUrl: 'https://example.com/penny-2.0.0.apk.sha256',
+      releaseNotes: null,
+    };
+
+    // Flush the promise chain of the immediate on-open check without advancing far
+    // enough to trigger the one-minute interval.
+    const flushCheck = () => act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('suggests the update when a newer version is available', async () => {
+      checkForAppUpdate.mockResolvedValue(AVAILABLE_UPDATE);
+
+      const { getByTestId } = await render(<AppInitializer />);
+      await flushCheck();
+
+      expect(getByTestId('update-available-modal')).toBeTruthy();
+      expect(getByTestId('update-modal-version').props.children).toBe('2.0.0');
+    });
+
+    it('does not suggest an update when the app is already up to date', async () => {
+      checkForAppUpdate.mockResolvedValue({ success: true, isUpdateAvailable: false });
+
+      const { queryByTestId } = await render(<AppInitializer />);
+      await flushCheck();
+
+      expect(queryByTestId('update-available-modal')).toBeNull();
+    });
+
+    it('does not suggest an update when the check fails', async () => {
+      checkForAppUpdate.mockResolvedValue({
+        success: false,
+        isUpdateAvailable: false,
+        errorCode: 'network_error',
+      });
+
+      const { queryByTestId } = await render(<AppInitializer />);
+      await flushCheck();
+
+      expect(queryByTestId('update-available-modal')).toBeNull();
+    });
+
+    it('re-checks for updates about once a minute', async () => {
+      checkForAppUpdate.mockResolvedValue({ success: true, isUpdateAvailable: false });
+
+      await render(<AppInitializer />);
+      await flushCheck();
+      expect(checkForAppUpdate).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(3 * 60 * 1000);
+      });
+      expect(checkForAppUpdate).toHaveBeenCalledTimes(4);
+    });
+
+    it('stops suggesting a version the user dismissed until the app restarts', async () => {
+      checkForAppUpdate.mockResolvedValue(AVAILABLE_UPDATE);
+
+      const { getByTestId, queryByTestId } = await render(<AppInitializer />);
+      await flushCheck();
+      expect(getByTestId('update-available-modal')).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.press(getByTestId('update-modal-dismiss'));
+      });
+      expect(queryByTestId('update-available-modal')).toBeNull();
+
+      // The next minute's check still finds 2.0.0, but it must stay silent.
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60 * 1000);
+      });
+      expect(queryByTestId('update-available-modal')).toBeNull();
+    });
+
+    it('suggests a newer version even after an earlier one was dismissed', async () => {
+      checkForAppUpdate.mockResolvedValue(AVAILABLE_UPDATE);
+
+      const { getByTestId, queryByTestId } = await render(<AppInitializer />);
+      await flushCheck();
+      expect(getByTestId('update-modal-version').props.children).toBe('2.0.0');
+
+      await act(async () => {
+        fireEvent.press(getByTestId('update-modal-dismiss'));
+      });
+      expect(queryByTestId('update-available-modal')).toBeNull();
+
+      // A still-newer release appears; the dialog should return for it.
+      checkForAppUpdate.mockResolvedValue({
+        ...AVAILABLE_UPDATE,
+        latestVersion: '2.1.0',
+        downloadUrl: 'https://example.com/penny-2.1.0.apk',
+      });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(60 * 1000);
+      });
+
+      expect(getByTestId('update-available-modal')).toBeTruthy();
+      expect(getByTestId('update-modal-version').props.children).toBe('2.1.0');
+    });
+
+    it('starts the download and closes the dialog when the user updates', async () => {
+      const startDownload = jest.fn();
+      useUpdateDownload.mockReturnValue({
+        isDownloading: false,
+        downloadProgress: null,
+        startDownload,
+      });
+      checkForAppUpdate.mockResolvedValue(AVAILABLE_UPDATE);
+
+      const { getByTestId, queryByTestId } = await render(<AppInitializer />);
+      await flushCheck();
+      expect(getByTestId('update-available-modal')).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.press(getByTestId('update-modal-now'));
+      });
+
+      expect(startDownload).toHaveBeenCalledWith(
+        'https://example.com/penny-2.0.0.apk',
+        expect.objectContaining({ checksumUrl: 'https://example.com/penny-2.0.0.apk.sha256' }),
+      );
+      expect(queryByTestId('update-available-modal')).toBeNull();
     });
   });
 });

--- a/app/modals/UpdateAvailableModal.js
+++ b/app/modals/UpdateAvailableModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, useWindowDimensions } from 'react-native';
 import { Portal, Modal, Text, Divider } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -11,15 +11,26 @@ import UpdateContentPanel from '../components/UpdateContentPanel';
 export default function UpdateAvailableModal({ visible, onDismiss, onUpdate, updateData }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
+  const { height: windowHeight } = useWindowDimensions();
 
   if (!updateData) return null;
 
   const updateResult = { type: 'available', ...updateData };
 
+  // react-native-paper's Modal drops its children into an auto-height Surface, so a
+  // percentage height (or maxHeight) here never resolves — it stays "hug content". The
+  // shared UpdateContentPanel fills its parent with a flex:1 ScrollView, which then
+  // collapses to zero height, leaving the dialog empty. Pin an absolute height so the
+  // scroll region always has room and the update content is actually visible.
+  const containerHeight = Math.round(windowHeight * 0.8);
+
   return (
     <Portal>
       <Modal visible={visible} onDismiss={onDismiss} dismissable>
-        <View style={[styles.modalContainer, { backgroundColor: colors.card }]}>
+        <View
+          testID="update-modal-container"
+          style={[styles.modalContainer, { backgroundColor: colors.card, height: containerHeight }]}
+        >
           <View style={styles.header}>
             <TouchableOpacity onPress={onDismiss} style={styles.backButton}>
               <Ionicons name="arrow-back" size={24} color={colors.text} />
@@ -77,7 +88,6 @@ const styles = StyleSheet.create({
   modalContainer: {
     borderRadius: BORDER_RADIUS.lg,
     margin: SPACING.md,
-    maxHeight: '95%',
     overflow: 'hidden',
   },
 });

--- a/app/screens/AppInitializer.js
+++ b/app/screens/AppInitializer.js
@@ -8,15 +8,14 @@ import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { performDailyBackupIfNeeded } from '../services/DailyBackupService';
 import { useDialog } from '../contexts/DialogContext';
 import { checkForAppUpdate } from '../services/AppUpdateService';
-import { getPreference, setPreference, PREF_KEYS } from '../services/PreferencesDB';
 import { useUpdateDownload } from '../contexts/UpdateDownloadContext';
 import { useSqliteFileImport } from '../hooks/useSqliteFileImport';
 import useNotificationResponseRouter from '../hooks/useNotificationResponseRouter';
 import { syncBackgroundBankTaskRegistrationAsync } from '../services/notifications/backgroundBankTask';
 import UpdateAvailableModal from '../modals/UpdateAvailableModal';
 
-const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
-const UPDATE_REMINDER_DELAY_DAYS = 3;
+// Poll for a newer release this often while the app is open and in the foreground.
+const UPDATE_CHECK_INTERVAL_MS = 60 * 1000;
 
 /**
  * AppInitializer handles first-time setup and app initialization
@@ -26,9 +25,27 @@ const AppInitializer = () => {
   const { isFirstLaunch, isLoading, setFirstLaunchComplete, t } = useLocalization();
   const { colors } = useThemeColors();
   const { showDialog } = useDialog();
-  const { startDownload } = useUpdateDownload();
+  const { startDownload, isDownloading } = useUpdateDownload();
   const [isInitializing, setIsInitializing] = useState(false);
   const [pendingUpdate, setPendingUpdate] = useState(null);
+
+  // Versions the user has already dealt with this session (dismissed or chose to install).
+  // Held in a ref, not persisted, so the suppression clears on app restart — exactly
+  // "don't prompt again for this version until the user restarts the app".
+  const dismissedVersionsRef = useRef(new Set());
+  // Latest-value mirrors read inside the long-lived interval callback, so its closure
+  // never acts on stale state.
+  const pendingUpdateRef = useRef(null);
+  const isDownloadingRef = useRef(false);
+  const isCheckingRef = useRef(false);
+
+  useEffect(() => {
+    pendingUpdateRef.current = pendingUpdate;
+  }, [pendingUpdate]);
+
+  useEffect(() => {
+    isDownloadingRef.current = isDownloading;
+  }, [isDownloading]);
 
   // Handle SQLite/backup files opened with the app (Android ACTION_VIEW).
   // Disabled during first launch so the import warning doesn't appear before
@@ -39,48 +56,75 @@ const AppInitializer = () => {
   // notification-processing screen (handles both cold-start and warm taps).
   useNotificationResponseRouter();
 
-  // Run once on every app open (after first launch is complete)
+  // Run the daily backup once on every app open (after first launch is complete).
   useEffect(() => {
     if (!isFirstLaunch) {
       performDailyBackupIfNeeded();
-
-      const runUpdateCheck = async () => {
-        try {
-          const now = Date.now();
-          const lastCheckIso = await getPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, null);
-          const lastCheckMs = lastCheckIso ? Date.parse(lastCheckIso) : NaN;
-
-          if (Number.isFinite(lastCheckMs) && now - lastCheckMs < AUTO_CHECK_INTERVAL_MS) {
-            return;
-          }
-
-          await setPreference(PREF_KEYS.UPDATE_LAST_CHECK_AT, new Date(now).toISOString());
-
-          const result = await checkForAppUpdate();
-          if (!result.success || !result.isUpdateAvailable) {
-            return;
-          }
-
-          const skipUntilIso = await getPreference(PREF_KEYS.UPDATE_SKIP_UNTIL, null);
-          const skipUntilMs = skipUntilIso ? Date.parse(skipUntilIso) : NaN;
-          if (Number.isFinite(skipUntilMs) && skipUntilMs > now) {
-            return;
-          }
-
-          setPendingUpdate({
-            latestVersion: result.latestVersion,
-            currentVersion: result.currentVersion,
-            downloadUrl: result.downloadUrl,
-            checksumUrl: result.checksumUrl || null,
-            releaseNotes: result.releaseNotes || null,
-          });
-        } catch (error) {
-          console.warn('[AppInitializer] Failed to auto-check updates:', error);
-        }
-      };
-
-      runUpdateCheck();
     }
+  }, [isFirstLaunch]);
+
+  // Poll for app updates every minute while the app is open, regardless of which screen
+  // the user is viewing. When a newer release is found we surface the update dialog. A
+  // version the user dismisses is silenced for the rest of the session (handleUpdateDismiss),
+  // while re-checks keep running so a still-newer release can prompt again.
+  useEffect(() => {
+    if (isFirstLaunch) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const runUpdateCheck = async () => {
+      // Never stack work or prompts: skip while a check is already running, a download is
+      // in progress, or the update dialog is already on screen.
+      if (isCheckingRef.current || isDownloadingRef.current || pendingUpdateRef.current) {
+        return;
+      }
+      isCheckingRef.current = true;
+      try {
+        const result = await checkForAppUpdate();
+        if (cancelled || !result.success || !result.isUpdateAvailable) {
+          return;
+        }
+        // The user already dealt with this version this session — stay quiet until restart.
+        if (dismissedVersionsRef.current.has(result.latestVersion)) {
+          return;
+        }
+        // Guard again: state may have changed while the network request was in flight.
+        if (pendingUpdateRef.current || isDownloadingRef.current) {
+          return;
+        }
+        setPendingUpdate({
+          latestVersion: result.latestVersion,
+          currentVersion: result.currentVersion,
+          downloadUrl: result.downloadUrl,
+          checksumUrl: result.checksumUrl || null,
+          releaseNotes: result.releaseNotes || null,
+        });
+      } catch (error) {
+        console.warn('[AppInitializer] Failed to auto-check updates:', error);
+      } finally {
+        isCheckingRef.current = false;
+      }
+    };
+
+    // Check immediately on open, then once a minute.
+    runUpdateCheck();
+    const intervalId = setInterval(runUpdateCheck, UPDATE_CHECK_INTERVAL_MS);
+
+    // Re-check the moment the app returns to the foreground, so a user coming back to an
+    // open screen sees a current result without waiting for the next interval tick.
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') {
+        runUpdateCheck();
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+      subscription.remove();
+    };
   }, [isFirstLaunch]);
 
   // Process any bank notifications captured while the app was backgrounded.
@@ -120,20 +164,20 @@ const AppInitializer = () => {
     });
   }, [isFirstLaunch]);
 
-  const handleUpdateDismiss = useCallback(async () => {
-    if (pendingUpdate) {
-      const suppressUntil = new Date(
-        Date.now() + UPDATE_REMINDER_DELAY_DAYS * 24 * 60 * 60 * 1000,
-      ).toISOString();
-      await setPreference(PREF_KEYS.UPDATE_SKIP_UNTIL, suppressUntil);
-      await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, pendingUpdate.latestVersion);
+  const handleUpdateDismiss = useCallback(() => {
+    // Silence this version until the app restarts. dismissedVersionsRef is in-memory only,
+    // so relaunching the app clears it and the update can be suggested again.
+    if (pendingUpdate?.latestVersion) {
+      dismissedVersionsRef.current.add(pendingUpdate.latestVersion);
     }
     setPendingUpdate(null);
   }, [pendingUpdate]);
 
-  const handleUpdateNow = useCallback(async (downloadUrl) => {
-    if (pendingUpdate) {
-      await setPreference(PREF_KEYS.UPDATE_LAST_PROMPTED_VERSION, pendingUpdate.latestVersion);
+  const handleUpdateNow = useCallback((downloadUrl) => {
+    // Treat "update now" as resolving this version too, so we don't re-prompt for it this
+    // session (e.g. if the user backs out of the Android package installer).
+    if (pendingUpdate?.latestVersion) {
+      dismissedVersionsRef.current.add(pendingUpdate.latestVersion);
     }
     const checksumUrl = pendingUpdate?.checksumUrl || null;
     setPendingUpdate(null);


### PR DESCRIPTION
## Summary

Auto-update prompting used to run once per app open, gated to at most once every 24 hours, and hid a dismissed version for 3 days via a persisted preference. This makes the app poll for a newer release every minute while it's open — on whatever screen is showing — and surface the update dialog as soon as one is found. Cancelling now hides a version only until the app restarts (in-memory), not for a persisted 3 days. It also fixes the update dialog rendering **empty** on device: react-native-paper's `Modal` places children in an auto-height `Surface`, so the panel's percentage `maxHeight` never resolved and the shared `UpdateContentPanel`'s `flex: 1` `ScrollView` collapsed to zero height.

## Changes

- **app/screens/AppInitializer.js** — replace the 24h-gated single check with a 60s polling interval (plus an immediate check on open and on foreground return). Track dismissed versions in an in-memory ref instead of a persisted `UPDATE_SKIP_UNTIL` date, so a cancelled version is silenced only until restart while re-checks keep running for still-newer releases. Guard against stacked checks/prompts while a check is in flight, a download is running, or the dialog is already open. Drop the now-unused `PreferencesDB` import.
- **app/modals/UpdateAvailableModal.js** — pin the dialog to an absolute height (`windowHeight * 0.8` via `useWindowDimensions`) so the shared panel's scroll region has room and the content is actually visible; remove the percentage `maxHeight` that couldn't resolve inside paper's auto-height Surface.
- **__tests__/screens/AppInitializer.test.js** — add an "Automatic update checking" suite: dialog shows when an update is available, stays silent when up to date / on failure, re-checks ~once a minute, suppresses a dismissed version until restart, still prompts for a newer version, and starts the download on "update now".
- **__tests__/modals/UpdateAvailableModal.test.js** — add a regression guard that the dialog container carries a concrete numeric height so it can't render empty.

## Testing

- `npm test` — 142 suites / 4175 tests pass.
- `npx eslint` on the four changed files — clean.
- Note: the empty-dialog fix is a layout issue (auto-height parent) that Jest's non-layout renderer can't reproduce; the guard test asserts the container now has an absolute pixel height instead of an unresolved percentage.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new strings; existing keys reused with fallbacks)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194vQQ8DzBw8rhTWEDu1fDC

---
_Generated by [Claude Code](https://claude.ai/code/session_0194vQQ8DzBw8rhTWEDu1fDC)_