### PR TITLE
fix(notifications): keep learned category on unmatched-account pending items

### DIFF
--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -453,6 +453,45 @@ describe('processBankNotifications', () => {
     );
   });
 
+  // Regression: a learned merchant->category must still pre-fill the pending item
+  // even when the account cannot be resolved. Reproduces the real T-Bank case —
+  // the notification carries a card mask that isn't bound yet AND there are two
+  // non-hidden RUB accounts, so the single-account fallback can't fire. The
+  // category (merchant-derived) must not be dropped just because the account is
+  // unknown, otherwise a binding visible in the bindings list never gets applied.
+  it('pre-fills the learned category in the pending item even when the account does not resolve', async () => {
+    const TBANK_PURCHASE = {
+      title: 'PEREKRESTOK',
+      text: 'Покупка на 1304,89 ₽, кэшбэк 65 ₽, счет карты *4087 Доступно 148 000 ₽',
+      packageName: 'com.idamob.tinkoff.android',
+      postTime: 1782000900000,
+    };
+    NotificationAccess.getRecentNotifications.mockResolvedValue([TBANK_PURCHASE]);
+    // Card mask *4087 is not bound to any account.
+    AccountsDB.getAccountByCardMask.mockResolvedValue(null);
+    // Two non-hidden RUB accounts → the single-currency fallback finds >1 match
+    // and returns null, so no account resolves.
+    AccountsDB.getAllAccounts.mockResolvedValue([
+      { id: 23, currency: 'RUB', hidden: 0 },
+      { id: 24, currency: 'RUB', hidden: 0 },
+    ]);
+    // But the merchant already has a learned category.
+    NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-transport' });
+
+    const summary = await pipeline.processBankNotifications();
+
+    expect(summary).toEqual({ created: 0, pending: 1, skipped: 0 });
+    expect(OperationsDB.createOperation).not.toHaveBeenCalled();
+    expect(PendingNotificationsDB.addPendingNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        merchant: 'PEREKRESTOK',
+        cardMask: '*4087',
+        accountId: null,
+        categoryId: 'cat-transport',
+      }),
+    );
+  });
+
   describe('C2C transfers always require a manual category', () => {
     it('queues a C2C transfer even when the card resolves and the source is trusted', async () => {
       NotificationAccess.getRecentNotifications.mockResolvedValue([C2C]);

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -369,10 +369,14 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
       ...descriptor,
       date,
       accountId: resolution.accountId,
-      // Pre-fill the resolved category whenever we have an account to book
-      // against; a currency mismatch is no longer a blocker since it is resolved
-      // by conversion at save time.
-      categoryId: resolution.matchedAccount ? resolution.categoryId : null,
+      // Pre-fill the learned category whenever the merchant rule resolved one,
+      // regardless of whether the account matched. The category is derived from
+      // the merchant, not the account, so dropping it when the account is unknown
+      // (an as-yet-unbound card, or several non-hidden accounts sharing the
+      // notification's currency so the single-account fallback can't fire) throws
+      // away a binding the user already trained — forcing them to re-pick it on
+      // every notification even though it shows up in the bindings list.
+      categoryId: resolution.categoryId,
     });
     summary.pending += 1;
   }


### PR DESCRIPTION
## Проблема

Категория, выученная для продавца (merchant → category), **терялась** при постановке уведомления в review-очередь, если счёт не резолвился:

```js
categoryId: resolution.matchedAccount ? resolution.categoryId : null,
```

Категория происходит из merchant-правила и **не зависит от счёта**, поэтому её сброс при неопределённом счёте выбрасывал привязку, которую пользователь уже обучил — при том что она видна в списке привязок.

## Где всплывает (реальный кейс T-Bank)

Пуши T-Bank несут card mask (`счет карты *4087`), но не дают сильного «single-account» сигнала. Когда:
- маска карты ещё не привязана к счёту, **или**
- несколько нескрытых счетов делят валюту уведомления (напр. два рублёвых: `T-bank card` + `T-bank credit card`), из-за чего фолбэк «ровно один счёт в валюте» не срабатывает,

— счёт резолвится в `null`, и выученная категория молча отбрасывалась. Симптом: «привязка есть в списке, но не применяется, поле категории в pending пустое».

Парсер T-Bank при этом отрабатывает формат корректно (проверено на реальных уведомлениях) — баг был чисто в логике постановки в очередь.

## Изменение

Категория подставляется в pending-элемент всегда, когда merchant-правило её вернуло, независимо от совпадения счёта. Пользователь всё ещё выбирает счёт в review, но выученная категория больше не теряется.

## Тесты

- Добавлен регрешн-тест, воспроизводящий реальный кейс T-Bank (непривязанная карта `*5285`/`*4087` + два нескрытых RUB-счёта + выученная категория).
- `npx jest __tests__/services/notifications` → **258/258 passing**.
