### PR TITLE
feat: parse Tinkoff "Доступно" available-balance notification template

### DIFF
--- a/__tests__/services/notifications/tinkoffParser.test.js
+++ b/__tests__/services/notifications/tinkoffParser.test.js
@@ -147,6 +147,63 @@ describe('Tinkoff notification parser', () => {
     });
   });
 
+  describe('"Доступно" available-balance template (single line, no merchant)', () => {
+    // The newer T-Bank template: no merchant title, and the available balance
+    // ("Доступно") trails the transaction on the same line after ". ".
+    const TINKOFF_TOPUP = {
+      text: 'Пополнение на 242 787,85 ₽, счет RUB. Доступно 281 787,85 ₽',
+      packageName: 'com.idamob.tinkoff.android',
+      postTime: 1782000900000,
+    };
+
+    let result;
+    beforeEach(() => {
+      result = parseBankNotification(TINKOFF_TOPUP);
+    });
+
+    it('recognizes the notification and returns an object', () => {
+      expect(result).not.toBeNull();
+    });
+
+    it('maps Пополнение to an income operation', () => {
+      expect(result.kind).toBe('ПОПОЛНЕНИЕ');
+      expect(result.type).toBe('income');
+    });
+
+    it('extracts the transaction amount, stripping the space grouping', () => {
+      expect(result.amount).toBe('242787.85');
+    });
+
+    it('never reads the "Доступно" available-balance amount', () => {
+      expect(result.amount).not.toBe('281787.85');
+      const { raw, ...structured } = result;
+      expect(JSON.stringify(structured)).not.toContain('281787');
+    });
+
+    it('extracts the account currency from "счет RUB"', () => {
+      expect(result.currency).toBe('RUB');
+    });
+
+    it('has no merchant when the title is absent', () => {
+      expect(result.merchant).toBeNull();
+    });
+
+    it('keeps the full raw text for auditing', () => {
+      expect(result.raw).toBe(TINKOFF_TOPUP.text);
+    });
+
+    it('strips a "Доступно" balance even for an expense kind on one line', () => {
+      const expense = parseBankNotification({
+        title: 'Пятерочка',
+        text: 'Покупка на 549,90 ₽, счет RUB. Доступно 12 300,10 ₽',
+        packageName: 'com.idamob.tinkoff.android',
+      });
+      expect(expense.type).toBe('expense');
+      expect(expense.amount).toBe('549.90');
+      expect(expense.amount).not.toBe('12300.10');
+    });
+  });
+
   describe('kind keyword handling', () => {
     it('folds ё so Платёж is recognized as ПЛАТЕЖ', () => {
       const result = parseBankNotification({

--- a/app/services/notifications/bankParsers/tinkoff.js
+++ b/app/services/notifications/bankParsers/tinkoff.js
@@ -10,6 +10,15 @@
  *   text:  Платеж на 1 000 ₽, счет RUB
  *          Баланс 39 000 ₽
  *
+ * A second, newer template carries no merchant title and puts an *available*
+ * balance ("Доступно") on the same line as the transaction, separated by ". ":
+ *
+ *   text:  Пополнение на 242 787,85 ₽, счет RUB. Доступно 281 787,85 ₽
+ *
+ * Both the "Баланс" and "Доступно" balance segments are stripped before parsing
+ * (see step 1 in `parse`) so their amounts can never be read as the transaction
+ * amount.
+ *
  * Field mapping for that example:
  *
  *   | Field           | Example        | Becomes                              |
@@ -34,6 +43,9 @@
  *   symbol when no "счет" segment is present.
  * - **The balance line is stripped before anything else** so its amount
  *   ("39 000 ₽") can never be mistaken for the transaction amount ("1 000 ₽").
+ *   Both balance keywords are handled: "Баланс" (full balance, on its own line)
+ *   and "Доступно" (available balance, which may sit on the same line after the
+ *   transaction, separated by ". ").
  * - **Russian numerics.** Amounts group with spaces (regular / non-breaking /
  *   narrow / thin) and use a comma decimal separator ("1 000,50"), both handled
  *   by normalizeAmount below.
@@ -198,8 +210,12 @@ export const parse = (notification) => {
   if (!text) return null;
 
   // 1. Strip the balance line so its amount is never read as the transaction
-  //    amount. Everything from the "Баланс" keyword onward is dropped.
-  const balanceIdx = text.search(/Баланс/iu);
+  //    amount. Everything from the balance keyword onward is dropped. Two
+  //    keywords are used by Tinkoff: "Баланс" (full balance, usually on its own
+  //    line) and "Доступно" (available balance, which can trail the transaction
+  //    on the same line after ". "). The transaction amount always precedes the
+  //    balance, so cutting at the first balance keyword leaves it intact.
+  const balanceIdx = text.search(/Баланс|Доступно/iu);
   const primary = (balanceIdx >= 0 ? text.slice(0, balanceIdx) : text).trim();
   if (!primary) return null;
 

--- a/docs/NOTIFICATION_PROCESSING.md
+++ b/docs/NOTIFICATION_PROCESSING.md
@@ -101,6 +101,17 @@ text:  Платеж на 1 000 ₽, счет RUB
 | merchant (title)  | `МегаФон`      | bound to a **category**                  |
 | balance           | `Баланс 39 000 ₽` | **ignored**                           |
 
+A second, newer template carries no merchant title and puts an *available*
+balance (`Доступно`) on the same line as the transaction, separated by `. `:
+
+```
+text:  Пополнение на 242 787,85 ₽, счет RUB. Доступно 281 787,85 ₽
+```
+
+Here `Пополнение` maps to `income`, `amount` is `242787.85`, `currency` is `RUB`,
+and the `Доступно 281 787,85 ₽` balance segment is stripped and ignored just like
+`Баланс`.
+
 The parser lives in `app/services/notifications/bankParsers/tinkoff.js` and is
 registered in `bankParsers/index.js`. Key differences from the Ameria parser,
 each driven by the format:
@@ -111,7 +122,8 @@ each driven by the format:
   `счет RUB` (an unambiguous account signal), falling back to the amount's ₽/$/€
   symbol when absent.
 - **The balance line is stripped first** so `39 000 ₽` can never be read as the
-  transaction amount.
+  transaction amount. Both `Баланс` and `Доступно` are recognized as balance
+  keywords, whether on their own line or trailing the transaction after `. `.
 - **Russian numerics**: space thousands grouping (regular / non-breaking / narrow)
   and a comma decimal separator (`1 000,50`) are both normalized.
 - **No date/time in the body**, so the ingestion layer falls back to the


### PR DESCRIPTION
## Summary

Adds support for a newer T-Bank / Tinkoff notification shape where the *available* balance (`Доступно`) trails the transaction on the same line after `. ` and no merchant title is present, e.g. `Пополнение на 242 787,85 ₽, счет RUB. Доступно 281 787,85 ₽`. Previously only `Баланс` (on its own line) was recognized and stripped, so the new template's balance figure was left un-stripped, contrary to the parser's design guarantee that a balance amount can never be read as the transaction amount.

## Changes

- **app/services/notifications/bankParsers/tinkoff.js** — recognize both `Баланс` and `Доступно` as balance keywords and strip the balance segment before amount extraction (works whether the balance is on its own line or trails the transaction after `. `). Updated the header doc comment with the new template.
- **docs/NOTIFICATION_PROCESSING.md** — document the second template (no merchant title, same-line `Доступно` balance) and the dual balance-keyword handling.
- **__tests__/services/notifications/tinkoffParser.test.js** — add a suite covering the new template: income mapping, amount extraction, never reading the `Доступно` balance amount, currency from `счет RUB`, null merchant, and same-line balance stripping for an expense.

## Testing

- `npm test -- __tests__/services/notifications/tinkoffParser.test.js` — 1 suite / 46 tests pass.
- `npm test -- __tests__/services/notifications/` — 8 suites / 250 tests pass.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (notification suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no UI strings changed)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015nHccaVbou4DfRr5BDcyaR)_