### PR TITLE
chore(gitignore): ignore node_modules symlinks, not just the directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 .worktrees/
 .claude/worktrees/
 # React Native
-node_modules/
+# No trailing slash: also matches the node_modules SYMLINK used in git
+# worktrees (a trailing slash matches directories only, which let the
+# symlink get staged by `git add -A` — bit PR #1214).
+node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Что

`node_modules/` → `node_modules` в `.gitignore` (без завершающего слэша).

## Зачем

Слэш на конце матчит **только директории**. В git-worktree `node_modules` — это симлинк на node_modules основного чекаута (чтобы гонять Jest без переустановки зависимостей), и он под правило не подпадал: `git status` показывал его как untracked, а `git add -A` стейджил как `120000` symlink-блоб.

Эта грабля уже ломала CI в PR #1214 (`bun install` падал с ENOENT на закоммиченном симлинке) и чуть не повторилась в #1231 — поймано на этапе коммита.

Без слэша паттерн матчит и директорию, и симлинк; поведение для обычных чекаутов не меняется.
