### PR TITLE
feat(operations): show the undo bar inline beneath the just-added operation

### DIFF
--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -10,6 +10,27 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import OperationListItem from '../../../app/components/operations/OperationListItem';
 
+// Mock the inline undo bar: its own animation/timer lifecycle is covered in
+// UndoSnackbar.test.js. Here we only need to verify the wiring — that it is
+// rendered for the right operation and forwards the undo action.
+jest.mock('../../../app/components/operations/UndoSnackbar', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  /* eslint-disable react/prop-types */
+  return function MockUndoSnackbar({ operationId, message, actionLabel, onUndo }) {
+    return React.createElement(
+      Text,
+      {
+        testID: `undo-bar-${operationId}`,
+        accessibilityLabel: actionLabel,
+        onPress: () => onUndo(operationId),
+      },
+      message,
+    );
+  };
+  /* eslint-enable react/prop-types */
+});
+
 const mockColors = {
   text: '#fff',
   mutedText: '#888',
@@ -79,6 +100,44 @@ describe('OperationListItem', () => {
       expect(getByLabelText('dismiss suggestion')).toBeTruthy();
       expect(getByText('Monthly pass')).toBeTruthy();
       expect(getByText('Bus fare')).toBeTruthy();
+    });
+  });
+
+  describe('Undo Bar Rendering', () => {
+    it('does not render the undo bar when showUndo is false', async () => {
+      const { queryByTestId } = await render(<OperationListItem {...baseProps} />);
+      expect(queryByTestId('undo-bar-1')).toBeNull();
+    });
+
+    it('renders the undo bar beneath the operation when showUndo is true', async () => {
+      const { getByTestId, getByText } = await render(
+        <OperationListItem
+          {...baseProps}
+          showUndo
+          undoMessage="operation_added"
+          undoActionLabel="undo"
+          onUndo={jest.fn()}
+          onUndoClosed={jest.fn()}
+        />,
+      );
+      expect(getByTestId('undo-bar-1')).toBeTruthy();
+      expect(getByText('operation_added')).toBeTruthy();
+    });
+
+    it('calls onUndo with the operation id when the undo action is triggered', async () => {
+      const onUndo = jest.fn();
+      const { getByTestId } = await render(
+        <OperationListItem
+          {...baseProps}
+          showUndo
+          undoMessage="operation_added"
+          undoActionLabel="undo"
+          onUndo={onUndo}
+          onUndoClosed={jest.fn()}
+        />,
+      );
+      await fireEvent.press(getByTestId('undo-bar-1'));
+      expect(onUndo).toHaveBeenCalledWith('1');
     });
   });
 

--- a/__tests__/components/operations/OperationsList.test.js
+++ b/__tests__/components/operations/OperationsList.test.js
@@ -41,12 +41,17 @@ jest.mock('../../../app/components/operations/DateSeparator', () => {
 jest.mock('../../../app/components/operations/OperationListItem', () => {
   const React = require('react');
   /* eslint-disable react/prop-types */
-  return function MockOperationListItem({ operation, formatCurrency, getCategoryInfo, getAccountName }) {
+  return function MockOperationListItem({ operation, formatCurrency, getCategoryInfo, getAccountName, showUndo }) {
     // invoke utility callbacks so their coverage counters are hit
     if (formatCurrency) formatCurrency(operation.accountId, operation.amount);
     if (getCategoryInfo) getCategoryInfo(operation.categoryId);
     if (getAccountName) getAccountName(operation.accountId);
-    return React.createElement('View', { testID: `op-item-${operation.id}` });
+    return React.createElement(
+      'View',
+      { testID: `op-item-${operation.id}` },
+      // Marker child so tests can assert which operation gets the inline undo bar.
+      showUndo ? React.createElement('View', { testID: `op-undo-${operation.id}` }) : null,
+    );
   };
   /* eslint-enable react/prop-types */
 });
@@ -398,6 +403,30 @@ describe('OperationsList', () => {
       const section = toSection(group);
       const { sp } = await getSectionListProps({ groupedOperations: [group], categories: catsNoIcon });
       await render(sp.renderItem({ item: section.data[0], index: 0, section }));
+    });
+  });
+
+  describe('branch coverage — undoOperationId match', () => {
+    it('renders the inline undo bar only on the matching operation', async () => {
+      const group = makeGroup(TODAY, [
+        { id: 'op-undo', type: 'expense', amount: '10.00', accountId: 'acc-usd', categoryId: 'cat-1' },
+        { id: 'op-plain', type: 'income', amount: '20.00', accountId: 'acc-usd', categoryId: 'cat-1' },
+      ]);
+      const section = toSection(group);
+      const { sp } = await getSectionListProps({
+        groupedOperations: [group],
+        undoOperationId: 'op-undo',
+        undoToken: 3,
+        undoMessage: 'operation_added',
+        undoActionLabel: 'undo',
+        onUndo: jest.fn(),
+        onUndoClosed: jest.fn(),
+      });
+      const matched = await render(sp.renderItem({ item: section.data[0], index: 0, section }));
+      expect(matched.getByTestId('op-undo-op-undo')).toBeTruthy();
+
+      const plain = await render(sp.renderItem({ item: section.data[1], index: 1, section }));
+      expect(plain.queryByTestId('op-undo-op-plain')).toBeNull();
     });
   });
 

--- a/__tests__/components/operations/UndoSnackbar.test.js
+++ b/__tests__/components/operations/UndoSnackbar.test.js
@@ -5,6 +5,7 @@ import UndoSnackbar from '../../../app/components/operations/UndoSnackbar';
 
 const mockColors = {
   surface: '#1e1e1e',
+  altRow: '#242424',
   border: '#333',
   primary: '#4C9EFF',
   text: '#ffffff',

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
+import UndoSnackbar from './UndoSnackbar';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
 
@@ -32,6 +33,13 @@ const OperationListItem = ({
   suggestionChips,
   onApplySuggestion,
   onDismissSuggestion,
+  showUndo,
+  undoToken,
+  undoMessage,
+  undoActionLabel,
+  undoDuration,
+  onUndo,
+  onUndoClosed,
 }) => {
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
@@ -162,6 +170,21 @@ const OperationListItem = ({
         </View>
       </TouchableRipple>
 
+      {/* Inline "just added" undo bar — sits directly beneath the operation it
+          refers to, between it and the operation before it. */}
+      {showUndo && (
+        <UndoSnackbar
+          key={undoToken}
+          operationId={operation.id}
+          message={undoMessage}
+          actionLabel={undoActionLabel}
+          duration={undoDuration}
+          colors={colors}
+          onUndo={onUndo}
+          onClosed={onUndoClosed}
+        />
+      )}
+
       {suggestionChips && suggestionChips.length > 0 && (
         <DescriptionSuggestionRow
           chips={suggestionChips}
@@ -181,6 +204,7 @@ const OperationListItem = ({
 
 OperationListItem.propTypes = {
   operation: PropTypes.shape({
+    id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     accountId: PropTypes.string.isRequired,
     categoryId: PropTypes.string,
@@ -205,6 +229,13 @@ OperationListItem.propTypes = {
   suggestionChips: PropTypes.arrayOf(PropTypes.string),
   onApplySuggestion: PropTypes.func,
   onDismissSuggestion: PropTypes.func,
+  showUndo: PropTypes.bool,
+  undoToken: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  undoMessage: PropTypes.string,
+  undoActionLabel: PropTypes.string,
+  undoDuration: PropTypes.number,
+  onUndo: PropTypes.func,
+  onUndoClosed: PropTypes.func,
 };
 
 OperationListItem.defaultProps = {
@@ -213,6 +244,13 @@ OperationListItem.defaultProps = {
   suggestionChips: null,
   onApplySuggestion: () => {},
   onDismissSuggestion: () => {},
+  showUndo: false,
+  undoToken: 0,
+  undoMessage: '',
+  undoActionLabel: '',
+  undoDuration: 5000,
+  onUndo: () => {},
+  onUndoClosed: () => {},
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -71,6 +71,12 @@ const OperationsList = forwardRef(({
   pendingSuggestions,
   onApplySuggestion,
   onDismissSuggestion,
+  undoOperationId,
+  undoToken,
+  undoMessage,
+  undoActionLabel,
+  onUndo,
+  onUndoClosed,
 }, ref) => {
 
   // Format date label for the separator header.
@@ -330,10 +336,16 @@ const OperationsList = forwardRef(({
           suggestionChips={item.id === pendingSuggestionId ? pendingSuggestions : null}
           onApplySuggestion={onApplySuggestion}
           onDismissSuggestion={onDismissSuggestion}
+          showUndo={item.id === undoOperationId}
+          undoToken={undoToken}
+          undoMessage={undoMessage}
+          undoActionLabel={undoActionLabel}
+          onUndo={onUndo}
+          onUndoClosed={onUndoClosed}
         />
       </View>
     );
-  }, [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency, onEditOperation, pendingSuggestionId, pendingSuggestions, onApplySuggestion, onDismissSuggestion]);
+  }, [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency, onEditOperation, pendingSuggestionId, pendingSuggestions, onApplySuggestion, onDismissSuggestion, undoOperationId, undoToken, undoMessage, undoActionLabel, onUndo, onUndoClosed]);
 
   const keyExtractor = useCallback((item) => item.id, []);
 
@@ -366,7 +378,7 @@ const OperationsList = forwardRef(({
       renderSectionHeader={renderSectionHeader}
       renderSectionFooter={renderSectionFooter}
       keyExtractor={keyExtractor}
-      extraData={[accounts, categories, pendingSuggestionId]}
+      extraData={[accounts, categories, pendingSuggestionId, undoOperationId, undoToken]}
       getItemLayout={getItemLayout}
       ListHeaderComponent={
         (topInset > 0 || headerComponent)
@@ -440,6 +452,12 @@ OperationsList.propTypes = {
   pendingSuggestions: PropTypes.arrayOf(PropTypes.string),
   onApplySuggestion: PropTypes.func,
   onDismissSuggestion: PropTypes.func,
+  undoOperationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  undoToken: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  undoMessage: PropTypes.string,
+  undoActionLabel: PropTypes.string,
+  onUndo: PropTypes.func,
+  onUndoClosed: PropTypes.func,
 };
 
 OperationsList.defaultProps = {
@@ -455,6 +473,12 @@ OperationsList.defaultProps = {
   pendingSuggestions: [],
   onApplySuggestion: () => {},
   onDismissSuggestion: () => {},
+  undoOperationId: null,
+  undoToken: 0,
+  undoMessage: '',
+  undoActionLabel: '',
+  onUndo: () => {},
+  onUndoClosed: () => {},
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/UndoSnackbar.js
+++ b/app/components/operations/UndoSnackbar.js
@@ -5,22 +5,21 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import {
   SPACING,
   FONT_SIZE,
-  BORDER_RADIUS,
   DURATION,
   ICON_SIZE,
-  ELEVATION,
-  Z_INDEX,
 } from '../../styles/designTokens';
 
 /**
  * UndoSnackbar
  *
- * A transient "just-added" bar that floats above the tab bar and offers a brief
- * window to undo the last created operation. A thin progress bar depletes over
- * `duration`, giving the user a clear visual cue for how much time remains.
+ * A transient "just-added" bar that renders inline within the operations list,
+ * directly beneath the operation it refers to (between that operation and the
+ * one before it), offering a brief window to undo the last created operation. A
+ * thin progress bar depletes over `duration`, giving the user a clear visual cue
+ * for how much time remains.
  *
  * Lifecycle is intentionally split so the exit animation always plays:
- *  - `onUndo(operationId)` performs the undo (called before the slide-out).
+ *  - `onUndo(operationId)` performs the undo (called before the fade-out).
  *  - `onClosed()` tells the parent to unmount, and fires only after the exit
  *    animation completes (whether dismissed by timeout or by the Undo tap).
  *
@@ -33,7 +32,6 @@ const UndoSnackbar = ({
   actionLabel,
   duration,
   colors,
-  bottomOffset,
   onUndo,
   onClosed,
 }) => {
@@ -58,7 +56,7 @@ const UndoSnackbar = ({
   }, [revealAnim, onClosed]);
 
   useEffect(() => {
-    // Entry: slide up + fade in.
+    // Entry: gentle slide up + fade in within the row's reserved slot.
     Animated.timing(revealAnim, {
       toValue: 1,
       duration: DURATION.normal,
@@ -81,63 +79,60 @@ const UndoSnackbar = ({
   }, []);
 
   const handleUndoPress = useCallback(() => {
-    // Perform the undo first (so it's immediate), then slide the bar away.
+    // Perform the undo first (so it's immediate), then fade the bar away.
     animateOut(() => onUndo(operationId));
   }, [animateOut, onUndo, operationId]);
 
+  // Subtle rise into place; the slot height is reserved immediately (transforms
+  // don't affect layout), so the row above never jumps.
   const translateY = revealAnim.interpolate({
     inputRange: [0, 1],
-    outputRange: [40, 0],
+    outputRange: [6, 0],
   });
 
   return (
-    <View
-      pointerEvents="box-none"
-      style={[styles.wrapper, { bottom: bottomOffset }]}
+    <Animated.View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.altRow || colors.surface,
+          borderTopColor: colors.border,
+          opacity: revealAnim,
+          transform: [{ translateY }],
+        },
+      ]}
     >
-      <Animated.View
-        style={[
-          styles.card,
-          {
-            backgroundColor: colors.surface,
-            borderColor: colors.border,
-            opacity: revealAnim,
-            transform: [{ translateY }],
-          },
-        ]}
-      >
-        <View style={styles.content}>
-          <Icon
-            name="check-circle"
-            size={ICON_SIZE.md}
-            color={colors.primary}
-          />
-          <Text style={[styles.message, { color: colors.text }]} numberOfLines={1}>
-            {message}
+      <View style={styles.content}>
+        <Icon
+          name="check-circle"
+          size={ICON_SIZE.md}
+          color={colors.primary}
+        />
+        <Text style={[styles.message, { color: colors.text }]} numberOfLines={1}>
+          {message}
+        </Text>
+        <TouchableOpacity
+          onPress={handleUndoPress}
+          style={styles.actionButton}
+          accessibilityRole="button"
+          accessibilityLabel={actionLabel}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Icon name="undo-variant" size={ICON_SIZE.sm} color={colors.primary} />
+          <Text style={[styles.actionText, { color: colors.primary }]}>
+            {actionLabel}
           </Text>
-          <TouchableOpacity
-            onPress={handleUndoPress}
-            style={styles.actionButton}
-            accessibilityRole="button"
-            accessibilityLabel={actionLabel}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          >
-            <Icon name="undo-variant" size={ICON_SIZE.sm} color={colors.primary} />
-            <Text style={[styles.actionText, { color: colors.primary }]}>
-              {actionLabel}
-            </Text>
-          </TouchableOpacity>
-        </View>
-        <View style={[styles.progressTrack, { backgroundColor: colors.border }]}>
-          <Animated.View
-            style={[
-              styles.progressFill,
-              { backgroundColor: colors.primary, transform: [{ scaleX: progressAnim }] },
-            ]}
-          />
-        </View>
-      </Animated.View>
-    </View>
+        </TouchableOpacity>
+      </View>
+      <View style={[styles.progressTrack, { backgroundColor: colors.border }]}>
+        <Animated.View
+          style={[
+            styles.progressFill,
+            { backgroundColor: colors.primary, transform: [{ scaleX: progressAnim }] },
+          ]}
+        />
+      </View>
+    </Animated.View>
   );
 };
 
@@ -155,19 +150,17 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
     textTransform: 'uppercase',
   },
-  card: {
-    borderRadius: BORDER_RADIUS.lg,
-    borderWidth: 1,
+  container: {
+    borderTopWidth: 1,
+    // Clip the depleting progress fill to the bar's bounds.
     overflow: 'hidden',
-    width: '92%',
-    ...ELEVATION.high,
   },
   content: {
     alignItems: 'center',
     flexDirection: 'row',
     gap: SPACING.sm,
     paddingHorizontal: SPACING.lg,
-    paddingVertical: SPACING.md,
+    paddingVertical: SPACING.sm,
   },
   message: {
     flex: 1,
@@ -184,13 +177,6 @@ const styles = StyleSheet.create({
     height: 3,
     width: '100%',
   },
-  wrapper: {
-    alignItems: 'center',
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    zIndex: Z_INDEX.toast,
-  },
 });
 
 UndoSnackbar.propTypes = {
@@ -203,15 +189,14 @@ UndoSnackbar.propTypes = {
     border: PropTypes.string.isRequired,
     primary: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
+    altRow: PropTypes.string,
   }).isRequired,
-  bottomOffset: PropTypes.number,
   onUndo: PropTypes.func.isRequired,
   onClosed: PropTypes.func.isRequired,
 };
 
 UndoSnackbar.defaultProps = {
   duration: 5000,
-  bottomOffset: 140,
 };
 
 export default memo(UndoSnackbar);

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -21,7 +21,6 @@ import ListCard from '../components/ListCard';
 import OperationsList from '../components/operations/OperationsList';
 import QuickAddForm from '../components/operations/QuickAddForm';
 import PickerModal from '../components/operations/PickerModal';
-import UndoSnackbar from '../components/operations/UndoSnackbar';
 import SearchOverlay from '../components/search/SearchOverlay';
 import SearchBar from '../components/search/SearchBar';
 import FilterChipStrip from '../components/search/FilterChipStrip';
@@ -947,6 +946,12 @@ const OperationsScreen = () => {
         pendingSuggestions={pendingSuggestions}
         onApplySuggestion={handleApplySuggestion}
         onDismissSuggestion={handleDismissSuggestion}
+        undoOperationId={undoInfo ? undoInfo.id : null}
+        undoToken={undoInfo ? undoInfo.token : 0}
+        undoMessage={t('operation_added')}
+        undoActionLabel={t('undo')}
+        onUndo={handleUndoAdd}
+        onUndoClosed={handleUndoClosed}
       />
 
       {/* Floating search area — overlays the list so its content scrolls behind
@@ -1015,20 +1020,6 @@ const OperationsScreen = () => {
         >
           <Icon name="chevron-up" size={24} color={colors.text} />
         </TouchableOpacity>
-      )}
-
-      {/* Undo bar for the most recently added operation (auto-hides after 5s) */}
-      {undoInfo && (
-        <UndoSnackbar
-          key={undoInfo.token}
-          operationId={undoInfo.id}
-          message={t('operation_added')}
-          actionLabel={t('undo')}
-          duration={5000}
-          colors={colors}
-          onUndo={handleUndoAdd}
-          onClosed={handleUndoClosed}
-        />
       )}
 
       <OperationModal


### PR DESCRIPTION
## Summary

After adding an operation, the "operation added / undo" bar floated as an absolutely-positioned overlay, detached from the operation it referred to and easy to miss. It now renders **inline within the operations list, directly beneath the just-added operation** — between that operation and the one before it — so the undo affordance is anchored to the thing it undoes. This mirrors the existing `DescriptionSuggestionRow` inline pattern.

## Changes

- **app/components/operations/UndoSnackbar.js** — drop the absolute `wrapper`/`bottomOffset` and restyle as an inline bar (subtle `altRow` background + top divider) that fits within the operations card. The entry/exit animation, depleting countdown, auto-dismiss timer, and undo lifecycle are unchanged.
- **app/components/operations/OperationListItem.js** — render the undo bar for the operation whose id matches the active undo target, placed right below the row (above the suggestion row), keyed by `undoToken` so back-to-back adds restart it. Added `id` to the `operation` propType shape.
- **app/components/operations/OperationsList.js** — thread `undoOperationId` / `undoToken` / message / handlers through `renderItem` and `extraData`, alongside the existing `pendingSuggestionId` wiring.
- **app/screens/OperationsScreen.js** — pass the undo state into `OperationsList` and remove the floating snackbar render (and its now-unused import).
- **__tests__/components/operations/*** — cover the inline wiring in `OperationListItem` and `OperationsList`, and add `altRow` to the `UndoSnackbar` test colors.

No new user-facing strings — the existing `operation_added` and `undo` keys are reused.

## Testing

- `npm test` — 147 suites / 4268 tests pass.
- `npx eslint` on all changed files — clean (0 errors, 0 warnings).

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (reuses existing keys)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

Closes #

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfAHfqfLgJmUS45D2USHiT)_