### PR TITLE
fix(operations): match transfer account row gap to category rows

### DIFF
--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -962,7 +962,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
   accountRows: {
-    gap: SPACING.sm,
+    gap: SPACING.xs,
   },
   accountShortcutBalance: {
     fontSize: 10,


### PR DESCRIPTION
## Проблема

На главном экране в quick-add форме при выборе типа «перевод» расстояние между строками предложенных аккаунтов отличалось от расстояния между строками предложенных категорий у расхода/дохода.

## Причина

Строки категорий рендерятся внутри контейнера `categoryRows` с `gap: SPACING.xs` (4px), а строки аккаунтов — внутри `accountRows` с `gap: SPACING.sm` (8px).

## Фикс

`accountRows.gap` → `SPACING.xs`, чтобы совпадало с сеткой категорий. Ширина и высота чипов уже одинаковые — теперь и вертикальный зазор.
