### PR TITLE
feat(notifications): quick-add category grid on the binding card + resolve accounts by card mask on reload

### DIFF
--- a/__tests__/components/CategoryGridSelector.suggestions.test.js
+++ b/__tests__/components/CategoryGridSelector.suggestions.test.js
@@ -1,0 +1,131 @@
+/**
+ * Suggestions-mode tests for CategoryGridSelector — the QuickAdd-style grid the
+ * notification binding card uses when `topCategoryIds` is supplied: an "All
+ * categories" entry plus the most-frequent leaf shortcuts, with an in-place
+ * parent hierarchy behind the entry.
+ *
+ * Kept in its own file (and every positive check waits via waitFor, which
+ * flushes pending commits) to sidestep the react-test-renderer in-suite quirk
+ * that leaves a render uncommitted after an earlier test's async act — see the
+ * note atop CategoryGridSelector.test.js.
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import CategoryGridSelector from '../../app/components/CategoryGridSelector';
+
+const colors = {
+  text: '#000', mutedText: '#888', border: '#ddd', selected: '#eee',
+  primary: '#6200ee', surface: '#fff', inputBackground: '#f0f0f0',
+};
+const t = (k) => k;
+
+// Ten expense leaves (e1..e9 + a nested one) so the >8 "All categories" threshold
+// is met, plus a folder to drill into and one income leaf that must be excluded.
+const MANY = [
+  ...Array.from({ length: 9 }, (_, i) => ({
+    id: `e${i + 1}`, name: `E${i + 1}`, type: 'entry', categoryType: 'expense', parentId: null, isShadow: false,
+  })),
+  { id: 'fold', name: 'Folder', type: 'folder', categoryType: 'expense', parentId: null, isShadow: false },
+  { id: 'nested', name: 'Nested', type: 'entry', categoryType: 'expense', parentId: 'fold', isShadow: false },
+  { id: 'inc', name: 'Salary', type: 'entry', categoryType: 'income', parentId: null, isShadow: false },
+];
+
+const renderSuggest = (props = {}) => render(
+  <CategoryGridSelector
+    categories={MANY}
+    categoryType="expense"
+    onSelect={jest.fn()}
+    colors={colors}
+    t={t}
+    topCategoryIds={['e3', 'e1', 'e2']}
+    {...props}
+  />,
+);
+
+describe('CategoryGridSelector — suggestions mode', () => {
+  it('shows an "All categories" entry plus the frequency-ordered shortcuts', async () => {
+    const { getByTestId, queryByTestId } = await renderSuggest();
+    // History order first (e3, e1, e2), then fillers up to 7.
+    await waitFor(() => expect(getByTestId('category-grid-e3')).toBeTruthy());
+    expect(getByTestId('category-grid-all')).toBeTruthy();
+    expect(getByTestId('category-grid-e1')).toBeTruthy();
+    // Folders and the nested leaf are not surfaced as shortcuts, and nothing
+    // beyond the 7th shortcut shows until the browser is opened.
+    expect(queryByTestId('category-grid-fold')).toBeNull();
+    expect(queryByTestId('category-grid-nested')).toBeNull();
+    expect(queryByTestId('category-grid-e9')).toBeNull();
+    // Income categories never appear in an expense grid.
+    expect(queryByTestId('category-grid-inc')).toBeNull();
+  });
+
+  it('highlights the selected shortcut', async () => {
+    const { getByTestId } = await renderSuggest({ selectedCategoryId: 'e3' });
+    await waitFor(() => expect(getByTestId('category-grid-e3')).toBeTruthy());
+    expect(getByTestId('category-grid-e3').props.accessibilityState.selected).toBe(true);
+  });
+
+  it('omits the "All categories" entry and shows every leaf when there are few (<=8)', async () => {
+    const FEW = [
+      { id: 'a', name: 'A', type: 'entry', categoryType: 'expense', parentId: null, isShadow: false },
+      { id: 'b', name: 'B', type: 'entry', categoryType: 'expense', parentId: null, isShadow: false },
+    ];
+    const { getByTestId, queryByTestId } = await render(
+      <CategoryGridSelector
+        categories={FEW}
+        categoryType="expense"
+        onSelect={jest.fn()}
+        colors={colors}
+        t={t}
+        topCategoryIds={[]}
+      />,
+    );
+    await waitFor(() => expect(getByTestId('category-grid-a')).toBeTruthy());
+    expect(getByTestId('category-grid-b')).toBeTruthy();
+    expect(queryByTestId('category-grid-all')).toBeNull();
+  });
+
+  it('selects a shortcut leaf', async () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = await renderSuggest({ onSelect });
+    await waitFor(() => expect(getByTestId('category-grid-e3')).toBeTruthy());
+    fireEvent.press(getByTestId('category-grid-e3'));
+    expect(onSelect).toHaveBeenCalledWith('e3');
+  });
+
+  it('Back at the browse root returns to the shortcuts without selecting', async () => {
+    const onSelect = jest.fn();
+    const { getByTestId, queryByTestId } = await renderSuggest({ onSelect });
+
+    await waitFor(() => expect(getByTestId('category-grid-all')).toBeTruthy());
+    fireEvent.press(getByTestId('category-grid-all'));
+    await waitFor(() => expect(getByTestId('category-grid-back')).toBeTruthy());
+    fireEvent.press(getByTestId('category-grid-back'));
+    await waitFor(() => expect(getByTestId('category-grid-all')).toBeTruthy());
+    expect(queryByTestId('category-grid-fold')).toBeNull();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('opens the parent hierarchy from "All categories", drills a folder, selects a nested leaf', async () => {
+    const onSelect = jest.fn();
+    const { getByTestId, queryByTestId } = await renderSuggest({ onSelect });
+
+    // "All categories" reveals the parent grid: all root leaves + the folder + Back.
+    await waitFor(() => expect(getByTestId('category-grid-all')).toBeTruthy());
+    fireEvent.press(getByTestId('category-grid-all'));
+    await waitFor(() => expect(getByTestId('category-grid-fold')).toBeTruthy());
+    expect(getByTestId('category-grid-back')).toBeTruthy();
+    expect(getByTestId('category-grid-e9')).toBeTruthy(); // now visible in the full grid
+    expect(queryByTestId('category-grid-all')).toBeNull();
+    // The nested leaf lives inside the folder, not at the browse root.
+    expect(queryByTestId('category-grid-nested')).toBeNull();
+
+    // Drill the folder, select the nested leaf.
+    fireEvent.press(getByTestId('category-grid-fold'));
+    await waitFor(() => expect(getByTestId('category-grid-nested')).toBeTruthy());
+    fireEvent.press(getByTestId('category-grid-nested'));
+    expect(onSelect).toHaveBeenCalledWith('nested');
+    // Selecting collapses back to the shortcuts.
+    await waitFor(() => expect(getByTestId('category-grid-all')).toBeTruthy());
+  });
+});

--- a/__tests__/components/operations/NotificationBindingStack.test.js
+++ b/__tests__/components/operations/NotificationBindingStack.test.js
@@ -20,6 +20,13 @@ jest.mock('../../../app/services/notifications/parseBankNotification', () => ({
 jest.mock('../../../app/services/currency', () => ({
   convertAmount: jest.fn(() => '10.00'),
 }));
+// The card's category grid pulls top categories from history; stub it so the
+// deck renders deterministically without touching the DB. An empty list keeps
+// the grid in its filler-only state (every category shown as a shortcut).
+jest.mock('../../../app/hooks/useTopCategoryIds', () => ({
+  __esModule: true,
+  default: jest.fn(() => []),
+}));
 
 const COLORS = {
   background: '#fff', surface: '#f5f5f5', primary: '#6200ee',

--- a/__tests__/hooks/usePendingOperationSuggestions.test.js
+++ b/__tests__/hooks/usePendingOperationSuggestions.test.js
@@ -9,6 +9,7 @@ import usePendingOperationSuggestions, { canSaveSuggestion } from '../../app/hoo
 import * as pipeline from '../../app/services/notifications/processBankNotifications';
 import * as PendingNotificationsDB from '../../app/services/PendingNotificationsDB';
 import * as NotificationRulesDB from '../../app/services/NotificationRulesDB';
+import * as AccountsDB from '../../app/services/AccountsDB';
 import { kindRequiresCategory } from '../../app/services/notifications/parseBankNotification';
 import { appEvents, EVENTS } from '../../app/services/eventEmitter';
 
@@ -16,6 +17,9 @@ jest.mock('../../app/services/notifications/processBankNotifications');
 jest.mock('../../app/services/PendingNotificationsDB');
 jest.mock('../../app/services/NotificationRulesDB', () => ({
   getLabelForMerchant: jest.fn(),
+}));
+jest.mock('../../app/services/AccountsDB', () => ({
+  getAccountByCardMask: jest.fn(),
 }));
 jest.mock('../../app/services/notifications/parseBankNotification', () => ({
   kindRequiresCategory: jest.fn(),
@@ -82,6 +86,7 @@ describe('usePendingOperationSuggestions', () => {
     pipeline.resolvePendingNotification.mockResolvedValue({ id: 'op1' });
     pipeline.dismissPendingNotification.mockResolvedValue();
     NotificationRulesDB.getLabelForMerchant.mockResolvedValue(null);
+    AccountsDB.getAccountByCardMask.mockResolvedValue(null);
     kindRequiresCategory.mockReturnValue(false);
   });
 
@@ -128,6 +133,50 @@ describe('usePendingOperationSuggestions', () => {
       PendingNotificationsDB.getPendingNotifications.mockResolvedValue([TRANSFER]);
       const { result } = await renderHook(() => usePendingOperationSuggestions());
       await waitFor(() => expect(result.current.choices).toEqual({ p2: TRANSFER_CHOICE }));
+    });
+
+    it('re-resolves the account for a card-bound item the pipeline left unresolved', async () => {
+      // The card was bound after this item was enqueued (or only became matchable
+      // once matching went last-4): the empty account must fill in from the card.
+      const UNRESOLVED = { ...EXPENSE, id: 'p9', accountId: null, cardMask: '*7027' };
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([UNRESOLVED]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 9, name: 'T-bank' });
+
+      const { result } = await renderHook(() => usePendingOperationSuggestions());
+      await waitFor(() => expect(result.current.choices.p9?.accountId).toBe(9));
+      expect(AccountsDB.getAccountByCardMask).toHaveBeenCalledWith('*7027');
+    });
+
+    it('leaves the account null when the card resolves to nothing', async () => {
+      const UNRESOLVED = { ...EXPENSE, id: 'p9', accountId: null, cardMask: '*0000' };
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([UNRESOLVED]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue(null);
+
+      const { result } = await renderHook(() => usePendingOperationSuggestions());
+      await waitFor(() => expect(result.current.choices.p9).toBeTruthy());
+      expect(result.current.choices.p9.accountId).toBeNull();
+    });
+
+    it('does not look up a card for an item that already has an account', async () => {
+      // EXPENSE ships with accountId: 1, so the card lookup is skipped entirely.
+      const { result } = await renderHook(() => usePendingOperationSuggestions());
+      await waitFor(() => expect(result.current.choices.p1).toBeTruthy());
+      expect(AccountsDB.getAccountByCardMask).not.toHaveBeenCalled();
+    });
+
+    it('backfills a resolved account onto an existing unresolved choice on reload', async () => {
+      const UNRESOLVED = { ...EXPENSE, id: 'p9', accountId: null, cardMask: '*7027' };
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([UNRESOLVED]);
+      AccountsDB.getAccountByCardMask.mockResolvedValueOnce(null); // not bound yet
+      const { result } = await renderHook(() => usePendingOperationSuggestions());
+      await waitFor(() => expect(result.current.choices.p9?.accountId).toBeNull());
+
+      // The card gets bound; the next reload should pick up the account.
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 9 });
+      await act(async () => {
+        appEvents.emit(EVENTS.RELOAD_ALL);
+      });
+      await waitFor(() => expect(result.current.choices.p9?.accountId).toBe(9));
     });
 
     it('seeds the label from the learned merchant override', async () => {

--- a/__tests__/hooks/useTopCategoryIds.test.js
+++ b/__tests__/hooks/useTopCategoryIds.test.js
@@ -1,0 +1,61 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import useTopCategoryIds from '../../app/hooks/useTopCategoryIds';
+import * as OperationsDB from '../../app/services/OperationsDB';
+import { appEvents, EVENTS } from '../../app/services/eventEmitter';
+
+jest.mock('../../app/services/OperationsDB', () => ({
+  getTopCategoriesFromLastMonth: jest.fn(),
+}));
+
+describe('useTopCategoryIds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    OperationsDB.getTopCategoriesFromLastMonth.mockResolvedValue([
+      { categoryId: 'c1', count: 9 },
+      { categoryId: 'c2', count: 4 },
+    ]);
+  });
+
+  it('loads the frequency-ordered ids on mount', async () => {
+    const { result } = await renderHook(() => useTopCategoryIds());
+    await waitFor(() => expect(result.current).toEqual(['c1', 'c2']));
+    expect(OperationsDB.getTopCategoriesFromLastMonth).toHaveBeenCalledWith(10);
+  });
+
+  it('degrades to an empty list when the query fails', async () => {
+    OperationsDB.getTopCategoriesFromLastMonth.mockRejectedValue(new Error('db down'));
+    const { result } = await renderHook(() => useTopCategoryIds());
+    await waitFor(() => expect(OperationsDB.getTopCategoriesFromLastMonth).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
+  });
+
+  it('drops rows without a category id', async () => {
+    OperationsDB.getTopCategoriesFromLastMonth.mockResolvedValue([
+      { categoryId: 'c1', count: 9 },
+      { categoryId: null, count: 2 },
+    ]);
+    const { result } = await renderHook(() => useTopCategoryIds());
+    await waitFor(() => expect(result.current).toEqual(['c1']));
+  });
+
+  it('reloads when an operation changes', async () => {
+    const { result } = await renderHook(() => useTopCategoryIds());
+    await waitFor(() => expect(result.current).toEqual(['c1', 'c2']));
+
+    OperationsDB.getTopCategoriesFromLastMonth.mockResolvedValue([{ categoryId: 'c9', count: 1 }]);
+    await act(async () => {
+      appEvents.emit(EVENTS.OPERATION_CHANGED);
+    });
+    await waitFor(() => expect(result.current).toEqual(['c9']));
+  });
+
+  it('unsubscribes on unmount', async () => {
+    const { unmount } = await renderHook(() => useTopCategoryIds());
+    await waitFor(() => expect(OperationsDB.getTopCategoriesFromLastMonth).toHaveBeenCalled());
+    const callsBefore = OperationsDB.getTopCategoriesFromLastMonth.mock.calls.length;
+    await unmount();
+    appEvents.emit(EVENTS.RELOAD_ALL);
+    await act(async () => { await Promise.resolve(); });
+    expect(OperationsDB.getTopCategoriesFromLastMonth.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/__tests__/services/AccountsDB.test.js
+++ b/__tests__/services/AccountsDB.test.js
@@ -101,6 +101,120 @@ describe('AccountsDB', () => {
     });
   });
 
+  describe('getAccountByCardMask', () => {
+    it('returns null for an empty mask without querying', async () => {
+      const result = await AccountsDB.getAccountByCardMask('');
+      expect(result).toBeNull();
+      expect(db.getDrizzle).not.toHaveBeenCalled();
+    });
+
+    it('returns the exact-literal match via the fast path', async () => {
+      const account = { id: 1, name: 'T-bank', cardMask: '4083***5285', currency: 'RUB' };
+      mockDrizzle.limit.mockResolvedValue([account]);
+
+      const result = await AccountsDB.getAccountByCardMask('4083***5285');
+
+      expect(result).toEqual(account);
+      // The fast path answers, so no full-table fallback scan is needed.
+      expect(mockDrizzle.orderBy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a last-4 match when the literal differs', async () => {
+      // A notification carries "*5285" but the account stored the full mask.
+      mockDrizzle.limit.mockResolvedValue([]); // no exact literal match
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 1, name: 'Cash', cardMask: null, currency: 'RUB' },
+        { id: 2, name: 'T-bank', cardMask: '4083***5285', currency: 'RUB' },
+      ]);
+
+      const result = await AccountsDB.getAccountByCardMask('*5285');
+
+      expect(result).toMatchObject({ id: 2, name: 'T-bank' });
+    });
+
+    it('returns the lowest-id account when two share a last-4', async () => {
+      mockDrizzle.limit.mockResolvedValue([]);
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 5, name: 'B', cardMask: '9999***5285' },
+        { id: 3, name: 'A', cardMask: '•• 5285' },
+      ]);
+
+      const result = await AccountsDB.getAccountByCardMask('*5285');
+
+      expect(result).toMatchObject({ id: 3 });
+    });
+
+    it('returns null when no account matches by literal or last-4', async () => {
+      mockDrizzle.limit.mockResolvedValue([]);
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 1, name: 'Cash', cardMask: '*1234' },
+      ]);
+
+      const result = await AccountsDB.getAccountByCardMask('*5285');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setAccountCardMask', () => {
+    let mockTxDb;
+    beforeEach(() => {
+      mockTxDb = { runAsync: jest.fn().mockResolvedValue(undefined) };
+      jest.spyOn(db, 'executeTransaction').mockImplementation(async (cb) => cb(mockTxDb));
+    });
+
+    it('binds the mask and strips it from another account sharing the last-4', async () => {
+      // Account 2 already holds the same card under a different format; it must
+      // give it up so the card has a single owner.
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 1, name: 'T-bank', cardMask: null },
+        { id: 2, name: 'Old', cardMask: '4083***5285' },
+      ]);
+
+      await AccountsDB.setAccountCardMask(1, '*5285');
+
+      // Clears the clashing account, then sets the target.
+      expect(mockTxDb.runAsync).toHaveBeenCalledTimes(2);
+      expect(mockTxDb.runAsync).toHaveBeenNthCalledWith(
+        1,
+        'UPDATE accounts SET card_mask = NULL, updated_at = ? WHERE id = ?',
+        [expect.any(String), 2],
+      );
+      expect(mockTxDb.runAsync).toHaveBeenNthCalledWith(
+        2,
+        'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
+        ['*5285', expect.any(String), 1],
+      );
+    });
+
+    it('only writes the target account when no other holds the card', async () => {
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 1, name: 'T-bank', cardMask: null },
+        { id: 2, name: 'Other', cardMask: '*1234' },
+      ]);
+
+      await AccountsDB.setAccountCardMask(1, '*5285');
+
+      expect(mockTxDb.runAsync).toHaveBeenCalledTimes(1);
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
+        ['*5285', expect.any(String), 1],
+      );
+    });
+
+    it('clears the mask without scanning when passed a falsy value', async () => {
+      await AccountsDB.setAccountCardMask(1, null);
+
+      // No clash scan needed when clearing.
+      expect(mockDrizzle.orderBy).not.toHaveBeenCalled();
+      expect(mockTxDb.runAsync).toHaveBeenCalledTimes(1);
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
+        [null, expect.any(String), 1],
+      );
+    });
+  });
+
   describe('createAccount', () => {
     it('creates a new account with all fields', async () => {
       const newAccount = {

--- a/__tests__/utils/cardMask.test.js
+++ b/__tests__/utils/cardMask.test.js
@@ -1,0 +1,41 @@
+import { cardMaskLast4, cardMasksMatch } from '../../app/utils/cardMask';
+
+describe('cardMaskLast4', () => {
+  it('extracts the trailing four digits regardless of decoration or BIN prefix', () => {
+    expect(cardMaskLast4('*5285')).toBe('5285');
+    expect(cardMaskLast4('•• 5285')).toBe('5285');
+    expect(cardMaskLast4('••5285')).toBe('5285');
+    expect(cardMaskLast4('4083***5285')).toBe('5285');
+    expect(cardMaskLast4('4083 12** **** 5285')).toBe('5285');
+    expect(cardMaskLast4('5285')).toBe('5285');
+  });
+
+  it('returns null when fewer than four digits are present', () => {
+    expect(cardMaskLast4('***')).toBeNull();
+    expect(cardMaskLast4('•• 12')).toBeNull();
+    expect(cardMaskLast4('')).toBeNull();
+    expect(cardMaskLast4(null)).toBeNull();
+    expect(cardMaskLast4(undefined)).toBeNull();
+  });
+});
+
+describe('cardMasksMatch', () => {
+  it('matches masks that share their last four digits despite formatting', () => {
+    // The exact scenario behind the empty-account bug: a notification's short
+    // mask vs. a full mask a user typed into the account editor.
+    expect(cardMasksMatch('*5285', '4083***5285')).toBe(true);
+    expect(cardMasksMatch('•• 5285', '5285')).toBe(true);
+    expect(cardMasksMatch('4083***5285', '*5285')).toBe(true);
+  });
+
+  it('does not match different cards', () => {
+    expect(cardMasksMatch('*5285', '*1234')).toBe(false);
+    expect(cardMasksMatch('4083***5285', '4083***1234')).toBe(false);
+  });
+
+  it('never matches when either side lacks a comparable last-4', () => {
+    expect(cardMasksMatch('*5285', null)).toBe(false);
+    expect(cardMasksMatch(null, '*5285')).toBe(false);
+    expect(cardMasksMatch('12', '12')).toBe(false);
+  });
+});

--- a/app/components/CategoryGridSelector.js
+++ b/app/components/CategoryGridSelector.js
@@ -4,17 +4,31 @@ import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 
-const COLUMNS = 3;
+// Legacy (flat all-root) grid width vs. the quick-add-style suggestions grid,
+// which lays chips four-across to match the QuickAdd form.
+const LEGACY_COLUMNS = 3;
+const SUGGEST_COLUMNS = 4;
+// Shortcut counts shown in suggestions mode, mirroring the QuickAdd form: 7
+// alongside the "All categories" entry (8 slots over two rows of four), or a
+// full 8 shortcuts when there are few enough categories to skip the entry.
+const TOP_WITH_ALL = 7;
+const TOP_WITHOUT_ALL = 8;
 
 /**
  * Inline hierarchical category grid.
  *
- * The same chip-grid browser the QuickAdd panel uses, lifted into a standalone
- * component so other surfaces (e.g. the notification review queue) can pick a
- * category without a flat dropdown. Categories at the current folder level are
- * laid out as a grid of icon chips: folders drill in (a Back chip pops out),
- * leaf entries select. The selected leaf is highlighted, and the folder the
- * user drills through supplies the parent context a flat list never showed.
+ * Two layouts, selected by whether `topCategoryIds` is supplied:
+ *
+ * - **Legacy (no `topCategoryIds`)**: a flat grid of the current folder level's
+ *   categories (folders drill in, a Back chip pops out), three chips across.
+ *   Used by the Settings → Notification processing review queue.
+ *
+ * - **Suggestions (`topCategoryIds` given)**: mirrors the QuickAdd category
+ *   picker — an "All categories" entry plus the most-frequent leaf shortcuts,
+ *   four across. Tapping "All categories" reveals the parent hierarchy in the
+ *   same grid (a Back chip returns to the shortcuts); folders drill in, leaves
+ *   select. Used by the notification binding card over the quick-add panel, so
+ *   its category picker reads identically to the one right beneath it.
  *
  * @param {Array}    categories        All categories (folders + entries).
  * @param {string}   categoryType      'expense' | 'income' — restricts the grid.
@@ -22,6 +36,8 @@ const COLUMNS = 3;
  * @param {Function} onSelect          Called with the tapped leaf category id.
  * @param {Object}   colors            Theme colours.
  * @param {Function} t                 Translation function.
+ * @param {string[]} [topCategoryIds]  Most-frequent-first category ids; presence
+ *   switches the grid into the QuickAdd-style suggestions layout.
  */
 export default function CategoryGridSelector({
   categories,
@@ -30,9 +46,16 @@ export default function CategoryGridSelector({
   onSelect,
   colors,
   t,
+  topCategoryIds,
 }) {
+  const suggestMode = Array.isArray(topCategoryIds);
+  const columns = suggestMode ? SUGGEST_COLUMNS : LEGACY_COLUMNS;
+
   // Folders drilled into: [{ id, name }]. Empty array = root level.
   const [breadcrumb, setBreadcrumb] = useState([]);
+  // In suggestions mode the grid opens on the shortcuts; "All categories" flips
+  // it to the hierarchy browser. In legacy mode the hierarchy is always shown.
+  const [browsing, setBrowsing] = useState(!suggestMode);
   const currentFolderId = breadcrumb.length ? breadcrumb[breadcrumb.length - 1].id : null;
 
   // Non-shadow categories (folders + entries) of the requested type.
@@ -47,37 +70,109 @@ export default function CategoryGridSelector({
     [typed, currentFolderId],
   );
 
+  // Leaf entries of this type, used for the suggestions shortcuts and to decide
+  // whether an "All categories" entry is warranted (mirrors QuickAdd's >8 rule).
+  const typedLeaves = useMemo(() => typed.filter((c) => c.type !== 'folder'), [typed]);
+  const showAllButton = typedLeaves.length > 8;
+
+  // The frequency-ordered leaf shortcuts, filled from remaining leaves by natural
+  // order when history is short — the same shape as QuickAdd's topCategoriesForType.
+  const topCategories = useMemo(() => {
+    if (!suggestMode) return [];
+    const wanted = showAllButton ? TOP_WITH_ALL : TOP_WITHOUT_ALL;
+    const byId = new Map(typedLeaves.map((c) => [c.id, c]));
+    const fromHistory = (topCategoryIds || [])
+      .map((id) => byId.get(id))
+      .filter(Boolean)
+      .slice(0, wanted);
+    const historyIds = new Set(fromHistory.map((c) => c.id));
+    const fillers = typedLeaves.filter((c) => !historyIds.has(c.id)).slice(0, wanted - fromHistory.length);
+    return [...fromHistory, ...fillers];
+  }, [suggestMode, showAllButton, typedLeaves, topCategoryIds]);
+
   const enterFolder = useCallback((folder) => {
     const name = folder.nameKey ? t(folder.nameKey) : folder.name;
     setBreadcrumb((prev) => [...prev, { id: folder.id, name }]);
   }, [t]);
 
+  // Back: pop a folder level; at root in suggestions mode, return to the shortcuts.
   const goBack = useCallback(() => {
-    setBreadcrumb((prev) => prev.slice(0, -1));
+    setBreadcrumb((prev) => {
+      if (prev.length === 0) {
+        if (suggestMode) setBrowsing(false);
+        return prev;
+      }
+      return prev.slice(0, -1);
+    });
+  }, [suggestMode]);
+
+  // Open the hierarchy browser (suggestions mode only) at the root level.
+  const openBrowse = useCallback(() => {
+    setBreadcrumb([]);
+    setBrowsing(true);
   }, []);
 
-  // Build the slot list: a Back chip (only inside a folder) followed by the
-  // level's categories, then pad the final row with invisible spacers so chips
-  // keep an even width regardless of how many fill the last row.
-  const rows = useMemo(() => {
-    const slots = [];
-    if (breadcrumb.length > 0) slots.push({ kind: 'back' });
-    levelItems.forEach((item) => slots.push({ kind: 'item', item }));
-
-    const chunked = [];
-    for (let i = 0; i < slots.length; i += COLUMNS) chunked.push(slots.slice(i, i + COLUMNS));
-    if (chunked.length) {
-      const last = chunked[chunked.length - 1];
-      while (last.length < COLUMNS) last.push({ kind: 'spacer', id: `spacer-${last.length}` });
+  // Select a leaf; in suggestions mode also collapse the browser back to the
+  // shortcuts so the next open starts clean.
+  const selectLeaf = useCallback((id) => {
+    onSelect(id);
+    if (suggestMode) {
+      setBrowsing(false);
+      setBreadcrumb([]);
     }
-    return chunked;
-  }, [breadcrumb.length, levelItems]);
+  }, [onSelect, suggestMode]);
 
   const chipBackground = colors.inputBackground || colors.surface;
+
+  // Build the slot list for the current view, then chunk into rows and pad the
+  // final row with invisible spacers so chips keep an even width.
+  const rows = useMemo(() => {
+    const slots = [];
+    if (suggestMode && !browsing) {
+      if (showAllButton) slots.push({ kind: 'all' });
+      topCategories.forEach((item) => slots.push({ kind: 'item', item }));
+    } else {
+      // Hierarchy browser (legacy always, or suggestions after "All categories").
+      // Suggestions mode shows a Back chip at every level (root Back returns to
+      // the shortcuts); legacy only inside a folder.
+      if (breadcrumb.length > 0 || suggestMode) slots.push({ kind: 'back' });
+      levelItems.forEach((item) => slots.push({ kind: 'item', item }));
+    }
+
+    const chunked = [];
+    for (let i = 0; i < slots.length; i += columns) chunked.push(slots.slice(i, i + columns));
+    if (chunked.length) {
+      const last = chunked[chunked.length - 1];
+      while (last.length < columns) last.push({ kind: 'spacer', id: `spacer-${last.length}` });
+    }
+    return chunked;
+  }, [suggestMode, browsing, showAllButton, topCategories, breadcrumb.length, levelItems, columns]);
 
   const renderSlot = (slot, key) => {
     if (slot.kind === 'spacer') {
       return <View key={key} style={[styles.chip, styles.invisible]} />;
+    }
+
+    if (slot.kind === 'all') {
+      return (
+        <Pressable
+          key={key}
+          testID="category-grid-all"
+          onPress={openBrowse}
+          accessibilityRole="button"
+          accessibilityLabel={t('all_categories') || 'All categories'}
+          style={({ pressed }) => [
+            styles.chip,
+            { backgroundColor: chipBackground, borderColor: colors.border },
+            pressed && { backgroundColor: colors.selected },
+          ]}
+        >
+          <Icon name="menu" size={18} color={colors.text} />
+          <Text style={[styles.chipText, { color: colors.text }]} numberOfLines={2}>
+            {t('all_categories') || 'All categories'}
+          </Text>
+        </Pressable>
+      );
     }
 
     if (slot.kind === 'back') {
@@ -112,7 +207,7 @@ export default function CategoryGridSelector({
       <Pressable
         key={key}
         testID={`category-grid-${item.id}`}
-        onPress={() => (isFolder ? enterFolder(item) : onSelect(item.id))}
+        onPress={() => (isFolder ? enterFolder(item) : selectLeaf(item.id))}
         accessibilityRole="button"
         accessibilityState={{ selected: isSelected }}
         style={({ pressed }) => [
@@ -146,12 +241,12 @@ export default function CategoryGridSelector({
       ) : (
         rows.map((row, ri) => (
           <View key={`row-${ri}`} style={styles.row}>
-            {row.map((slot, ci) => {
+            {row.map((slot) => {
               const key = slot.kind === 'item'
                 ? `item-${slot.item.id}`
                 : slot.kind === 'spacer'
                   ? slot.id
-                  : `back-${ri}`;
+                  : `${slot.kind}-${ri}`;
               return renderSlot(slot, key);
             })}
           </View>
@@ -177,10 +272,12 @@ CategoryGridSelector.propTypes = {
   onSelect: PropTypes.func.isRequired,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
+  topCategoryIds: PropTypes.arrayOf(PropTypes.string),
 };
 
 CategoryGridSelector.defaultProps = {
   selectedCategoryId: null,
+  topCategoryIds: null,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/NotificationBindingCard.js
+++ b/app/components/operations/NotificationBindingCard.js
@@ -12,6 +12,7 @@ import { Ionicons } from '@expo/vector-icons';
 import SimplePicker from '../SimplePicker';
 import FormInput from '../FormInput';
 import CategoryGridSelector from '../CategoryGridSelector';
+import useTopCategoryIds from '../../hooks/useTopCategoryIds';
 import { kindRequiresCategory } from '../../services/notifications/parseBankNotification';
 import { canSaveSuggestion } from '../../hooks/usePendingOperationSuggestions';
 import { getCategoryDisplayName } from '../../utils/categoryUtils';
@@ -55,6 +56,9 @@ const NotificationBindingCard = ({
   const isTransfer = item.type === 'transfer';
   const categoryRequired = !isTransfer && kindRequiresCategory(item.kind, item.packageName);
   const canSave = canSaveSuggestion(item, choice);
+  // Most-frequent categories drive the QuickAdd-style shortcut grid below, so the
+  // card's category picker matches the quick-add form it sits over.
+  const topCategoryIds = useTopCategoryIds();
 
   const accountItems = useMemo(
     () => accounts.map((a) => ({ label: a.name, subLabel: a.currency, value: a.id })),
@@ -222,6 +226,7 @@ const NotificationBindingCard = ({
               onSelect={(categoryId) => onChoiceChange({ categoryId })}
               colors={colors}
               t={t}
+              topCategoryIds={topCategoryIds}
             />
           </>
         )}

--- a/app/hooks/usePendingOperationSuggestions.js
+++ b/app/hooks/usePendingOperationSuggestions.js
@@ -9,6 +9,7 @@ import {
 } from '../services/notifications/processBankNotifications';
 import { kindRequiresCategory } from '../services/notifications/parseBankNotification';
 import { getLabelForMerchant } from '../services/NotificationRulesDB';
+import { getAccountByCardMask } from '../services/AccountsDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 
 // Enable LayoutAnimation on the classic Android renderer (a no-op on Fabric, where
@@ -110,6 +111,18 @@ export default function usePendingOperationSuggestions() {
             .catch(() => existing?.labelOverride ?? '');
         }),
       );
+      // Re-resolve the account for any item the pipeline enqueued without one but
+      // that carries a card mask: the card→account binding may have been created
+      // (or made matchable) after the item was queued, so a card the user has
+      // since bound resolves now instead of leaving the account field blank.
+      const resolvedAccountIds = await Promise.all(
+        list.map((item) => {
+          if (item.accountId != null || !item.cardMask) return Promise.resolve(item.accountId ?? null);
+          return getAccountByCardMask(item.cardMask)
+            .then((account) => (account ? account.id : null))
+            .catch(() => null);
+        }),
+      );
       if (!mountedRef.current) return;
       setSuggestions(list);
       // Seed choices with any suggested account/category, the bound ATM target
@@ -118,10 +131,11 @@ export default function usePendingOperationSuggestions() {
         const next = { ...prev };
         list.forEach((item, i) => {
           const learned = overrides[i] ?? '';
+          const resolvedAccountId = resolvedAccountIds[i];
           const existing = next[item.id];
           if (!existing) {
             next[item.id] = {
-              accountId: item.accountId ?? null,
+              accountId: item.accountId ?? resolvedAccountId ?? null,
               categoryId: item.categoryId ?? null,
               toAccountId: item.type === 'transfer' ? atmId : null,
               labelOverride: learned,
@@ -135,6 +149,12 @@ export default function usePendingOperationSuggestions() {
           // (e.g. by saving a sibling ATM card) unblocks Save without a re-pick.
           if (item.type === 'transfer' && existing.toAccountId == null && atmId != null) {
             updated = { ...updated, toAccountId: atmId };
+          }
+          // Backfill an unresolved account with one now matched from the card mask
+          // (a binding created after this card first appeared), mirroring the ATM
+          // target backfill. Never overrides an account already chosen/suggested.
+          if (existing.accountId == null && resolvedAccountId != null) {
+            updated = { ...updated, accountId: resolvedAccountId };
           }
           // Refresh a non-edited label with the latest learned name (e.g. a
           // sibling just renamed this shop); never touch a field being edited.

--- a/app/hooks/useTopCategoryIds.js
+++ b/app/hooks/useTopCategoryIds.js
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'react';
+import * as OperationsDB from '../services/OperationsDB';
+import { appEvents, EVENTS } from '../services/eventEmitter';
+
+/**
+ * The ids of the most-frequently-used categories over the last 90 days, ordered
+ * most-frequent first, across both expense and income (the consumer filters to
+ * the type it needs). This is the same history signal the quick-add form uses
+ * for its category shortcuts, exposed as a standalone hook so other surfaces —
+ * e.g. the notification binding card — can offer the same "All categories + top
+ * shortcuts" grid instead of a flat all-categories list.
+ *
+ * Stays fresh by reloading on the app-wide OPERATION_CHANGED and RELOAD_ALL
+ * events (a booked/edited operation shifts the frequencies). Any load failure
+ * degrades to an empty list, so a consumer simply falls back to showing its own
+ * categories rather than erroring.
+ *
+ * @param {number} [limitPerType=10] - how many top ids to fetch per type.
+ * @returns {string[]} ordered category ids (may be empty).
+ */
+export default function useTopCategoryIds(limitPerType = 10) {
+  const [ids, setIds] = useState([]);
+
+  const load = useCallback(async () => {
+    try {
+      const rows = await OperationsDB.getTopCategoriesFromLastMonth(limitPerType);
+      setIds((rows || []).map((r) => r.categoryId).filter(Boolean));
+    } catch (error) {
+      setIds([]);
+    }
+  }, [limitPerType]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // appEvents.on returns its own unsubscribe, so returning it cleans up.
+  useEffect(() => appEvents.on(EVENTS.OPERATION_CHANGED, load), [load]);
+  useEffect(() => appEvents.on(EVENTS.RELOAD_ALL, load), [load]);
+
+  return ids;
+}

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -3,6 +3,7 @@ import * as Currency from './currency';
 import { eq, sql, desc, asc, isNull, and } from 'drizzle-orm';
 import { accounts } from '../db/schema';
 import * as BalanceHistoryDB from './BalanceHistoryDB';
+import { cardMaskLast4 } from '../utils/cardMask';
 
 /**
  * Get all accounts using Drizzle
@@ -83,21 +84,40 @@ export const createAccount = async (account) => {
 
 /**
  * Find a non-deleted account bound to the given card mask.
- * @param {string} cardMask - e.g. "4083***7027"
+ *
+ * Matching is by the card's last four digits, not the raw literal: the mask a
+ * bank notification carries ("*5285") and the one stored on the account (a
+ * user-typed "4083***5285", or one learned from a differently-decorated earlier
+ * notification) rarely agree character-for-character, and the last four digits
+ * are the only stable identity a bank exposes. An exact literal match is tried
+ * first as a fast, index-served path before the last-4 fallback scan.
+ *
+ * @param {string} cardMask - e.g. "4083***7027" or "*7027"
  * @returns {Promise<Object|null>}
  */
 export const getAccountByCardMask = async (cardMask) => {
   if (!cardMask) return null;
   try {
     const db = await getDrizzle();
-    // ORDER BY id keeps the result deterministic if two accounts ever share a
-    // mask (single-ownership is enforced on write, but data can predate that).
-    const results = await db.select()
+    // Fast path: an exact literal match (index-friendly, and the common case
+    // once a mask was learned from this very notification format). Single-owner
+    // is enforced on write, so at most one row matches a literal.
+    const exact = await db.select()
       .from(accounts)
       .where(and(eq(accounts.cardMask, cardMask), isNull(accounts.deletedAt)))
-      .orderBy(asc(accounts.id))
       .limit(1);
-    return results[0] || null;
+    if (exact[0]) return exact[0];
+
+    // Fallback: match by last four digits so a differently-formatted stored mask
+    // ("4083***5285") still resolves a notification's short mask ("*5285"). Sort
+    // by id so the result is deterministic if two accounts ever share a last-4.
+    const last4 = cardMaskLast4(cardMask);
+    if (!last4) return null;
+    const all = await getAllAccounts();
+    const matches = (all || [])
+      .filter((a) => cardMaskLast4(a.cardMask) === last4)
+      .sort((a, b) => a.id - b.id);
+    return matches[0] || null;
   } catch (error) {
     console.error('Failed to get account by card mask:', error);
     throw error;
@@ -116,13 +136,26 @@ export const getAccountByCardMask = async (cardMask) => {
 export const setAccountCardMask = async (accountId, cardMask) => {
   const mask = cardMask || null;
   try {
+    // Any other account holding the same card must give it up so a card has a
+    // single owner. Comparison is by last-4 (not the raw literal) to match how
+    // getAccountByCardMask resolves — otherwise a "4083***5285" on one account
+    // and a learned "*5285" on another would both claim the same card.
+    let clashingIds = [];
+    if (mask) {
+      const last4 = cardMaskLast4(mask);
+      if (last4) {
+        const all = await getAllAccounts();
+        clashingIds = (all || [])
+          .filter((a) => a.id !== accountId && cardMaskLast4(a.cardMask) === last4)
+          .map((a) => a.id);
+      }
+    }
     await executeTransaction(async (db) => {
       const now = new Date().toISOString();
-      if (mask) {
-        // Strip the mask from any other account so it has a single owner.
+      for (const id of clashingIds) {
         await db.runAsync(
-          'UPDATE accounts SET card_mask = NULL, updated_at = ? WHERE card_mask = ? AND id != ?',
-          [now, mask, accountId],
+          'UPDATE accounts SET card_mask = NULL, updated_at = ? WHERE id = ?',
+          [now, id],
         );
       }
       await db.runAsync(

--- a/app/utils/cardMask.js
+++ b/app/utils/cardMask.js
@@ -1,0 +1,38 @@
+/**
+ * Card-mask helpers for bank-notification → account matching.
+ *
+ * A bank only ever reveals a card's last four digits; everything else in a mask
+ * (the BIN prefix, and the bullet / asterisk / space decoration around the
+ * digits) is cosmetic and varies by source. The T-Bank parser emits "*5285",
+ * another notification format might carry "•• 5285", and a user typing the mask
+ * into the account editor uses the full "4083***5285". Matching on the raw
+ * literal makes those miss each other, so a card's identity is defined here by
+ * its trailing four digits alone.
+ */
+
+/**
+ * The last four digits of a card mask, or null when fewer than four digits are
+ * present. Ignores every non-digit character (decoration) and any BIN prefix.
+ *
+ * @param {string|null|undefined} mask - e.g. "*5285", "•• 5285", "4083***5285"
+ * @returns {string|null} e.g. "5285"
+ */
+export const cardMaskLast4 = (mask) => {
+  if (mask == null) return null;
+  const digits = String(mask).replace(/\D/g, '');
+  if (digits.length < 4) return null;
+  return digits.slice(-4);
+};
+
+/**
+ * Whether two card masks refer to the same physical card, i.e. share their last
+ * four digits. Two masks that don't both yield a comparable last-4 never match.
+ *
+ * @param {string|null|undefined} a
+ * @param {string|null|undefined} b
+ * @returns {boolean}
+ */
+export const cardMasksMatch = (a, b) => {
+  const la = cardMaskLast4(a);
+  return la != null && la === cardMaskLast4(b);
+};


### PR DESCRIPTION
Two fixes to the inline notification binding card that sits over the quick-add panel, from the screenshots on Drive.

### 1. Category grid — match the quick-add layout (feature)
The card's category picker rendered a flat grid of **every** root category, which overflowed the fixed-height card. It now uses the same layout as the quick-add form: an **"All categories"** entry plus the **7 most-frequent** leaf shortcuts; tapping "All categories" reveals the **parent hierarchy in place** (folders drill in, a Back chip returns).

- New optional `topCategoryIds` prop on `CategoryGridSelector` switches it into this suggestions layout; without it the component keeps its legacy flat grid, so the **Settings → Notification processing** review queue is unchanged.
- New `useTopCategoryIds` hook supplies the frequency signal (same source the quick-add form uses), refreshed on `OPERATION_CHANGED` / `RELOAD_ALL`.

### 2. Empty ACCOUNT field for an already-bound card (bug)
A pending item enqueued **before** its card→account binding existed was stored with a null account and never re-checked, so the field stayed blank even after the card (`*5285` → T-bank card) was bound.

- `usePendingOperationSuggestions.reload` now **re-resolves the account from the card mask** whenever a pending item has none — a binding created after the fact fills the field in (mirrors the existing ATM-target backfill).
- Hardening: `getAccountByCardMask` falls back to the card's **last four digits** after an exact-literal miss, so a short notification mask (`*5285`) still resolves an account stored with a full/differently-decorated mask (`4083***5285`, which the account editor's placeholder invites). `setAccountCardMask`'s single-owner strip matches the same way. New `utils/cardMask` helper.

### Tests
`cardMask` util, `getAccountByCardMask`/`setAccountCardMask` last-4 paths, `useTopCategoryIds`, the suggestions-mode grid, and account re-resolution on reload. Full suite green (152 suites / 4373 tests), ESLint clean.

_Not verified on a device (needs a build with the native notification module); confidence rests on the test suite and parity with the quick-add grid._
