### PR TITLE
feat(notifications): add Tinkoff/T-Bank notification parser

### DIFF
--- a/__tests__/services/notifications/tinkoffParser.test.js
+++ b/__tests__/services/notifications/tinkoffParser.test.js
@@ -1,0 +1,315 @@
+/**
+ * Tests for the Tinkoff / T-Bank notification parser
+ * (`com.idamob.tinkoff.android`), exercised through the public
+ * `parseBankNotification` dispatcher.
+ *
+ * Tinkoff's format differs from Ameria's: the merchant is the notification
+ * title, the body is short Russian text with a space-grouped amount and an
+ * explicit account currency, and a balance line follows that must be ignored.
+ */
+
+import {
+  parseBankNotification,
+  kindRequiresCategory,
+  kindIsTransfer,
+} from '../../../app/services/notifications/parseBankNotification';
+
+// The canonical Tinkoff "Платеж" notification from the screenshot.
+const TINKOFF_PAYMENT = {
+  title: 'МегаФон',
+  text: 'Платеж на 1 000 ₽, счет RUB\nБаланс 39 000 ₽',
+  packageName: 'com.idamob.tinkoff.android',
+  postTime: 1782000900000,
+};
+
+describe('Tinkoff notification parser', () => {
+  describe('canonical Платеж (payment) template', () => {
+    let result;
+    beforeEach(() => {
+      result = parseBankNotification(TINKOFF_PAYMENT);
+    });
+
+    it('recognizes the notification and returns an object', () => {
+      expect(result).not.toBeNull();
+    });
+
+    it('maps Платеж to an expense operation', () => {
+      expect(result.kind).toBe('ПЛАТЕЖ');
+      expect(result.type).toBe('expense');
+    });
+
+    it('extracts and normalizes the amount (strips the space grouping)', () => {
+      expect(result.amount).toBe('1000');
+    });
+
+    it('uses the transaction amount, never the balance amount', () => {
+      expect(result.amount).not.toBe('39000');
+      const { raw, ...structured } = result;
+      expect(JSON.stringify(structured)).not.toContain('39000');
+    });
+
+    it('extracts the account currency from "счет RUB"', () => {
+      expect(result.currency).toBe('RUB');
+    });
+
+    it('takes the merchant from the notification title', () => {
+      expect(result.merchant).toBe('МегаФон');
+    });
+
+    it('has no card mask (this format carries none)', () => {
+      expect(result.cardMask).toBeNull();
+    });
+
+    it('has no country', () => {
+      expect(result.country).toBeNull();
+    });
+
+    it('leaves date/time null so the pipeline uses the post time', () => {
+      expect(result.date).toBeNull();
+      expect(result.time).toBeNull();
+    });
+
+    it('does not require a manual category', () => {
+      expect(result.requiresCategory).toBe(false);
+    });
+
+    it('is not a transfer', () => {
+      expect(result.isTransfer).toBe(false);
+    });
+
+    it('passes through the source package name', () => {
+      expect(result.packageName).toBe('com.idamob.tinkoff.android');
+    });
+
+    it('keeps the raw text for auditing', () => {
+      expect(result.raw).toBe(TINKOFF_PAYMENT.text);
+    });
+  });
+
+  describe('other expense kinds', () => {
+    it('maps Покупка to an expense', () => {
+      const result = parseBankNotification({
+        title: 'Пятерочка',
+        text: 'Покупка на 549,90 ₽, счет RUB\nБаланс 12 300,10 ₽',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.kind).toBe('ПОКУПКА');
+      expect(result.type).toBe('expense');
+      expect(result.amount).toBe('549.90');
+      expect(result.merchant).toBe('Пятерочка');
+    });
+
+    it('maps Оплата to an expense', () => {
+      const result = parseBankNotification({
+        title: 'ЖКХ',
+        text: 'Оплата 2 500 ₽, счет RUB',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.kind).toBe('ОПЛАТА');
+      expect(result.type).toBe('expense');
+      expect(result.amount).toBe('2500');
+    });
+
+    it('maps Списание to an expense', () => {
+      const result = parseBankNotification({
+        title: 'Яндекс.Плюс',
+        text: 'Списание 299 ₽, счет RUB\nБаланс 5 00 ₽',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.kind).toBe('СПИСАНИЕ');
+      expect(result.type).toBe('expense');
+      expect(result.amount).toBe('299');
+    });
+  });
+
+  describe('income kinds', () => {
+    it('maps Пополнение to income', () => {
+      const result = parseBankNotification({
+        title: 'Иван И.',
+        text: 'Пополнение на 5 000 ₽, счет RUB\nБаланс 44 000 ₽',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.kind).toBe('ПОПОЛНЕНИЕ');
+      expect(result.type).toBe('income');
+      expect(result.amount).toBe('5000');
+      expect(result.merchant).toBe('Иван И.');
+    });
+
+    it('maps Возврат to income', () => {
+      const result = parseBankNotification({
+        title: 'OZON',
+        text: 'Возврат 1 200 ₽, счет RUB',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.kind).toBe('ВОЗВРАТ');
+      expect(result.type).toBe('income');
+      expect(result.amount).toBe('1200');
+    });
+  });
+
+  describe('kind keyword handling', () => {
+    it('folds ё so Платёж is recognized as ПЛАТЕЖ', () => {
+      const result = parseBankNotification({
+        title: 'МегаФон',
+        text: 'Платёж на 1 000 ₽, счет RUB',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.kind).toBe('ПЛАТЕЖ');
+      expect(result.type).toBe('expense');
+    });
+
+    it('recognizes the kind case-insensitively', () => {
+      const result = parseBankNotification({
+        title: 'МегаФон',
+        text: 'ПЛАТЕЖ на 1 000 ₽, счет RUB',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.kind).toBe('ПЛАТЕЖ');
+    });
+  });
+
+  describe('amount normalization', () => {
+    const amountFor = (body) =>
+      parseBankNotification({
+        title: 'Shop',
+        text: `Покупка ${body}`,
+        packageName: 'com.idamob.tinkoff.android',
+      })?.amount;
+
+    it('handles a whole-number amount with no grouping', () => {
+      expect(amountFor('500 ₽, счет RUB')).toBe('500');
+    });
+
+    it('strips a non-breaking-space thousands group', () => {
+      expect(amountFor('1 234 ₽, счет RUB')).toBe('1234');
+    });
+
+    it('strips a narrow no-break-space thousands group', () => {
+      expect(amountFor('1 234 567 ₽, счет RUB')).toBe('1234567');
+    });
+
+    it('reads comma as the decimal separator', () => {
+      expect(amountFor('12,50 ₽, счет RUB')).toBe('12.50');
+    });
+
+    it('reads dot-grouping with comma decimal', () => {
+      expect(amountFor('1.234,56 ₽, счет RUB')).toBe('1234.56');
+    });
+
+    it('does not corrupt a comma decimal by 100x', () => {
+      expect(amountFor('42,50 ₽, счет RUB')).not.toBe('4250');
+    });
+  });
+
+  describe('currency handling', () => {
+    it('prefers the explicit "счет" ISO code over the amount symbol', () => {
+      const result = parseBankNotification({
+        title: 'Shop',
+        text: 'Покупка на 1 000 ₽, счет RUB',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.currency).toBe('RUB');
+    });
+
+    it('falls back to the ₽ symbol when no "счет" segment is present', () => {
+      const result = parseBankNotification({
+        title: 'Shop',
+        text: 'Покупка на 1 000 ₽',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.currency).toBe('RUB');
+    });
+  });
+
+  describe('optional card mask', () => {
+    it('extracts a masked card number when one is present', () => {
+      const result = parseBankNotification({
+        title: 'МегаФон',
+        text: 'Платеж на 1 000 ₽, счет RUB, карта *1234\nБаланс 39 000 ₽',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(result.cardMask).toBe('*1234');
+    });
+  });
+
+  describe('source-app dispatch', () => {
+    it('routes the Tinkoff package to the Tinkoff parser', () => {
+      const result = parseBankNotification(TINKOFF_PAYMENT);
+      expect(result).not.toBeNull();
+      expect(result.packageName).toBe('com.idamob.tinkoff.android');
+    });
+
+    it('parses via fallback when the package is missing (manual paste)', () => {
+      const result = parseBankNotification({
+        title: 'МегаФон',
+        text: 'Платеж на 1 000 ₽, счет RUB\nБаланс 39 000 ₽',
+      });
+      expect(result).not.toBeNull();
+      expect(result.kind).toBe('ПЛАТЕЖ');
+    });
+
+    it('does not misparse an Ameria pipe notification', () => {
+      // Ameria text has no Cyrillic kind, so the Tinkoff parser returns null and
+      // the Ameria parser handles it — the result must be the Ameria PURCHASE.
+      const result = parseBankNotification({
+        text: 'PURCHASE | 3,900.00 AMD | 4083***7027, | NAREK MEHRABYAN, AM | 28.06.2026 10:15 | BALANCE: 133,719.97 AMD',
+        packageName: 'com.banqr.ameriabank',
+      });
+      expect(result.kind).toBe('PURCHASE');
+      expect(result.currency).toBe('AMD');
+    });
+  });
+
+  describe('per-app kind helpers', () => {
+    it('never requires a manual category for a Tinkoff kind', () => {
+      expect(kindRequiresCategory('ПЛАТЕЖ', 'com.idamob.tinkoff.android')).toBe(false);
+      expect(kindRequiresCategory('ПОКУПКА', 'com.idamob.tinkoff.android')).toBe(false);
+    });
+
+    it('never treats a Tinkoff kind as a transfer', () => {
+      expect(kindIsTransfer('ПЛАТЕЖ', 'com.idamob.tinkoff.android')).toBe(false);
+      expect(kindIsTransfer('ПОПОЛНЕНИЕ', 'com.idamob.tinkoff.android')).toBe(false);
+    });
+  });
+
+  describe('rejection of non-transaction notifications', () => {
+    it('returns null for an unknown Russian kind (e.g. Перевод, not yet handled)', () => {
+      expect(
+        parseBankNotification({
+          title: 'Иван И.',
+          text: 'Перевод 1 000 ₽, счет RUB',
+          packageName: 'com.idamob.tinkoff.android',
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null for an informational message with no kind', () => {
+      expect(
+        parseBankNotification({
+          title: 'Тинькофф',
+          text: 'Ваш код подтверждения: 1234',
+          packageName: 'com.idamob.tinkoff.android',
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null when the amount is missing', () => {
+      expect(
+        parseBankNotification({
+          title: 'МегаФон',
+          text: 'Платеж выполнен, счет RUB',
+          packageName: 'com.idamob.tinkoff.android',
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null for empty or malformed input', () => {
+      expect(
+        parseBankNotification({ text: '', packageName: 'com.idamob.tinkoff.android' }),
+      ).toBeNull();
+      expect(
+        parseBankNotification({ packageName: 'com.idamob.tinkoff.android' }),
+      ).toBeNull();
+    });
+  });
+});

--- a/app/services/notifications/bankParsers/index.js
+++ b/app/services/notifications/bankParsers/index.js
@@ -3,8 +3,9 @@
  *
  * Each banking app formats its notifications differently, so parsing rules are
  * grouped per source app (Android package name) rather than assumed to be
- * universal. Today only Ameriabank (`com.banqr.ameriabank`) is supported; adding
- * another bank is just another parser module registered here.
+ * universal. Ameriabank (`com.banqr.ameriabank`) and Tinkoff / T-Bank
+ * (`com.idamob.tinkoff.android`) are supported today; adding another bank is just
+ * another parser module registered here.
  *
  * A parser is an object: `{ packageNames: string[], parse(notification) =>
  * descriptor|null, kindRequiresCategory(kind) => boolean,
@@ -12,9 +13,10 @@
  */
 
 import ameriabank from './ameriabank';
+import tinkoff from './tinkoff';
 
 /** All registered bank parsers. Order matters only for the fallback scan below. */
-export const BANK_PARSERS = [ameriabank];
+export const BANK_PARSERS = [ameriabank, tinkoff];
 
 /**
  * The parser registered for a given source app, or null if none handles it.

--- a/app/services/notifications/bankParsers/tinkoff.js
+++ b/app/services/notifications/bankParsers/tinkoff.js
@@ -1,0 +1,270 @@
+/**
+ * Bank notification parser for the Tinkoff / T-Bank app
+ * (`com.idamob.tinkoff.android`).
+ *
+ * Unlike Ameria's single pipe-delimited line, Tinkoff posts a short Russian
+ * notification whose **title is the merchant** and whose **body** carries the
+ * kind, amount and account currency, followed by a balance line:
+ *
+ *   title: МегаФон
+ *   text:  Платеж на 1 000 ₽, счет RUB
+ *          Баланс 39 000 ₽
+ *
+ * Field mapping for that example:
+ *
+ *   | Field           | Example        | Becomes                              |
+ *   | --------------- | -------------- | ------------------------------------ |
+ *   | kind            | `Платеж`       | operation `type: 'expense'`          |
+ *   | amount          | `1 000`        | `amount: '1000'`                     |
+ *   | account currency| `счет RUB`     | `currency: 'RUB'` (account matching) |
+ *   | merchant        | `МегаФон`      | bound to a **category** (from title) |
+ *   | balance         | `Баланс 39 000 ₽` | **ignored**                       |
+ *
+ * Design notes, and how this differs from the Ameria parser:
+ *
+ * - **Merchant is the notification title.** Tinkoff puts the counterparty
+ *   ("МегаФон") in the title, not the body, so the parser reads it from
+ *   `notification.title`.
+ * - **No card mask.** This notification format carries no masked card number, so
+ *   `cardMask` is null and account resolution falls back to the single
+ *   currency-matching account (see resolveNotification). The account currency is
+ *   therefore the key account signal, and it is taken from the explicit ISO code
+ *   in the "счет RUB" segment — more reliable than mapping the ₽ symbol, and it
+ *   names the very account the charge hit. It falls back to the amount's currency
+ *   symbol when no "счет" segment is present.
+ * - **The balance line is stripped before anything else** so its amount
+ *   ("39 000 ₽") can never be mistaken for the transaction amount ("1 000 ₽").
+ * - **Russian numerics.** Amounts group with spaces (regular / non-breaking /
+ *   narrow / thin) and use a comma decimal separator ("1 000,50"), both handled
+ *   by normalizeAmount below.
+ * - **No date/time in the body.** The ingestion layer falls back to the
+ *   notification's post time, so `date`/`time` are null.
+ *
+ * `parse` is pure (no side effects) so it can be exhaustively unit-tested and
+ * reused regardless of how notifications are ingested.
+ *
+ * Registered against its source-app package in `bankParsers/index.js`.
+ */
+
+/** Android package name(s) this parser handles. */
+export const PACKAGE_NAMES = ['com.idamob.tinkoff.android'];
+
+/**
+ * Maps a Tinkoff notification "kind" keyword (uppercased, `ё` folded to `е`) to
+ * an operation type. Extend this table to support more kinds without touching
+ * the parsing logic below.
+ *
+ * Only kinds that share the "<kind> [на] <amount> <cur>, счет <CUR>" body layout
+ * are listed. Transfers ("Перевод") and cash withdrawals ("Снятие") are
+ * intentionally omitted for now: their bodies name a counterparty/target account
+ * differently and would need target-account binding, so — rather than guess —
+ * an unrecognized kind returns null and the notification is skipped.
+ */
+const KIND_TO_TYPE = {
+  ПОКУПКА: 'expense', // card purchase
+  ПЛАТЕЖ: 'expense', // payment (folded from ПЛАТЁЖ too)
+  ОПЛАТА: 'expense', // payment/bill
+  СПИСАНИЕ: 'expense', // direct debit / write-off
+  ПОПОЛНЕНИЕ: 'income', // top-up / deposit
+  ВОЗВРАТ: 'income', // refund
+};
+
+/**
+ * Tinkoff expense/income notifications never move money between the user's own
+ * accounts (that would be a "Перевод"/"Снятие", which this parser does not yet
+ * handle), so no kind is a transfer.
+ * @returns {boolean}
+ */
+export const kindIsTransfer = () => false;
+
+/**
+ * No Tinkoff kind here forces a manual category: a purchase/payment carries a
+ * real merchant (the title) whose category can be inferred and learned.
+ * @returns {boolean}
+ */
+export const kindRequiresCategory = () => false;
+
+// "1 000 ₽" / "10 $" / "1 000,50 RUB" — a number (space/comma/dot punctuation
+// allowed inside it) followed by a currency symbol or 3-letter code. Anchored on
+// a leading digit so the "RUB" in "счет RUB" (no number) never matches.
+const AMOUNT_CURRENCY_RE =
+  /(\d[\d\s.,]*?)\s*(₽|руб\.?|р\.|\$|€|[A-Za-z]{3})/u;
+
+// "счет RUB" / "счёт RUB" — the explicit account currency ISO code.
+const ACCOUNT_CURRENCY_RE = /сч[её]т\s+([A-Za-z]{3})\b/iu;
+
+// A masked card number if the notification happens to include one, e.g. "*1234"
+// or "•• 5678". Optional — this format usually omits it.
+const CARD_MASK_RE = /[*•]{1,4}\s?(\d{4})\b/;
+
+// Currency symbol → ISO code. Anything already a 3-letter code passes through.
+const SYMBOL_TO_CODE = {
+  '₽': 'RUB',
+  руб: 'RUB',
+  'руб.': 'RUB',
+  'р.': 'RUB',
+  $: 'USD',
+  '€': 'EUR',
+};
+
+/**
+ * Resolve a currency token (symbol or code) to an ISO code.
+ * @param {string} token
+ * @returns {string|null}
+ */
+const currencyCode = (token) => {
+  if (!token) return null;
+  const key = token.toLowerCase();
+  if (SYMBOL_TO_CODE[token]) return SYMBOL_TO_CODE[token];
+  if (SYMBOL_TO_CODE[key]) return SYMBOL_TO_CODE[key];
+  if (/^[A-Za-z]{3}$/.test(token)) return token.toUpperCase();
+  return null;
+};
+
+/**
+ * Normalize a Russian-formatted amount string to a plain decimal string.
+ *
+ * Spaces (regular, non-breaking, narrow, thin) are always thousands grouping and
+ * are stripped first. The remaining separators are then read with the same
+ * dual-convention logic used elsewhere: when both a dot and a comma are present
+ * the later one is the decimal separator; a lone comma that is not a 3-digit
+ * group is a decimal separator ("12,50" → "12.50") while a 3-digit group is
+ * treated as grouping ("1,234" → "1234").
+ *
+ * The result is a string so it feeds the decimal currency layer without ever
+ * becoming a lossy float.
+ *
+ * @param {string} raw - e.g. "1 000,50"
+ * @returns {string|null} e.g. "1000.50", or null when no digits are present
+ */
+const normalizeAmount = (raw) => {
+  if (!raw) return null;
+  // Strip all whitespace (incl. non-breaking / narrow / thin) — grouping only.
+  let s = raw.replace(/[\s]/g, '');
+  s = s.replace(/[^\d.,]/g, '');
+  if (!/\d/.test(s)) return null;
+
+  const lastDot = s.lastIndexOf('.');
+  const lastComma = s.lastIndexOf(',');
+
+  if (lastDot !== -1 && lastComma !== -1) {
+    if (lastComma > lastDot) {
+      s = s.replace(/\./g, '').replace(',', '.'); // comma decimal, dot grouping
+    } else {
+      s = s.replace(/,/g, ''); // dot decimal, comma grouping
+    }
+  } else if (lastComma !== -1) {
+    const parts = s.split(',');
+    if (parts.length === 2 && parts[1].length !== 3) {
+      s = s.replace(',', '.'); // single comma, not a 3-digit group -> decimal
+    } else {
+      s = s.replace(/,/g, ''); // grouping
+    }
+  } else if (lastDot !== -1) {
+    const parts = s.split('.');
+    if (parts.length > 2) {
+      s = s.replace(/\./g, ''); // multiple dots -> grouping
+    }
+    // single dot -> keep as the decimal point
+  }
+
+  return s;
+};
+
+/**
+ * Parse a Tinkoff notification into a normalized transaction descriptor.
+ *
+ * @param {{ title?: string, text?: string, packageName?: string, postTime?: number }} notification
+ * @returns {null | {
+ *   kind: string,             // e.g. 'ПЛАТЕЖ'
+ *   type: 'expense'|'income', // operation type the kind maps to
+ *   amount: string,           // normalized decimal string, e.g. '1000'
+ *   currency: string,         // ISO code, e.g. 'RUB' (from "счет RUB")
+ *   cardMask: string|null,    // usually null for this format
+ *   merchant: string|null,    // e.g. 'МегаФон' (from the title)
+ *   country: string|null,     // always null (not present in this format)
+ *   date: string|null,        // null — no date in the body; pipeline uses postTime
+ *   time: string|null,        // null
+ *   requiresCategory: boolean,// false
+ *   isTransfer: boolean,      // false
+ *   packageName: string|null, // source app, passed through for rule scoping
+ *   raw: string,              // the original text, kept for auditing/debugging
+ * }}
+ */
+export const parse = (notification) => {
+  if (!notification || typeof notification.text !== 'string') return null;
+
+  const text = notification.text.trim();
+  if (!text) return null;
+
+  // 1. Strip the balance line so its amount is never read as the transaction
+  //    amount. Everything from the "Баланс" keyword onward is dropped.
+  const balanceIdx = text.search(/Баланс/iu);
+  const primary = (balanceIdx >= 0 ? text.slice(0, balanceIdx) : text).trim();
+  if (!primary) return null;
+
+  // 2. Kind — the first Cyrillic word that is a known kind. Must be present for
+  //    us to recognize this as a transaction.
+  const words = primary.match(/[А-Яа-яЁё]+/gu) || [];
+  let kind = null;
+  let type = null;
+  for (const word of words) {
+    const normalized = word.toUpperCase().replace(/Ё/g, 'Е');
+    if (KIND_TO_TYPE[normalized]) {
+      kind = normalized;
+      type = KIND_TO_TYPE[normalized];
+      break;
+    }
+  }
+  if (!kind) return null;
+
+  // 3. Amount + currency — required; without it there's nothing to record.
+  const amountMatch = primary.match(AMOUNT_CURRENCY_RE);
+  if (!amountMatch) return null;
+  const amount = normalizeAmount(amountMatch[1]);
+  if (!amount) return null;
+
+  // 4. Currency — prefer the explicit account ISO code ("счет RUB"), since with
+  //    no card mask the account is matched by currency; fall back to the amount's
+  //    symbol/code.
+  const accountCurrencyMatch = primary.match(ACCOUNT_CURRENCY_RE);
+  const currency = accountCurrencyMatch
+    ? accountCurrencyMatch[1].toUpperCase()
+    : currencyCode(amountMatch[2]);
+  if (!currency) return null;
+
+  // 5. Card mask — optional; usually absent in this format.
+  const cardSegment = primary.match(CARD_MASK_RE);
+  const cardMask = cardSegment ? cardSegment[0].replace(/\s/g, '') : null;
+
+  // 6. Merchant — the notification title (the counterparty). Bound to a category.
+  const merchant =
+    typeof notification.title === 'string' && notification.title.trim()
+      ? notification.title.trim()
+      : null;
+
+  return {
+    kind,
+    type,
+    amount,
+    currency,
+    cardMask,
+    merchant,
+    country: null,
+    // No date/time in the Tinkoff body — the ingestion layer falls back to the
+    // notification's post time.
+    date: null,
+    time: null,
+    requiresCategory: false,
+    isTransfer: false,
+    packageName: notification.packageName || null,
+    raw: text,
+  };
+};
+
+export default {
+  packageNames: PACKAGE_NAMES,
+  parse,
+  kindRequiresCategory,
+  kindIsTransfer,
+};

--- a/app/services/notifications/notificationFilters.js
+++ b/app/services/notifications/notificationFilters.js
@@ -25,6 +25,7 @@ import * as PreferencesDB from '../PreferencesDB';
  */
 export const DEFAULT_FILTER_PACKAGES = [
   'com.banq.ameriabank',
+  'com.idamob.tinkoff.android',
   'com.android.systemui',
   'org.telegram.messenger',
 ];

--- a/app/services/notifications/parseBankNotification.js
+++ b/app/services/notifications/parseBankNotification.js
@@ -6,9 +6,9 @@
  * notification to the parser registered for its source app and exposes the
  * per-app `kindRequiresCategory` helper.
  *
- * Today only Ameriabank (`com.banqr.ameriabank`) is supported. When a second
- * bank is added it becomes another parser module in `bankParsers/` — nothing
- * here changes.
+ * Ameriabank (`com.banqr.ameriabank`) and Tinkoff / T-Bank
+ * (`com.idamob.tinkoff.android`) are supported today. Adding another bank is just
+ * another parser module in `bankParsers/` — nothing here changes.
  */
 
 import { BANK_PARSERS, getParserForPackage } from './bankParsers';

--- a/docs/NOTIFICATION_PROCESSING.md
+++ b/docs/NOTIFICATION_PROCESSING.md
@@ -81,6 +81,48 @@ category:
   `destinationAmount` in target currency, `exchangeRate` source→target); a missing
   rate routes to review instead of booking a wrong amount.
 
+### Tinkoff / T-Bank (`com.idamob.tinkoff.android`) — a second bank, a new format
+
+Tinkoff posts a different shape from Ameria's single pipe-delimited line: the
+**merchant is the notification title** and the short Russian body carries the
+kind, amount and account currency, followed by a balance line.
+
+```
+title: МегаФон
+text:  Платеж на 1 000 ₽, счет RUB
+       Баланс 39 000 ₽
+```
+
+| Template field    | Example        | Becomes                                  |
+| ----------------- | -------------- | ---------------------------------------- |
+| kind              | `Платеж`       | operation `type: 'expense'`              |
+| amount            | `1 000`        | `amount: '1000'` (space grouping stripped) |
+| account currency  | `счет RUB`     | `currency: 'RUB'` (account matching)     |
+| merchant (title)  | `МегаФон`      | bound to a **category**                  |
+| balance           | `Баланс 39 000 ₽` | **ignored**                           |
+
+The parser lives in `app/services/notifications/bankParsers/tinkoff.js` and is
+registered in `bankParsers/index.js`. Key differences from the Ameria parser,
+each driven by the format:
+
+- **Merchant comes from the title**, not the body.
+- **No card mask** in this format, so account resolution relies on the single
+  currency-matching account. The currency is read from the explicit ISO code in
+  `счет RUB` (an unambiguous account signal), falling back to the amount's ₽/$/€
+  symbol when absent.
+- **The balance line is stripped first** so `39 000 ₽` can never be read as the
+  transaction amount.
+- **Russian numerics**: space thousands grouping (regular / non-breaking / narrow)
+  and a comma decimal separator (`1 000,50`) are both normalized.
+- **No date/time in the body**, so the ingestion layer falls back to the
+  notification's post time.
+
+Recognized kinds map to `expense` (`Покупка`, `Платеж`, `Оплата`, `Списание`) or
+`income` (`Пополнение`, `Возврат`). Kinds needing their own layout or a target
+account (`Перевод`, `Снятие`) are not yet handled — an unrecognized kind returns
+`null` and the notification is skipped rather than mis-booked. Covered by
+`__tests__/services/notifications/tinkoffParser.test.js`.
+
 ### Live auto-refresh
 
 While the processing panel is open it re-runs the pipeline and reloads both the


### PR DESCRIPTION
## Summary

Adds a second bank-notification parser for **Tinkoff / T-Bank** (`com.idamob.tinkoff.android`). Tinkoff uses a different notification format from Ameria: the merchant is the notification **title** and the short Russian body carries the kind, amount and account currency, followed by a balance line. The existing per-app parser registry made this a self-contained addition — the dispatcher, resolver and pipeline are unchanged.

```
title: МегаФон
text:  Платеж на 1 000 ₽, счет RUB
       Баланс 39 000 ₽
```

| Template field   | Example             | Becomes                             |
| ---------------- | ------------------- | ----------------------------------- |
| kind             | `Платеж`            | operation `type: 'expense'`         |
| amount           | `1 000`             | `amount: '1000'`                    |
| account currency | `счет RUB`          | `currency: 'RUB'` (account matching)|
| merchant (title) | `МегаФон`           | bound to a **category**             |
| balance          | `Баланс 39 000 ₽`   | **ignored**                         |

## Changes

- **app/services/notifications/bankParsers/tinkoff.js** — new parser. Reads the merchant from the title; strips the `Баланс …` line first so its amount is never read as the transaction amount; normalizes Russian numerics (space thousands grouping incl. non-breaking/narrow spaces, comma decimal); takes the currency from the explicit `счет RUB` ISO code (the key account signal, since this format has no card mask) with a ₽/$/€ symbol fallback; maps `Покупка/Платеж/Оплата/Списание` → expense and `Пополнение/Возврат` → income. Unrecognized kinds (e.g. `Перевод/Снятие`) return `null` and are skipped rather than mis-booked.
- **app/services/notifications/bankParsers/index.js** — register the Tinkoff parser in `BANK_PARSERS`.
- **app/services/notifications/notificationFilters.js** — add `com.idamob.tinkoff.android` to the shipped filter defaults.
- **app/services/notifications/parseBankNotification.js** — update the module doc to list Tinkoff as a supported source app.
- **docs/NOTIFICATION_PROCESSING.md** — document the Tinkoff format, field mapping and design differences from the Ameria parser.
- **__tests__/services/notifications/tinkoffParser.test.js** — new suite covering the canonical payment, expense/income kinds, `ё` folding, amount normalization, currency selection, optional card mask, source-app dispatch (incl. no cross-contamination with the Ameria pipe format), and rejection cases.

## Testing

- `npm test` — 147 suites / 4256 tests pass.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no user-facing strings; parser + package registration only)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBGehTYYASshY873m2hmNc

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBGehTYYASshY873m2hmNc)_