### PR TITLE
fix(graphs): устранить OOM jest-воркера из-за бесконечного ре-рендера в эффекте валют

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -102,12 +102,7 @@ jobs:
 
       - name: Run tests
         id: test
-        # The full suite under --coverage peaks past a Jest worker's default heap
-        # on the heaviest suites ("Jest worker ran out of memory"). Run a single
-        # worker with a larger heap so the peak fits within the runner's RAM.
-        env:
-          NODE_OPTIONS: --max-old-space-size=6144
-        run: bun run test -- --coverage --maxWorkers=1 2>&1 | tee test-output.txt
+        run: bun run test -- --coverage 2>&1 | tee test-output.txt
         continue-on-error: true
 
       - name: Post test results

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -280,15 +280,19 @@ const GraphsScreen = () => {
   // When converting, detect account currencies that cannot be expressed in the
   // selected currency (no offline and no live rate) so the UI can flag that some
   // operations are excluded rather than silently dropping them.
+  // Functional guards keep the empty state referentially stable: setting a fresh
+  // `[]` on every run would re-render, and since `currencies` gets a new identity
+  // whenever `accounts` does, that render would re-fire this effect — an infinite
+  // loop. Returning `prev` when already empty lets React bail out.
   useEffect(() => {
     if (!convertAllCurrencies || !selectedCurrency) {
-      setUnconvertedCurrencies([]);
+      setUnconvertedCurrencies(prev => (prev.length === 0 ? prev : []));
       return;
     }
     let cancelled = false;
     getUnconvertibleCurrencies(currencies, selectedCurrency)
       .then(list => { if (!cancelled) setUnconvertedCurrencies(list); })
-      .catch(() => { if (!cancelled) setUnconvertedCurrencies([]); });
+      .catch(() => { if (!cancelled) setUnconvertedCurrencies(prev => (prev.length === 0 ? prev : [])); });
     return () => { cancelled = true; };
   }, [convertAllCurrencies, selectedCurrency, currencies]);
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,5 @@
 module.exports = {
   preset: 'jest-expo',
-  // Recycle a worker once its heap grows past this after a test file. The full
-  // suite under `--coverage` accumulates enough per-file state to crash a worker
-  // ("Jest worker ran out of memory"); restarting idle workers keeps CI stable.
-  workerIdleMemoryLimit: '512MB',
   setupFilesAfterEnv: [
     '<rootDir>/jest.setup.js',
   ],


### PR DESCRIPTION
## Что

PR #1243 внёс в `GraphsScreen` эффект детекции неконвертируемых валют, который в ветке очистки звал `setUnconvertedCurrencies([])` свежим массивом на каждом прогоне. Эффект зависит от массива `currencies`, чья identity меняется всякий раз, когда меняется ссылка на `accounts` → обновление состояния запускало ре-рендер → эффект гонялся снова → бесконечный цикл.

В проде `accounts` из контекста стабилен, поэтому баг не проявлялся. Но в `GraphsScreen.test.js` мок `useAccountsData` отдаёт новый `accounts` на каждый рендер, из-за чего цикл раскручивал кучу до OOM воркера jest под `--coverage`:

```
FAIL __tests__/screens/GraphsScreen.test.js
  ● Test suite failed to run
    Jest worker ran out of memory and crashed
```

CI показывал зелёный только потому, что `... | tee test-output.txt` затирает код выхода jest (проблема пайпа, не трогаю в этом PR), но sticky-коммент с результатами тестов показывал падение.

## Фикс

- Функциональные guard-обновления (`prev => prev.length === 0 ? prev : []`) — React делает bail-out, цикл не запускается.
- Откат band-aid'ов, добавленных в #1243 ровно под этот OOM (корень теперь устранён):
  - `workerIdleMemoryLimit: '512MB'` в `jest.config.js`
  - `--maxWorkers=1` + `NODE_OPTIONS=--max-old-space-size=6144` в `npm-test.yml`

## Проверка

- Сьют `GraphsScreen` под `--coverage` проходит даже на 1500MB кучи (до фикса падал и на 3500MB).
- Полный сьют под `--coverage` с дефолтным конфигом (8GB/2 ядра, как раннер): **155 сьютов, 4445 тестов зелёные**, пик памяти воркера в норме.
