### PR TITLE
feat(graphs): operations list for leaf categories in pie charts

### DIFF
--- a/__tests__/components/graphs/CategoryOperationsList.test.js
+++ b/__tests__/components/graphs/CategoryOperationsList.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import CategoryOperationsList from '../../../app/components/graphs/CategoryOperationsList';
+import { useDisplaySettings } from '../../../app/contexts/DisplaySettingsContext';
+
+jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
+}));
+
+jest.mock('../../../assets/currencies.json', () => ({
+  USD: { decimal_digits: 2, symbol: '$' },
+  JPY: { decimal_digits: 0, symbol: '¥' },
+}));
+
+const colors = { text: '#000000', mutedText: '#888888', border: '#dddddd', primary: '#0000ff' };
+
+describe('CategoryOperationsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDisplaySettings.mockReturnValue({ hideBalances: false });
+  });
+
+  it('renders a spinner while loading', async () => {
+    const { getByTestId } = await render(
+      <CategoryOperationsList operations={[]} loading currency="USD" colors={colors} language="en" />,
+    );
+    expect(getByTestId('category-operations-loading')).toBeTruthy();
+  });
+
+  it('renders the empty text when there are no operations', async () => {
+    const { getByText } = await render(
+      <CategoryOperationsList operations={[]} currency="USD" colors={colors} language="en" emptyText="nothing here" />,
+    );
+    expect(getByText('nothing here')).toBeTruthy();
+  });
+
+  it('shows the label as primary text and the date as secondary text', async () => {
+    const ops = [{ id: '1', amount: '12.50', date: '2024-03-05', description: 'Coffee' }];
+    const { getByText } = await render(
+      <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+    );
+    expect(getByText('Coffee')).toBeTruthy();
+    expect(getByText('March 5')).toBeTruthy();
+    expect(getByText('$12.50')).toBeTruthy();
+  });
+
+  it('formats the date in the genitive month form for Russian', async () => {
+    const ops = [{ id: '1', amount: '12.50', date: '2024-07-05', description: 'Кофе' }];
+    const { getByText } = await render(
+      <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="ru" />,
+    );
+    // Genitive "июля", not the standalone nominative "Июль".
+    expect(getByText('5 июля')).toBeTruthy();
+  });
+
+  it('falls back to the date as primary text when the operation has no label', async () => {
+    const ops = [{ id: '2', amount: '100', date: '2024-03-05', description: '' }];
+    const { getByText } = await render(
+      <CategoryOperationsList operations={ops} currency="JPY" colors={colors} language="en" />,
+    );
+    expect(getByText('March 5')).toBeTruthy();
+    expect(getByText('¥100')).toBeTruthy();
+  });
+
+  it('masks amounts when hideBalances is true', async () => {
+    useDisplaySettings.mockReturnValue({ hideBalances: true });
+    const ops = [{ id: '3', amount: '12.50', date: '2024-03-05', description: 'Coffee' }];
+    const { getByText, queryByText } = await render(
+      <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+    );
+    expect(getByText('••••')).toBeTruthy();
+    expect(queryByText('$12.50')).toBeNull();
+  });
+
+  it('renders every operation in the list', async () => {
+    const ops = [
+      { id: '1', amount: '10.00', date: '2024-03-05', description: 'A' },
+      { id: '2', amount: '20.00', date: '2024-03-06', description: 'B' },
+      { id: '3', amount: '30.00', date: '2024-03-07', description: 'C' },
+    ];
+    const { getByText } = await render(
+      <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+    );
+    expect(getByText('A')).toBeTruthy();
+    expect(getByText('B')).toBeTruthy();
+    expect(getByText('C')).toBeTruthy();
+  });
+});

--- a/__tests__/components/graphs/CustomLegend.test.js
+++ b/__tests__/components/graphs/CustomLegend.test.js
@@ -78,7 +78,7 @@ describe('CustomLegend', () => {
       const singleItem = [{ name: 'Single', amount: 100, color: '#000', categoryId: 'cat-1' }];
       const { getByText } = await render(<CustomLegend {...defaultProps} data={singleItem} />);
       expect(getByText('Single')).toBeTruthy();
-      expect(getByText('100.0%')).toBeTruthy();
+      expect(getByText('100%')).toBeTruthy();
     });
 
     it('renders color indicators for each item', async () => {
@@ -121,15 +121,15 @@ describe('CustomLegend', () => {
   describe('Percentage Calculations', () => {
     it('calculates correct percentages', async () => {
       const { getByText } = await render(<CustomLegend {...defaultProps} />);
-      // Total is 150, Food is 100 (66.7%), Transport is 50 (33.3%)
-      expect(getByText('66.7%')).toBeTruthy();
-      expect(getByText('33.3%')).toBeTruthy();
+      // Total is 150, Food is 100 (67%), Transport is 50 (33%)
+      expect(getByText('67%')).toBeTruthy();
+      expect(getByText('33%')).toBeTruthy();
     });
 
     it('shows 100% for single item', async () => {
       const singleItem = [{ name: 'Only', amount: 50, color: '#000', categoryId: 'cat-1' }];
       const { getByText } = await render(<CustomLegend {...defaultProps} data={singleItem} />);
-      expect(getByText('100.0%')).toBeTruthy();
+      expect(getByText('100%')).toBeTruthy();
     });
 
     it('handles zero total gracefully', async () => {
@@ -151,7 +151,7 @@ describe('CustomLegend', () => {
       ];
       const { getAllByText } = await render(<CustomLegend {...defaultProps} data={manyItems} />);
       // Each item should be 25% of 100 total
-      expect(getAllByText('25.0%').length).toBe(4);
+      expect(getAllByText('25%').length).toBe(4);
     });
   });
 
@@ -210,17 +210,20 @@ describe('CustomLegend', () => {
       expect(queryByTestId('icon-chevron-right')).toBeNull();
     });
 
-    it('does not show chevron for leaf categories (hasChildren is false)', async () => {
+    it('shows a list icon (not a chevron) for leaf categories (hasChildren is false)', async () => {
       const leafData = [
         { name: 'Leaf', amount: 100, color: '#000', categoryId: 'cat-leaf', hasChildren: false },
       ];
       const { queryByTestId } = await render(
         <CustomLegend {...defaultProps} data={leafData} isClickable={true} />,
       );
+      // A leaf drills into its operations list, not another chart — so it gets a
+      // list glyph rather than the parent's chevron.
       expect(queryByTestId('icon-chevron-right')).toBeNull();
+      expect(queryByTestId('icon-format-list-bulleted')).toBeTruthy();
     });
 
-    it('leaf category is not clickable even when isClickable is true', async () => {
+    it('leaf category is clickable to open its operations', async () => {
       const onItemPress = jest.fn();
       const leafData = [
         { name: 'Leaf', amount: 100, color: '#000', categoryId: 'cat-leaf', hasChildren: false },
@@ -229,7 +232,7 @@ describe('CustomLegend', () => {
         <CustomLegend {...defaultProps} data={leafData} isClickable={true} onItemPress={onItemPress} />,
       );
       await fireEvent.press(getByText('Leaf'));
-      expect(onItemPress).not.toHaveBeenCalled();
+      expect(onItemPress).toHaveBeenCalledWith('cat-leaf');
     });
 
     it('item without categoryId is not clickable even when isClickable is true', async () => {
@@ -321,8 +324,8 @@ describe('CustomLegend', () => {
 
     it('still shows the percentage', async () => {
       const { getByText } = await render(<CustomLegend {...defaultProps} />);
-      expect(getByText('66.7%')).toBeTruthy();
-      expect(getByText('33.3%')).toBeTruthy();
+      expect(getByText('67%')).toBeTruthy();
+      expect(getByText('33%')).toBeTruthy();
     });
   });
 
@@ -331,7 +334,7 @@ describe('CustomLegend', () => {
       const smallData = [{ name: 'Tiny', amount: 0.01, color: '#000', categoryId: 'cat-1' }];
       const { getByText } = await render(<CustomLegend {...defaultProps} data={smallData} />);
       expect(getByText('$0.01')).toBeTruthy();
-      expect(getByText('100.0%')).toBeTruthy();
+      expect(getByText('100%')).toBeTruthy();
     });
 
     it('handles very large amounts (millions)', async () => {
@@ -361,8 +364,8 @@ describe('CustomLegend', () => {
         { name: 'B', amount: 66.67, color: '#2', categoryId: 'b' },
       ];
       const { getByText } = await render(<CustomLegend {...defaultProps} data={decimalData} />);
-      expect(getByText('33.3%')).toBeTruthy();
-      expect(getByText('66.7%')).toBeTruthy();
+      expect(getByText('33%')).toBeTruthy();
+      expect(getByText('67%')).toBeTruthy();
     });
   });
 });

--- a/__tests__/components/graphs/ExpensePieChart.test.js
+++ b/__tests__/components/graphs/ExpensePieChart.test.js
@@ -74,4 +74,35 @@ describe('ExpensePieChart', () => {
     const { queryAllByTestId } = await render(<ExpensePieChart {...defaultProps} />);
     expect(queryAllByTestId('icon-dots-horizontal').length).toBe(0);
   });
+
+  describe('leaf category (operations list)', () => {
+    const operations = [
+      { id: '1', amount: '12.50', date: '2024-01-15', description: 'Coffee', type: 'expense' },
+    ];
+
+    it('renders the operations list instead of the donut', async () => {
+      const { getByText, queryByTestId } = await render(
+        <ExpensePieChart {...defaultProps} isLeafCategory={true} operations={operations} />,
+      );
+      expect(queryByTestId('donut-chart')).toBeNull();
+      expect(getByText('Coffee')).toBeTruthy();
+      expect(getByText('$12.50')).toBeTruthy();
+    });
+
+    it('shows the empty state when the leaf has no operations', async () => {
+      const { getByText, queryByTestId } = await render(
+        <ExpensePieChart {...defaultProps} isLeafCategory={true} operations={[]} />,
+      );
+      expect(queryByTestId('donut-chart')).toBeNull();
+      expect(getByText('no_expense_data')).toBeTruthy();
+    });
+
+    it('shows a spinner while the leaf operations load', async () => {
+      const { getByTestId, queryByTestId } = await render(
+        <ExpensePieChart {...defaultProps} isLeafCategory={true} loadingOperations={true} operations={[]} />,
+      );
+      expect(queryByTestId('donut-chart')).toBeNull();
+      expect(getByTestId('category-operations-loading')).toBeTruthy();
+    });
+  });
 });

--- a/__tests__/components/graphs/IncomePieChart.test.js
+++ b/__tests__/components/graphs/IncomePieChart.test.js
@@ -74,4 +74,27 @@ describe('IncomePieChart', () => {
     const { queryAllByTestId } = await render(<IncomePieChart {...defaultProps} />);
     expect(queryAllByTestId('icon-dots-horizontal').length).toBe(0);
   });
+
+  describe('leaf category (operations list)', () => {
+    const operations = [
+      { id: '1', amount: '3000.00', date: '2024-01-15', description: 'Payday', type: 'income' },
+    ];
+
+    it('renders the operations list instead of the donut', async () => {
+      const { getByText, queryByTestId } = await render(
+        <IncomePieChart {...defaultProps} isLeafCategory={true} operations={operations} />,
+      );
+      expect(queryByTestId('donut-chart')).toBeNull();
+      expect(getByText('Payday')).toBeTruthy();
+      expect(getByText('$3000.00')).toBeTruthy();
+    });
+
+    it('shows the empty state when the leaf has no operations', async () => {
+      const { getByText, queryByTestId } = await render(
+        <IncomePieChart {...defaultProps} isLeafCategory={true} operations={[]} />,
+      );
+      expect(queryByTestId('donut-chart')).toBeNull();
+      expect(getByText('no_income_data')).toBeTruthy();
+    });
+  });
 });

--- a/__tests__/hooks/useCategoryOperations.test.js
+++ b/__tests__/hooks/useCategoryOperations.test.js
@@ -1,0 +1,133 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import useCategoryOperations from '../../app/hooks/useCategoryOperations';
+import * as OperationsDB from '../../app/services/OperationsDB';
+
+jest.mock('../../app/services/OperationsDB', () => ({
+  getOperationsByCategoryAndCurrency: jest.fn(),
+}));
+
+jest.mock('../../app/services/BalanceHistoryDB', () => ({
+  formatDate: jest.fn((date) => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }),
+}));
+
+let capturedOperationChangedCallback = null;
+jest.mock('../../app/services/eventEmitter', () => ({
+  appEvents: {
+    on: jest.fn((event, cb) => {
+      if (event === 'OPERATION_CHANGED') {
+        capturedOperationChangedCallback = cb;
+      }
+      return jest.fn(); // unsubscribe no-op
+    }),
+  },
+  EVENTS: {
+    OPERATION_CHANGED: 'OPERATION_CHANGED',
+  },
+}));
+
+describe('useCategoryOperations', () => {
+  const year = 2024;
+  const month = 0; // January
+  const currency = 'USD';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOperationChangedCallback = null;
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  it('stays idle and does not query when no leaf category is selected', async () => {
+    const { result } = await renderHook(() =>
+      useCategoryOperations(year, month, currency, null, 'expense'),
+    );
+
+    await waitFor(() => expect(result.current.loadingOperations).toBe(false));
+    expect(OperationsDB.getOperationsByCategoryAndCurrency).not.toHaveBeenCalled();
+    expect(result.current.operations).toEqual([]);
+  });
+
+  it('does not query when currency is missing', async () => {
+    const { result } = await renderHook(() =>
+      useCategoryOperations(year, month, '', 'cat-1', 'expense'),
+    );
+
+    await waitFor(() => expect(result.current.loadingOperations).toBe(false));
+    expect(OperationsDB.getOperationsByCategoryAndCurrency).not.toHaveBeenCalled();
+  });
+
+  it('loads operations for a single month with the correct bounds', async () => {
+    const ops = [{ id: '1', amount: '10', date: '2024-01-05' }];
+    OperationsDB.getOperationsByCategoryAndCurrency.mockResolvedValue(ops);
+
+    const { result } = await renderHook(() =>
+      useCategoryOperations(year, month, currency, 'cat-1', 'expense'),
+    );
+
+    await waitFor(() => expect(result.current.operations).toEqual(ops));
+    expect(OperationsDB.getOperationsByCategoryAndCurrency).toHaveBeenCalledWith(
+      'cat-1',
+      'USD',
+      '2024-01-01',
+      '2024-01-31',
+      'expense',
+    );
+  });
+
+  it('uses full-year bounds when month is null', async () => {
+    OperationsDB.getOperationsByCategoryAndCurrency.mockResolvedValue([]);
+
+    const { result } = await renderHook(() =>
+      useCategoryOperations(year, null, currency, 'cat-1', 'income'),
+    );
+
+    await waitFor(() => expect(result.current.loadingOperations).toBe(false));
+    expect(OperationsDB.getOperationsByCategoryAndCurrency).toHaveBeenCalledWith(
+      'cat-1',
+      'USD',
+      '2024-01-01',
+      '2024-12-31',
+      'income',
+    );
+  });
+
+  it('reloads when OPERATION_CHANGED fires', async () => {
+    OperationsDB.getOperationsByCategoryAndCurrency
+      .mockResolvedValueOnce([{ id: '1', amount: '10', date: '2024-01-05' }])
+      .mockResolvedValueOnce([{ id: '2', amount: '20', date: '2024-01-06' }]);
+
+    const { result } = await renderHook(() =>
+      useCategoryOperations(year, month, currency, 'cat-1', 'expense'),
+    );
+
+    await waitFor(() => expect(result.current.operations.length).toBe(1));
+    expect(capturedOperationChangedCallback).not.toBeNull();
+
+    await act(async () => {
+      await capturedOperationChangedCallback();
+    });
+
+    await waitFor(() => expect(result.current.operations[0].id).toBe('2'));
+    expect(OperationsDB.getOperationsByCategoryAndCurrency).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles errors gracefully', async () => {
+    OperationsDB.getOperationsByCategoryAndCurrency.mockRejectedValue(new Error('boom'));
+
+    const { result } = await renderHook(() =>
+      useCategoryOperations(year, month, currency, 'cat-1', 'expense'),
+    );
+
+    await waitFor(() => expect(result.current.loadingOperations).toBe(false));
+    expect(result.current.operations).toEqual([]);
+    expect(console.error).toHaveBeenCalledWith('Failed to load category operations:', expect.any(Error));
+  });
+});

--- a/app/components/graphs/CategoryOperationsList.js
+++ b/app/components/graphs/CategoryOperationsList.js
@@ -1,0 +1,154 @@
+import React from 'react';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import PropTypes from 'prop-types';
+import currencies from '../../../assets/currencies.json';
+import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+
+const formatOpAmount = (amount, currency) => {
+  const info = currencies[currency];
+  const symbol = info?.symbol ?? currency;
+  const decimals = info?.decimal_digits ?? 2;
+  return `${symbol}${parseFloat(amount).toFixed(decimals)}`;
+};
+
+// Format "day month" in the app's language. Formatting day + month together lets
+// ICU pick the *genitive* month form used in dates ("5 июля", not the standalone
+// "Июль") and yields locale-correct ordering/spelling for every language. The
+// T00:00:00 suffix pins the bare YYYY-MM-DD to local midnight so it never slips
+// a day west of Greenwich.
+const formatOpDate = (dateStr, language) => {
+  if (typeof dateStr !== 'string') return '';
+  const date = new Date(`${dateStr}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return dateStr;
+  try {
+    return date.toLocaleDateString(language || undefined, { day: 'numeric', month: 'long' });
+  } catch {
+    return date.toLocaleDateString(undefined, { day: 'numeric', month: 'long' });
+  }
+};
+
+/**
+ * Flat, read-only list of a single category's operations, shown in place of the
+ * donut once the pie-chart drill-down reaches a leaf category. Renders plain
+ * Views (no inner ScrollView) so the parent chart ScrollView measures and
+ * animates its height.
+ */
+const CategoryOperationsList = ({ operations, loading, currency, colors, language, emptyText }) => {
+  const { hideBalances } = useDisplaySettings();
+
+  if (loading) {
+    return (
+      <View testID="category-operations-loading" style={styles.centerBox}>
+        <ActivityIndicator size="small" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (!operations || operations.length === 0) {
+    return (
+      <Text style={[styles.empty, { color: colors.mutedText }]}>{emptyText}</Text>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {operations.map((op, index) => {
+        const labels = visibleListLabels(parseLabels(op.description));
+        const dateText = formatOpDate(op.date, language);
+        const primary = labels.length ? labels.map(displayLabel).join(', ') : dateText;
+        const secondary = labels.length ? dateText : null;
+        const isLast = index === operations.length - 1;
+
+        return (
+          <View
+            key={op.id}
+            style={[
+              styles.row,
+              !isLast && { borderBottomColor: colors.border, borderBottomWidth: StyleSheet.hairlineWidth },
+            ]}
+          >
+            <View style={styles.textCol}>
+              <Text style={[styles.primary, { color: colors.text }]} numberOfLines={1}>
+                {primary}
+              </Text>
+              {secondary ? (
+                <Text style={[styles.secondary, { color: colors.mutedText }]} numberOfLines={1}>
+                  {secondary}
+                </Text>
+              ) : null}
+            </View>
+            <Text style={[styles.amount, { color: colors.text }]} numberOfLines={1}>
+              {hideBalances ? '••••' : formatOpAmount(op.amount, currency)}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+};
+
+CategoryOperationsList.propTypes = {
+  operations: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      date: PropTypes.string,
+      description: PropTypes.string,
+    }),
+  ),
+  loading: PropTypes.bool,
+  currency: PropTypes.string.isRequired,
+  colors: PropTypes.object.isRequired,
+  language: PropTypes.string,
+  emptyText: PropTypes.string,
+};
+
+CategoryOperationsList.defaultProps = {
+  operations: [],
+  loading: false,
+  language: undefined,
+  emptyText: '',
+};
+
+const styles = StyleSheet.create({
+  amount: {
+    fontSize: 13,
+    fontWeight: '600',
+    marginLeft: 10,
+  },
+  centerBox: {
+    alignItems: 'center',
+    paddingVertical: 32,
+  },
+  container: {
+    flex: 1,
+    marginTop: 4,
+  },
+  empty: {
+    fontSize: 14,
+    paddingVertical: 32,
+    textAlign: 'center',
+  },
+  primary: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  row: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 2,
+    paddingVertical: 10,
+  },
+  secondary: {
+    fontSize: 11,
+    marginTop: 2,
+  },
+  textCol: {
+    flex: 1,
+    minWidth: 0,
+  },
+});
+
+export default CategoryOperationsList;

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -29,15 +29,21 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
   return (
     <View style={styles.legendContainer}>
       {data.map((item, index) => {
-        const percentage = total > 0 ? ((item.amount / total) * 100).toFixed(1) : 0;
-        const isExpandable = isClickable && item.categoryId && item.hasChildren;
-        const ItemWrapper = isExpandable ? TouchableOpacity : View;
-        const wrapperProps = isExpandable ? {
+        // Whole-number percentages — "100.0%" overflowed the fixed column, and a
+        // single decimal adds no real signal to a legend.
+        const percentage = total > 0 ? Math.round((item.amount / total) * 100) : 0;
+        // Every category row is pressable: a parent drills into its children,
+        // a leaf opens the list of that category's operations for the period.
+        const isPressable = isClickable && !!item.categoryId;
+        const ItemWrapper = isPressable ? TouchableOpacity : View;
+        const wrapperProps = isPressable ? {
           onPress: () => onItemPress(item.categoryId),
           activeOpacity: 0.7,
           accessibilityRole: 'button',
           accessibilityLabel: `View details for ${item.name}`,
-          accessibilityHint: 'Double tap to filter by this category',
+          accessibilityHint: item.hasChildren
+            ? 'Double tap to filter by this category'
+            : 'Double tap to view operations',
         } : {};
 
         return (
@@ -46,7 +52,7 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
             style={[
               styles.legendItem,
               { borderBottomColor: colors.border },
-              isExpandable && styles.legendItemClickable,
+              isPressable && styles.legendItemClickable,
             ]}
             {...wrapperProps}
           >
@@ -56,9 +62,9 @@ const CustomLegend = ({ data, currency, colors, onItemPress, isClickable }) => {
               <Text style={[styles.legendName, { color: colors.text }]} numberOfLines={1}>
                 {item.name}
               </Text>
-              {isExpandable && (
+              {isPressable && (
                 <Icon
-                  name="chevron-right"
+                  name={item.hasChildren ? 'chevron-right' : 'format-list-bulleted'}
                   size={16}
                   color={colors.mutedText}
                   style={styles.legendChevron}

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -3,16 +3,35 @@ import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
 import DonutChart from './DonutChart';
 import CustomLegend from './CustomLegend';
+import CategoryOperationsList from './CategoryOperationsList';
 
 const ExpensePieChart = ({
   colors,
   t,
+  language,
   loading,
   chartData,
   selectedCurrency,
   onLegendItemPress,
-  selectedCategory,
+  isLeafCategory,
+  operations,
+  loadingOperations,
 }) => {
+  // A leaf category has no sub-categories left to break down — show its actual
+  // operations for the period instead of a pointless single-slice donut.
+  if (isLeafCategory) {
+    return (
+      <CategoryOperationsList
+        operations={operations}
+        loading={loadingOperations}
+        currency={selectedCurrency}
+        colors={colors}
+        language={language}
+        emptyText={t('no_expense_data')}
+      />
+    );
+  }
+
   if (loading) {
     return (
       <View style={styles.loadingContainer}>
@@ -41,7 +60,7 @@ const ExpensePieChart = ({
           currency={selectedCurrency}
           colors={colors}
           onItemPress={onLegendItemPress}
-          isClickable={selectedCategory === 'all'}
+          isClickable
         />
       </View>
     </View>
@@ -51,11 +70,21 @@ const ExpensePieChart = ({
 ExpensePieChart.propTypes = {
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
+  language: PropTypes.string,
   loading: PropTypes.bool.isRequired,
   chartData: PropTypes.array.isRequired,
   selectedCurrency: PropTypes.string.isRequired,
   onLegendItemPress: PropTypes.func.isRequired,
-  selectedCategory: PropTypes.string.isRequired,
+  isLeafCategory: PropTypes.bool,
+  operations: PropTypes.array,
+  loadingOperations: PropTypes.bool,
+};
+
+ExpensePieChart.defaultProps = {
+  language: undefined,
+  isLeafCategory: false,
+  operations: [],
+  loadingOperations: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -3,16 +3,35 @@ import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
 import DonutChart from './DonutChart';
 import CustomLegend from './CustomLegend';
+import CategoryOperationsList from './CategoryOperationsList';
 
 const IncomePieChart = ({
   colors,
   t,
+  language,
   loadingIncome,
   incomeChartData,
   selectedCurrency,
   onLegendItemPress,
-  selectedIncomeCategory,
+  isLeafCategory,
+  operations,
+  loadingOperations,
 }) => {
+  // A leaf category has no sub-categories left to break down — show its actual
+  // operations for the period instead of a pointless single-slice donut.
+  if (isLeafCategory) {
+    return (
+      <CategoryOperationsList
+        operations={operations}
+        loading={loadingOperations}
+        currency={selectedCurrency}
+        colors={colors}
+        language={language}
+        emptyText={t('no_income_data')}
+      />
+    );
+  }
+
   if (loadingIncome) {
     return (
       <View style={styles.loadingContainer}>
@@ -41,7 +60,7 @@ const IncomePieChart = ({
           currency={selectedCurrency}
           colors={colors}
           onItemPress={onLegendItemPress}
-          isClickable={selectedIncomeCategory === 'all'}
+          isClickable
         />
       </View>
     </View>
@@ -51,11 +70,21 @@ const IncomePieChart = ({
 IncomePieChart.propTypes = {
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
+  language: PropTypes.string,
   loadingIncome: PropTypes.bool.isRequired,
   incomeChartData: PropTypes.array.isRequired,
   selectedCurrency: PropTypes.string.isRequired,
   onLegendItemPress: PropTypes.func.isRequired,
-  selectedIncomeCategory: PropTypes.string.isRequired,
+  isLeafCategory: PropTypes.bool,
+  operations: PropTypes.array,
+  loadingOperations: PropTypes.bool,
+};
+
+IncomePieChart.defaultProps = {
+  language: undefined,
+  isLeafCategory: false,
+  operations: [],
+  loadingOperations: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/hooks/useCategoryOperations.js
+++ b/app/hooks/useCategoryOperations.js
@@ -1,0 +1,74 @@
+import { useState, useCallback, useEffect } from 'react';
+import { getOperationsByCategoryAndCurrency } from '../services/OperationsDB';
+import { formatDate } from '../services/BalanceHistoryDB';
+import { appEvents, EVENTS } from '../services/eventEmitter';
+
+/**
+ * Load the individual operations of a single (leaf) category for the Graphs
+ * pie-chart drill-down. When `categoryId` is null (no leaf selected) the hook
+ * stays idle and returns an empty list without querying the DB. Reloads on
+ * period / currency / category change and on OPERATION_CHANGED.
+ *
+ * @param {number} selectedYear
+ * @param {number|null} selectedMonth - null means full-year
+ * @param {string} selectedCurrency
+ * @param {string|null} categoryId - leaf category id, or null when inactive
+ * @param {string} [type] - 'expense' | 'income'
+ */
+const useCategoryOperations = (selectedYear, selectedMonth, selectedCurrency, categoryId, type) => {
+  const [operations, setOperations] = useState([]);
+  const [loadingOperations, setLoadingOperations] = useState(false);
+
+  const loadOperations = useCallback(async () => {
+    if (!selectedCurrency || !categoryId) {
+      setOperations([]);
+      return;
+    }
+
+    try {
+      setLoadingOperations(true);
+
+      let startDate, endDate;
+      if (selectedMonth === null) {
+        startDate = new Date(selectedYear, 0, 1);
+        endDate = new Date(selectedYear, 11, 31, 23, 59, 59);
+      } else {
+        startDate = new Date(selectedYear, selectedMonth, 1);
+        endDate = new Date(selectedYear, selectedMonth + 1, 0, 23, 59, 59);
+      }
+
+      const ops = await getOperationsByCategoryAndCurrency(
+        categoryId,
+        selectedCurrency,
+        formatDate(startDate),
+        formatDate(endDate),
+        type,
+      );
+
+      setOperations(ops);
+    } catch (error) {
+      console.error('Failed to load category operations:', error);
+      setOperations([]);
+    } finally {
+      setLoadingOperations(false);
+    }
+  }, [selectedYear, selectedMonth, selectedCurrency, categoryId, type]);
+
+  useEffect(() => {
+    loadOperations();
+  }, [loadOperations]);
+
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.OPERATION_CHANGED, () => {
+      loadOperations();
+    });
+    return unsubscribe;
+  }, [loadOperations]);
+
+  return {
+    operations,
+    loadingOperations,
+  };
+};
+
+export default useCategoryOperations;

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -20,6 +20,7 @@ import IncomePieChart from '../components/graphs/IncomePieChart';
 import ExpensePieChart from '../components/graphs/ExpensePieChart';
 import useExpenseData from '../hooks/useExpenseData';
 import useIncomeData from '../hooks/useIncomeData';
+import useCategoryOperations from '../hooks/useCategoryOperations';
 import useBalanceHistory from '../hooks/useBalanceHistory';
 
 const CARD_HEADER_HEIGHT = 56;
@@ -28,7 +29,7 @@ const CARD_GAP = 8;
 
 const GraphsScreen = () => {
   const { colors } = useThemeColors();
-  const { t } = useLocalization();
+  const { t, language } = useLocalization();
   const { accounts } = useAccountsData();
 
   const { width: windowWidth } = useWindowDimensions();
@@ -419,6 +420,40 @@ const GraphsScreen = () => {
     return cat ? cat.name : null;
   }, [selectedIncomeCategory, categories]);
 
+  // A selected category with no sub-categories is a "leaf": the drill-down has
+  // bottomed out, so the pie chart shows its operations instead of a breakdown.
+  const expenseCategoryIsLeaf = useMemo(() => {
+    if (selectedCategory === 'all') return false;
+    return !categories.some(c => c.parentId === selectedCategory);
+  }, [selectedCategory, categories]);
+
+  const incomeCategoryIsLeaf = useMemo(() => {
+    if (selectedIncomeCategory === 'all') return false;
+    return !categories.some(c => c.parentId === selectedIncomeCategory);
+  }, [selectedIncomeCategory, categories]);
+
+  const {
+    operations: expenseOperations,
+    loadingOperations: loadingExpenseOperations,
+  } = useCategoryOperations(
+    selectedYear,
+    selectedMonth,
+    selectedCurrency,
+    expenseCategoryIsLeaf ? selectedCategory : null,
+    'expense',
+  );
+
+  const {
+    operations: incomeOperations,
+    loadingOperations: loadingIncomeOperations,
+  } = useCategoryOperations(
+    selectedYear,
+    selectedMonth,
+    selectedCurrency,
+    incomeCategoryIsLeaf ? selectedIncomeCategory : null,
+    'income',
+  );
+
   // Shared category parent lookup
   const getParentCategoryId = useCallback((categoryId) => {
     if (categoryId === 'all') return 'all';
@@ -606,11 +641,14 @@ const GraphsScreen = () => {
                     <IncomePieChart
                       colors={colors}
                       t={t}
+                      language={language}
                       loadingIncome={loadingIncome}
                       incomeChartData={incomeChartData}
                       selectedCurrency={selectedCurrency}
                       onLegendItemPress={handleIncomeLegendItemPress}
-                      selectedIncomeCategory={selectedIncomeCategory}
+                      isLeafCategory={incomeCategoryIsLeaf}
+                      operations={incomeOperations}
+                      loadingOperations={loadingIncomeOperations}
                     />
                   </Animated.View>
                 </ScrollView>
@@ -668,11 +706,14 @@ const GraphsScreen = () => {
                     <ExpensePieChart
                       colors={colors}
                       t={t}
+                      language={language}
                       loading={loading}
                       chartData={chartData}
                       selectedCurrency={selectedCurrency}
                       onLegendItemPress={handleExpenseLegendItemPress}
-                      selectedCategory={selectedCategory}
+                      isLeafCategory={expenseCategoryIsLeaf}
+                      operations={expenseOperations}
+                      loadingOperations={loadingExpenseOperations}
                     />
                   </Animated.View>
                 </ScrollView>

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1114,6 +1114,45 @@ export const getIncomeByCategoryAndCurrency = async (currency, startDate, endDat
 };
 
 /**
+ * Get the individual operations of a single category, filtered by account
+ * currency and date range. Used by the Graphs pie chart drill-down: once a leaf
+ * category is selected there are no sub-categories left to break down, so the
+ * chart shows the actual operations instead. Only the exact category_id is
+ * matched (a leaf has no descendants), so no hierarchy walk is needed.
+ * @param {string} categoryId
+ * @param {string} currency - Currency code (e.g., 'USD', 'AMD')
+ * @param {string} startDate - ISO date string (YYYY-MM-DD)
+ * @param {string} endDate - ISO date string (YYYY-MM-DD)
+ * @param {string} [type] - Optional operation type filter ('expense' | 'income')
+ * @returns {Promise<Array>}
+ */
+export const getOperationsByCategoryAndCurrency = async (categoryId, currency, startDate, endDate, type = null) => {
+  try {
+    let sql = `SELECT o.* FROM operations o
+       JOIN accounts a ON o.account_id = a.id
+       WHERE o.category_id = ?
+         AND a.currency = ?
+         AND o.date >= ?
+         AND o.date <= ?`;
+
+    const params = [categoryId, currency, startDate, endDate];
+
+    if (type) {
+      sql += ' AND o.type = ?';
+      params.push(type);
+    }
+
+    sql += ' ORDER BY o.date DESC, o.created_at DESC';
+
+    const results = await queryAll(sql, params);
+    return (results || []).map(mapOperationFields).filter(Boolean);
+  } catch (error) {
+    console.error('Failed to get operations by category and currency:', error);
+    throw error;
+  }
+};
+
+/**
  * Check if operation exists
  * @param {number} id
  * @returns {Promise<boolean>}


### PR DESCRIPTION
## Что и зачем

В пончиковых чартах расходов/доходов на экране «Графики» добавлен дрилл-даун до реальных операций и поправлены проценты в легенде.

### Список операций для листовых категорий
Раньше по легенде можно было проваливаться только в **родительскую** категорию (донат её подкатегорий), листовые были некликабельны. Теперь кликабельны все категории:
- **Родитель** (`hasChildren`) → донат детей, иконка `chevron-right` (как раньше).
- **Лист** (без подкатегорий) → **список операций этой категории за выбранный месяц** (или год), иконка списка. Вместо бессмысленного доната из одного сегмента.

Работает и для расходов, и для доходов. Кнопка «назад» (чип с именем категории) уводит на уровень выше. Список фильтруется по той же валюте, что и донат; уважает `hideBalances`.

### Целочисленные проценты в легенде
`((amount/total)*100).toFixed(1)` → `Math.round(...)`. `100.0%` не влезало в фиксированную колонку (символ `%` уезжал на новую строку).

### Даты в генитиве
Дата операции форматируется через `toLocaleDateString(language, { day, month: 'long' })` — ICU выдаёт родительный падеж для дат («5 июля», а не «Июль») и корректные формы для всех 11 языков.

## Изменения
- **new** `app/components/graphs/CategoryOperationsList.js` — компактный read-only список (без своего ScrollView, чтобы работала анимация высоты карточки).
- **new** `app/hooks/useCategoryOperations.js` — загрузка операций листовой категории (idle без выбора; перезагрузка по `OPERATION_CHANGED`).
- `app/services/OperationsDB.js` — `getOperationsByCategoryAndCurrency(...)`.
- `CustomLegend.js` / `ExpensePieChart.js` / `IncomePieChart.js` / `GraphsScreen.js` — проводка.

## Тесты
- Обновлены: `CustomLegend`, `ExpensePieChart`, `IncomePieChart` (целые проценты, кликабельность листов, листовая ветка).
- Добавлены: `CategoryOperationsList`, `useCategoryOperations`.
- Весь набор зелёный: **154 suite / 4406 тестов**, eslint чистый.
