### PR TITLE
refactor(updates): redesign update-available modal as a compact card

### DIFF
--- a/__tests__/modals/UpdateAvailableModal.test.js
+++ b/__tests__/modals/UpdateAvailableModal.test.js
@@ -1,6 +1,10 @@
 /**
  * Tests for UpdateAvailableModal component
- * Covers rendering branches: null updateData, with/without releaseNotes, single/multiple notes
+ *
+ * The modal is a compact, content-hugging card shown over any screen when a newer
+ * release is found. It reuses the release-note parsing from UpdateContentPanel but
+ * renders its own condensed layout (icon badge + title, meta line, bounded "What's
+ * new" scroll region, and a Later / Update now action row).
  */
 
 import React from 'react';
@@ -53,77 +57,84 @@ describe('UpdateAvailableModal', () => {
   });
 
   describe('Basic rendering', () => {
-    it('renders version numbers when updateData is provided', async () => {
+    it('renders the latest version in the meta line', async () => {
       const { getByText } = await render(
         <UpdateAvailableModal {...baseProps} updateData={baseUpdateData} />,
       );
       expect(getByText('v2.0.0')).toBeTruthy();
     });
 
-    it('gives the dialog a bounded absolute height so its content is not empty', async () => {
-      // Regression guard: paper's Modal wraps children in an auto-height Surface, so a
-      // percentage height never resolves and the shared panel's flex:1 ScrollView
-      // collapses to zero height — an empty dialog. The container must carry a concrete
-      // numeric height (windowHeight * 0.8 = 640 here).
+    it('hugs its content — the card carries no fixed height', async () => {
+      // Regression guard: the old modal pinned the shared full-screen panel to 80% of the
+      // window, stranding a single card in a large void. The redesigned card must size to
+      // its content, so the container must NOT declare a fixed numeric height.
       const { getByTestId } = await render(
         <UpdateAvailableModal {...baseProps} updateData={baseUpdateData} />,
       );
       const flat = RN.StyleSheet.flatten(getByTestId('update-modal-container').props.style);
-      // A concrete pixel height (not a percentage or undefined) is what keeps the shared
-      // panel's flex:1 ScrollView from collapsing; the exact value tracks the window height.
-      expect(typeof flat.height).toBe('number');
-      expect(flat.height).toBeGreaterThan(0);
+      expect(flat.height).toBeUndefined();
     });
 
-    it('renders dismiss button and calls onDismiss when pressed', async () => {
+    it('bounds the "what\'s new" scroll region so long changelogs never grow the card', async () => {
+      // Regression guard: the notes list can span several skipped versions. Only that region
+      // scrolls (bounded maxHeight); the header and actions stay put and always visible.
+      const updateData = {
+        ...baseUpdateData,
+        releaseNotes: [{ version: '2.0.0', notes: 'Some notes' }],
+      };
+      const { getByTestId } = await render(
+        <UpdateAvailableModal {...baseProps} updateData={updateData} />,
+      );
+      const flat = RN.StyleSheet.flatten(getByTestId('update-notes-scroll').props.style);
+      expect(typeof flat.maxHeight).toBe('number');
+      expect(flat.maxHeight).toBeGreaterThan(0);
+    });
+
+    it('dismisses when the close (×) icon is pressed', async () => {
       const onDismiss = jest.fn();
       const { getByText } = await render(
         <UpdateAvailableModal {...baseProps} onDismiss={onDismiss} updateData={baseUpdateData} />,
       );
-      // The back button wraps an Ionicons 'arrow-back' icon; press it to trigger onDismiss
-      await fireEvent.press(getByText('arrow-back'));
+      // Ionicons renders its `name` as text in tests; the close affordance is the 'close' glyph.
+      await fireEvent.press(getByText('close'));
       expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onUpdate with downloadUrl, checksum and version when a release download button is pressed', async () => {
+    it('dismisses when the Later button is pressed', async () => {
+      const onDismiss = jest.fn();
+      const { getByText } = await render(
+        <UpdateAvailableModal {...baseProps} onDismiss={onDismiss} updateData={baseUpdateData} />,
+      );
+      await fireEvent.press(getByText('later'));
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onUpdate with the download URL when "Update now" is pressed', async () => {
       const onUpdate = jest.fn();
       const { getByLabelText } = await render(
         <UpdateAvailableModal {...baseProps} onUpdate={onUpdate} updateData={baseUpdateData} />,
       );
-      // The newest version is synthesized into a card so its per-release download button is reachable.
-      await fireEvent.press(getByLabelText('Download version 2.0.0'));
-      expect(onUpdate).toHaveBeenCalledWith('https://example.com/app.apk', undefined, '2.0.0');
+      await fireEvent.press(getByLabelText('update_now v2.0.0'));
+      expect(onUpdate).toHaveBeenCalledWith('https://example.com/app.apk');
     });
   });
 
   describe('Without releaseNotes', () => {
-    it('shows install hint text when releaseNotes is null', async () => {
-      const { getByText } = await render(
+    it('shows the generic availability message when releaseNotes is null', async () => {
+      const { getByText, queryByText } = await render(
         <UpdateAvailableModal
           {...baseProps}
           updateData={{ ...baseUpdateData, releaseNotes: null }}
         />,
       );
-      // update_install_hint should be rendered as the fallback
-      expect(getByText('update_install_hint')).toBeTruthy();
-    });
-
-    it('does not show the update hint below the button when releaseNotes is null', async () => {
-      const { getAllByText } = await render(
-        <UpdateAvailableModal
-          {...baseProps}
-          updateData={{ ...baseUpdateData, releaseNotes: null }}
-        />,
-      );
-      // When no releaseNotes, the hint above the button is NOT rendered
-      // Only the hint text in the else branch is shown (once)
-      const hints = getAllByText('update_install_hint');
-      expect(hints).toHaveLength(1);
+      expect(getByText('update_available_message')).toBeTruthy();
+      // No "What's new" section when there is nothing to show.
+      expect(queryByText('whats_new')).toBeNull();
     });
   });
 
   describe('With releaseNotes', () => {
-    it('shows changelog section when releaseNotes is provided', async () => {
+    it('shows the "what\'s new" section when releaseNotes is provided', async () => {
       const updateData = {
         ...baseUpdateData,
         releaseNotes: [{ version: '2.0.0', notes: '**Bold feature** added' }],
@@ -145,20 +156,20 @@ describe('UpdateAvailableModal', () => {
       expect(getByText('Bold and italic text')).toBeTruthy();
     });
 
-    it('shows the release version label on each changelog entry', async () => {
+    it('renders a single release without a redundant in-list version label', async () => {
       const updateData = {
         ...baseUpdateData,
         releaseNotes: [{ version: '2.0.0', notes: 'Single release' }],
       };
-      const { getByText } = await render(
+      const { getByText, getAllByText } = await render(
         <UpdateAvailableModal {...baseProps} updateData={updateData} />,
       );
-      // The version now lives only on its release card (the single bottom header is gone).
-      expect(getByText('v2.0.0')).toBeTruthy();
+      // The version appears once (the meta line); a lone release doesn't repeat it in the body.
+      expect(getAllByText('v2.0.0')).toHaveLength(1);
       expect(getByText('Single release')).toBeTruthy();
     });
 
-    it('shows every release version when there are multiple release notes', async () => {
+    it('labels each release when there are multiple release notes', async () => {
       const updateData = {
         ...baseUpdateData,
         releaseNotes: [
@@ -166,39 +177,14 @@ describe('UpdateAvailableModal', () => {
           { version: '1.9.0', notes: 'Bug fix' },
         ],
       };
-      const { getByText } = await render(
+      const { getByText, getAllByText } = await render(
         <UpdateAvailableModal {...baseProps} updateData={updateData} />,
       );
-      // Each release is its own card with its own version label.
-      expect(getByText('v2.0.0')).toBeTruthy();
+      // Each release contributes its own version label; v2.0.0 also appears in the meta line.
+      expect(getAllByText('v2.0.0').length).toBeGreaterThanOrEqual(1);
       expect(getByText('v1.9.0')).toBeTruthy();
       expect(getByText('New feature')).toBeTruthy();
-    });
-
-    it('shows changelog section instead of install hint when releaseNotes is provided', async () => {
-      const updateData = {
-        ...baseUpdateData,
-        releaseNotes: [{ version: '2.0.0', notes: 'New stuff' }],
-      };
-      const { queryByText, getByText } = await render(
-        <UpdateAvailableModal {...baseProps} updateData={updateData} />,
-      );
-      // Changelog header shown, install hint not shown
-      expect(getByText('whats_new')).toBeTruthy();
-      expect(queryByText('update_install_hint')).toBeNull();
-    });
-  });
-
-  describe('Invisible state', () => {
-    it('renders without crashing when visible=false (updateData still provided)', async () => {
-      // When visible=false but updateData is provided, the modal renders (hidden by Portal)
-      await render(
-        <UpdateAvailableModal
-          {...baseProps}
-          visible={false}
-          updateData={baseUpdateData}
-        />,
-      );
+      expect(getByText('Bug fix')).toBeTruthy();
     });
   });
 
@@ -245,6 +231,18 @@ describe('UpdateAvailableModal', () => {
         <UpdateAvailableModal {...baseProps} updateData={updateData} />,
       );
       expect(getByText('link text')).toBeTruthy();
+    });
+  });
+
+  describe('Invisible state', () => {
+    it('renders without crashing when visible=false (updateData still provided)', async () => {
+      await render(
+        <UpdateAvailableModal
+          {...baseProps}
+          visible={false}
+          updateData={baseUpdateData}
+        />,
+      );
     });
   });
 });

--- a/app/modals/UpdateAvailableModal.js
+++ b/app/modals/UpdateAvailableModal.js
@@ -1,52 +1,144 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, useWindowDimensions } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, ScrollView, useWindowDimensions } from 'react-native';
 import { Portal, Modal, Text, Divider } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
-import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
-import UpdateContentPanel from '../components/UpdateContentPanel';
+import { SPACING, BORDER_RADIUS } from '../styles/layout';
+import { parseReleaseNotes, formatReleaseDateTime } from '../components/UpdateContentPanel';
+
+// Picks the release-note entry describing the version we're prompting the user to install.
+// Prefers the entry whose version matches the latest release; otherwise falls back to the
+// first (newest) entry so a mislabelled payload still surfaces some notes.
+const findLeadRelease = (releaseNotes, latestVersion) => {
+  if (!Array.isArray(releaseNotes) || releaseNotes.length === 0) return null;
+  return releaseNotes.find((r) => r.version === latestVersion) || releaseNotes[0];
+};
 
 export default function UpdateAvailableModal({ visible, onDismiss, onUpdate, updateData }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { height: windowHeight } = useWindowDimensions();
 
+  // The release notes can span several skipped versions; the notes region scrolls within a
+  // bounded height so a long changelog never grows the card past the actions. Everything else
+  // (header, meta, buttons) hugs its content, so a single short release yields a short card.
+  const notesMaxHeight = Math.round(windowHeight * 0.4);
+
+  const parsedReleases = useMemo(() => {
+    const list = Array.isArray(updateData?.releaseNotes) ? updateData.releaseNotes : [];
+    return list
+      .map((r) => ({ version: r.version, ...parseReleaseNotes(r.notes, r.version), publishedAt: r.publishedAt }))
+      .filter((r) => r.body);
+  }, [updateData]);
+
   if (!updateData) return null;
 
-  const updateResult = { type: 'available', ...updateData };
+  const { latestVersion, currentVersion, downloadUrl } = updateData;
+  const lead = findLeadRelease(updateData.releaseNotes, latestVersion);
+  const leadParsed = lead ? parseReleaseNotes(lead.notes, lead.version) : null;
+  const dateLabel = leadParsed ? formatReleaseDateTime(lead.publishedAt, leadParsed.date) : null;
+  const hasNotes = parsedReleases.length > 0;
+  const showVersionLabels = parsedReleases.length > 1;
 
-  // react-native-paper's Modal drops its children into an auto-height Surface, so a
-  // percentage height (or maxHeight) here never resolves — it stays "hug content". The
-  // shared UpdateContentPanel fills its parent with a flex:1 ScrollView, which then
-  // collapses to zero height, leaving the dialog empty. Pin an absolute height so the
-  // scroll region always has room and the update content is actually visible.
-  const containerHeight = Math.round(windowHeight * 0.8);
+  const metaText = dateLabel ? `v${latestVersion} · ${dateLabel}` : `v${latestVersion}`;
 
   return (
     <Portal>
-      <Modal visible={visible} onDismiss={onDismiss} dismissable>
+      <Modal
+        visible={visible}
+        onDismiss={onDismiss}
+        dismissable
+        contentContainerStyle={styles.modalWrapper}
+      >
         <View
           testID="update-modal-container"
-          style={[styles.modalContainer, { backgroundColor: colors.card, height: containerHeight }]}
+          style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}
         >
           <View style={styles.header}>
-            <TouchableOpacity onPress={onDismiss} style={styles.backButton}>
-              <Ionicons name="arrow-back" size={24} color={colors.text} />
+            <View style={[styles.iconBadge, { backgroundColor: `${colors.primary}22` }]}>
+              <Ionicons name="arrow-up-circle" size={24} color={colors.primary} />
+            </View>
+            <View style={styles.headerText}>
+              <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
+                {t('update_available_title') || 'Update available'}
+              </Text>
+              <Text style={[styles.meta, { color: colors.mutedText }]} numberOfLines={1}>
+                {metaText}
+              </Text>
+            </View>
+            <TouchableOpacity
+              onPress={onDismiss}
+              style={styles.closeButton}
+              accessibilityRole="button"
+              accessibilityLabel={t('later') || 'Later'}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              <Ionicons name="close" size={22} color={colors.mutedText} />
             </TouchableOpacity>
-            <Text variant="titleLarge" style={[styles.headerTitle, { color: colors.text }]}>
-              {t('update_available_title') || 'Update available'}
-            </Text>
-            <View style={styles.backButton} />
           </View>
-          <Divider />
-          <UpdateContentPanel
-            isChecking={false}
-            updateResult={updateResult}
-            downloadedApks={[]}
-            onUpdate={onUpdate}
-          />
+
+          {currentVersion ? (
+            <Text style={[styles.fromVersion, { color: colors.mutedText }]}>
+              {(t('update_from_version') || 'installed: v{currentVersion}').replace('{currentVersion}', currentVersion)}
+            </Text>
+          ) : null}
+
+          <Divider style={styles.divider} />
+
+          {hasNotes ? (
+            <ScrollView
+              testID="update-notes-scroll"
+              style={[styles.notes, { maxHeight: notesMaxHeight }]}
+              contentContainerStyle={styles.notesContent}
+              showsVerticalScrollIndicator={false}
+            >
+              <Text style={[styles.notesLabel, { color: colors.mutedText }]}>
+                {t('whats_new') || "What's new"}
+              </Text>
+              {parsedReleases.map((release) => (
+                <View key={release.version} style={styles.releaseBlock}>
+                  {showVersionLabels ? (
+                    <Text style={[styles.releaseVersion, { color: colors.text }]}>
+                      v{release.version}
+                    </Text>
+                  ) : null}
+                  <Text style={[styles.releaseBody, { color: colors.text }]}>
+                    {release.body}
+                  </Text>
+                </View>
+              ))}
+            </ScrollView>
+          ) : (
+            <Text style={[styles.emptyNotes, { color: colors.mutedText }]}>
+              {(t('update_available_message') || 'A newer app version ({latestVersion}) is available. Download and install the APK from GitHub.').replace('{latestVersion}', `v${latestVersion}`)}
+            </Text>
+          )}
+
+          <View style={styles.actions}>
+            <TouchableOpacity
+              onPress={onDismiss}
+              style={[styles.button, styles.laterButton, { borderColor: colors.border }]}
+              accessibilityRole="button"
+              accessibilityLabel={t('later') || 'Later'}
+            >
+              <Text style={[styles.laterText, { color: colors.text }]}>
+                {t('later') || 'Later'}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => onUpdate(downloadUrl)}
+              style={[styles.button, styles.updateButton, { backgroundColor: colors.primary }]}
+              accessibilityRole="button"
+              accessibilityLabel={`${t('update_now') || 'Update now'} v${latestVersion}`}
+            >
+              <Ionicons name="cloud-download-outline" size={18} color="#fff" />
+              <Text style={styles.updateText}>
+                {t('update_now') || 'Update now'}
+              </Text>
+            </TouchableOpacity>
+          </View>
         </View>
       </Modal>
     </Portal>
@@ -64,30 +156,125 @@ UpdateAvailableModal.propTypes = {
     releaseNotes: PropTypes.arrayOf(PropTypes.shape({
       version: PropTypes.string,
       notes: PropTypes.string,
+      publishedAt: PropTypes.string,
     })),
   }),
 };
 
 const styles = StyleSheet.create({
-  backButton: {
+  actions: {
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.md,
+  },
+  button: {
     alignItems: 'center',
-    height: 40,
+    borderRadius: BORDER_RADIUS.md,
+    flexDirection: 'row',
+    gap: SPACING.xs,
+    height: 46,
     justifyContent: 'center',
-    width: 40,
+  },
+  card: {
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    paddingBottom: SPACING.lg,
+    paddingTop: SPACING.md,
+  },
+  closeButton: {
+    alignItems: 'center',
+    height: 32,
+    justifyContent: 'center',
+    width: 32,
+  },
+  divider: {
+    marginTop: SPACING.md,
+  },
+  emptyNotes: {
+    fontSize: 14,
+    lineHeight: 20,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.md,
+  },
+  fromVersion: {
+    fontSize: 12.5,
+    paddingHorizontal: SPACING.lg,
+    paddingLeft: 68,
+    paddingTop: SPACING.xs,
   },
   header: {
     alignItems: 'center',
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: HORIZONTAL_PADDING,
-    paddingVertical: SPACING.lg,
+    gap: SPACING.md,
+    paddingHorizontal: SPACING.lg,
   },
-  headerTitle: {
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  iconBadge: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    height: 40,
+    justifyContent: 'center',
+    width: 40,
+  },
+  laterButton: {
+    borderWidth: StyleSheet.hairlineWidth,
+    flex: 0.55,
+  },
+  laterText: {
+    fontSize: 15,
     fontWeight: '600',
   },
-  modalContainer: {
-    borderRadius: BORDER_RADIUS.lg,
-    margin: SPACING.md,
-    overflow: 'hidden',
+  meta: {
+    fontSize: 12.5,
+    fontVariant: ['tabular-nums'],
+    marginTop: 1,
+  },
+  modalWrapper: {
+    marginHorizontal: SPACING.lg,
+  },
+  notes: {
+    marginTop: SPACING.sm,
+  },
+  notesContent: {
+    paddingBottom: SPACING.xs,
+    paddingHorizontal: SPACING.lg,
+    paddingTop: SPACING.sm,
+  },
+  notesLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+    marginBottom: SPACING.sm,
+    textTransform: 'uppercase',
+  },
+  releaseBlock: {
+    marginBottom: SPACING.sm,
+  },
+  releaseBody: {
+    fontSize: 13.5,
+    lineHeight: 20,
+  },
+  releaseVersion: {
+    fontSize: 13,
+    fontWeight: '700',
+    marginBottom: 2,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '700',
+    letterSpacing: -0.1,
+  },
+  updateButton: {
+    flex: 1,
+  },
+  updateText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
## Summary

The "update available" prompt that appears over any screen reused the full-screen Settings update panel (`UpdateContentPanel`) pinned to **80% of the window height**. For a single release that left one small card stranded at the top of a large empty sheet — the "weird" look reported. This replaces it with a purpose-built compact card that sizes to its content.

## Changes

- **app/modals/UpdateAvailableModal.js** — rewrote the modal as a content-hugging card: accent icon badge + title, a `v{version} · date` meta line, the installed version, a bounded/scrollable "What's new" region, and a `Later` / `Update now` action row. Only the notes region scrolls (capped at ~40% of window height), so short changelogs yield a short card while long ones never push the actions off screen. Release-note parsing (`parseReleaseNotes`, `formatReleaseDateTime`) is reused from `UpdateContentPanel`; the full-screen Settings panel is unchanged. `Update now` calls `onUpdate(downloadUrl)`; the close (×), `Later` button, and tapping outside all dismiss.
- **__tests__/modals/UpdateAvailableModal.test.js** — updated for the new layout: the container hugs content (no fixed height), the "What's new" scroll region carries a bounded `maxHeight`, close/Later dismiss, and `Update now` invokes `onUpdate` with the download URL. Markdown-stripping and multi-release coverage retained.

## Testing

- `npm test` — 147 suites / 4270 tests pass.
- `npx eslint` on the changed files — clean.
- Reused existing i18n keys (`update_available_title`, `whats_new`, `update_now`, `later`, `update_from_version`, `update_available_message`) — no new strings, so all 11 languages are already covered.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (reuses existing keys)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CWisyoRuV2NkyDJfuRy1d

---
_Generated by [Claude Code](https://claude.ai/code/session_012CWisyoRuV2NkyDJfuRy1d)_