### PR TITLE
feat(notifications): swipe to deactivate an app and order enabled filters first

### DIFF
--- a/__tests__/components/NotificationFiltersContentPanel.test.js
+++ b/__tests__/components/NotificationFiltersContentPanel.test.js
@@ -91,6 +91,20 @@ describe('NotificationFiltersContentPanel', () => {
     expect(getByTestId('app-filter-org.telegram.messenger').props.accessibilityState.checked).toBe(true);
   });
 
+  it('lists enabled apps first, then hidden ones, each alphabetically', async () => {
+    // systemui is hidden; the other two are visible. Enabled group comes first
+    // (ameriabank before telegram), then the hidden systemui row.
+    const { getAllByTestId, getByTestId } = await render(<NotificationFiltersContentPanel />);
+    await waitFor(() => expect(getByTestId('app-filter-com.banq.ameriabank')).toBeTruthy());
+
+    const order = getAllByTestId(/^app-filter-/).map((node) => node.props.testID);
+    expect(order).toEqual([
+      'app-filter-com.banq.ameriabank',
+      'app-filter-org.telegram.messenger',
+      'app-filter-com.android.systemui',
+    ]);
+  });
+
   it('toggles a visible app off when its row is tapped', async () => {
     const { getByTestId } = await render(<NotificationFiltersContentPanel />);
     await waitFor(() => expect(getByTestId('app-filter-org.telegram.messenger')).toBeTruthy());

--- a/__tests__/components/NotificationProcessingContentPanel.test.js
+++ b/__tests__/components/NotificationProcessingContentPanel.test.js
@@ -44,6 +44,7 @@ jest.mock('../../app/services/notifications/notificationFilters', () => ({
   getHiddenPackages: jest.fn(),
   registerSeenPackages: jest.fn(),
   filterNotificationsByApp: jest.fn(),
+  hidePackage: jest.fn(),
 }));
 
 const PENDING = {
@@ -72,6 +73,7 @@ describe('NotificationProcessingContentPanel', () => {
     notificationFilters.getHiddenPackages.mockResolvedValue([]);
     notificationFilters.registerSeenPackages.mockResolvedValue([]);
     notificationFilters.filterNotificationsByApp.mockImplementation((items) => items);
+    notificationFilters.hidePackage.mockResolvedValue([]);
     pipeline.isBankNotificationsEnabled.mockResolvedValue(true);
     pipeline.processBankNotifications.mockResolvedValue({ created: 0, pending: 1, skipped: 0 });
     pipeline.resolvePendingNotification.mockResolvedValue({ id: 1 });
@@ -199,6 +201,39 @@ describe('NotificationProcessingContentPanel', () => {
     await waitFor(() => expect(getByText('NAREK MEHRABYAN')).toBeTruthy());
     // The chat notification's app is hidden, so its text must not appear.
     expect(queryByText('New message')).toBeNull();
+  });
+
+  it('deactivates an app from the recent feed via its swipe action and drops its cards', async () => {
+    // The Swipeable mock renders the right-actions inline, so the "Hide" button
+    // is present without performing an actual gesture.
+    notificationFilters.hidePackage.mockResolvedValue(['com.chat']);
+    // Filter for real so the optimistic setHidden actually removes the app's cards.
+    notificationFilters.filterNotificationsByApp.mockImplementation((items, hidden) =>
+      items.filter((n) => !(hidden || []).includes(n.packageName)),
+    );
+    const { getByTestId, getByText, queryByText } = await render(<NotificationProcessingContentPanel />);
+    await waitFor(() => expect(getByText('New message')).toBeTruthy());
+
+    fireEvent.press(getByTestId('deactivate-app-com.chat'));
+    await waitFor(() =>
+      expect(notificationFilters.hidePackage).toHaveBeenCalledWith('com.chat'),
+    );
+    // Core claim of the feature: the hidden app's card leaves the feed at once,
+    // driven by the optimistic setHidden(['com.chat']).
+    await waitFor(() => expect(queryByText('New message')).toBeNull());
+  });
+
+  it('renders a notification with no packageName as a plain, non-swipeable card', async () => {
+    // A packageName-less notification exercises the plain-card branch: it renders
+    // but exposes no swipe-to-hide affordance (there is no app to filter by).
+    const NO_PKG_RAW = { title: 'System', text: 'No package here', postTime: 1718000300000 };
+    NotificationAccess.getRecentNotifications.mockResolvedValue([NO_PKG_RAW, CHAT_RAW]);
+    const { getByText, queryByTestId } = await render(<NotificationProcessingContentPanel />);
+    await waitFor(() => expect(getByText('No package here')).toBeTruthy());
+
+    // The plain card has no deactivate button; the app-backed card still does.
+    expect(queryByTestId('deactivate-app-undefined')).toBeNull();
+    expect(queryByTestId('deactivate-app-com.chat')).toBeTruthy();
   });
 
   it('shows a distinct "all filtered" empty state when every recent item is hidden', async () => {

--- a/__tests__/services/notifications/notificationFilters.test.js
+++ b/__tests__/services/notifications/notificationFilters.test.js
@@ -4,6 +4,7 @@ import {
   getHiddenPackages,
   setHiddenPackages,
   togglePackageVisibility,
+  hidePackage,
   getKnownPackages,
   registerSeenPackages,
   isPackageHidden,
@@ -91,6 +92,36 @@ describe('notificationFilters', () => {
     it('propagates a persistence failure to the caller', async () => {
       PreferencesDB.setJsonPreference.mockRejectedValueOnce(new Error('disk full'));
       await expect(togglePackageVisibility('com.chat')).rejects.toThrow('disk full');
+    });
+  });
+
+  describe('hidePackage', () => {
+    it('hides a visible app by adding it to the hidden set', async () => {
+      const next = await hidePackage('com.chat');
+      expect(next).toContain('com.chat');
+      expect(store.hidden).toContain('com.chat');
+    });
+
+    it('is idempotent for an already-hidden app and does not re-persist', async () => {
+      store.hidden = ['com.chat'];
+      const next = await hidePackage('com.chat');
+      expect(next).toEqual(['com.chat']);
+      expect(PreferencesDB.setJsonPreference).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op for an empty package name and does not persist', async () => {
+      store.hidden = ['a'];
+      const next = await hidePackage('');
+      expect(next).toEqual(['a']);
+      expect(PreferencesDB.setJsonPreference).not.toHaveBeenCalled();
+    });
+
+    it('serializes concurrent hides so neither write is lost (race regression)', async () => {
+      // Fired together, the two read-modify-writes would race and drop one under a
+      // naive last-write-wins; the serialized chain must persist both.
+      await Promise.all([hidePackage('com.a'), hidePackage('com.b')]);
+      expect(store.hidden).toContain('com.a');
+      expect(store.hidden).toContain('com.b');
     });
   });
 

--- a/app/components/NotificationFiltersContentPanel.js
+++ b/app/components/NotificationFiltersContentPanel.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, ScrollView, ActivityIndicator, RefreshControl, TouchableOpacity } from 'react-native';
 import { Text, Switch } from 'react-native-paper';
@@ -168,6 +168,20 @@ export default function NotificationFiltersContentPanel({ bottomInset }) {
     }
   }, []);
 
+  // Enabled (visible) apps first, then hidden ones — each group sorted
+  // alphabetically. Recomputed from the persisted lists so toggling a row moves
+  // it into the right group. `known` already arrives sorted, but re-sorting here
+  // keeps the two groups internally alphabetical regardless of input order.
+  const orderedApps = useMemo(() => {
+    const hiddenSet = new Set(hidden);
+    return [...known].sort((a, b) => {
+      const aHidden = hiddenSet.has(a);
+      const bHidden = hiddenSet.has(b);
+      if (aHidden !== bHidden) return aHidden ? 1 : -1;
+      return a.localeCompare(b);
+    });
+  }, [known, hidden]);
+
   if (loading) {
     return (
       <View style={styles.centered}>
@@ -280,7 +294,7 @@ export default function NotificationFiltersContentPanel({ bottomInset }) {
           </Text>
         </View>
       ) : (
-        known.map((pkg) => {
+        orderedApps.map((pkg) => {
           const checked = !isPackageHidden(pkg, hidden);
           return (
             <TouchableOpacity

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -7,10 +7,12 @@ import {
   ActivityIndicator,
   RefreshControl,
   TouchableOpacity,
+  Pressable,
   LayoutAnimation,
   Platform,
   UIManager,
 } from 'react-native';
+import { Swipeable } from 'react-native-gesture-handler';
 import { Text } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -36,6 +38,7 @@ import {
   getHiddenPackages,
   registerSeenPackages,
   filterNotificationsByApp,
+  hidePackage,
 } from '../services/notifications/notificationFilters';
 import { getPendingNotifications } from '../services/PendingNotificationsDB';
 import { getLabelForMerchant } from '../services/NotificationRulesDB';
@@ -333,6 +336,36 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
     }
   }, [reloadPending]);
 
+  // Deactivate an app straight from the recent feed: swiping a card left reveals
+  // a "Hide" action that filters out every notification from that app. Hiding
+  // updates the local set immediately so the swiped card (and its siblings from
+  // the same app) drop out of the feed at once, without waiting for a refresh.
+  const handleDeactivateApp = useCallback(async (packageName) => {
+    if (!packageName) return;
+    try {
+      const next = await hidePackage(packageName);
+      if (mountedRef.current) setHidden(Array.isArray(next) ? next : []);
+    } catch (error) {
+      // Non-fatal; the next silent refresh reconciles the hidden set from storage.
+    }
+  }, []);
+
+  const renderDeactivateAction = useCallback((packageName) => (
+    <Pressable
+      testID={`deactivate-app-${packageName}`}
+      style={[styles.swipeDeactivate, { backgroundColor: colors.delete }]}
+      onPress={() => handleDeactivateApp(packageName)}
+      accessibilityRole="button"
+      accessibilityLabel={t('notification_filter_hide') || 'Hide'}
+      accessibilityHint={t('notification_filter_hide_app') || 'Hide notifications from this app'}
+    >
+      <Ionicons name="notifications-off" size={20} color="#ffffff" />
+      <Text style={styles.swipeDeactivateText} numberOfLines={1}>
+        {t('notification_filter_hide') || 'Hide'}
+      </Text>
+    </Pressable>
+  ), [colors.delete, handleDeactivateApp, t]);
+
   // The feed, with hidden apps filtered out.
   const visibleRecent = useMemo(
     () => filterNotificationsByApp(recent, hidden),
@@ -598,9 +631,8 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
           // Before the first seed (`null`) nothing is new, so the initial batch
           // renders at rest.
           const isNew = previouslySeen != null && !previouslySeen.has(key);
-          return (
+          const card = (
             <NotificationCard
-              key={key}
               notification={notification}
               colors={colors}
               t={t}
@@ -608,6 +640,23 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
               reAddState={reAddState[key]}
               animateIn={isNew}
             />
+          );
+          // Only offer swipe-to-hide when the source app is known — a card with no
+          // packageName can't be filtered by app, so it stays a plain card. A keyed
+          // Fragment carries the list key without adding an extra layout node.
+          if (!notification.packageName) {
+            return <React.Fragment key={key}>{card}</React.Fragment>;
+          }
+          return (
+            <Swipeable
+              key={key}
+              renderRightActions={() => renderDeactivateAction(notification.packageName)}
+              overshootRight={false}
+              friction={2}
+              rightThreshold={60}
+            >
+              {card}
+            </Swipeable>
           );
         })
       )}
@@ -752,5 +801,23 @@ const styles = StyleSheet.create({
   selectedCategoryText: {
     fontSize: 12,
     fontWeight: '600',
+  },
+  // Swipe-to-deactivate action revealed under a recent-notification card. The
+  // marginBottom matches the card's own marginBottom (SPACING.md) so the button's
+  // bottom edge lines up with the card's.
+  swipeDeactivate: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    justifyContent: 'center',
+    marginBottom: SPACING.md,
+    marginLeft: SPACING.xs,
+    paddingHorizontal: SPACING.md,
+    width: 72,
+  },
+  swipeDeactivateText: {
+    color: '#ffffff',
+    fontSize: 11,
+    fontWeight: '600',
+    marginTop: 2,
   },
 });

--- a/app/services/notifications/notificationFilters.js
+++ b/app/services/notifications/notificationFilters.js
@@ -58,6 +58,35 @@ export const setHiddenPackages = async (list) => {
   );
 };
 
+// Serializes all hidden-set mutations so concurrent read-modify-writes can't
+// lose an update. Each mutation chains off the previous one, so a second hide
+// fired before the first has persisted still reads the first's result rather
+// than a stale snapshot (last-write-wins would otherwise drop one). The chain is
+// kept alive across failures (`.catch`) so one rejected write can't wedge it.
+let hiddenWriteChain = Promise.resolve();
+
+/**
+ * Run a hidden-set mutation under the serialized write chain. `apply(set)`
+ * mutates the passed Set in place and returns whether it actually changed
+ * anything (only then is the result persisted). The read of the current state
+ * happens inside the chained step, so it always sees the prior mutation's write.
+ * @param {(hidden: Set<string>) => boolean} apply
+ * @returns {Promise<string[]>} the updated hidden list
+ */
+const mutateHiddenSet = (apply) => {
+  const run = hiddenWriteChain.then(async () => {
+    const hidden = new Set(await getHiddenPackages());
+    const changed = apply(hidden);
+    const next = Array.from(hidden);
+    if (changed) await setHiddenPackages(next);
+    return next;
+  });
+  // Keep the chain healthy regardless of this step's outcome; the caller still
+  // sees the real result/rejection via `run`.
+  hiddenWriteChain = run.catch(() => {});
+  return run;
+};
+
 /**
  * Flip a single app's visibility based on the CURRENT persisted state rather
  * than a caller-supplied flag. Reading-then-flipping from the source of truth
@@ -66,18 +95,30 @@ export const setHiddenPackages = async (list) => {
  * @param {string} packageName
  * @returns {Promise<string[]>} the updated hidden list
  */
-export const togglePackageVisibility = async (packageName) => {
-  const hidden = new Set(await getHiddenPackages());
-  if (!packageName) return Array.from(hidden);
-  if (hidden.has(packageName)) {
-    hidden.delete(packageName); // was hidden → show it
-  } else {
-    hidden.add(packageName); // was visible → hide it
-  }
-  const next = Array.from(hidden);
-  await setHiddenPackages(next);
-  return next;
-};
+export const togglePackageVisibility = (packageName) =>
+  mutateHiddenSet((hidden) => {
+    if (!packageName) return false;
+    if (hidden.has(packageName)) {
+      hidden.delete(packageName); // was hidden → show it
+    } else {
+      hidden.add(packageName); // was visible → hide it
+    }
+    return true;
+  });
+
+/**
+ * Hide a single app from the feed. Unlike togglePackageVisibility this only ever
+ * adds (idempotent), so it is safe for the swipe-to-deactivate action on the
+ * processing page, where the swiped card is always for a currently-visible app.
+ * @param {string} packageName
+ * @returns {Promise<string[]>} the updated hidden list
+ */
+export const hidePackage = (packageName) =>
+  mutateHiddenSet((hidden) => {
+    if (!packageName || hidden.has(packageName)) return false;
+    hidden.add(packageName);
+    return true;
+  });
 
 /**
  * Every package Penny knows about for the filter list: the shipped defaults

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "Apps",
   "notification_filter_apps_hint": "Deaktivieren Sie eine App, um ihre Benachrichtigungen aus der Liste auszublenden",
   "notification_filter_apps_empty": "Noch keine Apps. Sie erscheinen hier, sobald Benachrichtigungen eintreffen.",
+  "notification_filter_hide": "Ausblenden",
+  "notification_filter_hide_app": "Benachrichtigungen dieser App ausblenden",
   "cancel": "Abbrechen",
   "save": "Speichern",
   "add": "Hinzufügen",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "Apps",
   "notification_filter_apps_hint": "Uncheck an app to hide its notifications from the feed",
   "notification_filter_apps_empty": "No apps yet. They'll appear here as notifications arrive.",
+  "notification_filter_hide": "Hide",
+  "notification_filter_hide_app": "Hide notifications from this app",
   "cancel": "Cancel",
   "save": "Save",
   "add": "Add",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "Aplicaciones",
   "notification_filter_apps_hint": "Desmarca una app para ocultar sus notificaciones de la lista",
   "notification_filter_apps_empty": "Aún no hay apps. Aparecerán aquí a medida que lleguen notificaciones.",
+  "notification_filter_hide": "Ocultar",
+  "notification_filter_hide_app": "Ocultar las notificaciones de esta app",
   "cancel": "Cancelar",
   "save": "Guardar",
   "add": "Añadir",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "Applications",
   "notification_filter_apps_hint": "Décochez une application pour masquer ses notifications de la liste",
   "notification_filter_apps_empty": "Aucune application pour le moment. Elles apparaîtront ici au fur et à mesure des notifications.",
+  "notification_filter_hide": "Masquer",
+  "notification_filter_hide_app": "Masquer les notifications de cette application",
   "cancel": "Annuler",
   "save": "Enregistrer",
   "add": "Ajouter",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "Հավելվածներ",
   "notification_filter_apps_hint": "Հանեք նշումը՝ հավելվածի ծանուցումները ցանկից թաքցնելու համար",
   "notification_filter_apps_empty": "Դեռ հավելվածներ չկան։ Դրանք կհայտնվեն այստեղ ծանուցումների ստացման հետ։",
+  "notification_filter_hide": "Թաքցնել",
+  "notification_filter_hide_app": "Թաքցնել այս հավելվածի ծանուցումները",
   "cancel": "Չեղարկել",
   "save": "Պահպանել",
   "add": "Ավելացնել",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "App",
   "notification_filter_apps_hint": "Deseleziona un'app per nasconderne le notifiche dall'elenco",
   "notification_filter_apps_empty": "Ancora nessuna app. Appariranno qui man mano che arrivano le notifiche.",
+  "notification_filter_hide": "Nascondi",
+  "notification_filter_hide_app": "Nascondi le notifiche di questa app",
   "cancel": "Annulla",
   "save": "Salva",
   "add": "Aggiungi",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "アプリ",
   "notification_filter_apps_hint": "アプリのチェックを外すと、その通知が一覧から非表示になります",
   "notification_filter_apps_empty": "アプリはまだありません。通知が届くとここに表示されます。",
+  "notification_filter_hide": "非表示",
+  "notification_filter_hide_app": "このアプリの通知を非表示にする",
   "cancel": "キャンセル",
   "save": "保存",
   "add": "追加",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "앱",
   "notification_filter_apps_hint": "앱의 체크를 해제하면 목록에서 해당 알림이 숨겨집니다",
   "notification_filter_apps_empty": "아직 앱이 없습니다. 알림이 도착하면 여기에 표시됩니다.",
+  "notification_filter_hide": "숨기기",
+  "notification_filter_hide_app": "이 앱의 알림 숨기기",
   "cancel": "취소",
   "save": "저장",
   "add": "추가",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "Apps",
   "notification_filter_apps_hint": "Desmarque um app para ocultar suas notificações da lista",
   "notification_filter_apps_empty": "Ainda não há apps. Eles aparecerão aqui conforme as notificações chegarem.",
+  "notification_filter_hide": "Ocultar",
+  "notification_filter_hide_app": "Ocultar as notificações deste app",
   "cancel": "Cancelar",
   "save": "Salvar",
   "add": "Adicionar",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "Приложения",
   "notification_filter_apps_hint": "Снимите флажок, чтобы скрыть уведомления приложения из ленты",
   "notification_filter_apps_empty": "Пока нет приложений. Они появятся здесь по мере поступления уведомлений.",
+  "notification_filter_hide": "Скрыть",
+  "notification_filter_hide_app": "Скрыть уведомления этого приложения",
   "cancel": "Отмена",
   "save": "Сохранить",
   "add": "Добавить",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -76,6 +76,8 @@
   "notification_filter_apps": "应用",
   "notification_filter_apps_hint": "取消勾选某个应用，即可在列表中隐藏其通知",
   "notification_filter_apps_empty": "暂无应用。收到通知后将显示在此处。",
+  "notification_filter_hide": "隐藏",
+  "notification_filter_hide_app": "隐藏此应用的通知",
   "cancel": "取消",
   "save": "保存",
   "add": "添加",


### PR DESCRIPTION
## Summary

On the notification-processing page, swiping a recent notification left now reveals a **Hide** action (the same swipe UI as planned operations) that filters out every notification from that app. On the filters page, apps are now ordered with enabled (visible) ones first, then hidden ones, each group alphabetical.

## Changes

- **app/components/NotificationProcessingContentPanel.js** — wrap each recent-notification card in a `Swipeable`; swipe-left reveals a **Hide** button that hides the app via an optimistic `setHidden`, so the card (and its siblings from the same app) leave the feed at once. Cards with no `packageName` render as plain, non-swipeable cards (keyed `Fragment`, no extra node). Button has `accessibilityLabel` + `accessibilityHint`.
- **app/components/NotificationFiltersContentPanel.js** — `useMemo` `orderedApps`: enabled (not hidden) apps first, then hidden, each sorted alphabetically.
- **app/services/notifications/notificationFilters.js** — add idempotent `hidePackage()`; route it and `togglePackageVisibility()` through a shared, **serialized** `mutateHiddenSet()` so concurrent read-modify-writes can't lose an update.
- **assets/i18n/*.json** — add `notification_filter_hide` and `notification_filter_hide_app` for all 11 languages.
- **__tests__/** — cover the swipe-deactivate flow (incl. the card dropping out of the feed), the no-`packageName` plain-card branch, `hidePackage` (hide / idempotent / empty-name), the concurrent-hide race regression, and the enabled-first filter ordering.

## Testing

- `npm test` — 149 suites / 4321 tests pass.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — or n/a
- [ ] Linked the related issue with `Closes #NNN` below — or n/a

Closes #
