### PR TITLE
fix(updates): don't dismiss update prompt on outside tap

### DIFF
--- a/__tests__/modals/UpdateAvailableModal.test.js
+++ b/__tests__/modals/UpdateAvailableModal.test.js
@@ -100,6 +100,18 @@ describe('UpdateAvailableModal', () => {
       expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 
+    it('does NOT dismiss when the surrounding scrim is tapped', async () => {
+      // Regression guard: an available-update prompt must not be dismissible by a stray tap
+      // outside the card. Only the ×, "Later", or the hardware back button dismiss it, so the
+      // scrim is an inert View — pressing it fires no onDismiss.
+      const onDismiss = jest.fn();
+      const { getByTestId } = await render(
+        <UpdateAvailableModal {...baseProps} onDismiss={onDismiss} updateData={baseUpdateData} />,
+      );
+      await fireEvent.press(getByTestId('update-modal-scrim'));
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+
     it('dismisses when the Later button is pressed', async () => {
       const onDismiss = jest.fn();
       const { getByText } = await render(

--- a/app/modals/UpdateAvailableModal.js
+++ b/app/modals/UpdateAvailableModal.js
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, ScrollView, useWindowDimensions, Modal, Pressable } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, ScrollView, useWindowDimensions, Modal } from 'react-native';
 import { Text, Divider } from 'react-native-paper';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -48,9 +48,13 @@ export default function UpdateAvailableModal({ visible, onDismiss, onUpdate, upd
   // laid out via a Portal host that, under the New Architecture + Android edge-to-edge, fails
   // to span the full screen — the scrim covered only the content above the card, leaving an
   // undimmed band between the list and this panel. A core Modal owns a full-screen native
-  // window, so the scrim (a plain absolute-fill Pressable) reliably dims the entire screen
-  // and the card centres deterministically. `statusBarTranslucent`/`navigationBarTranslucent`
-  // let that window extend under both system bars so the dim is truly edge-to-edge.
+  // window, so the scrim (a plain absolute-fill View) reliably dims the entire screen and the
+  // card centres deterministically. `statusBarTranslucent`/`navigationBarTranslucent` let that
+  // window extend under both system bars so the dim is truly edge-to-edge.
+  //
+  // The scrim is a plain View (not a Pressable): tapping outside the card must NOT dismiss the
+  // prompt. Dismissal is deliberate only — the × icon, the "Later" button, or the hardware back
+  // button (onRequestClose) — so a stray tap can't silently bury an available update.
   return (
     <Modal
       visible={visible}
@@ -60,13 +64,11 @@ export default function UpdateAvailableModal({ visible, onDismiss, onUpdate, upd
       animationType="fade"
       onRequestClose={onDismiss}
     >
-      <Pressable
+      <View
         testID="update-modal-scrim"
         style={[styles.scrim, { backgroundColor: colors.modalBackground }]}
-        onPress={onDismiss}
       >
-        {/* Inner Pressable swallows taps on the card so they don't dismiss via the scrim. */}
-        <Pressable style={styles.cardWrapper} onPress={() => {}}>
+        <View style={styles.cardWrapper}>
           <View
             testID="update-modal-container"
             style={[styles.card, { backgroundColor: colors.card, borderColor: colors.border }]}
@@ -155,8 +157,8 @@ export default function UpdateAvailableModal({ visible, onDismiss, onUpdate, upd
               </TouchableOpacity>
             </View>
           </View>
-        </Pressable>
-      </Pressable>
+        </View>
+      </View>
     </Modal>
   );
 }

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../../node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../../node_modules


### PR DESCRIPTION
## Что

Плашка «доступно обновление» больше не закрывается тапом в произвольное место экрана. Закрыть её можно только осознанно — крестиком, кнопкой «Позже» или аппаратной кнопкой «назад».

## Почему

Скрим модалки был `Pressable` c `onPress={onDismiss}`, поэтому любой случайный тап по фону молча хоронил доступное обновление. Заменил скрим и его обёртку на инертные `View` — жест закрытия теперь только намеренный.

## Изменения

- `app/modals/UpdateAvailableModal.js` — скрим и card-wrapper теперь `View` вместо `Pressable`; убран неиспользуемый импорт `Pressable`; `onRequestClose` (back) сохранён.
- `__tests__/modals/UpdateAvailableModal.test.js` — регрессионный тест: тап по `update-modal-scrim` не вызывает `onDismiss`.

## Тесты

`UpdateAvailableModal` (19) и `AppInitializer` (26) — все зелёные.