### PR TITLE
fix(operations): show label suggestions above the undo bar, not under it

### DIFF
--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -170,8 +170,19 @@ const OperationListItem = ({
         </View>
       </TouchableRipple>
 
-      {/* Inline "just added" undo bar — sits directly beneath the operation it
-          refers to, between it and the operation before it. */}
+      {/* Label suggestions render directly beneath the operation; the undo bar
+          sits below them. When a just-added operation shows both, the labels
+          are the primary action and the undo/cancel bar reads as the secondary
+          affordance underneath — its top border separates the two cleanly. */}
+      {suggestionChips && suggestionChips.length > 0 && (
+        <DescriptionSuggestionRow
+          chips={suggestionChips}
+          colors={colors}
+          onApply={onApplySuggestion}
+          onDismiss={onDismissSuggestion}
+        />
+      )}
+
       {showUndo && (
         <UndoSnackbar
           key={undoToken}
@@ -182,15 +193,6 @@ const OperationListItem = ({
           colors={colors}
           onUndo={onUndo}
           onClosed={onUndoClosed}
-        />
-      )}
-
-      {suggestionChips && suggestionChips.length > 0 && (
-        <DescriptionSuggestionRow
-          chips={suggestionChips}
-          colors={colors}
-          onApply={onApplySuggestion}
-          onDismiss={onDismissSuggestion}
         />
       )}
 


### PR DESCRIPTION
## Проблема

После добавления операции инлайн-бар отмены визуально «сразу же заменялся» предложениями лейблов.

## Разбор

Оба блока привязаны к одной и той же операции (`undoInfo.id` и `pendingSuggestionId` = `createdOperation.id`, выставляются подряд в `handleQuickAdd`) и рендерятся в одной ячейке. Реального конфликта состояний нет — ничто не сбрасывает `undoInfo` при появлении предложений, они честно сосуществуют.

Дело было в порядке в JSX: бар отмены шёл первым, поэтому тонкая полоска отмены появлялась, а затем под ней выскакивали заметные чипы-лейблы и перетягивали внимание — отсюда ощущение подмены.

## Фикс

Поменял порядок: предложения лейблов теперь идут сразу под операцией как основное действие, бар отмены — под ними. Верхняя граница бара отмены отделяет его от лейблов, так что «cancel» читается как вторичная опция под лейблами — ровно как просили.

Только реордер JSX, без изменения логики.

## Тесты

Полный набор — 4439/4439 зелёные (один флаки-тест отвалился на первом прогоне, на повторе стабильно зелёный; изменение на тайминги не влияет).
