### PR TITLE
feat(notifications): bind multiple cards to one account

### DIFF
--- a/__tests__/components/NotificationBindingsContentPanel.test.js
+++ b/__tests__/components/NotificationBindingsContentPanel.test.js
@@ -65,7 +65,8 @@ describe('NotificationBindingsContentPanel', () => {
     NotificationRulesDB.clearMerchantRuleLabel.mockResolvedValue();
     NotificationRulesDB.upsertMerchantRule.mockResolvedValue();
     NotificationRulesDB.upsertMerchantLabel.mockResolvedValue();
-    AccountsDB.setAccountCardMask.mockResolvedValue();
+    AccountsDB.addAccountCardMask.mockResolvedValue();
+    AccountsDB.removeAccountCardMask.mockResolvedValue();
     pipeline.resolveAtmTargetAccount.mockResolvedValue({ id: 2, name: 'Cash', currency: 'AMD' });
     pipeline.setAtmTargetAccount.mockResolvedValue();
     pipeline.clearAtmTargetAccount.mockResolvedValue();
@@ -88,12 +89,19 @@ describe('NotificationBindingsContentPanel', () => {
     await waitFor(() => expect(getByText('notification_bindings_empty')).toBeTruthy());
   });
 
-  it('removes a card binding by clearing the account card mask', async () => {
+  it('removes a card binding by dropping just that card from the account', async () => {
     const { getAllByLabelText, getByText } = await render(<NotificationBindingsContentPanel />);
     await waitFor(() => expect(getByText('4083***7027')).toBeTruthy());
     // First remove button belongs to the card binding (rendered first).
     fireEvent.press(getAllByLabelText('notification_bindings_remove')[0]);
-    await waitFor(() => expect(mockUpdateAccount).toHaveBeenCalledWith(1, { cardMask: null }, false));
+    await waitFor(() => expect(AccountsDB.removeAccountCardMask).toHaveBeenCalledWith(1, '4083***7027'));
+  });
+
+  it('lists each card of a multi-card account as its own binding row', async () => {
+    mockAccounts = [{ id: 1, name: 'Checking', currency: 'AMD', cardMask: '4083***7027|*1234' }, CASH_ACCOUNT];
+    const { getByText } = await render(<NotificationBindingsContentPanel />);
+    await waitFor(() => expect(getByText('4083***7027')).toBeTruthy());
+    expect(getByText('*1234')).toBeTruthy();
   });
 
   it('removes the ATM cash target binding', async () => {

--- a/__tests__/services/AccountsDB.test.js
+++ b/__tests__/services/AccountsDB.test.js
@@ -108,20 +108,19 @@ describe('AccountsDB', () => {
       expect(db.getDrizzle).not.toHaveBeenCalled();
     });
 
-    it('returns the exact-literal match via the fast path', async () => {
-      const account = { id: 1, name: 'T-bank', cardMask: '4083***5285', currency: 'RUB' };
-      mockDrizzle.limit.mockResolvedValue([account]);
+    it('returns the exact-literal match', async () => {
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 1, name: 'Cash', cardMask: null, currency: 'RUB' },
+        { id: 2, name: 'T-bank', cardMask: '4083***5285', currency: 'RUB' },
+      ]);
 
       const result = await AccountsDB.getAccountByCardMask('4083***5285');
 
-      expect(result).toEqual(account);
-      // The fast path answers, so no full-table fallback scan is needed.
-      expect(mockDrizzle.orderBy).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ id: 2, name: 'T-bank' });
     });
 
     it('falls back to a last-4 match when the literal differs', async () => {
       // A notification carries "*5285" but the account stored the full mask.
-      mockDrizzle.limit.mockResolvedValue([]); // no exact literal match
       mockDrizzle.orderBy.mockResolvedValue([
         { id: 1, name: 'Cash', cardMask: null, currency: 'RUB' },
         { id: 2, name: 'T-bank', cardMask: '4083***5285', currency: 'RUB' },
@@ -132,8 +131,16 @@ describe('AccountsDB', () => {
       expect(result).toMatchObject({ id: 2, name: 'T-bank' });
     });
 
+    it('matches any card in an account holding several', async () => {
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 1, name: 'T-bank', cardMask: '*5285|4083***1234', currency: 'RUB' },
+      ]);
+
+      expect(await AccountsDB.getAccountByCardMask('*1234')).toMatchObject({ id: 1 });
+      expect(await AccountsDB.getAccountByCardMask('*5285')).toMatchObject({ id: 1 });
+    });
+
     it('returns the lowest-id account when two share a last-4', async () => {
-      mockDrizzle.limit.mockResolvedValue([]);
       mockDrizzle.orderBy.mockResolvedValue([
         { id: 5, name: 'B', cardMask: '9999***5285' },
         { id: 3, name: 'A', cardMask: '•• 5285' },
@@ -145,7 +152,6 @@ describe('AccountsDB', () => {
     });
 
     it('returns null when no account matches by literal or last-4', async () => {
-      mockDrizzle.limit.mockResolvedValue([]);
       mockDrizzle.orderBy.mockResolvedValue([
         { id: 1, name: 'Cash', cardMask: '*1234' },
       ]);
@@ -156,62 +162,100 @@ describe('AccountsDB', () => {
     });
   });
 
-  describe('setAccountCardMask', () => {
+  describe('getAccountCardMasks', () => {
+    it('parses the account card_mask list', async () => {
+      mockDrizzle.limit.mockResolvedValue([{ id: 1, cardMask: '*5285|4083***1234' }]);
+      expect(await AccountsDB.getAccountCardMasks(1)).toEqual(['*5285', '4083***1234']);
+    });
+
+    it('returns an empty list when the account has no cards', async () => {
+      mockDrizzle.limit.mockResolvedValue([{ id: 1, cardMask: null }]);
+      expect(await AccountsDB.getAccountCardMasks(1)).toEqual([]);
+    });
+  });
+
+  describe('addAccountCardMask', () => {
     let mockTxDb;
     beforeEach(() => {
       mockTxDb = { runAsync: jest.fn().mockResolvedValue(undefined) };
       jest.spyOn(db, 'executeTransaction').mockImplementation(async (cb) => cb(mockTxDb));
     });
 
-    it('binds the mask and strips it from another account sharing the last-4', async () => {
-      // Account 2 already holds the same card under a different format; it must
-      // give it up so the card has a single owner.
+    it('appends to the target keeping its existing cards, and strips it from another owner', async () => {
+      // Target already holds one card; account 2 holds the incoming card under a
+      // different format and must give it up (single owner).
       mockDrizzle.orderBy.mockResolvedValue([
-        { id: 1, name: 'T-bank', cardMask: null },
-        { id: 2, name: 'Old', cardMask: '4083***5285' },
+        { id: 1, name: 'T-bank', cardMask: '*1111' },
+        { id: 2, name: 'Old', cardMask: '4083***5285|*2222' },
       ]);
 
-      await AccountsDB.setAccountCardMask(1, '*5285');
+      await AccountsDB.addAccountCardMask(1, '*5285');
 
-      // Clears the clashing account, then sets the target.
       expect(mockTxDb.runAsync).toHaveBeenCalledTimes(2);
-      expect(mockTxDb.runAsync).toHaveBeenNthCalledWith(
-        1,
-        'UPDATE accounts SET card_mask = NULL, updated_at = ? WHERE id = ?',
-        [expect.any(String), 2],
-      );
-      expect(mockTxDb.runAsync).toHaveBeenNthCalledWith(
-        2,
-        'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
-        ['*5285', expect.any(String), 1],
-      );
-    });
-
-    it('only writes the target account when no other holds the card', async () => {
-      mockDrizzle.orderBy.mockResolvedValue([
-        { id: 1, name: 'T-bank', cardMask: null },
-        { id: 2, name: 'Other', cardMask: '*1234' },
-      ]);
-
-      await AccountsDB.setAccountCardMask(1, '*5285');
-
-      expect(mockTxDb.runAsync).toHaveBeenCalledTimes(1);
+      // Old owner keeps its other card, loses 5285.
       expect(mockTxDb.runAsync).toHaveBeenCalledWith(
         'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
-        ['*5285', expect.any(String), 1],
+        ['*2222', expect.any(String), 2],
+      );
+      // Target gains the new card alongside its existing one.
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
+        ['*1111|*5285', expect.any(String), 1],
       );
     });
 
-    it('clears the mask without scanning when passed a falsy value', async () => {
-      await AccountsDB.setAccountCardMask(1, null);
+    it('is a no-op when the target already holds the card and no other does', async () => {
+      mockDrizzle.orderBy.mockResolvedValue([
+        { id: 1, name: 'T-bank', cardMask: '4083***5285' },
+      ]);
 
-      // No clash scan needed when clearing.
-      expect(mockDrizzle.orderBy).not.toHaveBeenCalled();
-      expect(mockTxDb.runAsync).toHaveBeenCalledTimes(1);
+      await AccountsDB.addAccountCardMask(1, '*5285');
+
+      expect(db.executeTransaction).not.toHaveBeenCalled();
+    });
+
+    it('ignores a mask without four digits', async () => {
+      await AccountsDB.addAccountCardMask(1, '**');
+      expect(db.getDrizzle).not.toHaveBeenCalled();
+      expect(db.executeTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeAccountCardMask', () => {
+    let mockTxDb;
+    beforeEach(() => {
+      mockTxDb = { runAsync: jest.fn().mockResolvedValue(undefined) };
+      jest.spyOn(db, 'executeTransaction').mockImplementation(async (cb) => cb(mockTxDb));
+    });
+
+    it('removes just the named card and keeps the rest', async () => {
+      mockDrizzle.limit.mockResolvedValue([{ id: 1, cardMask: '*5285|4083***1234' }]);
+
+      await AccountsDB.removeAccountCardMask(1, '*5285');
+
+      expect(mockTxDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
+        ['4083***1234', expect.any(String), 1],
+      );
+    });
+
+    it('clears the column when removing the last card', async () => {
+      mockDrizzle.limit.mockResolvedValue([{ id: 1, cardMask: '*5285' }]);
+
+      await AccountsDB.removeAccountCardMask(1, '4083***5285'); // different format, same last-4
+
       expect(mockTxDb.runAsync).toHaveBeenCalledWith(
         'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
         [null, expect.any(String), 1],
       );
+    });
+
+    it('is a no-op when the account does not hold the card', async () => {
+      mockDrizzle.limit.mockResolvedValue([{ id: 1, cardMask: '*1234' }]);
+
+      await AccountsDB.removeAccountCardMask(1, '*5285');
+
+      expect(db.executeTransaction).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -120,7 +120,7 @@ describe('processBankNotifications', () => {
     OperationsDB.createOperation.mockResolvedValue({ id: 1 });
     PendingNotificationsDB.addPendingNotification.mockResolvedValue({ id: 'p1' });
     AccountsDB.getAccountById.mockResolvedValue(null);
-    AccountsDB.setAccountCardMask.mockResolvedValue();
+    AccountsDB.addAccountCardMask.mockResolvedValue();
     // No ATM "cash" target account bound by default.
     PreferencesDB.getNumberPreference.mockResolvedValue(null);
     PreferencesDB.setPreference.mockResolvedValue();
@@ -677,7 +677,7 @@ describe('processBankNotifications', () => {
       expect(OperationsDB.createOperation).toHaveBeenCalledWith(
         expect.objectContaining({ accountId: 7, categoryId: 'cat-food', amount: '3900.00', date: '2026-06-28' }),
       );
-      expect(AccountsDB.setAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
+      expect(AccountsDB.addAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
       expect(NotificationRulesDB.upsertMerchantRule).toHaveBeenCalledWith('NAREK MEHRABYAN', 'cat-food', PKG);
       expect(PreferencesDB.setJsonPreference).toHaveBeenCalledWith(
         'bank_notifications_packages', [PKG],
@@ -788,7 +788,7 @@ describe('processBankNotifications', () => {
         accountId: 7, categoryId: 'cat-food',
         learnCardMask: false, learnMerchant: false, learnSource: false,
       });
-      expect(AccountsDB.setAccountCardMask).not.toHaveBeenCalled();
+      expect(AccountsDB.addAccountCardMask).not.toHaveBeenCalled();
       expect(NotificationRulesDB.upsertMerchantRule).not.toHaveBeenCalled();
     });
 
@@ -891,7 +891,7 @@ describe('processBankNotifications', () => {
       expect(OperationsDB.createOperation).toHaveBeenCalledWith(
         expect.objectContaining({ accountId: 7, categoryId: 'cat-loan' }),
       );
-      expect(AccountsDB.setAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
+      expect(AccountsDB.addAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
       // ...but the friend -> category rule is never remembered.
       expect(NotificationRulesDB.upsertMerchantRule).not.toHaveBeenCalled();
     });
@@ -906,7 +906,7 @@ describe('processBankNotifications', () => {
       expect(OperationsDB.createOperation).toHaveBeenCalledWith(
         expect.objectContaining({ accountId: 7, categoryId: 'cat-fees' }),
       );
-      expect(AccountsDB.setAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
+      expect(AccountsDB.addAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
       // ...but the generic gateway -> category rule is never remembered.
       expect(NotificationRulesDB.upsertMerchantRule).not.toHaveBeenCalled();
     });
@@ -935,7 +935,7 @@ describe('processBankNotifications', () => {
         }),
       );
       // Learns the card -> source-account binding.
-      expect(AccountsDB.setAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
+      expect(AccountsDB.addAccountCardMask).toHaveBeenCalledWith(7, '4083***7027');
       // Binds the cash account for future auto-create ("first time" binding).
       expect(PreferencesDB.setPreference).toHaveBeenCalledWith('bank_notifications_atm_account', '9');
       // Trusts the source package for auto-create.

--- a/__tests__/utils/cardMask.test.js
+++ b/__tests__/utils/cardMask.test.js
@@ -1,4 +1,9 @@
-import { cardMaskLast4, cardMasksMatch } from '../../app/utils/cardMask';
+import {
+  cardMaskLast4,
+  cardMasksMatch,
+  parseCardMasks,
+  serializeCardMasks,
+} from '../../app/utils/cardMask';
 
 describe('cardMaskLast4', () => {
   it('extracts the trailing four digits regardless of decoration or BIN prefix', () => {
@@ -37,5 +42,47 @@ describe('cardMasksMatch', () => {
     expect(cardMasksMatch('*5285', null)).toBe(false);
     expect(cardMasksMatch(null, '*5285')).toBe(false);
     expect(cardMasksMatch('12', '12')).toBe(false);
+  });
+});
+
+describe('parseCardMasks', () => {
+  it('splits a delimiter-joined list, trimming blanks', () => {
+    expect(parseCardMasks('*5285|4083***1234')).toEqual(['*5285', '4083***1234']);
+    expect(parseCardMasks(' *5285 | *1234 ')).toEqual(['*5285', '*1234']);
+  });
+
+  it('treats a legacy single mask as a one-element list', () => {
+    expect(parseCardMasks('4083***7027')).toEqual(['4083***7027']);
+  });
+
+  it('returns an empty list for null/empty', () => {
+    expect(parseCardMasks(null)).toEqual([]);
+    expect(parseCardMasks('')).toEqual([]);
+    expect(parseCardMasks('||')).toEqual([]);
+  });
+});
+
+describe('serializeCardMasks', () => {
+  it('joins masks with the delimiter', () => {
+    expect(serializeCardMasks(['*5285', '4083***1234'])).toBe('*5285|4083***1234');
+  });
+
+  it('drops blanks and de-duplicates by last-4', () => {
+    expect(serializeCardMasks(['*5285', '  ', '4083***5285', '*1234'])).toBe('*5285|*1234');
+  });
+
+  it('strips any stray delimiter from a mask', () => {
+    expect(serializeCardMasks(['*5285|garbage'])).toBe('*5285garbage');
+  });
+
+  it('returns null for an empty result', () => {
+    expect(serializeCardMasks([])).toBeNull();
+    expect(serializeCardMasks(['', '   '])).toBeNull();
+    expect(serializeCardMasks(null)).toBeNull();
+  });
+
+  it('round-trips with parseCardMasks', () => {
+    const stored = serializeCardMasks(['*5285', '4083***1234']);
+    expect(parseCardMasks(stored)).toEqual(['*5285', '4083***1234']);
   });
 });

--- a/app/components/NotificationBindingsContentPanel.js
+++ b/app/components/NotificationBindingsContentPanel.js
@@ -11,6 +11,7 @@ import { useCategories } from '../contexts/CategoriesContext';
 import SimplePicker from './SimplePicker';
 import FormInput from './FormInput';
 import { getCategoryDisplayName } from '../utils/categoryUtils';
+import { parseCardMasks } from '../utils/cardMask';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import {
   getAllMerchantRules,
@@ -48,7 +49,7 @@ export default function NotificationBindingsContentPanel({ bottomInset }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { accounts } = useAccountsData();
-  const { updateAccount, reloadAccounts } = useAccountsActions();
+  const { reloadAccounts } = useAccountsActions();
   const { categories } = useCategories();
 
   const [loading, setLoading] = useState(true);
@@ -117,23 +118,26 @@ export default function NotificationBindingsContentPanel({ bottomInset }) {
   }, [reload]);
 
   // ── Card bindings ──
+  // One row per bound card: an account can hold several, stored as a list.
   const cardBindings = useMemo(
-    () => accounts.filter((a) => a.cardMask),
+    () => accounts.flatMap((a) => parseCardMasks(a.cardMask).map((mask) => ({ account: a, mask }))),
     [accounts],
   );
 
-  const handleReassignCard = useCallback(async (account, newAccountId) => {
+  const handleReassignCard = useCallback(async (account, mask, newAccountId) => {
     if (newAccountId == null || newAccountId === account.id) return;
-    // setAccountCardMask re-points the mask and strips it from its old owner in
-    // one transaction, then the context reload refreshes both rows.
-    await AccountsDB.setAccountCardMask(newAccountId, account.cardMask);
+    // addAccountCardMask moves just this card: it strips it from the old owner and
+    // adds it to the new one in one transaction, leaving both accounts' other
+    // cards untouched. Reload refreshes both rows.
+    await AccountsDB.addAccountCardMask(newAccountId, mask);
     await reloadAccounts();
   }, [reloadAccounts]);
 
-  const handleRemoveCard = useCallback(async (account) => {
-    // Context action clears the field and reloads accounts for us.
-    await updateAccount(account.id, { cardMask: null }, false);
-  }, [updateAccount]);
+  const handleRemoveCard = useCallback(async (account, mask) => {
+    // Drop only this card; the account keeps its other bindings.
+    await AccountsDB.removeAccountCardMask(account.id, mask);
+    await reloadAccounts();
+  }, [reloadAccounts]);
 
   const handleChangeAtm = useCallback(async (newAccountId) => {
     if (newAccountId == null) return;
@@ -251,27 +255,27 @@ export default function NotificationBindingsContentPanel({ bottomInset }) {
               || 'Which account each card, and ATM cash, maps to'}
           </Text>
 
-          {cardBindings.map((account) => (
+          {cardBindings.map(({ account, mask }) => (
             <View
-              key={`card-${account.id}`}
+              key={`card-${account.id}-${mask}`}
               style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
             >
               <View style={styles.cardTitleRow}>
                 <View style={styles.cardTitleText}>
                   <Ionicons name="card-outline" size={16} color={colors.mutedText} />
                   <Text style={[styles.bindingKey, { color: colors.text }]} numberOfLines={1}>
-                    {account.cardMask}
+                    {mask}
                   </Text>
                 </View>
                 {renderRemoveButton(
-                  () => handleRemoveCard(account),
+                  () => handleRemoveCard(account, mask),
                   t('notification_bindings_remove') || 'Remove binding',
                 )}
               </View>
               <View style={[styles.pickerWrap, { borderColor: colors.border }]}>
                 <SimplePicker
                   value={account.id}
-                  onValueChange={(v) => handleReassignCard(account, v)}
+                  onValueChange={(v) => handleReassignCard(account, mask, v)}
                   items={accountItems}
                   colors={colors}
                   closeLabel={t('close') || 'Close'}

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -19,6 +19,7 @@ import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useOperationsData } from '../contexts/OperationsDataContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { getDefaultAccountId, setDefaultAccountId } from '../services/PreferencesDB';
+import { parseCardMasks, serializeCardMasks, cardMaskLast4 } from '../utils/cardMask';
 import currencies from '../../assets/currencies.json';
 
 // Rounding steps offered for operations auto-created from bank notifications.
@@ -463,6 +464,9 @@ export default function AccountsScreen({ onBackStateChange }) {
 
   const [editingId, setEditingId] = useState(null);
   const [editValues, setEditValues] = useState({});
+  // Draft text for the "add a card" input; the committed masks live on
+  // editValues.cardMask as a delimiter-joined list.
+  const [newCardMask, setNewCardMask] = useState('');
   const [errors, setErrors] = useState({});
   // Pinned default account for QuickAdd. A single stored id (or null = "latest
   // used"), so making one account the default inherently clears any previous one.
@@ -512,6 +516,7 @@ export default function AccountsScreen({ onBackStateChange }) {
     currencySlideAnim.setValue(Dimensions.get('window').width);
     setEditingId(id);
     setEditValues(values);
+    setNewCardMask('');
     Animated.timing(formPanelAnim, {
       toValue: 1,
       duration: 260,
@@ -643,7 +648,31 @@ export default function AccountsScreen({ onBackStateChange }) {
   }, []);
 
   const handleCardMaskChange = useCallback((text) => {
-    setEditValues(v => ({ ...v, cardMask: text }));
+    setNewCardMask(text);
+  }, []);
+
+  // Commit the draft mask to the account's card list (skip blanks and duplicates).
+  const handleAddCardMask = useCallback(() => {
+    const mask = newCardMask.trim();
+    if (!mask) return;
+    setEditValues(v => {
+      const list = parseCardMasks(v.cardMask);
+      const last4 = cardMaskLast4(mask);
+      const exists = list.some(m => (last4 ? cardMaskLast4(m) === last4 : m === mask));
+      if (exists) return v;
+      return { ...v, cardMask: serializeCardMasks([...list, mask]) };
+    });
+    setNewCardMask('');
+  }, [newCardMask]);
+
+  const handleRemoveCardMask = useCallback((mask) => {
+    setEditValues(v => {
+      const last4 = cardMaskLast4(mask);
+      const kept = parseCardMasks(v.cardMask).filter(
+        m => (last4 ? cardMaskLast4(m) !== last4 : m !== mask),
+      );
+      return { ...v, cardMask: serializeCardMasks(kept) };
+    });
   }, []);
 
   const handleRoundingSelect = useCallback((value) => {
@@ -1016,20 +1045,51 @@ export default function AccountsScreen({ onBackStateChange }) {
             </TouchableRipple>
             {errors.currency && <Text variant="bodySmall" style={styles.error}>{errors.currency}</Text>}
 
-            {/* Card mask (for bank-notification matching) */}
+            {/* Card masks (for bank-notification matching) — an account can hold
+                several cards, so they are managed as a list. */}
             <Text style={[modalSharedStyles.fieldLabel, { color: colors.mutedText }]}>
               {(t('card_mask') || 'Card number').toUpperCase()}
             </Text>
-            <PaperTextInput
-              mode="outlined"
-              theme={paperInputTheme}
-              value={editValues.cardMask || ''}
-              onChangeText={handleCardMaskChange}
-              autoCapitalize="characters"
-              autoCorrect={false}
-              placeholder="4083***7027"
-              style={modalSharedStyles.textInput}
-            />
+            {parseCardMasks(editValues.cardMask).map((mask) => (
+              <View
+                key={mask}
+                style={[styles.cardMaskRow, { borderColor: colors.border, backgroundColor: colors.surface }]}
+              >
+                <Icon name="card-outline" size={16} color={colors.mutedText} />
+                <Text style={[styles.cardMaskValue, { color: colors.text }]} numberOfLines={1}>
+                  {mask}
+                </Text>
+                <TouchableRipple
+                  onPress={() => handleRemoveCardMask(mask)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${t('delete') || 'Delete'} ${mask}`}
+                  style={styles.cardMaskRemove}
+                >
+                  <Icon name="close" size={18} color={colors.mutedText} />
+                </TouchableRipple>
+              </View>
+            ))}
+            <View style={styles.cardMaskAddRow}>
+              <PaperTextInput
+                mode="outlined"
+                theme={paperInputTheme}
+                value={newCardMask}
+                onChangeText={handleCardMaskChange}
+                onSubmitEditing={handleAddCardMask}
+                autoCapitalize="characters"
+                autoCorrect={false}
+                placeholder="4083***7027"
+                style={[modalSharedStyles.textInput, styles.cardMaskInput]}
+              />
+              <Button
+                mode="contained-tonal"
+                onPress={handleAddCardMask}
+                disabled={!newCardMask.trim()}
+                style={styles.cardMaskAddBtn}
+              >
+                {t('add') || 'Add'}
+              </Button>
+            </View>
             <Text style={[styles.cardMaskHint, { color: colors.mutedText }]}>
               {t('card_mask_hint') || 'Used to match bank notifications to this account'}
             </Text>
@@ -1310,9 +1370,41 @@ const styles = StyleSheet.create({
     marginTop: SPACING.sm,
     overflow: 'hidden',
   },
+  cardMaskAddBtn: {
+    alignSelf: 'center',
+  },
+  cardMaskAddRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+  },
   cardMaskHint: {
     fontSize: 12,
     marginTop: 4,
+  },
+  cardMaskInput: {
+    flex: 1,
+  },
+  cardMaskRemove: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.sm,
+    justifyContent: 'center',
+    minHeight: 32,
+    minWidth: 32,
+  },
+  cardMaskRow: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    marginBottom: SPACING.xs,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.xs,
+  },
+  cardMaskValue: {
+    flex: 1,
+    fontSize: 14,
   },
   centeredBodyMedium: {
     marginBottom: SPACING.lg,

--- a/app/services/AccountsDB.js
+++ b/app/services/AccountsDB.js
@@ -3,7 +3,7 @@ import * as Currency from './currency';
 import { eq, sql, desc, asc, isNull, and } from 'drizzle-orm';
 import { accounts } from '../db/schema';
 import * as BalanceHistoryDB from './BalanceHistoryDB';
-import { cardMaskLast4 } from '../utils/cardMask';
+import { cardMaskLast4, parseCardMasks, serializeCardMasks } from '../utils/cardMask';
 
 /**
  * Get all accounts using Drizzle
@@ -85,12 +85,12 @@ export const createAccount = async (account) => {
 /**
  * Find a non-deleted account bound to the given card mask.
  *
- * Matching is by the card's last four digits, not the raw literal: the mask a
- * bank notification carries ("*5285") and the one stored on the account (a
- * user-typed "4083***5285", or one learned from a differently-decorated earlier
- * notification) rarely agree character-for-character, and the last four digits
- * are the only stable identity a bank exposes. An exact literal match is tried
- * first as a fast, index-served path before the last-4 fallback scan.
+ * An account can hold several cards (its masks live as a delimiter-joined list in
+ * `card_mask`), so every account's list is scanned. Matching prefers an exact
+ * literal within a list (fast, precise) and falls back to the card's last four
+ * digits — the only stable identity a bank exposes — so a notification's short
+ * mask ("*5285") still resolves an account storing a full one ("4083***5285").
+ * Lowest id wins if two accounts ever claim the same card.
  *
  * @param {string} cardMask - e.g. "4083***7027" or "*7027"
  * @returns {Promise<Object|null>}
@@ -98,26 +98,22 @@ export const createAccount = async (account) => {
 export const getAccountByCardMask = async (cardMask) => {
   if (!cardMask) return null;
   try {
-    const db = await getDrizzle();
-    // Fast path: an exact literal match (index-friendly, and the common case
-    // once a mask was learned from this very notification format). Single-owner
-    // is enforced on write, so at most one row matches a literal.
-    const exact = await db.select()
-      .from(accounts)
-      .where(and(eq(accounts.cardMask, cardMask), isNull(accounts.deletedAt)))
-      .limit(1);
+    const all = await getAllAccounts();
+    const withMasks = (all || []).map((a) => ({ account: a, masks: parseCardMasks(a.cardMask) }));
+
+    const exact = withMasks
+      .filter((x) => x.masks.includes(cardMask))
+      .map((x) => x.account)
+      .sort((a, b) => a.id - b.id);
     if (exact[0]) return exact[0];
 
-    // Fallback: match by last four digits so a differently-formatted stored mask
-    // ("4083***5285") still resolves a notification's short mask ("*5285"). Sort
-    // by id so the result is deterministic if two accounts ever share a last-4.
     const last4 = cardMaskLast4(cardMask);
     if (!last4) return null;
-    const all = await getAllAccounts();
-    const matches = (all || [])
-      .filter((a) => cardMaskLast4(a.cardMask) === last4)
+    const byLast4 = withMasks
+      .filter((x) => x.masks.some((m) => cardMaskLast4(m) === last4))
+      .map((x) => x.account)
       .sort((a, b) => a.id - b.id);
-    return matches[0] || null;
+    return byLast4[0] || null;
   } catch (error) {
     console.error('Failed to get account by card mask:', error);
     throw error;
@@ -125,46 +121,89 @@ export const getAccountByCardMask = async (cardMask) => {
 };
 
 /**
- * Bind a card mask to an account (used by learn-on-first-sight), enforcing that
- * a given mask belongs to at most one account: any other account currently
- * holding the same mask has it cleared in the same transaction.
+ * The list of card masks bound to an account (empty when none).
+ * @param {number} accountId
+ * @returns {Promise<string[]>}
+ */
+export const getAccountCardMasks = async (accountId) => {
+  const account = await getAccountById(accountId);
+  return account ? parseCardMasks(account.cardMask) : [];
+};
+
+/**
+ * Add a card mask to an account (learn-on-first-sight / reassign), enforcing that
+ * a given physical card belongs to at most one account: any other account
+ * holding the same card (by last-4) gives it up in the same transaction. Adding
+ * a card the account already holds is a no-op (beyond the single-owner strip).
  *
  * @param {number} accountId
  * @param {string} cardMask
  * @returns {Promise<void>}
  */
-export const setAccountCardMask = async (accountId, cardMask) => {
-  const mask = cardMask || null;
+export const addAccountCardMask = async (accountId, cardMask) => {
+  const last4 = cardMaskLast4(cardMask);
+  if (!last4) return; // nothing usable to bind
   try {
-    // Any other account holding the same card must give it up so a card has a
-    // single owner. Comparison is by last-4 (not the raw literal) to match how
-    // getAccountByCardMask resolves — otherwise a "4083***5285" on one account
-    // and a learned "*5285" on another would both claim the same card.
-    let clashingIds = [];
-    if (mask) {
-      const last4 = cardMaskLast4(mask);
-      if (last4) {
-        const all = await getAllAccounts();
-        clashingIds = (all || [])
-          .filter((a) => a.id !== accountId && cardMaskLast4(a.cardMask) === last4)
-          .map((a) => a.id);
+    const all = await getAllAccounts();
+    const target = (all || []).find((a) => a.id === accountId);
+    if (!target) return;
+
+    // { id, value } writes: strip this card from other owners, add it to target.
+    const updates = [];
+    for (const other of all) {
+      if (other.id === accountId) continue;
+      const masks = parseCardMasks(other.cardMask);
+      const kept = masks.filter((m) => cardMaskLast4(m) !== last4);
+      if (kept.length !== masks.length) {
+        updates.push({ id: other.id, value: serializeCardMasks(kept) });
       }
     }
+    const targetMasks = parseCardMasks(target.cardMask);
+    if (!targetMasks.some((m) => cardMaskLast4(m) === last4)) {
+      updates.push({ id: accountId, value: serializeCardMasks([...targetMasks, cardMask]) });
+    }
+
+    if (updates.length === 0) return;
+
     await executeTransaction(async (db) => {
       const now = new Date().toISOString();
-      for (const id of clashingIds) {
+      for (const u of updates) {
         await db.runAsync(
-          'UPDATE accounts SET card_mask = NULL, updated_at = ? WHERE id = ?',
-          [now, id],
+          'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
+          [u.value, now, u.id],
         );
       }
+    });
+  } catch (error) {
+    console.error('Failed to add account card mask:', error);
+    throw error;
+  }
+};
+
+/**
+ * Remove a single card mask from an account (by last-4), leaving its other cards
+ * intact. A no-op when the account doesn't hold that card.
+ *
+ * @param {number} accountId
+ * @param {string} cardMask
+ * @returns {Promise<void>}
+ */
+export const removeAccountCardMask = async (accountId, cardMask) => {
+  const last4 = cardMaskLast4(cardMask);
+  try {
+    const account = await getAccountById(accountId);
+    if (!account) return;
+    const masks = parseCardMasks(account.cardMask);
+    const kept = masks.filter((m) => (last4 ? cardMaskLast4(m) !== last4 : m !== cardMask));
+    if (kept.length === masks.length) return; // nothing removed
+    await executeTransaction(async (db) => {
       await db.runAsync(
         'UPDATE accounts SET card_mask = ?, updated_at = ? WHERE id = ?',
-        [mask, now, accountId],
+        [serializeCardMasks(kept), new Date().toISOString(), accountId],
       );
     });
   } catch (error) {
-    console.error('Failed to set account card mask:', error);
+    console.error('Failed to remove account card mask:', error);
     throw error;
   }
 };

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -659,7 +659,7 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
   // Learn the card -> account binding (default on when a card mask is present).
   if (choices.learnCardMask !== false && pending.cardMask && accountId != null) {
     try {
-      await AccountsDB.setAccountCardMask(accountId, pending.cardMask);
+      await AccountsDB.addAccountCardMask(accountId, pending.cardMask);
     } catch (error) {
       console.error('[resolvePendingNotification] Failed to learn card mask:', error);
     }
@@ -778,7 +778,7 @@ const resolvePendingTransfer = async (pending, choices = {}) => {
   // Learn the card -> source-account binding (default on when a card is present).
   if (choices.learnCardMask !== false && pending.cardMask && accountId != null) {
     try {
-      await AccountsDB.setAccountCardMask(accountId, pending.cardMask);
+      await AccountsDB.addAccountCardMask(accountId, pending.cardMask);
     } catch (error) {
       console.error('[resolvePendingNotification] Failed to learn card mask:', error);
     }

--- a/app/utils/cardMask.js
+++ b/app/utils/cardMask.js
@@ -8,7 +8,17 @@
  * into the account editor uses the full "4083***5285". Matching on the raw
  * literal makes those miss each other, so a card's identity is defined here by
  * its trailing four digits alone.
+ *
+ * An account can be bound to several cards, so its masks are stored as a single
+ * delimiter-joined string in `accounts.card_mask` (the same one-column-list
+ * convention labelUtils uses for operation labels). `parseCardMasks` /
+ * `serializeCardMasks` convert between that stored form and a plain array; a
+ * legacy single mask parses as a one-element list, so old rows keep working.
  */
+
+// Separates masks within the `accounts.card_mask` column. A card mask never
+// contains a pipe, so it can never collide with a real value.
+export const CARD_MASK_DELIMITER = '|';
 
 /**
  * The last four digits of a card mask, or null when fewer than four digits are
@@ -35,4 +45,49 @@ export const cardMaskLast4 = (mask) => {
 export const cardMasksMatch = (a, b) => {
   const la = cardMaskLast4(a);
   return la != null && la === cardMaskLast4(b);
+};
+
+/** Trim a single mask and strip any delimiter char so it can't split a list. */
+const sanitizeMask = (raw) =>
+  (raw == null ? '' : String(raw)).split(CARD_MASK_DELIMITER).join('').trim();
+
+/**
+ * Split the stored `accounts.card_mask` value into individual masks. A legacy
+ * single mask (no delimiter) yields a one-element list; null/empty yields [].
+ *
+ * @param {string|null|undefined} stored
+ * @returns {string[]}
+ */
+export const parseCardMasks = (stored) => {
+  if (!stored) return [];
+  return String(stored)
+    .split(CARD_MASK_DELIMITER)
+    .map((m) => m.trim())
+    .filter(Boolean);
+};
+
+/**
+ * Join a list of masks into the stored column form, dropping blanks and
+ * de-duplicating by last-4 (a card only needs one entry regardless of the
+ * format each notification decorated it with). Returns null for an empty result
+ * so the column clears rather than storing an empty string.
+ *
+ * @param {Array<string|null|undefined>} masks
+ * @returns {string|null}
+ */
+export const serializeCardMasks = (masks) => {
+  if (!Array.isArray(masks)) return null;
+  const seen = new Set();
+  const out = [];
+  for (const raw of masks) {
+    const mask = sanitizeMask(raw);
+    if (!mask) continue;
+    // Dedupe by last-4 when available; fall back to the literal so an odd,
+    // digit-poor entry isn't silently swallowed.
+    const key = cardMaskLast4(mask) || `lit:${mask}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(mask);
+  }
+  return out.length ? out.join(CARD_MASK_DELIMITER) : null;
 };


### PR DESCRIPTION
Follow-up to #1197: an account can now be bound to **multiple cards**, not just one.

### Storage
Masks are kept as a `|`-delimited list in the existing `accounts.card_mask` column — the same one-column-list convention `labelUtils` already uses for operation labels. So there's **no migration and no backup-format change**, and a legacy single mask parses as a one-element list (fully backward compatible).

### Logic
- `utils/cardMask`: new `parseCardMasks` / `serializeCardMasks` (dedupe by last-4, strip stray delimiters).
- `AccountsDB.getAccountByCardMask` scans every account's list and matches by exact literal, then by last-4.
- `setAccountCardMask` → `addAccountCardMask` (append + single-owner strip by last-4). New `removeAccountCardMask` and `getAccountCardMasks`.
- The learn-on-resolve path now **adds** a card instead of overwriting, so an account accumulates its cards as notifications arrive.

### UI
- **Account editor**: card masks are managed as a list — an add field plus a per-card remove button.
- **Settings → Notification bindings**: one row per card; reassigning or removing acts on that individual card, leaving the account's other cards intact.

### Tests
New/updated coverage for the util (parse/serialize round-trip, dedupe), `AccountsDB` (multi-mask match, add with single-owner strip, remove one of many, `getAccountCardMasks`), the bindings panel (per-card rows + per-card remove), and the learning path (`addAccountCardMask`). Full suite green (152 suites / 4388 tests) with `--coverage`, ESLint clean.

_Not verified on a device (needs a build with the native notification module); confidence rests on the test suite._
