### PR TITLE
feat(graphs): переключатель пересчёта операций в других валютах

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -102,7 +102,12 @@ jobs:
 
       - name: Run tests
         id: test
-        run: bun run test -- --coverage 2>&1 | tee test-output.txt
+        # The full suite under --coverage peaks past a Jest worker's default heap
+        # on the heaviest suites ("Jest worker ran out of memory"). Run a single
+        # worker with a larger heap so the peak fits within the runner's RAM.
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+        run: bun run test -- --coverage --maxWorkers=1 2>&1 | tee test-output.txt
         continue-on-error: true
 
       - name: Post test results

--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -386,6 +386,7 @@ describe('CategorySpendingCard', () => {
         'EUR',
         'cat-transport',
         defaultCategories,
+        false,
       );
     });
 
@@ -401,6 +402,7 @@ describe('CategorySpendingCard', () => {
         'USD',
         'cat-food', // Falls back to first parent expense category
         defaultCategories,
+        false,
       );
     });
 
@@ -412,11 +414,13 @@ describe('CategorySpendingCard', () => {
         'USD',
         'cat-food',
         defaultCategories,
+        false,
       );
       expect(useCategoryMonthlySpending).toHaveBeenCalledWith(
         'USD',
         null, // No vs category selected
         defaultCategories,
+        false,
       );
     });
   });
@@ -521,6 +525,7 @@ describe('CategorySpendingCard', () => {
         'USD',
         'cat-transport',
         defaultCategories,
+        false,
       );
     });
 

--- a/__tests__/hooks/useCategoryMonthlySpending.test.js
+++ b/__tests__/hooks/useCategoryMonthlySpending.test.js
@@ -129,6 +129,7 @@ describe('useCategoryMonthlySpending', () => {
       expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
         mockCurrency,
         [mockCategoryId, 'cat-groceries', 'cat-restaurants'],
+        false,
       );
     });
 
@@ -144,6 +145,7 @@ describe('useCategoryMonthlySpending', () => {
         expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
           'EUR',
           [mockCategoryId],
+          false,
         );
       });
     });
@@ -308,6 +310,7 @@ describe('useCategoryMonthlySpending', () => {
         expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
           'USD',
           [mockCategoryId],
+          false,
         );
       });
 
@@ -321,6 +324,7 @@ describe('useCategoryMonthlySpending', () => {
         expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
           'EUR',
           [mockCategoryId],
+          false,
         );
       });
     });
@@ -338,6 +342,7 @@ describe('useCategoryMonthlySpending', () => {
         expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
           mockCurrency,
           ['cat-food'],
+          false,
         );
       });
 
@@ -351,6 +356,7 @@ describe('useCategoryMonthlySpending', () => {
         expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
           mockCurrency,
           ['cat-transport'],
+          false,
         );
       });
     });

--- a/__tests__/hooks/useExpenseData.test.js
+++ b/__tests__/hooks/useExpenseData.test.js
@@ -110,6 +110,8 @@ describe('useExpenseData', () => {
         mockCurrency,
         '2024-01-01',
         '2024-01-31',
+        null,
+        false,
       );
       expect(result.current.chartData.length).toBeGreaterThan(0);
     });
@@ -137,6 +139,8 @@ describe('useExpenseData', () => {
         mockCurrency,
         '2024-01-01',
         '2024-12-31',
+        null,
+        false,
       );
     });
 
@@ -475,10 +479,12 @@ describe('useExpenseData', () => {
         mockCurrency,
         expect.any(String),
         expect.any(String),
+        null,
+        false,
       );
       expect(OperationsDB.getSpendingByCategoryAndCurrency).toHaveBeenCalledTimes(1);
       const callArgs = OperationsDB.getSpendingByCategoryAndCurrency.mock.calls[0];
-      expect(callArgs).toHaveLength(3);
+      expect(callArgs).toHaveLength(5);
     });
 
     it('should include expenses from multiple accounts in the same currency', async () => {

--- a/__tests__/hooks/useIncomeData.test.js
+++ b/__tests__/hooks/useIncomeData.test.js
@@ -108,6 +108,7 @@ describe('useIncomeData', () => {
         mockCurrency,
         '2024-01-01',
         '2024-01-31',
+        false,
       );
       expect(result.current.incomeChartData.length).toBeGreaterThan(0);
     });
@@ -135,6 +136,7 @@ describe('useIncomeData', () => {
         mockCurrency,
         '2024-01-01',
         '2024-12-31',
+        false,
       );
     });
 
@@ -484,10 +486,11 @@ describe('useIncomeData', () => {
         mockCurrency,
         expect.any(String),
         expect.any(String),
+        false,
       );
       expect(OperationsDB.getIncomeByCategoryAndCurrency).toHaveBeenCalledTimes(1);
       const callArgs = OperationsDB.getIncomeByCategoryAndCurrency.mock.calls[0];
-      expect(callArgs).toHaveLength(3);
+      expect(callArgs).toHaveLength(4);
     });
 
     it('should roll up grandchild to immediate child when viewing subfolder', async () => {

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -997,6 +997,132 @@ describe('OperationsDB Service', () => {
       );
     });
 
+    describe('Cross-currency conversion (convertAll)', () => {
+      // Deterministic conversion: each foreign currency has a fixed rate to USD.
+      // A currency missing from the table (XYZ) yields a null rate → its rows are dropped.
+      const RATES = { USD: 1, AMD: 0.0025, EUR: 1.1 };
+      beforeEach(() => {
+        // Default: no offline rate, so conversion defers to the live fetch mock.
+        // Individual tests override getExchangeRate to exercise the offline-first path.
+        Currency.getExchangeRate.mockReturnValue(null);
+        Currency.fetchLiveExchangeRate.mockImplementation(async (from) => ({
+          rate: RATES[from] !== undefined ? String(RATES[from]) : null,
+          source: 'live',
+        }));
+        // Real convertAmount formats to the target currency's decimals; mirror that
+        // here so float noise (e.g. 50 * 1.1) doesn't leak into the assertions.
+        Currency.convertAmount.mockImplementation((amount, _from, _to, rate) =>
+          rate ? (parseFloat(amount) * parseFloat(rate)).toFixed(2) : null,
+        );
+        Currency.compare.mockImplementation((a, b) => {
+          const da = parseFloat(a);
+          const db = parseFloat(b);
+          return da < db ? -1 : da > db ? 1 : 0;
+        });
+      });
+
+      it('spending: drops the currency filter and groups by category + currency', async () => {
+        queryAll.mockResolvedValue([]);
+        await OperationsDB.getSpendingByCategoryAndCurrency('USD', '2025-12-01', '2025-12-31', null, true);
+
+        const [sql, params] = queryAll.mock.calls[0];
+        expect(sql).not.toContain('a.currency = ?');
+        expect(sql).toContain('GROUP BY o.category_id, a.currency');
+        expect(params).toEqual(['2025-12-01', '2025-12-31']);
+      });
+
+      it('spending: converts foreign subtotals to the target currency and merges by category', async () => {
+        queryAll.mockResolvedValue([
+          { category_id: 'cat1', currency: 'USD', total: 100 },
+          { category_id: 'cat1', currency: 'AMD', total: 4000 }, // 4000 * 0.0025 = 10
+          { category_id: 'cat2', currency: 'EUR', total: 50 },   // 50 * 1.1 = 55
+        ]);
+
+        const result = await OperationsDB.getSpendingByCategoryAndCurrency('USD', '2025-12-01', '2025-12-31', null, true);
+
+        // cat1: 100 (passthrough) + 10 = 110; cat2: 55. Sorted by total DESC.
+        expect(result).toEqual([
+          { category_id: 'cat1', total: '110' },
+          { category_id: 'cat2', total: '55' },
+        ]);
+      });
+
+      it('spending: drops subtotals whose currency has no rate to the target', async () => {
+        queryAll.mockResolvedValue([
+          { category_id: 'cat1', currency: 'USD', total: 100 },
+          { category_id: 'cat2', currency: 'XYZ', total: 999 }, // no rate → dropped
+        ]);
+
+        const result = await OperationsDB.getSpendingByCategoryAndCurrency('USD', '2025-12-01', '2025-12-31', null, true);
+
+        expect(result).toEqual([{ category_id: 'cat1', total: '100' }]);
+      });
+
+      it('spending: keeps the currency filter when an account is specified even if convertAll is set', async () => {
+        queryAll.mockResolvedValue([]);
+        await OperationsDB.getSpendingByCategoryAndCurrency('USD', '2025-12-01', '2025-12-31', 'acc1', true);
+
+        const [sql, params] = queryAll.mock.calls[0];
+        expect(sql).toContain('a.currency = ?');
+        expect(params).toEqual(['USD', '2025-12-01', '2025-12-31', 'acc1']);
+      });
+
+      it('income: converts foreign subtotals and drops the currency filter', async () => {
+        queryAll.mockResolvedValue([
+          { category_id: 'cat1', currency: 'EUR', total: 50 }, // 55
+          { category_id: 'cat1', currency: 'USD', total: 20 },
+        ]);
+
+        const result = await OperationsDB.getIncomeByCategoryAndCurrency('USD', '2025-12-01', '2025-12-31', true);
+
+        const [sql, params] = queryAll.mock.calls[0];
+        expect(sql).not.toContain('a.currency = ?');
+        expect(sql).toContain('GROUP BY o.category_id, a.currency');
+        expect(params).toEqual(['2025-12-01', '2025-12-31']);
+        expect(result).toEqual([{ category_id: 'cat1', total: '75' }]);
+      });
+
+      it('trend: converts each month total at the current rate and drops the currency filter', async () => {
+        queryAll.mockResolvedValue([
+          { year_month: '2025-11', amount: 100, currency: 'USD' },
+          { year_month: '2025-11', amount: 4000, currency: 'AMD' }, // 10
+          { year_month: '2025-12', amount: 50, currency: 'EUR' },   // 55
+        ]);
+
+        const result = await OperationsDB.getLast12MonthsSpendingByCategories('USD', ['cat1'], true);
+
+        const sql = queryAll.mock.calls[0][0];
+        expect(sql).not.toContain('a.currency = ?');
+        expect(result).toEqual([
+          { yearMonth: '2025-11', total: '110' },
+          { yearMonth: '2025-12', total: '55' },
+        ]);
+      });
+
+      it('spending: uses the offline rate first and skips the live fetch when available', async () => {
+        Currency.getExchangeRate.mockImplementation((from) =>
+          RATES[from] !== undefined ? String(RATES[from]) : null,
+        );
+        queryAll.mockResolvedValue([
+          { category_id: 'cat1', currency: 'AMD', total: 4000 }, // 4000 * 0.0025 = 10
+        ]);
+
+        const result = await OperationsDB.getSpendingByCategoryAndCurrency('USD', '2025-12-01', '2025-12-31', null, true);
+
+        expect(result).toEqual([{ category_id: 'cat1', total: '10' }]);
+        expect(Currency.fetchLiveExchangeRate).not.toHaveBeenCalled();
+      });
+
+      it('getUnconvertibleCurrencies returns currencies with no offline or live rate', async () => {
+        // EUR has an offline rate; XYZ has neither offline nor live; USD is the target.
+        Currency.getExchangeRate.mockImplementation((from) => (from === 'EUR' ? '1.1' : null));
+
+        const result = await OperationsDB.getUnconvertibleCurrencies(['USD', 'EUR', 'AMD', 'XYZ'], 'USD');
+
+        expect(result).toEqual(['XYZ']); // AMD resolves via the live mock, EUR offline, USD is target
+      });
+    });
+
     it('gets top categories from last 3 months', async () => {
       const mockResults = [
         { category_id: 'cat1', count: 15 },

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -348,6 +348,7 @@ const CategorySpendingCard = ({
   selectedCategory,
   onCategoryChange,
   categories,
+  convertAllCurrencies = false,
 }) => {
   // null = closed, 'primary' = picking primary, 'vs' = picking vs category
   const [pickerMode, setPickerMode] = useState(null);
@@ -436,8 +437,8 @@ const CategorySpendingCard = ({
     setShowStackedBar(false);
   }, []);
 
-  const { monthlyData, loading } = useCategoryMonthlySpending(selectedCurrency, effectiveCategory, categories);
-  const { monthlyData: vsMonthlyData, loading: vsLoading } = useCategoryMonthlySpending(selectedCurrency, effectiveVsCategory, categories);
+  const { monthlyData, loading } = useCategoryMonthlySpending(selectedCurrency, effectiveCategory, categories, convertAllCurrencies);
+  const { monthlyData: vsMonthlyData, loading: vsLoading } = useCategoryMonthlySpending(selectedCurrency, effectiveVsCategory, categories, convertAllCurrencies);
 
   const { hideBalances } = useDisplaySettings();
 
@@ -703,6 +704,7 @@ CategorySpendingCard.propTypes = {
   selectedCategory: PropTypes.string,
   onCategoryChange: PropTypes.func.isRequired,
   categories: PropTypes.array.isRequired,
+  convertAllCurrencies: PropTypes.bool,
 };
 
 const styles = StyleSheet.create({

--- a/app/hooks/useCategoryMonthlySpending.js
+++ b/app/hooks/useCategoryMonthlySpending.js
@@ -12,7 +12,7 @@ import { appEvents, EVENTS } from '../services/eventEmitter';
  * @param {string|null} selectedCategoryId - Category ID to show spending for
  * @param {Array} categories - Array of all categories
  */
-const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, categories) => {
+const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, categories, convertAllCurrencies = false) => {
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(false);
 
@@ -54,6 +54,7 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
       const spending = await getLast12MonthsSpendingByCategories(
         selectedCurrency,
         categoryIds,
+        convertAllCurrencies,
       );
 
       // Create a map of yearMonth to total for easy lookup
@@ -79,7 +80,7 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
     } finally {
       setLoading(false);
     }
-  }, [selectedCurrency, selectedCategoryId]);
+  }, [selectedCurrency, selectedCategoryId, convertAllCurrencies]);
 
   // Calculate total yearly spending using Decimal-safe addition before the final float conversion
   const totalYearlySpending = useMemo(() => {

--- a/app/hooks/useExpenseData.js
+++ b/app/hooks/useExpenseData.js
@@ -15,7 +15,7 @@ const CHART_COLORS = [
  * DB is queried once per period/currency/account change. Category switches
  * re-aggregate the cached raw data synchronously (no DB hit).
  */
-const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t) => {
+const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t, convertAllCurrencies = false) => {
   const [rawSpending, setRawSpending] = useState(null);
   const [loading, setLoading] = useState(false);
 
@@ -38,6 +38,8 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
         selectedCurrency,
         formatDate(startDate),
         formatDate(endDate),
+        null,
+        convertAllCurrencies,
       );
 
       setRawSpending(spending);
@@ -46,7 +48,7 @@ const useExpenseData = (selectedYear, selectedMonth, selectedCurrency, selectedC
     } finally {
       setLoading(false);
     }
-  }, [selectedYear, selectedMonth, selectedCurrency]);
+  }, [selectedYear, selectedMonth, selectedCurrency, convertAllCurrencies]);
 
   // Aggregate cached raw spending for the current category — no DB hit
   const chartData = useMemo(() => {

--- a/app/hooks/useIncomeData.js
+++ b/app/hooks/useIncomeData.js
@@ -15,7 +15,7 @@ const CHART_COLORS = [
  * DB is queried once per period/currency change. Category switches
  * re-aggregate the cached raw data synchronously (no DB hit).
  */
-const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIncomeCategory, categories, colors, t) => {
+const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIncomeCategory, categories, colors, t, convertAllCurrencies = false) => {
   const [rawIncome, setRawIncome] = useState(null);
   const [loadingIncome, setLoadingIncome] = useState(false);
 
@@ -38,6 +38,7 @@ const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIn
         selectedCurrency,
         formatDate(startDate),
         formatDate(endDate),
+        convertAllCurrencies,
       );
 
       setRawIncome(income);
@@ -46,7 +47,7 @@ const useIncomeData = (selectedYear, selectedMonth, selectedCurrency, selectedIn
     } finally {
       setLoadingIncome(false);
     }
-  }, [selectedYear, selectedMonth, selectedCurrency]);
+  }, [selectedYear, selectedMonth, selectedCurrency, convertAllCurrencies]);
 
   // Aggregate cached raw income for the current category — no DB hit
   const incomeChartData = useMemo(() => {

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -897,6 +897,15 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 12,
   },
+  fabToggle: {
+    alignItems: 'center',
+    borderRadius: 22,
+    bottom: 136,
+    height: 44,
+    justifyContent: 'center',
+    right: 238,
+    width: 44,
+  },
   fabWheel: {
     borderRadius: 16,
     borderWidth: 1,
@@ -908,15 +917,6 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
-  },
-  fabToggle: {
-    alignItems: 'center',
-    borderRadius: 22,
-    bottom: 136,
-    height: 44,
-    justifyContent: 'center',
-    right: 238,
-    width: 44,
   },
   fabWheelLeft: {
     borderRadius: 40,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
-import { View, Text, StyleSheet, ScrollView, useWindowDimensions } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing, SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import WheelPicker from '@quidone/react-native-wheel-picker';
@@ -7,7 +7,7 @@ import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
 import { TOP_CONTENT_SPACING } from '../styles/layout';
-import { getAvailableMonths } from '../services/OperationsDB';
+import { getAvailableMonths, getUnconvertibleCurrencies } from '../services/OperationsDB';
 import { getAllCategories } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { formatAmount } from '../services/currency';
@@ -41,6 +41,13 @@ const GraphsScreen = () => {
   // Combined period state: "YYYY-MM" for specific month or "YYYY-full" for full year
   const [selectedPeriod, setSelectedPeriod] = useState(`${now.getFullYear()}-${now.getMonth()}`);
   const [selectedCurrency, setSelectedCurrency] = useState('');
+  // When on, operations in other currencies are converted to selectedCurrency at
+  // the current rate and folded into the expense/income pie charts and the
+  // spending trend, instead of showing only same-currency operations.
+  const [convertAllCurrencies, setConvertAllCurrencies] = useState(false);
+  // Account currencies that have no rate (offline or live) to selectedCurrency —
+  // their operations are silently excluded from converted totals, so warn.
+  const [unconvertedCurrencies, setUnconvertedCurrencies] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedIncomeCategory, setSelectedIncomeCategory] = useState('all');
   const [categories, setCategories] = useState([]);
@@ -94,14 +101,14 @@ const GraphsScreen = () => {
     loading,
     loadExpenseData,
     totalExpenses,
-  } = useExpenseData(selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t);
+  } = useExpenseData(selectedYear, selectedMonth, selectedCurrency, selectedCategory, categories, colors, t, convertAllCurrencies);
 
   const {
     incomeChartData,
     loadingIncome,
     loadIncomeData,
     totalIncome,
-  } = useIncomeData(selectedYear, selectedMonth, selectedCurrency, selectedIncomeCategory, categories, colors, t);
+  } = useIncomeData(selectedYear, selectedMonth, selectedCurrency, selectedIncomeCategory, categories, colors, t, convertAllCurrencies);
 
   const {
     balanceHistoryData,
@@ -269,6 +276,21 @@ const GraphsScreen = () => {
     [...new Set(accounts.map(acc => acc.currency))],
   [accounts],
   );
+
+  // When converting, detect account currencies that cannot be expressed in the
+  // selected currency (no offline and no live rate) so the UI can flag that some
+  // operations are excluded rather than silently dropping them.
+  useEffect(() => {
+    if (!convertAllCurrencies || !selectedCurrency) {
+      setUnconvertedCurrencies([]);
+      return;
+    }
+    let cancelled = false;
+    getUnconvertibleCurrencies(currencies, selectedCurrency)
+      .then(list => { if (!cancelled) setUnconvertedCurrencies(list); })
+      .catch(() => { if (!cancelled) setUnconvertedCurrencies([]); });
+    return () => { cancelled = true; };
+  }, [convertAllCurrencies, selectedCurrency, currencies]);
 
   // Prepare picker items
   const currencyItems = useMemo(() =>
@@ -591,6 +613,16 @@ const GraphsScreen = () => {
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
         <View style={styles.content}>
+          {/* Warn when some account currencies can't be converted to the selected one */}
+          {convertAllCurrencies && unconvertedCurrencies.length > 0 && (
+            <View style={[styles.convertWarning, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
+              <Icon name="alert-outline" size={16} color={colors.mutedText} />
+              <Text style={[styles.convertWarningText, { color: colors.mutedText }]}>
+                {`${t('graphs_currencies_not_converted')}: ${unconvertedCurrencies.join(', ')}`}
+              </Text>
+            </View>
+          )}
+
           {/* Summary Cards Row — always-mounted, width/height driven by Animated */}
           <View style={styles.summaryCardsRow}>
             {/* Income card */}
@@ -756,9 +788,35 @@ const GraphsScreen = () => {
             selectedCategory={selectedCategoryForTrend}
             onCategoryChange={setSelectedCategoryForTrend}
             categories={categories}
+            convertAllCurrencies={convertAllCurrencies}
           />
         </View>
       </ScrollView>
+
+      {/* Convert-other-currencies toggle — only useful with more than one currency */}
+      {currencyItems.length > 1 && (
+        <TouchableOpacity
+          style={[
+            styles.fabWheel,
+            styles.fabToggle,
+            {
+              backgroundColor: convertAllCurrencies ? colors.primary : colors.surface + 'DE',
+              borderColor: convertAllCurrencies ? colors.primary : colors.border + '80',
+            },
+          ]}
+          onPress={() => setConvertAllCurrencies(v => !v)}
+          activeOpacity={0.7}
+          accessibilityRole="switch"
+          accessibilityState={{ checked: convertAllCurrencies }}
+          accessibilityLabel={t('graphs_convert_currencies')}
+        >
+          <Icon
+            name="cash-sync"
+            size={24}
+            color={convertAllCurrencies ? colors.surface : colors.mutedText}
+          />
+        </TouchableOpacity>
+      )}
 
       {/* Floating currency wheel FAB */}
       {currencyItems.length > 0 && (
@@ -825,6 +883,20 @@ const styles = StyleSheet.create({
     padding: TOP_CONTENT_SPACING,
     paddingTop: TOP_CONTENT_SPACING + 4,
   },
+  convertWarning: {
+    alignItems: 'center',
+    borderRadius: 12,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  convertWarningText: {
+    flex: 1,
+    fontSize: 12,
+  },
   fabWheel: {
     borderRadius: 16,
     borderWidth: 1,
@@ -836,6 +908,15 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
+  },
+  fabToggle: {
+    alignItems: 'center',
+    borderRadius: 22,
+    bottom: 136,
+    height: 44,
+    justifyContent: 'center',
+    right: 238,
+    width: 44,
   },
   fabWheelLeft: {
     borderRadius: 40,

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler } from 'react-native';
+import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler, AppState } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Text, Divider, TouchableRipple, Menu } from 'react-native-paper';
@@ -383,6 +383,25 @@ export default function SettingsScreen({ setSubPanelActive }) {
     });
     return () => subscription.remove();
   }, [activeSubPanel, isBackDisabled, navigateBack]);
+
+  // When the app is backgrounded while a subpanel is open, reset back to the main
+  // settings list so returning to the app lands on the settings root rather than
+  // mid-flow. Skipped while a long async step (Sheets export/import) is running so
+  // it isn't yanked out from under an in-flight operation.
+  const closeSubPanelRef = useRef(closeSubPanel);
+  closeSubPanelRef.current = closeSubPanel;
+  const isBackDisabledRef = useRef(isBackDisabled);
+  isBackDisabledRef.current = isBackDisabled;
+  const activeSubPanelRef = useRef(activeSubPanel);
+  activeSubPanelRef.current = activeSubPanel;
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState !== 'background') return;
+      if (!activeSubPanelRef.current || isBackDisabledRef.current) return;
+      closeSubPanelRef.current();
+    });
+    return () => subscription.remove();
+  }, []);
 
   const handleLanguageSelect = useCallback((lng) => {
     setLanguage(lng);

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1048,15 +1048,111 @@ export const getIncomeByCategory = async (startDate, endDate) => {
 };
 
 /**
+ * Fetch one exchange rate per distinct source currency into `targetCurrency`,
+ * in parallel. The offline rate is tried first (synchronous, no network) so a
+ * known currency pair never stalls the caller; only a currency absent from the
+ * offline table triggers a live fetch (see {@link Currency.fetchLiveExchangeRate}).
+ * A currency with neither an offline nor a live rate maps to a null rate and its
+ * amounts are dropped by callers.
+ * @param {Iterable<string>} currencies - source currency codes
+ * @param {string} targetCurrency
+ * @returns {Promise<Map<string, string|null>>} source currency → rate string or null
+ */
+const fetchRatesToTarget = async (currencies, targetCurrency) => {
+  const distinct = [...new Set([...currencies].filter(c => c && c !== targetCurrency))];
+  const rateByCurrency = new Map();
+  await Promise.all(distinct.map(async (from) => {
+    // Offline first — instant, avoids the multi-second live-fetch timeout on the
+    // graph-load path for currencies the bundled table already covers.
+    const offline = Currency.getExchangeRate(from, targetCurrency);
+    if (offline) {
+      rateByCurrency.set(from, offline);
+      return;
+    }
+    const { rate } = await Currency.fetchLiveExchangeRate(from, targetCurrency);
+    rateByCurrency.set(from, rate);
+  }));
+  return rateByCurrency;
+};
+
+/**
+ * Convert a raw amount to `targetCurrency` using a rate map from
+ * {@link fetchRatesToTarget}. Same-currency amounts pass through unchanged.
+ * @returns {string|null} converted amount, or null when the source currency has
+ *   no rate (or conversion failed) so the caller should skip the row.
+ */
+const convertWithRateMap = (rawAmount, fromCurrency, targetCurrency, rateByCurrency) => {
+  if (fromCurrency === targetCurrency) return rawAmount;
+  const rate = rateByCurrency.get(fromCurrency);
+  if (!rate) return null; // no rate available, cannot express in target
+  return Currency.convertAmount(rawAmount, fromCurrency, targetCurrency, rate);
+};
+
+/**
+ * Merge per-(category, currency) subtotals into per-category totals expressed in
+ * the target currency. Each subtotal recorded in a different currency is
+ * converted at the current exchange rate (offline first, live fallback);
+ * subtotals whose currency has no known rate are dropped.
+ * @param {Array<{category_id: string, currency: string, total: number}>} rows
+ * @param {string} targetCurrency
+ * @returns {Promise<Array<{category_id: string, total: string}>>} sorted by total DESC
+ */
+const mergeConvertedByCategory = async (rows, targetCurrency) => {
+  const rateByCurrency = await fetchRatesToTarget(rows.map(r => r.currency), targetCurrency);
+
+  const totals = new Map();
+  for (const row of rows) {
+    const converted = convertWithRateMap(String(row.total ?? '0'), row.currency, targetCurrency, rateByCurrency);
+    if (converted === null) continue;
+    totals.set(row.category_id, Currency.add(totals.get(row.category_id) || '0', converted));
+  }
+  return Array.from(totals.entries())
+    .map(([category_id, total]) => ({ category_id, total }))
+    .sort((a, b) => Currency.compare(b.total, a.total));
+};
+
+/**
+ * Given a set of source currencies, return those that cannot be converted to
+ * `targetCurrency` at all (no offline and no live rate). Used by the Graphs
+ * screen to warn that some operations are excluded from converted totals.
+ * @param {Iterable<string>} fromCurrencies
+ * @param {string} targetCurrency
+ * @returns {Promise<string[]>} currency codes with no available rate
+ */
+export const getUnconvertibleCurrencies = async (fromCurrencies, targetCurrency) => {
+  const rateByCurrency = await fetchRatesToTarget(fromCurrencies, targetCurrency);
+  return [...rateByCurrency.entries()].filter(([, rate]) => !rate).map(([currency]) => currency);
+};
+
+/**
  * Get spending by category filtered by currency and date range
  * @param {string} currency - Currency code (e.g., 'USD', 'AMD')
  * @param {string} startDate - ISO date string
  * @param {string} endDate - ISO date string
  * @param {string} [accountId] - Optional account ID to filter by specific account
+ * @param {boolean} [convertAll=false] - When true, include operations from every
+ *   currency and convert their amounts to `currency` at the current exchange rate
+ *   instead of restricting to accounts in `currency`. Ignored when `accountId` is
+ *   set (a single account has a single currency).
  * @returns {Promise<Array>}
  */
-export const getSpendingByCategoryAndCurrency = async (currency, startDate, endDate, accountId = null) => {
+export const getSpendingByCategoryAndCurrency = async (currency, startDate, endDate, accountId = null, convertAll = false) => {
   try {
+    if (convertAll && !accountId) {
+      const rows = await queryAll(
+        `SELECT o.category_id, a.currency as currency, SUM(CAST(o.amount AS REAL)) as total
+         FROM operations o
+         JOIN accounts a ON o.account_id = a.id
+         WHERE o.type = 'expense'
+           AND o.date >= ?
+           AND o.date <= ?
+           AND o.category_id IS NOT NULL
+         GROUP BY o.category_id, a.currency`,
+        [startDate, endDate],
+      );
+      return await mergeConvertedByCategory(rows || [], currency);
+    }
+
     let sql = `SELECT o.category_id, SUM(CAST(o.amount AS REAL)) as total
        FROM operations o
        JOIN accounts a ON o.account_id = a.id
@@ -1089,10 +1185,27 @@ export const getSpendingByCategoryAndCurrency = async (currency, startDate, endD
  * @param {string} currency - Currency code (e.g., 'USD', 'AMD')
  * @param {string} startDate - ISO date string
  * @param {string} endDate - ISO date string
+ * @param {boolean} [convertAll=false] - When true, include income from every
+ *   currency and convert amounts to `currency` at the current exchange rate.
  * @returns {Promise<Array>}
  */
-export const getIncomeByCategoryAndCurrency = async (currency, startDate, endDate) => {
+export const getIncomeByCategoryAndCurrency = async (currency, startDate, endDate, convertAll = false) => {
   try {
+    if (convertAll) {
+      const rows = await queryAll(
+        `SELECT o.category_id, a.currency as currency, SUM(CAST(o.amount AS REAL)) as total
+         FROM operations o
+         JOIN accounts a ON o.account_id = a.id
+         WHERE o.type = 'income'
+           AND o.date >= ?
+           AND o.date <= ?
+           AND o.category_id IS NOT NULL
+         GROUP BY o.category_id, a.currency`,
+        [startDate, endDate],
+      );
+      return await mergeConvertedByCategory(rows || [], currency);
+    }
+
     const results = await queryAll(
       `SELECT o.category_id, SUM(CAST(o.amount AS REAL)) as total
        FROM operations o
@@ -1855,9 +1968,12 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
  * Get spending by categories for the last 12 months (rolling)
  * @param {string} currency - Currency code
  * @param {Array<string>} categoryIds - Category IDs to include
+ * @param {boolean} [convertAll=false] - When true, include operations from every
+ *   currency and convert amounts to `currency` at the current exchange rate.
+ *   Past months are converted at today's rate too (a single "current rate" view).
  * @returns {Promise<Array<{yearMonth: string, total: string}>>} Array of {yearMonth: 'YYYY-MM', total as Decimal-safe string}
  */
-export const getLast12MonthsSpendingByCategories = async (currency, categoryIds) => {
+export const getLast12MonthsSpendingByCategories = async (currency, categoryIds, convertAll = false) => {
   try {
     if (!categoryIds || categoryIds.length === 0) {
       return [];
@@ -1871,25 +1987,44 @@ export const getLast12MonthsSpendingByCategories = async (currency, categoryIds)
     const startDateStr = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}-01`;
     const endDateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-31`;
 
+    // When converting, keep the account currency per row so each amount can be
+    // converted to the target currency before being summed into its month.
+    const currencyFilter = convertAll ? '' : 'AND a.currency = ?';
+    const params = convertAll
+      ? [startDateStr, endDateStr, ...categoryIds]
+      : [currency, startDateStr, endDateStr, ...categoryIds];
+
     const results = await queryAll(
       `SELECT
          strftime('%Y-%m', o.date) as year_month,
-         o.amount
+         o.amount,
+         a.currency as currency
        FROM operations o
        JOIN accounts a ON o.account_id = a.id
        WHERE o.type = 'expense'
-         AND a.currency = ?
+         ${currencyFilter}
          AND o.date >= ?
          AND o.date <= ?
          AND o.category_id IN (${placeholders})
        ORDER BY year_month ASC`,
-      [currency, startDateStr, endDateStr, ...categoryIds],
+      params,
     );
+
+    // Prefetch a rate per distinct source currency (offline first, live fallback).
+    const rateByCurrency = convertAll
+      ? await fetchRatesToTarget((results || []).map(r => r.currency), currency)
+      : new Map();
 
     const monthTotals = new Map();
     for (const row of results || []) {
+      let amount = String(row.amount || '0');
+      if (convertAll) {
+        const converted = convertWithRateMap(amount, row.currency, currency, rateByCurrency);
+        if (converted === null) continue; // no rate available, cannot express in target
+        amount = converted;
+      }
       const prev = monthTotals.get(row.year_month) || '0';
-      monthTotals.set(row.year_month, Currency.add(prev, String(row.amount || '0')));
+      monthTotals.set(row.year_month, Currency.add(prev, amount));
     }
 
     return Array.from(monthTotals.entries())

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -402,6 +402,8 @@
   "balance_history_details": "Saldohistorie Details",
   "actions": "Aktionen",
   "category_spending_trend": "Ausgabentrend",
+  "graphs_convert_currencies": "Andere Währungen umrechnen",
+  "graphs_currencies_not_converted": "Einige Währungen nicht umgerechnet",
   "yearly_total": "Jahresgesamt",
   "last_12_months_total": "Letzte 12 Monate",
   "no_spending_data": "Keine Ausgabedaten fur diese Kategorie",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -406,6 +406,8 @@
   "balance_history_details": "Balance History Details",
   "actions": "Actions",
   "category_spending_trend": "Spending Trend",
+  "graphs_convert_currencies": "Convert other currencies",
+  "graphs_currencies_not_converted": "Some currencies not converted",
   "yearly_total": "Yearly Total",
   "last_12_months_total": "Last 12 Months",
   "no_spending_data": "No spending data for this category",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -402,6 +402,8 @@
   "balance_history_details": "Detalles del historial de saldo",
   "actions": "Acciones",
   "category_spending_trend": "Tendencia de gastos",
+  "graphs_convert_currencies": "Convertir otras monedas",
+  "graphs_currencies_not_converted": "Algunas monedas sin convertir",
   "yearly_total": "Total anual",
   "last_12_months_total": "Ultimos 12 meses",
   "no_spending_data": "No hay datos de gastos para esta categoria",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -406,6 +406,8 @@
   "balance_history_details": "Détails de l'historique du solde",
   "actions": "Actions",
   "category_spending_trend": "Tendance des dépenses",
+  "graphs_convert_currencies": "Convertir les autres devises",
+  "graphs_currencies_not_converted": "Certaines devises non converties",
   "yearly_total": "Total annuel",
   "last_12_months_total": "12 derniers mois",
   "no_spending_data": "Aucune donnée de dépenses pour cette catégorie",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -401,6 +401,8 @@
   "balance_history_details": "Մնացորդի պատմության մանրամասներ",
   "actions": "Գործողություններ",
   "category_spending_trend": "Ծախսերի միտում",
+  "graphs_convert_currencies": "Փոխարկել այլ արժույթները",
+  "graphs_currencies_not_converted": "Որոշ արժույթներ չեն փոխարկվել",
   "yearly_total": "Տարեկան ընդամենը",
   "last_12_months_total": "Վերջին 12 ամիս",
   "no_spending_data": "Ծախսերի տվյալներ չկան այս կատեգորիայի համար",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -406,6 +406,8 @@
   "balance_history_details": "Dettagli storico saldo",
   "actions": "Azioni",
   "category_spending_trend": "Tendenza delle spese",
+  "graphs_convert_currencies": "Converti altre valute",
+  "graphs_currencies_not_converted": "Alcune valute non convertite",
   "yearly_total": "Totale annuale",
   "last_12_months_total": "Ultimi 12 mesi",
   "no_spending_data": "Nessun dato di spesa per questa categoria",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -406,6 +406,8 @@
   "balance_history_details": "残高履歴の詳細",
   "actions": "アクション",
   "category_spending_trend": "支出トレンド",
+  "graphs_convert_currencies": "他の通貨を換算",
+  "graphs_currencies_not_converted": "一部の通貨は換算されていません",
   "yearly_total": "年間合計",
   "last_12_months_total": "過去12ヶ月",
   "no_spending_data": "このカテゴリーの支出データがありません",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -406,6 +406,8 @@
   "balance_history_details": "잔액 내역 상세",
   "actions": "작업",
   "category_spending_trend": "지출 추세",
+  "graphs_convert_currencies": "다른 통화 환산",
+  "graphs_currencies_not_converted": "일부 통화는 환산되지 않음",
   "yearly_total": "연간 합계",
   "last_12_months_total": "최근 12개월",
   "no_spending_data": "이 카테고리의 지출 데이터가 없습니다",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -406,6 +406,8 @@
   "balance_history_details": "Detalhes do histórico de saldo",
   "actions": "Ações",
   "category_spending_trend": "Tendência de gastos",
+  "graphs_convert_currencies": "Converter outras moedas",
+  "graphs_currencies_not_converted": "Algumas moedas não convertidas",
   "yearly_total": "Total anual",
   "last_12_months_total": "Últimos 12 meses",
   "no_spending_data": "Nenhum dado de gastos para esta categoria",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -406,6 +406,8 @@
   "balance_history_details": "Детали истории баланса",
   "actions": "Действия",
   "category_spending_trend": "Тренд расходов",
+  "graphs_convert_currencies": "Пересчитывать другие валюты",
+  "graphs_currencies_not_converted": "Не пересчитаны валюты",
   "yearly_total": "Итого за год",
   "last_12_months_total": "За последние 12 месяцев",
   "no_spending_data": "Нет данных о расходах в этой категории",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -402,6 +402,8 @@
   "balance_history_details": "余额历史详情",
   "actions": "操作",
   "category_spending_trend": "支出趋势",
+  "graphs_convert_currencies": "换算其他货币",
+  "graphs_currencies_not_converted": "部分货币未换算",
   "yearly_total": "年度总计",
   "last_12_months_total": "过去12个月",
   "no_spending_data": "此类别没有支出数据",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   preset: 'jest-expo',
+  // Recycle a worker once its heap grows past this after a test file. The full
+  // suite under `--coverage` accumulates enough per-file state to crash a worker
+  // ("Jest worker ran out of memory"); restarting idle workers keeps CI stable.
+  workerIdleMemoryLimit: '512MB',
   setupFilesAfterEnv: [
     '<rootDir>/jest.setup.js',
   ],


### PR DESCRIPTION
## Что

Тумблер на экране «Графики» рядом с колёсами валюты и периода. Когда включён — операции из других валют пересчитываются в выбранную по текущему курсу и добавляются к:

- пайчарту расходов
- пайчарту доходов
- тренду расходов за 12 месяцев (прошлые месяцы — по сегодняшнему курсу)

Пример: в текущем месяце есть траты в рублях и драмах, просмотр в RUB — при включённом тумблере видно рубли + драмы, пересчитанные в рубли. Учитываются все валюты (USD, EUR, TRY и прочие).

## Детали

- **Курсы**: сначала оффлайн-курс (мгновенно, без сети), live-запрос только для валют вне оффлайн-таблицы. Так граф не залипает на сетевых таймаутах для распространённых валют.
- **Индикатор**: если у валюты счёта нет ни оффлайн, ни live курса — её операции не пересчитываются, и над графиками показывается предупреждение с перечислением таких валют (вместо тихого выпадения).
- Тумблер виден только когда у счетов больше одной валюты.
- DB-слой: флаг `convertAll` у `getSpendingByCategoryAndCurrency` / `getIncomeByCategoryAndCurrency` / `getLast12MonthsSpendingByCategories`; общие хелперы `fetchRatesToTarget` / `convertWithRateMap` / `mergeConvertedByCategory`.
- Локализация во всех 11 языках.

## Тесты

Добавлены юнит-тесты на конвертацию, offline-first путь и `getUnconvertibleCurrencies`. Полный сьют зелёный (149 сьютов, 4058 тестов).

## Пройдено code-review (/code-review high)

4 находки закрыты: сетевой залип на пути загрузки (offline-first), тихое выпадение валют (индикатор), дублирование цикла конвертации (общий хелпер), теснота тумблера на узких экранах (сжат и отцентрован).
