### PR TITLE
chore: allow send_later MCP tool without prompts in cloud sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__send_later"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Cloud (web) Claude Code sessions clone the repo fresh into an ephemeral container, so a repo-committed `.claude/settings.json` is the only permission scope that persists across sessions — user-level `~/.claude` settings never reach the container. This adds an allow-rule so the Claude Code Remote `send_later` tool (used to re-arm recurring self check-ins, e.g. PR-watch loops) stops triggering a permission prompt on every session.

## Changes

- **.claude/settings.json** (new) — add a `permissions.allow` entry for `mcp__Claude_Code_Remote__send_later` so the tool is auto-approved in every session that clones this repo.

## Testing

- No runtime code changed; this is a config-only addition. `.claude/settings.json` is valid JSON and follows the documented `permissions.allow` schema (`mcp__<server>__<tool>`).

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [ ] `npm test` is green (all suites pass) — n/a, config-only change with no runtime surface
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019knahAK9q6AGhiKDrATzRM)_