### PR TITLE
fix(notifications): async "Adding…" state on review-queue save

### DIFF
--- a/__tests__/components/NotificationProcessingContentPanel.test.js
+++ b/__tests__/components/NotificationProcessingContentPanel.test.js
@@ -333,4 +333,47 @@ describe('NotificationProcessingContentPanel', () => {
       await waitFor(() => expect(getByText('bank_notifications_readd_created')).toBeTruthy());
     });
   });
+
+  // Regression: enabling automatic geotagging made the save await an up-to-8s
+  // location fix. The card must collapse into an async "Adding…" state and drop
+  // its Save button so a slow fix can't be double-tapped into duplicate operations.
+  describe('async save (location capture)', () => {
+    it('collapses the card into an "Adding…" row and drops the Save button while saving', async () => {
+      // Hang the resolve so the card stays mid-save and we can observe the
+      // collapsed state (and the absence of a second Save affordance).
+      let finishSave;
+      pipeline.resolvePendingNotification.mockImplementation(
+        () => new Promise((resolve) => { finishSave = resolve; }),
+      );
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([{ ...PENDING, accountId: 1 }]);
+      const { getByText, queryByText } = await render(<NotificationProcessingContentPanel />);
+      await waitFor(() => expect(getByText('NAREK MEHRABYAN')).toBeTruthy());
+
+      fireEvent.press(getByText('save'));
+
+      // The card collapses to the progress row; the merchant is still shown but the
+      // Save button (and the whole form) is gone, so it can't be tapped again.
+      await waitFor(() => expect(getByText('bank_notifications_adding')).toBeTruthy());
+      expect(getByText('NAREK MEHRABYAN')).toBeTruthy();
+      expect(queryByText('save')).toBeNull();
+      expect(pipeline.resolvePendingNotification).toHaveBeenCalledTimes(1);
+
+      // Let the hung save finish so no promise dangles past the test.
+      await act(async () => { finishSave({ id: 1 }); });
+    });
+
+    it('re-expands the card when the save fails so the user can retry', async () => {
+      pipeline.resolvePendingNotification.mockRejectedValueOnce(new Error('no exchange rate'));
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([{ ...PENDING, accountId: 1 }]);
+      const { getByText, queryByText } = await render(<NotificationProcessingContentPanel />);
+      await waitFor(() => expect(getByText('NAREK MEHRABYAN')).toBeTruthy());
+
+      fireEvent.press(getByText('save'));
+
+      // After the rejection settles the form comes back (Save is pressable again)
+      // and the transient progress row is gone.
+      await waitFor(() => expect(getByText('save')).toBeTruthy());
+      expect(queryByText('bank_notifications_adding')).toBeNull();
+    });
+  });
 });

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -1,6 +1,16 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, ScrollView, ActivityIndicator, RefreshControl, TouchableOpacity } from 'react-native';
+import {
+  View,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+  RefreshControl,
+  TouchableOpacity,
+  LayoutAnimation,
+  Platform,
+  UIManager,
+} from 'react-native';
 import { Text } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -36,6 +46,23 @@ import * as Currency from '../services/currency';
 // newly-arrived notifications surface on their own, without a manual pull.
 const AUTO_REFRESH_MS = 3000;
 
+// Enable LayoutAnimation on the classic Android renderer. It is a no-op on Fabric
+// (the New Architecture drives layout animations natively), and the guard keeps it
+// from throwing when the method is absent.
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+// A short ease used when a review card collapses into its "Adding…" state and when
+// the finished card leaves the queue, so a save reads as a smooth transition
+// instead of an abrupt jump. Kept snappy to match the app's other 200–260ms moves.
+const CARD_COLLAPSE_ANIMATION = {
+  duration: 220,
+  create: { type: LayoutAnimation.Types.easeOut, property: LayoutAnimation.Properties.opacity },
+  update: { type: LayoutAnimation.Types.easeInEaseOut },
+  delete: { type: LayoutAnimation.Types.easeIn, property: LayoutAnimation.Properties.opacity },
+};
+
 /**
  * "Notification processing" settings subpanel — the main view.
  *
@@ -69,6 +96,11 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
   const [choices, setChoices] = useState({});
   // Per-recent-card re-add feedback: key -> 'loading' | 'created' | 'pending'.
   const [reAddState, setReAddState] = useState({});
+  // Per-review-card save state: pending id -> true while its save is in flight.
+  // A card mid-save collapses into a compact "Adding…" row and drops its action
+  // buttons, so the up-to-8s best-effort location fix inside the save can't be
+  // double-tapped into duplicate operations (the reason this is async at all).
+  const [savingIds, setSavingIds] = useState({});
   // Mirror of `choices` so reloadPending can read the latest values without
   // taking `choices` as a dependency (which would re-create it on every keystroke).
   const choicesRef = useRef(choices);
@@ -213,6 +245,23 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
     setChoices((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
   }, []);
 
+  // Drop save flags for cards that have left the queue (saved or dismissed) so the
+  // map only ever tracks cards still on screen.
+  useEffect(() => {
+    setSavingIds((prev) => {
+      const keys = Object.keys(prev);
+      if (keys.length === 0) return prev;
+      const live = new Set(pending.map((p) => p.id));
+      let changed = false;
+      const next = {};
+      keys.forEach((id) => {
+        if (live.has(id)) next[id] = prev[id];
+        else changed = true;
+      });
+      return changed ? next : prev;
+    });
+  }, [pending]);
+
   const handleSave = useCallback(async (item) => {
     const choice = choices[item.id] || {};
     if (choice.accountId == null) return;
@@ -220,16 +269,43 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
     if (item.type === 'transfer' && (choice.toAccountId == null || choice.toAccountId === choice.accountId)) {
       return;
     }
-    await resolvePendingNotification(item.id, {
-      accountId: choice.accountId,
-      categoryId: choice.categoryId || null,
-      toAccountId: choice.toAccountId ?? null,
-      // Send the field verbatim (string, possibly blank) so resolve treats it as
-      // authoritative — a cleared field reverts to the raw shop name.
-      labelOverride: choice.labelOverride ?? '',
-    });
-    await reloadPending();
-  }, [choices, reloadPending]);
+    // Ignore repeat taps while this item's save is already running.
+    if (savingIds[item.id]) return;
+
+    // Collapse the card into an "Adding…" state right away so the save feels
+    // instant even while the best-effort location fix inside resolve resolves in
+    // the background (it can take up to 8s). Dropping the Save button from the
+    // tree, together with the guard above, stops a second tap from booking a
+    // duplicate operation during the capture.
+    LayoutAnimation.configureNext(CARD_COLLAPSE_ANIMATION);
+    setSavingIds((prev) => ({ ...prev, [item.id]: true }));
+
+    try {
+      await resolvePendingNotification(item.id, {
+        accountId: choice.accountId,
+        categoryId: choice.categoryId || null,
+        toAccountId: choice.toAccountId ?? null,
+        // Send the field verbatim (string, possibly blank) so resolve treats it as
+        // authoritative — a cleared field reverts to the raw shop name.
+        labelOverride: choice.labelOverride ?? '',
+      });
+      // The pending row is deleted now; reloading drops the collapsed card from
+      // the queue (the effect above prunes its stale saving flag).
+      LayoutAnimation.configureNext(CARD_COLLAPSE_ANIMATION);
+      await reloadPending();
+    } catch (error) {
+      // The save failed (e.g. no exchange rate for a cross-currency booking) —
+      // expand the card again so the user can retry or adjust their choices.
+      if (mountedRef.current) {
+        LayoutAnimation.configureNext(CARD_COLLAPSE_ANIMATION);
+        setSavingIds((prev) => {
+          const next = { ...prev };
+          delete next[item.id];
+          return next;
+        });
+      }
+    }
+  }, [choices, reloadPending, savingIds]);
 
   const handleDismiss = useCallback(async (item) => {
     await dismissPendingNotification(item.id);
@@ -317,6 +393,32 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
         </View>
       ) : (
         pending.map((item) => {
+          // Mid-save: the full form is collapsed into a compact progress row so
+          // the save reads as instant, and the (now-absent) Save button can't be
+          // tapped again while the location fix resolves.
+          if (savingIds[item.id]) {
+            return (
+              <View
+                key={item.id}
+                style={[styles.card, styles.savingCard, { backgroundColor: colors.surface, borderColor: colors.border }]}
+                accessibilityRole="progressbar"
+                accessibilityLabel={t('bank_notifications_adding') || 'Adding operation…'}
+              >
+                <ActivityIndicator size="small" color={colors.primary} />
+                <View style={styles.savingBody}>
+                  <Text style={[styles.savingMerchant, { color: colors.text }]} numberOfLines={1}>
+                    {item.merchant || item.kind}
+                  </Text>
+                  <Text style={[styles.savingStatus, { color: colors.mutedText }]} numberOfLines={1}>
+                    {t('bank_notifications_adding') || 'Adding operation…'}
+                  </Text>
+                </View>
+                <Text style={[styles.cardAmount, { color: colors.mutedText }]}>
+                  {item.amount} {item.currency}
+                </Text>
+              </View>
+            );
+          }
           const choice = choices[item.id] || {};
           // ATM withdrawals resolve to a target (cash) account instead of a
           // category — they are booked as a transfer between the user's accounts.
@@ -614,6 +716,22 @@ const styles = StyleSheet.create({
   pickerWrap: {
     borderRadius: BORDER_RADIUS.sm,
     borderWidth: StyleSheet.hairlineWidth,
+  },
+  savingBody: {
+    flex: 1,
+  },
+  savingCard: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.md,
+  },
+  savingMerchant: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  savingStatus: {
+    fontSize: 12,
+    marginTop: 2,
   },
   scroll: {
     flex: 1,

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "Vorgang erneut hinzufügen",
   "bank_notifications_readd_created": "Vorgang hinzugefügt",
   "bank_notifications_readd_queued": "Zur Prüfliste hinzugefügt",
+  "bank_notifications_adding": "Vorgang wird hinzugefügt…",
   "bank_notifications_transfer_from": "Von Konto",
   "bank_notifications_transfer_to": "Auf Konto",
   "bank_notifications_transfer_label_help": "Optionale Bezeichnung für diese Überweisung",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -38,6 +38,7 @@
   "bank_notifications_readd": "Re-add operation",
   "bank_notifications_readd_created": "Operation added",
   "bank_notifications_readd_queued": "Added to review queue",
+  "bank_notifications_adding": "Adding operation…",
   "bank_notifications_transfer_from": "From account",
   "bank_notifications_transfer_to": "To account",
   "bank_notifications_transfer_label_help": "Optional label for this transfer",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "Volver a añadir operación",
   "bank_notifications_readd_created": "Operación añadida",
   "bank_notifications_readd_queued": "Añadido a la cola de revisión",
+  "bank_notifications_adding": "Añadiendo operación…",
   "bank_notifications_transfer_from": "Desde la cuenta",
   "bank_notifications_transfer_to": "A la cuenta",
   "bank_notifications_transfer_label_help": "Etiqueta opcional para esta transferencia",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "Rajouter l'opération",
   "bank_notifications_readd_created": "Opération ajoutée",
   "bank_notifications_readd_queued": "Ajouté à la file d'attente",
+  "bank_notifications_adding": "Ajout de l’opération…",
   "bank_notifications_transfer_from": "Du compte",
   "bank_notifications_transfer_to": "Vers le compte",
   "bank_notifications_transfer_label_help": "Libellé facultatif pour ce transfert",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "Կրկին ավելացնել գործարքը",
   "bank_notifications_readd_created": "Գործարքն ավելացվեց",
   "bank_notifications_readd_queued": "Ավելացվեց ստուգման հերթ",
+  "bank_notifications_adding": "Գործարքի ավելացում…",
   "bank_notifications_transfer_from": "Հաշվից",
   "bank_notifications_transfer_to": "Հաշվին",
   "bank_notifications_transfer_label_help": "Կամընտիր պիտակ այս փոխանցման համար",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "Aggiungi di nuovo",
   "bank_notifications_readd_created": "Operazione aggiunta",
   "bank_notifications_readd_queued": "Aggiunta alla coda di revisione",
+  "bank_notifications_adding": "Aggiunta operazione…",
   "bank_notifications_transfer_from": "Dal conto",
   "bank_notifications_transfer_to": "Al conto",
   "bank_notifications_transfer_label_help": "Etichetta facoltativa per questo trasferimento",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "操作を再追加",
   "bank_notifications_readd_created": "操作を追加しました",
   "bank_notifications_readd_queued": "確認キューに追加しました",
+  "bank_notifications_adding": "操作を追加中…",
   "bank_notifications_transfer_from": "出金口座",
   "bank_notifications_transfer_to": "入金口座",
   "bank_notifications_transfer_label_help": "この振替の任意のラベル",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "작업 다시 추가",
   "bank_notifications_readd_created": "작업이 추가됨",
   "bank_notifications_readd_queued": "검토 대기열에 추가됨",
+  "bank_notifications_adding": "작업 추가 중…",
   "bank_notifications_transfer_from": "출금 계좌",
   "bank_notifications_transfer_to": "입금 계좌",
   "bank_notifications_transfer_label_help": "이 이체의 선택적 라벨",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "Adicionar operação novamente",
   "bank_notifications_readd_created": "Operação adicionada",
   "bank_notifications_readd_queued": "Adicionado à fila de revisão",
+  "bank_notifications_adding": "Adicionando operação…",
   "bank_notifications_transfer_from": "Da conta",
   "bank_notifications_transfer_to": "Para a conta",
   "bank_notifications_transfer_label_help": "Rótulo opcional para esta transferência",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "Добавить снова",
   "bank_notifications_readd_created": "Операция добавлена",
   "bank_notifications_readd_queued": "Добавлено в очередь проверки",
+  "bank_notifications_adding": "Добавление операции…",
   "bank_notifications_transfer_from": "Со счёта",
   "bank_notifications_transfer_to": "На счёт",
   "bank_notifications_transfer_label_help": "Необязательная метка для этого перевода",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -30,6 +30,7 @@
   "bank_notifications_readd": "重新添加操作",
   "bank_notifications_readd_created": "操作已添加",
   "bank_notifications_readd_queued": "已加入待审核队列",
+  "bank_notifications_adding": "正在添加操作…",
   "bank_notifications_transfer_from": "转出账户",
   "bank_notifications_transfer_to": "转入账户",
   "bank_notifications_transfer_label_help": "此转账的可选标签",


### PR DESCRIPTION
## Summary

Enabling automatic geotagging made the notification review-queue **Save** await an up-to-8s location fix *inside* `resolvePendingNotification`, while the full form (and its Save button) stayed interactive. A second tap during that window booked a **duplicate operation**, and the frozen form made the app feel laggy. This makes the save asynchronous: the card collapses into an "Adding…" progress row immediately, the fix resolves in the background, and repeat taps are impossible.

## Changes

- **app/components/NotificationProcessingContentPanel.js** — on Save, collapse the review card into a compact "Adding…" row (spinner + merchant + amount) via `LayoutAnimation`, tracked by a new per-item `savingIds` flag. This drops the Save button from the tree and, together with an in-flight guard, prevents duplicate saves during the location capture. A failed save re-expands the card for retry; an effect prunes save flags once cards leave the queue.
- **assets/i18n/*.json** — add `bank_notifications_adding` ("Adding operation…") across all 11 languages.
- **__tests__/components/NotificationProcessingContentPanel.test.js** — regression tests for the collapse + Save-button-gone (double-tap guard) and the failure re-expand path.

## Testing

- `npm test` — 147 suites / 4266 tests pass (2 new).
- `npx eslint` on the changed files — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — or n/a
- [ ] Linked the related issue with `Closes #NNN` below — or n/a

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nY6FmujuvBFtEWynviMxy

---
_Generated by [Claude Code](https://claude.ai/code/session_014nY6FmujuvBFtEWynviMxy)_