### PR TITLE
fix(operations): stop toggling removeClippedSubviews, crashes Fabric

### DIFF
--- a/__tests__/components/operations/OperationsList.test.js
+++ b/__tests__/components/operations/OperationsList.test.js
@@ -407,8 +407,11 @@ describe('OperationsList', () => {
   });
 
   describe('branch coverage — undoOperationId match', () => {
-    it('disables subview clipping while the undo bar is inline', async () => {
-      // Rationale lives on the removeClippedSubviews prop in OperationsList.js.
+    it('never toggles subview clipping based on undo state', async () => {
+      // Regression (PENNY-16): toggling removeClippedSubviews at runtime on a
+      // mounted Fabric list desyncs the JS/native view lists and crashes with
+      // "IllegalStateException: addViewAt: failed to insert view ... at index
+      // N". Clipping must stay a constant regardless of undo/suggestion state.
       const group = makeGroup(TODAY, [
         { id: 'op-undo', type: 'expense', amount: '10.00', accountId: 'acc-usd', categoryId: 'cat-1' },
       ]);
@@ -417,7 +420,7 @@ describe('OperationsList', () => {
         undoOperationId: 'op-undo',
         undoToken: 1,
       });
-      expect(withUndo.sp.removeClippedSubviews).toBe(false);
+      expect(withUndo.sp.removeClippedSubviews).toBe(true);
 
       const withoutUndo = await getSectionListProps({
         groupedOperations: [group],

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -433,11 +433,15 @@ const OperationsList = forwardRef(({
       maxToRenderPerBatch={5}
       initialNumToRender={10}
       updateCellsBatchingPeriod={50}
-      // Android clipping can drop a subview that is inserted into an
-      // already-mounted cell — exactly how the inline undo bar appears. Disable
-      // clipping for the few seconds the bar is up; normal scrolling perf
-      // returns once it closes.
-      removeClippedSubviews={undoOperationId == null}
+      // NEVER toggle this at runtime. On Fabric (New Architecture, enabled for
+      // this app) flipping removeClippedSubviews on a mounted list desyncs the
+      // JS-side view list from SurfaceMountingManager's native one, crashing
+      // with "IllegalStateException: addViewAt: failed to insert view ... at
+      // index N" (IndexOutOfBoundsException) — see PENNY-16, caused by an
+      // earlier attempt to gate this on undoOperationId. The inline undo bar's
+      // visibility is guaranteed by UndoSnackbar mounting fully opaque instead
+      // (see its docblock), not by clipping tricks.
+      removeClippedSubviews={true}
     />
   );
 });

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -741,8 +741,9 @@ const OperationsScreen = () => {
   // Fallback cleanup: the snackbar's onClosed is the normal path, but it never
   // fires when the snackbar unmounts without animating out (its cell scrolled
   // beyond the render window, a filter excluding the row) or when the exit
-  // animation drops its completion callback. Undo state pins the list's
-  // removeClippedSubviews off, so it must not outlive its window.
+  // animation drops its completion callback. Without this, a leaked undoInfo
+  // would keep offering an undo action for an operation whose window has long
+  // since passed.
   useEffect(() => {
     if (!undoInfo) return undefined;
     const timer = setTimeout(() => setUndoInfo(null), UNDO_DURATION_MS + 1500);


### PR DESCRIPTION
## Инцидент

После релиза 0.193.2 (#1231) приложение стало крашиться серым экраном сразу после добавления операции. Sentry [PENNY-16](https://heywood8.sentry.io/issues/PENNY-16):

```
IllegalStateException: addViewAt: failed to insert view [6074] into parent [556] at index 71
Caused by: IndexOutOfBoundsException: index=71 count=70
  at com.facebook.react.fabric.mounting.SurfaceMountingManager.addViewAt
  at com.facebook.react.views.view.ReactClippingViewManager.addView
```

## Причина

#1231 переключал `removeClippedSubviews` на `OperationsList`'е в рантайме (`undoOperationId == null`), чтобы обойти невидимость инлайн-undo-бара на Android. Идея была верной для старой архитектуры, но приложение собрано с Fabric (`newArchEnabled: true`).

На Fabric переключение `removeClippedSubviews` на уже смонтированном списке рассинхронизирует JS-список вью и нативный `SurfaceMountingManager`: на следующей вставке нативная сторона пытается вставить view по индексу, которого в её представлении дерева уже нет — и вместо деградации кидает `IndexOutOfBoundsException`, роняя весь surface.

Остальные списки в приложении (`CategoriesScreen`, `PlannedOperationsScreen`) держат `removeClippedSubviews={true}` статично и не падают — крашит именно рантайм-тумблер, не сама клиппинг.

## Фикс

- `removeClippedSubviews` возвращён к статичному `true` на всех списках без исключений.
- Собственно видимость бара это не задевает: она гарантируется отдельным фиксом из #1231 (`UndoSnackbar` монтируется полностью непрозрачным вместо `opacity: 0` + native-driver fade-in) — эта часть не трогается и остаётся в силе.
- Тест на toggle переписан в обратную сторону: клиппинг теперь **не** меняется независимо от undo-состояния.

## Тесты

155 suites / 4439 tests — зелёные.
