### PR TITLE
feat(operations): exclude a single operation from spending average

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -193,6 +193,48 @@ describe('OperationsDB Service', () => {
       expect(result.longitude).toBeNull();
     });
 
+    it('maps exclude_from_avg to an excludeFromAvg boolean on read', async () => {
+      queryFirst.mockResolvedValue({
+        id: 3,
+        type: 'expense',
+        amount: '100',
+        account_id: 'acc1',
+        category_id: 'cat1',
+        date: '2025-12-05',
+        created_at: '2025-12-05T10:00:00Z',
+        exclude_from_avg: 1,
+      });
+      const flagged = await OperationsDB.getOperationById(3);
+      expect(flagged.excludeFromAvg).toBe(true);
+
+      queryFirst.mockResolvedValue({
+        id: 4,
+        type: 'expense',
+        amount: '100',
+        account_id: 'acc1',
+        category_id: 'cat1',
+        date: '2025-12-05',
+        created_at: '2025-12-05T10:00:00Z',
+        exclude_from_avg: 0,
+      });
+      const notFlagged = await OperationsDB.getOperationById(4);
+      expect(notFlagged.excludeFromAvg).toBe(false);
+    });
+
+    it('maps a missing exclude_from_avg column to false (legacy rows)', async () => {
+      queryFirst.mockResolvedValue({
+        id: 5,
+        type: 'expense',
+        amount: '100',
+        account_id: 'acc1',
+        category_id: 'cat1',
+        date: '2025-12-05',
+        created_at: '2025-12-05T10:00:00Z',
+      });
+      const result = await OperationsDB.getOperationById(5);
+      expect(result.excludeFromAvg).toBe(false);
+    });
+
     it('persists latitude/longitude in the INSERT on create', async () => {
       mockDb.getFirstAsync.mockResolvedValue({ balance: '1000' });
 
@@ -255,6 +297,46 @@ describe('OperationsDB Service', () => {
       const params = insertCall[1];
       expect(params[params.length - 2]).toBe(0);
       expect(params[params.length - 1]).toBe(0);
+    });
+
+    it('persists exclude_from_avg = 1 in the INSERT when the operation is flagged', async () => {
+      mockDb.getFirstAsync.mockResolvedValue({ balance: '1000' });
+
+      await OperationsDB.createOperation({
+        type: 'expense',
+        amount: '100',
+        accountId: 'acc1',
+        categoryId: 'cat1',
+        date: '2025-12-05',
+        excludeFromAvg: true,
+      });
+
+      const insertCall = mockDb.runAsync.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO operations'),
+      );
+      expect(insertCall[0]).toContain('exclude_from_avg');
+      // Column list ends with exclude_from_avg, latitude, longitude → the flag is
+      // the third param from the end (latitude/longitude stay last).
+      const params = insertCall[1];
+      expect(params[params.length - 3]).toBe(1);
+    });
+
+    it('defaults exclude_from_avg to 0 when the flag is not supplied', async () => {
+      mockDb.getFirstAsync.mockResolvedValue({ balance: '1000' });
+
+      await OperationsDB.createOperation({
+        type: 'expense',
+        amount: '100',
+        accountId: 'acc1',
+        categoryId: 'cat1',
+        date: '2025-12-05',
+      });
+
+      const insertCall = mockDb.runAsync.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO operations'),
+      );
+      const params = insertCall[1];
+      expect(params[params.length - 3]).toBe(0);
     });
 
     it('updates latitude/longitude when provided', async () => {
@@ -508,6 +590,58 @@ describe('OperationsDB Service', () => {
 
       // Should recalculate balance: reverse old (-(-100) = +100) + apply new (-200) = -100 net
       expect(Currency.add).toHaveBeenCalled();
+    });
+
+    it('persists exclude_from_avg when the flag is toggled on', async () => {
+      const oldOperation = {
+        id: 1,
+        type: 'expense',
+        amount: '100',
+        account_id: 'acc1',
+        category_id: 'cat1',
+        date: '2025-12-05',
+        exclude_from_avg: 0,
+      };
+      const updatedOperation = { ...oldOperation, exclude_from_avg: 1 };
+
+      mockDb.getFirstAsync
+        .mockResolvedValueOnce(oldOperation)     // Get old operation
+        .mockResolvedValueOnce(updatedOperation) // Get updated operation
+        .mockResolvedValueOnce({ balance: '1000' }); // Get account balance
+
+      await OperationsDB.updateOperation(1, { excludeFromAvg: true });
+
+      const updateCall = mockDb.runAsync.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('UPDATE operations SET'),
+      );
+      expect(updateCall[0]).toContain('exclude_from_avg = ?');
+      // Only the flag was changed, so params are [1 (flag), 1 (id for WHERE)].
+      expect(updateCall[1]).toEqual([1, 1]);
+    });
+
+    it('writes exclude_from_avg = 0 when the flag is toggled off', async () => {
+      const oldOperation = {
+        id: 1,
+        type: 'expense',
+        amount: '100',
+        account_id: 'acc1',
+        category_id: 'cat1',
+        date: '2025-12-05',
+        exclude_from_avg: 1,
+      };
+      const updatedOperation = { ...oldOperation, exclude_from_avg: 0 };
+
+      mockDb.getFirstAsync
+        .mockResolvedValueOnce(oldOperation)
+        .mockResolvedValueOnce(updatedOperation)
+        .mockResolvedValueOnce({ balance: '1000' });
+
+      await OperationsDB.updateOperation(1, { excludeFromAvg: false });
+
+      const updateCall = mockDb.runAsync.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('UPDATE operations SET'),
+      );
+      expect(updateCall[1]).toEqual([0, 1]);
     });
 
     it('handles account change in update', async () => {
@@ -798,6 +932,18 @@ describe('OperationsDB Service', () => {
       const result = await OperationsDB.getTotalExpenses('acc1', '2025-12-01', '2025-12-31');
 
       expect(result).toBe('0');
+    });
+
+    it('excludes operations flagged exclude_from_avg from the total (average/forecast)', async () => {
+      queryAll.mockResolvedValue([{ amount: '100' }]);
+
+      await OperationsDB.getTotalExpenses('acc1', '2025-12-01', '2025-12-31');
+
+      // The total feeding the daily average / burndown forecast must filter out
+      // user-flagged one-off operations, while remaining scoped to real expenses.
+      const sql = queryAll.mock.calls[0][0];
+      expect(sql).toContain('exclude_from_avg');
+      expect(sql).toContain("type = 'expense'");
     });
 
     it('gets total income for account in date range', async () => {

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -82,6 +82,12 @@ export const operations = sqliteTable('operations', {
   // and getLabelsNearLocation already scans like getDistinctLabels.
   latitude: text('latitude'),
   longitude: text('longitude'),
+  // When 1, this operation is left out of the daily spending average and the
+  // burndown forecast (getTotalExpenses) only. It still counts as a normal
+  // expense everywhere else — account balances, pie charts, category totals.
+  // 0 / null = counted (default). Lets a one-off large purchase not skew the
+  // forecast. Physically appended last by migration 0013 (after longitude).
+  excludeFromAvg: integer('exclude_from_avg').default(0),
 }, (table) => ({
   dateIdx: index('idx_operations_date').on(table.date),
   accountIdx: index('idx_operations_account').on(table.accountId),

--- a/app/hooks/useOperationForm.js
+++ b/app/hooks/useOperationForm.js
@@ -44,6 +44,7 @@ const useOperationForm = ({
     exchangeRate: '',
     destinationAmount: '',
     operationCurrency: '',
+    excludeFromAvg: false,
   });
   const [errors, setErrors] = useState({});
   const [showDatePicker, setShowDatePicker] = useState(false);
@@ -306,6 +307,7 @@ const useOperationForm = ({
             exchangeRate: loadExchangeRate,
             destinationAmount: loadDestAmount,
             operationCurrency: operation.type !== 'transfer' ? (operation.sourceCurrency || '') : '',
+            excludeFromAvg: !!operation.excludeFromAvg,
           });
         }
       } else if (isNew) {
@@ -331,6 +333,7 @@ const useOperationForm = ({
             toAccountId: '',
             exchangeRate: '',
             destinationAmount: '',
+            excludeFromAvg: false,
           });
         }
       }

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -10,6 +10,7 @@ import {
   Dimensions,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
+import { Switch } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -307,6 +308,13 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
   const handleDescriptionChange = useCallback((text) => {
     if (!isShadowOperation) {
       setValues(v => ({ ...v, description: text }));
+    }
+  }, [isShadowOperation, setValues]);
+
+  // Handler for the "exclude from spending average" toggle
+  const handleToggleExcludeFromAvg = useCallback((val) => {
+    if (!isShadowOperation) {
+      setValues(v => ({ ...v, excludeFromAvg: val }));
     }
   }, [isShadowOperation, setValues]);
 
@@ -643,6 +651,28 @@ export default function OperationModal({ visible, onClose, operation, isNew, onD
           />
         )}
 
+        {/* Exclude-from-average toggle. Only when editing an expense (the burndown
+            forecast / daily average is expense-based), never for shadow ops. */}
+        {!isNew && !isShadowOperation && values.type === 'expense' && (
+          <View style={styles.excludeAvgRow}>
+            <View style={styles.excludeAvgTextContainer}>
+              <Text style={[modalSharedStyles.fieldLabel, styles.excludeAvgLabel, { color: colors.mutedText }]}>
+                {(t('exclude_from_average') || 'Exclude from spending average').toUpperCase()}
+              </Text>
+              <Text style={[styles.excludeAvgHint, { color: colors.mutedText }]}>
+                {t('exclude_from_average_hint') || "Won't affect the daily average or burndown forecast"}
+              </Text>
+            </View>
+            <Switch
+              value={!!values.excludeFromAvg}
+              onValueChange={handleToggleExcludeFromAvg}
+              trackColor={{ false: colors.border, true: colors.primary + '66' }}
+              thumbColor={values.excludeFromAvg ? colors.primary : colors.mutedText}
+              testID="exclude-from-avg-switch"
+            />
+          </View>
+        )}
+
         {errors.general && <Text style={styles.error}>{errors.general}</Text>}
       </ModalShell>
 
@@ -768,6 +798,22 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginBottom: SPACING.sm,
   },
+  excludeAvgHint: {
+    fontSize: 12,
+  },
+  excludeAvgLabel: {
+    marginBottom: 2,
+  },
+  excludeAvgRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.md,
+    justifyContent: 'space-between',
+    marginBottom: SPACING.md,
+  },
+  excludeAvgTextContainer: {
+    flex: 1,
+  },
   folderBadge: {
     position: 'absolute',
     right: 4,
@@ -872,6 +918,7 @@ OperationModal.propTypes = {
     destinationAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     latitude: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     longitude: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    excludeFromAvg: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   }),
   isNew: PropTypes.bool,
   onDelete: PropTypes.func,

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -81,7 +81,7 @@ export const createBackup = async () => {
 const TABLE_FIELDS = {
   accounts:           ['id', 'name', 'balance', 'currency', 'display_order', 'hidden', 'monthly_target', 'card_mask', 'auto_txn_rounding', 'deleted_at', 'created_at', 'updated_at'],
   categories:         ['id', 'name', 'type', 'category_type', 'parent_id', 'icon', 'color', 'is_shadow', 'created_at', 'updated_at'],
-  operations:         ['id', 'type', 'amount', 'account_id', 'category_id', 'to_account_id', 'date', 'created_at', 'description', 'exchange_rate', 'destination_amount', 'source_currency', 'destination_currency', 'original_balance', 'latitude', 'longitude'],
+  operations:         ['id', 'type', 'amount', 'account_id', 'category_id', 'to_account_id', 'date', 'created_at', 'description', 'exchange_rate', 'destination_amount', 'source_currency', 'destination_currency', 'original_balance', 'exclude_from_avg', 'latitude', 'longitude'],
   budgets:            ['id', 'category_id', 'amount', 'currency', 'period_type', 'start_date', 'end_date', 'is_recurring', 'rollover_enabled', 'created_at', 'updated_at'],
   app_metadata:       ['key', 'value', 'updated_at'],
   balance_history:    ['id', 'account_id', 'date', 'balance', 'created_at'],
@@ -640,7 +640,7 @@ export const restoreBackup = async (backup, cancelToken) => {
         // value falls through to null (?? null) rather than failing the insert.
         const opType = VALID_OPERATION_TYPES.includes(operation.type) ? operation.type : 'expense';
         await db.runAsync(
-          'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, original_balance, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, original_balance, exclude_from_avg, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
           [
             opType,
             operation.amount || '0',
@@ -655,6 +655,8 @@ export const restoreBackup = async (backup, cancelToken) => {
             operation.source_currency || null,
             operation.destination_currency || null,
             operation.original_balance ?? null,
+            // Older backups lack this column → default to 0 (counted).
+            operation.exclude_from_avg ? 1 : 0,
             operation.latitude ?? null,
             operation.longitude ?? null,
           ],

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -52,6 +52,9 @@ const mapOperationFields = (dbOperation) => {
     destinationCurrency: dbOperation.destination_currency,
     latitude: dbOperation.latitude,
     longitude: dbOperation.longitude,
+    // Exposed as a boolean for the form/toggle. Stored as 0/1 (nullable) — the
+    // integer column coerces any legacy string value, so !! is safe here.
+    excludeFromAvg: !!dbOperation.exclude_from_avg,
   };
 };
 
@@ -496,19 +499,23 @@ export const createOperationInTx = async (db, operation) => {
     destination_amount: operation.destinationAmount || null,
     source_currency: operation.sourceCurrency || null,
     destination_currency: operation.destinationCurrency || null,
+    // 1 when the operation is excluded from the spending average / burndown
+    // forecast; 0 (counted) by default. Listed before latitude/longitude so those
+    // stay the last two columns/params.
+    exclude_from_avg: operation.excludeFromAvg ? 1 : 0,
     // ?? (not ||) so a valid 0.0 coordinate (equator / prime meridian) survives.
     latitude: operation.latitude ?? null,
     longitude: operation.longitude ?? null,
   };
 
   const result = await db.runAsync(
-    'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, exclude_from_avg, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [
       operationData.type, operationData.amount, operationData.account_id,
       operationData.category_id, operationData.to_account_id, operationData.date,
       operationData.created_at, operationData.description, operationData.exchange_rate,
       operationData.destination_amount, operationData.source_currency, operationData.destination_currency,
-      operationData.latitude, operationData.longitude,
+      operationData.exclude_from_avg, operationData.latitude, operationData.longitude,
     ],
   );
 
@@ -644,6 +651,10 @@ export const updateOperation = async (id, updates) => {
       if (updates.longitude !== undefined) {
         fields.push('longitude = ?');
         values.push(updates.longitude ?? null);
+      }
+      if (updates.excludeFromAvg !== undefined) {
+        fields.push('exclude_from_avg = ?');
+        values.push(updates.excludeFromAvg ? 1 : 0);
       }
 
       if (fields.length === 0) {
@@ -799,6 +810,11 @@ export const splitOperation = async (id, updates, newOperationData) => {
         destination_amount: newOperationData.destinationAmount || null,
         source_currency: newOperationData.sourceCurrency || null,
         destination_currency: newOperationData.destinationCurrency || null,
+        // The split-off sibling is part of the same expense, so it inherits the
+        // parent's average-exclusion flag unless the caller overrides it.
+        exclude_from_avg: newOperationData.excludeFromAvg !== undefined
+          ? (newOperationData.excludeFromAvg ? 1 : 0)
+          : (oldOperation.exclude_from_avg ? 1 : 0),
         latitude: newOperationData.latitude !== undefined
           ? (newOperationData.latitude ?? null)
           : (oldOperation.latitude ?? null),
@@ -808,12 +824,12 @@ export const splitOperation = async (id, updates, newOperationData) => {
       };
 
       const result = await db.runAsync(
-        'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO operations (type, amount, account_id, category_id, to_account_id, date, created_at, description, exchange_rate, destination_amount, source_currency, destination_currency, exclude_from_avg, latitude, longitude) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           newRow.type, newRow.amount, newRow.account_id, newRow.category_id,
           newRow.to_account_id, newRow.date, newRow.created_at, newRow.description,
           newRow.exchange_rate, newRow.destination_amount, newRow.source_currency, newRow.destination_currency,
-          newRow.latitude, newRow.longitude,
+          newRow.exclude_from_avg, newRow.latitude, newRow.longitude,
         ],
       );
 
@@ -942,11 +958,15 @@ export const getTotalExpenses = async (accountId, startDate, endDate) => {
   try {
     // Shadow-category ops are balance adjustments, not real spending — exclude
     // them so these totals agree with the pie charts, which filter shadows out.
+    // Operations flagged exclude_from_avg = 1 are user-marked one-offs kept out of
+    // the daily spending average / burndown forecast (this total is only consumed
+    // by the prediction, so excluding them here is exactly the intended scope).
     const results = await queryAll(
       `SELECT o.amount FROM operations o
        LEFT JOIN categories c ON o.category_id = c.id
        WHERE o.account_id = ? AND o.type = 'expense' AND o.date >= ? AND o.date <= ?
-         AND (c.is_shadow IS NULL OR c.is_shadow = 0)`,
+         AND (c.is_shadow IS NULL OR c.is_shadow = 0)
+         AND (o.exclude_from_avg IS NULL OR o.exclude_from_avg = 0)`,
       [accountId, startDate, endDate],
     );
     if (!results || results.length === 0) return '0';

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -164,6 +164,11 @@ const isSchemaComplete = async (rawDb) => {
     // Check accounts has auto_txn_rounding column (migration 0012).
     if (!accountsCols.some(c => c.name === 'auto_txn_rounding')) return false;
 
+    // Check operations has exclude_from_avg column (migration 0013). Without this
+    // check, an install complete through 0012 would report "schema complete" and
+    // skip migrate(), so 0013 would never add the column for existing users.
+    if (!opsCols.some(c => c.name === 'exclude_from_avg')) return false;
+
     return true;
   } catch (error) {
     console.warn('[DB] isSchemaComplete check failed:', error.message);
@@ -417,6 +422,14 @@ const detectAppliedMigrations = async (rawDb) => {
     const accCols = await getColumns('accounts');
     if (accCols.some(c => c.name === 'auto_txn_rounding')) {
       applied.push(12);
+    }
+  }
+
+  // Migration 0013: Adds operations.exclude_from_avg column.
+  if (await tableExists('operations')) {
+    const opsCols = await getColumns('operations');
+    if (opsCols.some(c => c.name === 'exclude_from_avg')) {
+      applied.push(13);
     }
   }
 

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Saldo-Anpassungen",
   "add_operation": "Vorgang hinzufügen",
   "edit_operation": "Vorgang bearbeiten",
+  "exclude_from_average": "Vom Ausgabendurchschnitt ausschließen",
+  "exclude_from_average_hint": "Diesen Vorgang nicht in Tagesdurchschnitt und Prognose einbeziehen",
   "amount": "Betrag",
   "description": "Beschreibung",
   "date": "Datum",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Balance Adjustments",
   "add_operation": "Add Operation",
   "edit_operation": "Edit Operation",
+  "exclude_from_average": "Exclude from spending average",
+  "exclude_from_average_hint": "Keep this operation out of the daily average and burndown forecast",
   "amount": "Amount",
   "description": "Description",
   "date": "Date",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Ajustes de saldo",
   "add_operation": "Añadir operación",
   "edit_operation": "Editar operación",
+  "exclude_from_average": "Excluir del promedio de gastos",
+  "exclude_from_average_hint": "No incluir esta operación en el promedio diario ni en la previsión",
   "amount": "Cantidad",
   "description": "Descripción",
   "date": "Fecha",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Ajustements de solde",
   "add_operation": "Ajouter une opération",
   "edit_operation": "Modifier l'opération",
+  "exclude_from_average": "Exclure de la moyenne des dépenses",
+  "exclude_from_average_hint": "Ne pas compter cette opération dans la moyenne quotidienne ni la prévision",
   "amount": "Montant",
   "description": "Description",
   "date": "Date",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Մնացորդի ճշգրտումներ",
   "add_operation": "Ավելացնել գործարք",
   "edit_operation": "Խմբագրել գործարքը",
+  "exclude_from_average": "Բացառել ծախսերի միջինից",
+  "exclude_from_average_hint": "Այս գործարքը չհաշվել օրական միջինում և կանխատեսման մեջ",
   "amount": "Գումար",
   "description": "Նկարագրություն",
   "date": "Ամսաթիվ",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Rettifiche saldo",
   "add_operation": "Aggiungi operazione",
   "edit_operation": "Modifica operazione",
+  "exclude_from_average": "Escludi dalla media di spesa",
+  "exclude_from_average_hint": "Non conteggiare questa operazione nella media giornaliera e nella previsione",
   "amount": "Importo",
   "description": "Descrizione",
   "date": "Data",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "残高調整",
   "add_operation": "取引を追加",
   "edit_operation": "取引を編集",
+  "exclude_from_average": "支出平均から除外",
+  "exclude_from_average_hint": "この取引を日次平均とバーンダウン予測に含めない",
   "amount": "金額",
   "description": "説明",
   "date": "日付",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "잔액 조정",
   "add_operation": "거래 추가",
   "edit_operation": "거래 편집",
+  "exclude_from_average": "지출 평균에서 제외",
+  "exclude_from_average_hint": "이 거래를 일일 평균 및 번다운 예측에서 제외합니다",
   "amount": "금액",
   "description": "설명",
   "date": "날짜",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Ajustes de saldo",
   "add_operation": "Adicionar operação",
   "edit_operation": "Editar operação",
+  "exclude_from_average": "Excluir da média de gastos",
+  "exclude_from_average_hint": "Não incluir esta operação na média diária nem na previsão",
   "amount": "Valor",
   "description": "Descrição",
   "date": "Data",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "Корректировка баланса",
   "add_operation": "Добавить операцию",
   "edit_operation": "Редактировать операцию",
+  "exclude_from_average": "Исключить из средних расходов",
+  "exclude_from_average_hint": "Не учитывать эту операцию в среднем и прогнозе расходов",
   "amount": "Сумма",
   "description": "Описание",
   "date": "Дата",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -207,6 +207,8 @@
   "balance_adjustments": "余额调整",
   "add_operation": "添加操作",
   "edit_operation": "编辑操作",
+  "exclude_from_average": "从支出平均值中排除",
+  "exclude_from_average_hint": "此操作不计入每日平均值和消耗预测",
   "amount": "金额",
   "description": "描述",
   "date": "日期",

--- a/drizzle/0013_operation_exclude_from_avg.js
+++ b/drizzle/0013_operation_exclude_from_avg.js
@@ -1,0 +1,14 @@
+/**
+ * Migration 0013: Per-operation exclusion from the spending average / burndown forecast
+ *
+ * Adds operations.exclude_from_avg — when set to 1, the operation is left out of
+ * the daily spending average and burndown forecast (getTotalExpenses), while
+ * still counting as a normal expense everywhere else (account balances, pie
+ * charts, category totals). Nullable; existing rows default to 0, which means
+ * "counted" (current behaviour). Lets a user keep a one-off large purchase from
+ * skewing the forecast.
+ */
+
+const sql = `ALTER TABLE \`operations\` ADD COLUMN \`exclude_from_avg\` integer DEFAULT 0;`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1766700000000,
       "tag": "0012_account_auto_txn_rounding",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1766800000000,
+      "tag": "0013_operation_exclude_from_avg",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -14,6 +14,7 @@ import m0009 from './0009_add_operation_location.js';
 import m0010 from './0010_bank_notifications.js';
 import m0011 from './0011_merchant_label_override.js';
 import m0012 from './0012_account_auto_txn_rounding.js';
+import m0013 from './0013_operation_exclude_from_avg.js';
 
 export default {
   journal,
@@ -31,6 +32,7 @@ export default {
     m0010,
     m0011,
     m0012,
+    m0013,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,


### PR DESCRIPTION
## What

Adds a per-operation **"Exclude from spending average"** toggle on the **edit operation** modal. When enabled, that operation is left out of the daily spending average and the burndown forecast, while still counting as a normal expense everywhere else (account balances, pie charts, category totals). This lets a one-off large purchase not skew the forecast.

## Why

Requested: an option to exclude a single operation from being counted in the average spending used by the burndown/forecast. Conceptually the successor to the old category-level `exclude_from_forecast` (removed in migration 0004), but now per-operation and more granular.

## How it works

- The forecast/daily-average is derived solely from `getTotalExpenses` (consumed only by the balance-history hook), so the exclusion is applied there and nowhere else — the account balance line still reflects the real expense; only the forecast slope ignores it.

## Changes

- **Schema + migration** — new `operations.exclude_from_avg` column (`integer`, default 0); `drizzle/0013_operation_exclude_from_avg.js`, registered in `migrations.js` + `_journal.json`.
- **`db.js`** — `detectAppliedMigrations` marker **and** `isSchemaComplete` check for 0013 (the latter is required or existing users would skip the migration).
- **`OperationsDB`** — map `excludeFromAvg` (boolean) on read; persist in create/update/split (split children inherit the parent's flag); filter flagged ops out of `getTotalExpenses`. New column placed before `latitude`/`longitude` in every INSERT so those stay the last params.
- **`OperationModal` + `useOperationForm`** — react-native-paper `Switch` row, shown for **edited, non-shadow expense** operations.
- **`BackupRestore`** — column added to CSV export and JSON restore for round-trip fidelity.
- **i18n** — `exclude_from_average` + `exclude_from_average_hint` across all 11 languages (parity verified: all 513 keys, all valid JSON).
- **Tests** — read-mapping, create/update persistence, and the `getTotalExpenses` exclusion.

## Notes / design calls

- Toggle is **edit-only** and **expense-only** (the average is expense-based); applied via **Save**.
- ⚠️ I could not run `npm test` locally (no node/npm in the dev environment). Edits were designed to keep existing assertions green; **CI is the source of truth for the suite here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)