### PR TITLE
fix(navigation): tighten bottom tab bar spacing with 5 tabs

### DIFF
--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -633,7 +633,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   floatingBarWide: {
-    width: '92%',
+    width: '84%',
   },
   floatingBarWrapper: {
     bottom: 0,

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -249,15 +249,15 @@ export default function SimpleTabs() {
   // reinstall the native gesture recognizer mid-animation and cause jitter).
   const isTransitioningShared = useSharedValue(false);
 
-  // The Accounts tab is optional — inserted right after Operations only when the
-  // "show accounts in main menu" preference is on.
+  // The Accounts tab is optional — inserted just before Settings (second to last)
+  // only when the "show accounts in main menu" preference is on.
   const TABS = useMemo(() => {
     const tabs = [{ key: 'Operations', label: t('operations') || 'Operations' }];
+    tabs.push({ key: 'Graphs', label: t('graphs') || 'Graphs' });
+    tabs.push({ key: 'Planned', label: t('planned') || 'Planned' });
     if (showAccountsTab) {
       tabs.push({ key: 'Accounts', label: t('accounts') || 'Accounts' });
     }
-    tabs.push({ key: 'Graphs', label: t('graphs') || 'Graphs' });
-    tabs.push({ key: 'Planned', label: t('planned') || 'Planned' });
     tabs.push({ key: 'Settings', label: t('settings') || 'Settings' });
     return tabs;
   }, [t, showAccountsTab]);
@@ -505,9 +505,9 @@ export default function SimpleTabs() {
   // preserved (not remounted) when the optional Accounts tab shifts positions.
   const orderedScreens = useMemo(() => {
     const list = [{ key: 'Operations', el: operationsScreen }];
-    if (showAccountsTab) list.push({ key: 'Accounts', el: accountsScreen });
     list.push({ key: 'Graphs', el: graphsScreen });
     list.push({ key: 'Planned', el: plannedScreen });
+    if (showAccountsTab) list.push({ key: 'Accounts', el: accountsScreen });
     list.push({ key: 'Settings', el: settingsScreen });
     return list;
   }, [showAccountsTab, operationsScreen, accountsScreen, graphsScreen, plannedScreen, settingsScreen]);


### PR DESCRIPTION
При включённом табе «Счета» нижнее меню состоит из 5 айтемов и растягивается до 92% ширины экрана — из-за этого промежутки между иконками слишком большие, само меню выглядит чересчур широким.

Сужаю `floatingBarWide` с 92% до 84%, чтобы ширина одного таба стала близка к 4-табному кейсу (70%) и промежутки ужались. На 4 таба не влияет.

Reported via screenshot (bottom menu too wide).
