### PR TITLE
ci: auto-retry failed workflow runs once for transient failures

### DIFF
--- a/.github/workflows/auto-retry.yml
+++ b/.github/workflows/auto-retry.yml
@@ -1,0 +1,48 @@
+name: Auto-retry failed runs
+
+# Rides out transient CI hiccups (flaky network, runner preemption, registry blips)
+# by re-running the failed jobs of any listed workflow exactly once.
+#
+# It fires when one of those workflows completes and acts only when:
+#   - the run genuinely failed (not cancelled / skipped), and
+#   - it was the FIRST attempt (run_attempt == 1).
+# `gh run rerun --failed` retries only the failed jobs, leaving successful ones as-is.
+# Because a retried run reports run_attempt == 2 on its next completion, this never
+# loops: every run is retried at most once, and a second failure is left for a human.
+#
+# NOTE: keep this workflow's own name OUT of the list below, and add new workflows
+# here when they are introduced (workflow_run has no wildcard for names).
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - EAS Build Android
+      - Build Android APK (EAS)
+      - Emulator Screenshots
+      - OSSAR
+      - PR Title Check
+      - Release Please
+    types:
+      - completed
+
+# Least privilege: only the rights needed to re-run a run.
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'failure'
+          && github.event.workflow_run.run_attempt == 1 }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed jobs once
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          echo "::notice::Transient-retry: re-running failed jobs of '${WORKFLOW_NAME}' run ${RUN_ID} (attempt 1 -> 2)"
+          gh run rerun "${RUN_ID}" --failed --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
## Что

Добавляет мета-workflow `.github/workflows/auto-retry.yml`, который автоматически переретраивает **упавшие джобы любого workflow один раз** — чтобы пережить транзиентные сбои CI (флапающая сеть, вытеснение раннера, блипы реестра).

## Как работает

- Триггерится на `workflow_run: completed` для всех текущих workflow'ов репо (CI, EAS Build Android, Build Android APK, Emulator Screenshots, OSSAR, PR Title Check, Release Please).
- Срабатывает только если: прогон реально **упал** (`conclusion == 'failure'`, не cancelled/skipped) **и** это была **первая попытка** (`run_attempt == 1`).
- `gh run rerun --failed` перезапускает только упавшие джобы, успешные не трогает.
- Ретрай ровно один: у переретраенного прогона `run_attempt == 2`, поэтому цикла нет — второй провал остаётся человеку.

## Заметки

- Права минимальные: `actions: write` + `contents: read`.
- У `workflow_run` нет wildcard по именам, поэтому список workflow'ов задан явно. При добавлении нового workflow его имя нужно дописать в список (в файле есть комментарий об этом).
- Сам auto-retry в список не входит, чтобы не ретраить себя.
