### PR TITLE
feat(operations): hide search pill until pulled down

### DIFF
--- a/__tests__/hooks/usePullToRevealSearch.test.js
+++ b/__tests__/hooks/usePullToRevealSearch.test.js
@@ -1,0 +1,83 @@
+import { renderHook, act } from '@testing-library/react-native';
+import usePullToRevealSearch from '../../app/hooks/usePullToRevealSearch';
+
+// react-native-reanimated + react-native-gesture-handler are mocked globally in
+// jest.setup.js:
+//  - useSharedValue(v) -> { value: v }
+//  - useAnimatedStyle(fn) -> {}
+//  - withTiming(value, cfg) -> value
+//  - Gesture.Pan()/.Native()/.Simultaneous() -> chainable no-op mocks
+// The Pan worklets (onStart/onUpdate/onEnd) are never invoked under the mock, so
+// these tests cover the hook's derived state and public API, not the native drag.
+
+describe('usePullToRevealSearch', () => {
+  describe('Shape', () => {
+    it('exposes the documented API', async () => {
+      const { result } = await renderHook(() => usePullToRevealSearch({ pinned: false }));
+
+      expect(result.current.revealPanGesture).toBeDefined();
+      expect(result.current.pillAnimatedStyle).toBeDefined();
+      expect(typeof result.current.pillShown).toBe('boolean');
+      expect(typeof result.current.setPeeked).toBe('function');
+      expect(typeof result.current.setScrollY).toBe('function');
+      expect(typeof result.current.setRevealHeight).toBe('function');
+    });
+  });
+
+  describe('pillShown', () => {
+    it('is hidden by default when not pinned', async () => {
+      const { result } = await renderHook(() => usePullToRevealSearch({ pinned: false }));
+      expect(result.current.pillShown).toBe(false);
+    });
+
+    it('is shown when pinned (search open / filters active)', async () => {
+      const { result } = await renderHook(() => usePullToRevealSearch({ pinned: true }));
+      expect(result.current.pillShown).toBe(true);
+    });
+
+    it('reveals when peeked and hides again when the peek is cleared', async () => {
+      const { result } = await renderHook(() => usePullToRevealSearch({ pinned: false }));
+
+      expect(result.current.pillShown).toBe(false);
+
+      await act(async () => {
+        result.current.setPeeked(true);
+      });
+      expect(result.current.pillShown).toBe(true);
+
+      await act(async () => {
+        result.current.setPeeked(false);
+      });
+      expect(result.current.pillShown).toBe(false);
+    });
+
+    it('stays shown while pinned even without a peek', async () => {
+      const { result, rerender } = await renderHook(
+        ({ pinned }) => usePullToRevealSearch({ pinned }),
+        { initialProps: { pinned: true } },
+      );
+
+      expect(result.current.pillShown).toBe(true);
+
+      // Unpinning with no peek returns it to hidden.
+      await act(async () => {
+        rerender({ pinned: false });
+      });
+      expect(result.current.pillShown).toBe(false);
+    });
+  });
+
+  describe('imperative setters', () => {
+    it('setScrollY and setRevealHeight are safe no-throw updates', async () => {
+      const { result } = await renderHook(() => usePullToRevealSearch({ pinned: false }));
+
+      expect(() => {
+        act(() => {
+          result.current.setScrollY(120);
+          result.current.setRevealHeight(48);
+          result.current.setRevealHeight(0); // ignored: non-positive height
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -1,5 +1,6 @@
 import React, { useMemo, useCallback, forwardRef, useRef, useImperativeHandle } from 'react';
 import { View, Text, StyleSheet, SectionList, ActivityIndicator } from 'react-native';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
 import DateSeparator from './DateSeparator';
@@ -79,6 +80,7 @@ const OperationsList = forwardRef(({
   undoActionLabel,
   onUndo,
   onUndoClosed,
+  revealPanGesture,
 }, ref) => {
 
   // Format date label for the separator header.
@@ -371,7 +373,18 @@ const OperationsList = forwardRef(({
     },
   }), [sections]);
 
-  return (
+  // Compose the (optional) pull-to-reveal Pan gesture with the list's own native
+  // scroll so both recognise together: the search pill reads the top pull while
+  // normal scrolling AND native pull-to-refresh keep working. Gesture.Native()
+  // attaches to the SectionList's underlying scroll view (the direct child of the
+  // GestureDetector below).
+  const scrollNativeGesture = useMemo(() => Gesture.Native(), []);
+  const composedGesture = useMemo(
+    () => (revealPanGesture ? Gesture.Simultaneous(revealPanGesture, scrollNativeGesture) : null),
+    [revealPanGesture, scrollNativeGesture],
+  );
+
+  const list = (
     <SectionList
       ref={sectionListRef}
       contentInsetAdjustmentBehavior="automatic"
@@ -436,6 +449,10 @@ const OperationsList = forwardRef(({
       removeClippedSubviews={true}
     />
   );
+
+  return composedGesture
+    ? <GestureDetector gesture={composedGesture}>{list}</GestureDetector>
+    : list;
 });
 
 OperationsList.displayName = 'OperationsList';
@@ -469,6 +486,7 @@ OperationsList.propTypes = {
   undoActionLabel: PropTypes.string,
   onUndo: PropTypes.func,
   onUndoClosed: PropTypes.func,
+  revealPanGesture: PropTypes.object,
 };
 
 OperationsList.defaultProps = {
@@ -492,6 +510,7 @@ OperationsList.defaultProps = {
   undoActionLabel: '',
   onUndo: () => {},
   onUndoClosed: () => {},
+  revealPanGesture: null,
 };
 
 const styles = StyleSheet.create({

--- a/app/hooks/usePullToRevealSearch.js
+++ b/app/hooks/usePullToRevealSearch.js
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Gesture } from 'react-native-gesture-handler';
+import {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  runOnJS,
+  Easing,
+} from 'react-native-reanimated';
+
+// Distance (px) of downward pull that fully reveals the search pill. Kept short
+// so a *light* flick brings it in well before the native pull-to-refresh reaches
+// its (much larger) trigger distance.
+const REVEAL_DISTANCE = 72;
+// Releasing past this fraction of REVEAL_DISTANCE commits the reveal; below it,
+// the pill snaps back to hidden. The same threshold applies to the reverse
+// (swipe-up) direction, so a light upward flick dismisses it.
+const COMMIT_RATIO = 0.45;
+// The list counts as "at the top" (where a downward pull should reveal rather
+// than scroll) within this many px of offset 0.
+const TOP_EPSILON = 4;
+const SHOW_DURATION = 220;
+const HIDE_DURATION = 180;
+const SHOW_EASING = Easing.out(Easing.cubic);
+const HIDE_EASING = Easing.in(Easing.cubic);
+
+/**
+ * usePullToRevealSearch — a hidden-by-default search pill that the user pulls
+ * into view with a light downward swipe at the top of the list, and dismisses
+ * with a light swipe back up.
+ *
+ * The reveal is driven by a Pan gesture that runs *simultaneously* with the
+ * list's native scroll (composed on the list side via `Gesture.Native()`), so
+ * scrolling and native pull-to-refresh keep working: only a pull that BEGINS at
+ * the very top engages the reveal, and it commits well short of the refresh
+ * threshold.
+ *
+ * `pinned` forces the pill visible and disables the pull (e.g. while the full
+ * search is open or filters are active) — this is the "…unless there are active
+ * filters" half of the behaviour.
+ *
+ * @param {object}  options
+ * @param {boolean} options.pinned  Keep the pill shown and ignore pull gestures.
+ * @returns {{
+ *   revealPanGesture: object,       // pass to OperationsList (composed with its native scroll)
+ *   pillAnimatedStyle: object,      // apply to the floating search container
+ *   pillShown: boolean,             // whether the pill occupies layout (drives the list's top inset)
+ *   setPeeked: (v: boolean) => void,// force the pulled-open state (e.g. reset on search close)
+ *   setScrollY: (y: number) => void,// feed the list's scroll offset (from onScroll)
+ *   setRevealHeight: (h: number) => void, // report the measured pill height (from onLayout)
+ * }}
+ */
+export default function usePullToRevealSearch({ pinned }) {
+  // 0 = pill fully hidden (translated up + transparent), 1 = fully shown.
+  const revealProgress = useSharedValue(pinned ? 1 : 0);
+  // Whether the pill was pulled into view. Only meaningful while not pinned.
+  const [peeked, setPeeked] = useState(false);
+
+  // Mirrors read by the gesture worklets on the UI thread.
+  const scrollYShared = useSharedValue(0);
+  const pinnedShared = useSharedValue(pinned);
+  const revealHeight = useSharedValue(48);
+  // Per-gesture bookkeeping captured on start.
+  const startedAtTop = useSharedValue(false);
+  const startProgress = useSharedValue(0);
+
+  useEffect(() => {
+    pinnedShared.value = pinned;
+  }, [pinned, pinnedShared]);
+
+  // Settle the pill to its resting state whenever the inputs change: pinned
+  // (search open / filters active) or a committed peek shows it; otherwise hide.
+  useEffect(() => {
+    if (pinned || peeked) {
+      revealProgress.value = withTiming(1, { duration: SHOW_DURATION, easing: SHOW_EASING });
+    } else {
+      revealProgress.value = withTiming(0, { duration: HIDE_DURATION, easing: HIDE_EASING });
+    }
+  }, [pinned, peeked, revealProgress]);
+
+  const commitPeek = useCallback((next) => {
+    setPeeked(next);
+  }, []);
+
+  const revealPanGesture = useMemo(() => Gesture.Pan()
+    // Engage on a vertical drag; hand horizontal drags back to the tab-swipe.
+    .activeOffsetY([-14, 14])
+    .failOffsetX([-18, 18])
+    .onStart(() => {
+      'worklet';
+      startedAtTop.value = scrollYShared.value <= TOP_EPSILON;
+      startProgress.value = revealProgress.value;
+    })
+    .onUpdate((e) => {
+      'worklet';
+      // Pinned open, or the pull didn't start at the top → leave it to the
+      // native scroll; the composed Native gesture keeps the list moving.
+      if (pinnedShared.value || !startedAtTop.value) return;
+      const next = startProgress.value + e.translationY / REVEAL_DISTANCE;
+      revealProgress.value = Math.min(1, Math.max(0, next));
+    })
+    .onEnd(() => {
+      'worklet';
+      if (pinnedShared.value || !startedAtTop.value) return;
+      const show = revealProgress.value >= COMMIT_RATIO;
+      revealProgress.value = withTiming(show ? 1 : 0, {
+        duration: show ? SHOW_DURATION : HIDE_DURATION,
+        easing: show ? SHOW_EASING : HIDE_EASING,
+      });
+      runOnJS(commitPeek)(show);
+    }),
+  [revealProgress, scrollYShared, pinnedShared, startedAtTop, startProgress, commitPeek]);
+
+  const pillAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: revealProgress.value,
+    // 0 → translated up by its own height (out of view); 1 → resting position.
+    transform: [{ translateY: (revealProgress.value - 1) * revealHeight.value }],
+  }));
+
+  const setScrollY = useCallback((y) => {
+    scrollYShared.value = y;
+  }, [scrollYShared]);
+
+  const setRevealHeight = useCallback((h) => {
+    if (h > 0) revealHeight.value = h;
+  }, [revealHeight]);
+
+  return {
+    revealPanGesture,
+    pillAnimatedStyle,
+    pillShown: pinned || peeked,
+    setPeeked,
+    setScrollY,
+    setRevealHeight,
+  };
+}

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -32,6 +32,7 @@ import useOperationPicker from '../hooks/useOperationPicker';
 import useQuickAddForm from '../hooks/useQuickAddForm';
 import useQuickAddLocation from '../hooks/useQuickAddLocation';
 import usePendingOperationSuggestions from '../hooks/usePendingOperationSuggestions';
+import usePullToRevealSearch from '../hooks/usePullToRevealSearch';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { useSearch } from '../contexts/SearchContext';
 import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
@@ -97,6 +98,19 @@ const OperationsScreen = () => {
   const prevSearchModeRef = useRef(searchMode);
   const quickAddMaxHeight = useSharedValue(1000); // Large enough to not clip
   const quickAddTranslateY = useSharedValue(0);
+
+  // Pull-to-reveal search: the pill is hidden by default and pulled into view
+  // with a light downward swipe at the top of the list; a light swipe up hides
+  // it again — unless a search/filter is active, which pins it visible.
+  const searchPinned = searchMode !== 'closed' || hasActiveSearch;
+  const {
+    revealPanGesture,
+    pillAnimatedStyle,
+    pillShown,
+    setPeeked: setSearchPeeked,
+    setScrollY: setSearchScrollY,
+    setRevealHeight: setSearchRevealHeight,
+  } = usePullToRevealSearch({ pinned: searchPinned });
 
   // Animate when searchMode changes
   useEffect(() => {
@@ -938,8 +952,16 @@ const OperationsScreen = () => {
   // The user is returning to the normal view and should land on the QuickAdd form.
   // Deferred via requestAnimationFrame so the scroll runs after the close animation settles.
   useEffect(() => {
-    const wasOpen = prevSearchModeRef.current === 'open';
+    const prevMode = prevSearchModeRef.current;
+    const wasOpen = prevMode === 'open';
     prevSearchModeRef.current = searchMode;
+
+    // Fully dismissing search (any state → 'closed') returns the pill to hidden,
+    // so a pulled-open pill doesn't linger once the user closes search. A bare
+    // peek (closed → closed) is left alone; only a real transition resets it.
+    if (prevMode !== 'closed' && searchMode === 'closed') {
+      setSearchPeeked(false);
+    }
 
     if (wasOpen && searchMode !== 'open') {
       // Defer one animation frame so FlatList layout has settled after the
@@ -949,15 +971,18 @@ const OperationsScreen = () => {
         flatListRef.current?.scrollToOffset({ offset: 0, animated: false });
       });
     }
-  }, [searchMode]);
+  }, [searchMode, setSearchPeeked]);
 
   // Handle scroll event to show/hide scroll-to-top button
   const handleScroll = useCallback((event) => {
     const offsetY = event.nativeEvent.contentOffset.y;
     scrollOffsetRef.current = offsetY;
+    // Feed the offset to the pull-to-reveal gesture so it only engages when a
+    // pull begins at the very top of the list.
+    setSearchScrollY(offsetY);
     // Show button when scrolled down past the calculator (roughly 250px)
     setShowScrollToTop(offsetY > 250);
-  }, []);
+  }, [setSearchScrollY]);
 
   // Scroll to top handler
   const scrollToTop = useCallback(() => {
@@ -977,14 +1002,18 @@ const OperationsScreen = () => {
   }, []);
 
   const handleSearchBarAreaLayout = useCallback((event) => {
-    setSearchBarAreaHeight(event.nativeEvent.layout.height);
-  }, []);
+    const { height } = event.nativeEvent.layout;
+    setSearchBarAreaHeight(height);
+    // Report the pill height so the hidden state translates it exactly off-screen.
+    setSearchRevealHeight(height);
+  }, [setSearchRevealHeight]);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <OperationsList
         ref={flatListRef}
-        topInset={searchBarAreaHeight}
+        topInset={pillShown ? searchBarAreaHeight : 0}
+        revealPanGesture={revealPanGesture}
         groupedOperations={groupedOperations}
         accounts={accounts}
         categories={categories}
@@ -1017,10 +1046,10 @@ const OperationsScreen = () => {
       {/* Floating search area — overlays the list so its content scrolls behind
           it instead of being clipped by an opaque band. The matching topInset on
           the list above keeps content from starting underneath the pill. */}
-      <View
-        style={styles.floatingSearchArea}
+      <Animated.View
+        style={[styles.floatingSearchArea, pillAnimatedStyle]}
         onLayout={handleSearchBarAreaLayout}
-        pointerEvents="box-none"
+        pointerEvents={pillShown ? 'box-none' : 'none'}
       >
         <SearchBar
           searchText={searchState?.text || ''}
@@ -1041,7 +1070,7 @@ const OperationsScreen = () => {
             t={t}
           />
         )}
-      </View>
+      </Animated.View>
 
       {/* Picker Modal for Account/Category selection */}
       <PickerModal

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -570,6 +570,9 @@ jest.mock('react-native-gesture-handler', () => {
       simultaneousWithExternalGesture: jest.fn().mockReturnThis(),
       requireExternalGestureToFail: jest.fn().mockReturnThis(),
     })),
+    Simultaneous: jest.fn((...gestures) => gestures[0]),
+    Race: jest.fn((...gestures) => gestures[0]),
+    Exclusive: jest.fn((...gestures) => gestures[0]),
   };
 
   return {


### PR DESCRIPTION
## Summary

The Operations search pill is now **hidden by default** and revealed with a **light downward swipe** at the top of the list — a gentle pull brings it in well before the native pull-to-refresh reaches its trigger distance. A **light swipe back up** dismisses it, **unless a search/filter is active**, which pins it visible.

This reuses the existing `searchMode` state machine (`'closed'` = no filters → hideable; `'collapsed'` = filters active → pinned), so the "…unless there are active filters" rule falls out of state that already exists.

## How it works

- **`app/hooks/usePullToRevealSearch.js`** (new) — a `Gesture.Pan()` that only engages when the drag **begins at the top** (`scrollY ≈ 0`), driving a `revealProgress` shared value. Reveals over ~72px of pull, commits at ~45% (a light flick, far short of the refresh threshold); the same logic in reverse handles swipe-to-hide. `pinned` forces it visible and disables the pull.
- **`app/components/operations/OperationsList.js`** — composes the reveal gesture with the list's own scroll via `Gesture.Simultaneous(revealPanGesture, Gesture.Native())`, so **scrolling and native pull-to-refresh keep working** while the pull is also read. Falls back to the plain `SectionList` when no gesture is passed (unchanged for existing callers/tests).
- **`app/screens/OperationsScreen.js`** — wires the hook: feeds scroll offset, reports pill height, drops the list `topInset` to 0 while hidden (reclaiming the space), animates/masks the floating pill (`opacity` + `translateY`, `pointerEvents: 'none'` when hidden), and resets the peek when search returns to `'closed'`.

## Trade-off

Native pull-to-refresh is preserved, so a **hard** pull both refreshes *and* reveals the pill (the reveal commits far below the refresh distance); a **light** pull only reveals. This keeps single-pull refresh intact rather than gating refresh behind the revealed state.

## Testing

- Added `__tests__/hooks/usePullToRevealSearch.test.js` (6 tests) and `Gesture.Simultaneous`/`Race`/`Exclusive` to the jest gesture-handler mock.
- Full suite green: **150 suites / 4320 tests passing**, lint clean.
- ⚠️ Not yet exercised on a device — the gesture UX (pull thresholds, coexistence with native refresh/scroll) should be validated on an Android device/emulator before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)