### PR TITLE
feat(graphs): пересчёт операций в drill-down категории + оригинальная сумма

### DIFF
--- a/__tests__/components/graphs/CategoryOperationsList.test.js
+++ b/__tests__/components/graphs/CategoryOperationsList.test.js
@@ -44,6 +44,24 @@ describe('CategoryOperationsList', () => {
     expect(getByText('$12.50')).toBeTruthy();
   });
 
+  it('shows the converted amount in the target currency and the original beside it', async () => {
+    const ops = [{ id: '1', amount: '4000', date: '2024-03-05', description: 'Rent', accountCurrency: 'AMD', convertedAmount: '10.00' }];
+    const { getByText } = await render(
+      <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+    );
+    expect(getByText('$10.00')).toBeTruthy();   // converted, selected currency
+    expect(getByText('֏4000')).toBeTruthy();    // original, account currency (AMD: 0 decimals)
+  });
+
+  it('does not show a separate original for a same-currency (convertedAmount null) op', async () => {
+    const ops = [{ id: '1', amount: '12.50', date: '2024-03-05', description: 'Coffee', accountCurrency: 'USD', convertedAmount: null }];
+    const { getByText, queryAllByText } = await render(
+      <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+    );
+    expect(getByText('$12.50')).toBeTruthy();
+    expect(queryAllByText('$12.50')).toHaveLength(1); // not duplicated as an "original"
+  });
+
   it('formats the date in the genitive month form for Russian', async () => {
     const ops = [{ id: '1', amount: '12.50', date: '2024-07-05', description: 'Кофе' }];
     const { getByText } = await render(

--- a/__tests__/components/graphs/CategoryOperationsList.test.js
+++ b/__tests__/components/graphs/CategoryOperationsList.test.js
@@ -10,6 +10,7 @@ jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
 jest.mock('../../../assets/currencies.json', () => ({
   USD: { decimal_digits: 2, symbol: '$' },
   JPY: { decimal_digits: 0, symbol: '¥' },
+  AMD: { decimal_digits: 0, symbol: '֏' },
 }));
 
 const colors = { text: '#000000', mutedText: '#888888', border: '#dddddd', primary: '#0000ff' };

--- a/__tests__/hooks/useCategoryOperations.test.js
+++ b/__tests__/hooks/useCategoryOperations.test.js
@@ -79,6 +79,7 @@ describe('useCategoryOperations', () => {
       '2024-01-01',
       '2024-01-31',
       'expense',
+      false,
     );
   });
 
@@ -96,6 +97,7 @@ describe('useCategoryOperations', () => {
       '2024-01-01',
       '2024-12-31',
       'income',
+      false,
     );
   });
 

--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -53,6 +53,7 @@ jest.mock('../../app/services/OperationsDB', () => ({
   getSpendingByCategoryAndCurrency: jest.fn(() => Promise.resolve([])),
   getIncomeByCategoryAndCurrency: jest.fn(() => Promise.resolve([])),
   getAvailableMonths: jest.fn(() => Promise.resolve([])),
+  getUnconvertibleCurrencies: jest.fn(() => Promise.resolve([])),
 }));
 
 jest.mock('../../app/services/CategoriesDB', () => ({

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1121,6 +1121,37 @@ describe('OperationsDB Service', () => {
 
         expect(result).toEqual(['XYZ']); // AMD resolves via the live mock, EUR offline, USD is target
       });
+
+      it('category operations: converts foreign ops, tags account currency, drops unrateable', async () => {
+        queryAll.mockResolvedValue([
+          { id: '1', type: 'expense', amount: '100', category_id: 'cat1', date: '2025-12-05', account_currency: 'USD' },
+          { id: '2', type: 'expense', amount: '4000', category_id: 'cat1', date: '2025-12-06', account_currency: 'AMD' }, // 4000 * 0.0025 = 10.00
+          { id: '3', type: 'expense', amount: '999', category_id: 'cat1', date: '2025-12-07', account_currency: 'XYZ' }, // no rate → dropped
+        ]);
+
+        const result = await OperationsDB.getOperationsByCategoryAndCurrency('cat1', 'USD', '2025-12-01', '2025-12-31', 'expense', true);
+
+        const sql = queryAll.mock.calls[0][0];
+        expect(sql).not.toContain('a.currency = ?');
+        expect(sql).toContain('a.currency as account_currency');
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({ id: '1', amount: '100', accountCurrency: 'USD', convertedAmount: null });
+        expect(result[1]).toMatchObject({ id: '2', amount: '4000', accountCurrency: 'AMD', convertedAmount: '10.00' });
+      });
+
+      it('category operations: keeps the currency filter and plain shape when convertAll is off', async () => {
+        queryAll.mockResolvedValue([
+          { id: '1', type: 'expense', amount: '100', category_id: 'cat1', date: '2025-12-05', account_currency: 'USD' },
+        ]);
+
+        const result = await OperationsDB.getOperationsByCategoryAndCurrency('cat1', 'USD', '2025-12-01', '2025-12-31', 'expense', false);
+
+        const [sql, params] = queryAll.mock.calls[0];
+        expect(sql).toContain('a.currency = ?');
+        expect(params).toContain('USD');
+        expect(result[0].convertedAmount).toBeUndefined();
+        expect(result[0].accountCurrency).toBeUndefined();
+      });
     });
 
     it('gets top categories from last 3 months', async () => {

--- a/app/components/graphs/CategoryOperationsList.js
+++ b/app/components/graphs/CategoryOperationsList.js
@@ -78,9 +78,17 @@ const CategoryOperationsList = ({ operations, loading, currency, colors, languag
                 </Text>
               ) : null}
             </View>
-            <Text style={[styles.amount, { color: colors.text }]} numberOfLines={1}>
-              {hideBalances ? '••••' : formatOpAmount(op.amount, currency)}
-            </Text>
+            <View style={styles.amountCol}>
+              <Text style={[styles.amount, { color: colors.text }]} numberOfLines={1}>
+                {hideBalances ? '••••' : formatOpAmount(op.convertedAmount != null ? op.convertedAmount : op.amount, currency)}
+              </Text>
+              {/* For a converted foreign operation, show the original amount too */}
+              {!hideBalances && op.convertedAmount != null && op.accountCurrency && op.accountCurrency !== currency ? (
+                <Text style={[styles.amountOriginal, { color: colors.mutedText }]} numberOfLines={1}>
+                  {formatOpAmount(op.amount, op.accountCurrency)}
+                </Text>
+              ) : null}
+            </View>
           </View>
         );
       })}
@@ -95,6 +103,8 @@ CategoryOperationsList.propTypes = {
       amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       date: PropTypes.string,
       description: PropTypes.string,
+      accountCurrency: PropTypes.string,
+      convertedAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     }),
   ),
   loading: PropTypes.bool,
@@ -115,7 +125,14 @@ const styles = StyleSheet.create({
   amount: {
     fontSize: 13,
     fontWeight: '600',
+  },
+  amountCol: {
+    alignItems: 'flex-end',
     marginLeft: 10,
+  },
+  amountOriginal: {
+    fontSize: 11,
+    marginTop: 2,
   },
   centerBox: {
     alignItems: 'center',

--- a/app/hooks/useCategoryOperations.js
+++ b/app/hooks/useCategoryOperations.js
@@ -14,8 +14,10 @@ import { appEvents, EVENTS } from '../services/eventEmitter';
  * @param {string} selectedCurrency
  * @param {string|null} categoryId - leaf category id, or null when inactive
  * @param {string} [type] - 'expense' | 'income'
+ * @param {boolean} [convertAllCurrencies] - include foreign-currency operations,
+ *   converted to selectedCurrency (each op carries accountCurrency + convertedAmount)
  */
-const useCategoryOperations = (selectedYear, selectedMonth, selectedCurrency, categoryId, type) => {
+const useCategoryOperations = (selectedYear, selectedMonth, selectedCurrency, categoryId, type, convertAllCurrencies = false) => {
   const [operations, setOperations] = useState([]);
   const [loadingOperations, setLoadingOperations] = useState(false);
 
@@ -43,6 +45,7 @@ const useCategoryOperations = (selectedYear, selectedMonth, selectedCurrency, ca
         formatDate(startDate),
         formatDate(endDate),
         type,
+        convertAllCurrencies,
       );
 
       setOperations(ops);
@@ -52,7 +55,7 @@ const useCategoryOperations = (selectedYear, selectedMonth, selectedCurrency, ca
     } finally {
       setLoadingOperations(false);
     }
-  }, [selectedYear, selectedMonth, selectedCurrency, categoryId, type]);
+  }, [selectedYear, selectedMonth, selectedCurrency, categoryId, type, convertAllCurrencies]);
 
   useEffect(() => {
     loadOperations();

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -467,6 +467,7 @@ const GraphsScreen = () => {
     selectedCurrency,
     expenseCategoryIsLeaf ? selectedCategory : null,
     'expense',
+    convertAllCurrencies,
   );
 
   const {
@@ -478,6 +479,7 @@ const GraphsScreen = () => {
     selectedCurrency,
     incomeCategoryIsLeaf ? selectedIncomeCategory : null,
     'income',
+    convertAllCurrencies,
   );
 
   // Shared category parent lookup

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -43,8 +43,9 @@ const GraphsScreen = () => {
   const [selectedCurrency, setSelectedCurrency] = useState('');
   // When on, operations in other currencies are converted to selectedCurrency at
   // the current rate and folded into the expense/income pie charts and the
-  // spending trend, instead of showing only same-currency operations.
-  const [convertAllCurrencies, setConvertAllCurrencies] = useState(false);
+  // spending trend, instead of showing only same-currency operations. On by
+  // default so multi-currency totals are complete out of the box.
+  const [convertAllCurrencies, setConvertAllCurrencies] = useState(true);
   // Account currencies that have no rate (offline or live) to selectedCurrency —
   // their operations are silently excluded from converted totals, so warn.
   const [unconvertedCurrencies, setUnconvertedCurrencies] = useState([]);
@@ -818,7 +819,7 @@ const GraphsScreen = () => {
         >
           <Icon
             name="cash-sync"
-            size={24}
+            size={30}
             color={convertAllCurrencies ? colors.surface : colors.mutedText}
           />
         </TouchableOpacity>
@@ -904,13 +905,14 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
   fabToggle: {
+    // Match the wheel FABs: same bottom baseline (from fabWheel) and the picker's
+    // rendered height (itemHeight 28 × visibleItemCount 3 = 84), rounded like them.
     alignItems: 'center',
-    borderRadius: 22,
-    bottom: 136,
-    height: 44,
+    borderRadius: 40,
+    height: 84,
     justifyContent: 'center',
-    right: 238,
-    width: 44,
+    right: 240,
+    width: 72,
   },
   fabWheel: {
     borderRadius: 16,

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1237,18 +1237,28 @@ export const getIncomeByCategoryAndCurrency = async (currency, startDate, endDat
  * @param {string} startDate - ISO date string (YYYY-MM-DD)
  * @param {string} endDate - ISO date string (YYYY-MM-DD)
  * @param {string} [type] - Optional operation type filter ('expense' | 'income')
+ * @param {boolean} [convertAll=false] - When true, include operations from every
+ *   currency (not just `currency`). Each returned operation carries its
+ *   `accountCurrency` and, for foreign operations, a `convertedAmount` in
+ *   `currency` (offline rate first, live fallback). Operations whose currency has
+ *   no available rate are dropped, matching the converted pie/trend totals.
  * @returns {Promise<Array>}
  */
-export const getOperationsByCategoryAndCurrency = async (categoryId, currency, startDate, endDate, type = null) => {
+export const getOperationsByCategoryAndCurrency = async (categoryId, currency, startDate, endDate, type = null, convertAll = false) => {
   try {
-    let sql = `SELECT o.* FROM operations o
+    let sql = `SELECT o.*, a.currency as account_currency FROM operations o
        JOIN accounts a ON o.account_id = a.id
        WHERE o.category_id = ?
-         AND a.currency = ?
          AND o.date >= ?
          AND o.date <= ?`;
 
-    const params = [categoryId, currency, startDate, endDate];
+    const params = [categoryId, startDate, endDate];
+
+    // Restrict to the selected currency unless converting everything.
+    if (!convertAll) {
+      sql += ' AND a.currency = ?';
+      params.push(currency);
+    }
 
     if (type) {
       sql += ' AND o.type = ?';
@@ -1258,7 +1268,32 @@ export const getOperationsByCategoryAndCurrency = async (categoryId, currency, s
     sql += ' ORDER BY o.date DESC, o.created_at DESC';
 
     const results = await queryAll(sql, params);
-    return (results || []).map(mapOperationFields).filter(Boolean);
+    const rows = results || [];
+
+    if (!convertAll) {
+      return rows.map(mapOperationFields).filter(Boolean);
+    }
+
+    // Attach the account currency and, for foreign operations, the converted
+    // amount in the target currency. Drop operations with no available rate so
+    // the list stays consistent with the converted pie total.
+    const rateByCurrency = await fetchRatesToTarget(rows.map(r => r.account_currency), currency);
+    const operations = [];
+    for (const row of rows) {
+      const op = mapOperationFields(row);
+      if (!op) continue;
+      const accountCurrency = row.account_currency;
+      if (accountCurrency === currency) {
+        operations.push({ ...op, accountCurrency, convertedAmount: null });
+        continue;
+      }
+      const rate = rateByCurrency.get(accountCurrency);
+      if (!rate) continue; // no rate available, cannot express in target
+      const convertedAmount = Currency.convertAmount(String(op.amount ?? '0'), accountCurrency, currency, rate);
+      if (convertedAmount === null) continue;
+      operations.push({ ...op, accountCurrency, convertedAmount });
+    }
+    return operations;
   } catch (error) {
     console.error('Failed to get operations by category and currency:', error);
     throw error;


### PR DESCRIPTION
## Проблема

При включённом переключателе пересчёта валют drill-down в листовую категорию пайчарта показывал «Нет данных о расходах за этот период», если операции были в другой валюте — хотя сам пайчарт эти операции учитывал (см. скрин: Аренда = ₽69.0K в пае, но список пуст, т.к. траты были в другой валюте).

Причина: `getOperationsByCategoryAndCurrency` фильтровал по валюте счёта (`a.currency = ?`) и отбрасывал операции в других валютах.

## Что сделано

1. **`getOperationsByCategoryAndCurrency`** получил флаг `convertAll`. Когда включён — фильтр по валюте снимается, и каждая операция тегируется:
   - `accountCurrency` — валюта счёта операции
   - `convertedAmount` — сумма в выбранной валюте (оффлайн-курс первым, live как фолбэк)
   
   Операции в валюте без курса отбрасываются — консистентно с пай/трендом.

2. **`useCategoryOperations`** прокидывает флаг; `GraphsScreen` передаёт `convertAllCurrencies` в оба вызова (расход/доход).

3. **`CategoryOperationsList`** для сконвертированных операций показывает сумму в выбранной валюте, а под ней — оригинальную сумму в валюте счёта (напр. `$10.00` / `֏4000`).

## Тесты

Добавлены юнит-тесты: конвертация операций категории + тег валюты + отбрасывание без курса (`OperationsDB.test`), отображение оригинальной суммы (`CategoryOperationsList.test`), сигнатура хука (`useCategoryOperations.test`). Затронутые сьюты зелёные (152 сьюта / 4204 теста локально).

Ветвь от актуального `main` (включает мёрж #1243 и фикс ре-рендера #1245), CI-костыли из #1243 не возвращаются.
