### PR TITLE
fix(settings): reset to main list when app is backgrounded on a subpanel

### DIFF
--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler, AppState } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Text, Divider, TouchableRipple, Menu } from 'react-native-paper';
@@ -383,6 +383,25 @@ export default function SettingsScreen({ setSubPanelActive }) {
     });
     return () => subscription.remove();
   }, [activeSubPanel, isBackDisabled, navigateBack]);
+
+  // When the app is backgrounded while a subpanel is open, reset back to the main
+  // settings list so returning to the app lands on the settings root rather than
+  // mid-flow. Skipped while a long async step (Sheets export/import) is running so
+  // it isn't yanked out from under an in-flight operation.
+  const closeSubPanelRef = useRef(closeSubPanel);
+  closeSubPanelRef.current = closeSubPanel;
+  const isBackDisabledRef = useRef(isBackDisabled);
+  isBackDisabledRef.current = isBackDisabled;
+  const activeSubPanelRef = useRef(activeSubPanel);
+  activeSubPanelRef.current = activeSubPanel;
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState !== 'background') return;
+      if (!activeSubPanelRef.current || isBackDisabledRef.current) return;
+      closeSubPanelRef.current();
+    });
+    return () => subscription.remove();
+  }, []);
 
   const handleLanguageSelect = useCallback((lng) => {
     setLanguage(lng);


### PR DESCRIPTION
## Проблема

Находясь на подпанели настроек (язык, экспорт, логи и т.д.), при переключении на другое приложение и возврате обратно юзер попадал на ту же подпанель, а не на корневой экран настроек.

## Причина

`SettingsScreen` — постоянно смонтированная вкладка, поэтому стейт `activeSubPanel` переживал уход приложения в фон и восстанавливался при возврате.

## Решение

Добавлен слушатель `AppState`, который при переходе в `background` сбрасывает подпанель через существующий `closeSubPanel()`:

- срабатывает на `background` (не на возврат в `active`) — при возврате уже открыт корень настроек, без визуального прыжка;
- guard через `isBackDisabled` — не дёргаем панель, если в фоне выполняется долгая операция (Sheets export/import);
- рефы на `closeSubPanel`/`isBackDisabled`/`activeSubPanel`, чтобы подписка вешалась один раз.

## Тесты

`__tests__/screens/SettingsScreen.test.js` — 45/45 passing.
