### PR TITLE
fix(operations): stop the undo bar flashing for a split second

### DIFF
--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -10,27 +10,6 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import OperationListItem from '../../../app/components/operations/OperationListItem';
 
-// Mock the inline undo bar: its own animation/timer lifecycle is covered in
-// UndoSnackbar.test.js. Here we only need to verify the wiring — that it is
-// rendered for the right operation and forwards the undo action.
-jest.mock('../../../app/components/operations/UndoSnackbar', () => {
-  const React = require('react');
-  const { Text } = require('react-native');
-  /* eslint-disable react/prop-types */
-  return function MockUndoSnackbar({ operationId, message, actionLabel, onUndo }) {
-    return React.createElement(
-      Text,
-      {
-        testID: `undo-bar-${operationId}`,
-        accessibilityLabel: actionLabel,
-        onPress: () => onUndo(operationId),
-      },
-      message,
-    );
-  };
-  /* eslint-enable react/prop-types */
-});
-
 const mockColors = {
   text: '#fff',
   mutedText: '#888',
@@ -100,44 +79,6 @@ describe('OperationListItem', () => {
       expect(getByLabelText('dismiss suggestion')).toBeTruthy();
       expect(getByText('Monthly pass')).toBeTruthy();
       expect(getByText('Bus fare')).toBeTruthy();
-    });
-  });
-
-  describe('Undo Bar Rendering', () => {
-    it('does not render the undo bar when showUndo is false', async () => {
-      const { queryByTestId } = await render(<OperationListItem {...baseProps} />);
-      expect(queryByTestId('undo-bar-1')).toBeNull();
-    });
-
-    it('renders the undo bar beneath the operation when showUndo is true', async () => {
-      const { getByTestId, getByText } = await render(
-        <OperationListItem
-          {...baseProps}
-          showUndo
-          undoMessage="operation_added"
-          undoActionLabel="undo"
-          onUndo={jest.fn()}
-          onUndoClosed={jest.fn()}
-        />,
-      );
-      expect(getByTestId('undo-bar-1')).toBeTruthy();
-      expect(getByText('operation_added')).toBeTruthy();
-    });
-
-    it('calls onUndo with the operation id when the undo action is triggered', async () => {
-      const onUndo = jest.fn();
-      const { getByTestId } = await render(
-        <OperationListItem
-          {...baseProps}
-          showUndo
-          undoMessage="operation_added"
-          undoActionLabel="undo"
-          onUndo={onUndo}
-          onUndoClosed={jest.fn()}
-        />,
-      );
-      await fireEvent.press(getByTestId('undo-bar-1'));
-      expect(onUndo).toHaveBeenCalledWith('1');
     });
   });
 

--- a/__tests__/components/operations/OperationsList.test.js
+++ b/__tests__/components/operations/OperationsList.test.js
@@ -41,17 +41,12 @@ jest.mock('../../../app/components/operations/DateSeparator', () => {
 jest.mock('../../../app/components/operations/OperationListItem', () => {
   const React = require('react');
   /* eslint-disable react/prop-types */
-  return function MockOperationListItem({ operation, formatCurrency, getCategoryInfo, getAccountName, showUndo }) {
+  return function MockOperationListItem({ operation, formatCurrency, getCategoryInfo, getAccountName }) {
     // invoke utility callbacks so their coverage counters are hit
     if (formatCurrency) formatCurrency(operation.accountId, operation.amount);
     if (getCategoryInfo) getCategoryInfo(operation.categoryId);
     if (getAccountName) getAccountName(operation.accountId);
-    return React.createElement(
-      'View',
-      { testID: `op-item-${operation.id}` },
-      // Marker child so tests can assert which operation gets the inline undo bar.
-      showUndo ? React.createElement('View', { testID: `op-undo-${operation.id}` }) : null,
-    );
+    return React.createElement('View', { testID: `op-item-${operation.id}` });
   };
   /* eslint-enable react/prop-types */
 });
@@ -406,48 +401,26 @@ describe('OperationsList', () => {
     });
   });
 
-  describe('branch coverage — undoOperationId match', () => {
-    it('never toggles subview clipping based on undo state', async () => {
+  describe('subview clipping is a constant', () => {
+    it('keeps removeClippedSubviews on regardless of list state', async () => {
       // Regression (PENNY-16): toggling removeClippedSubviews at runtime on a
       // mounted Fabric list desyncs the JS/native view lists and crashes with
       // "IllegalStateException: addViewAt: failed to insert view ... at index
-      // N". Clipping must stay a constant regardless of undo/suggestion state.
+      // N". Clipping must stay a constant — the undo affordance now floats
+      // outside the list instead of relying on any clipping trick.
       const group = makeGroup(TODAY, [
-        { id: 'op-undo', type: 'expense', amount: '10.00', accountId: 'acc-usd', categoryId: 'cat-1' },
+        { id: 'op-1', type: 'expense', amount: '10.00', accountId: 'acc-usd', categoryId: 'cat-1' },
       ]);
-      const withUndo = await getSectionListProps({
+      const first = await getSectionListProps({
         groupedOperations: [group],
-        undoOperationId: 'op-undo',
-        undoToken: 1,
+        pendingSuggestionId: 'op-1',
       });
-      expect(withUndo.sp.removeClippedSubviews).toBe(true);
+      expect(first.sp.removeClippedSubviews).toBe(true);
 
-      const withoutUndo = await getSectionListProps({
+      const second = await getSectionListProps({
         groupedOperations: [group],
       });
-      expect(withoutUndo.sp.removeClippedSubviews).toBe(true);
-    });
-
-    it('renders the inline undo bar only on the matching operation', async () => {
-      const group = makeGroup(TODAY, [
-        { id: 'op-undo', type: 'expense', amount: '10.00', accountId: 'acc-usd', categoryId: 'cat-1' },
-        { id: 'op-plain', type: 'income', amount: '20.00', accountId: 'acc-usd', categoryId: 'cat-1' },
-      ]);
-      const section = toSection(group);
-      const { sp } = await getSectionListProps({
-        groupedOperations: [group],
-        undoOperationId: 'op-undo',
-        undoToken: 3,
-        undoMessage: 'operation_added',
-        undoActionLabel: 'undo',
-        onUndo: jest.fn(),
-        onUndoClosed: jest.fn(),
-      });
-      const matched = await render(sp.renderItem({ item: section.data[0], index: 0, section }));
-      expect(matched.getByTestId('op-undo-op-undo')).toBeTruthy();
-
-      const plain = await render(sp.renderItem({ item: section.data[1], index: 1, section }));
-      expect(plain.queryByTestId('op-undo-op-plain')).toBeNull();
+      expect(second.sp.removeClippedSubviews).toBe(true);
     });
   });
 

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
-import UndoSnackbar from './UndoSnackbar';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
 
@@ -33,13 +32,6 @@ const OperationListItem = ({
   suggestionChips,
   onApplySuggestion,
   onDismissSuggestion,
-  showUndo,
-  undoToken,
-  undoMessage,
-  undoActionLabel,
-  undoDuration,
-  onUndo,
-  onUndoClosed,
 }) => {
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
@@ -170,29 +162,15 @@ const OperationListItem = ({
         </View>
       </TouchableRipple>
 
-      {/* Label suggestions render directly beneath the operation; the undo bar
-          sits below them. When a just-added operation shows both, the labels
-          are the primary action and the undo/cancel bar reads as the secondary
-          affordance underneath — its top border separates the two cleanly. */}
+      {/* Label suggestions render directly beneath the just-added operation. The
+          undo affordance is no longer inline here — it floats above the tab bar
+          (see OperationsScreen), out of the virtualized list. */}
       {suggestionChips && suggestionChips.length > 0 && (
         <DescriptionSuggestionRow
           chips={suggestionChips}
           colors={colors}
           onApply={onApplySuggestion}
           onDismiss={onDismissSuggestion}
-        />
-      )}
-
-      {showUndo && (
-        <UndoSnackbar
-          key={undoToken}
-          operationId={operation.id}
-          message={undoMessage}
-          actionLabel={undoActionLabel}
-          duration={undoDuration}
-          colors={colors}
-          onUndo={onUndo}
-          onClosed={onUndoClosed}
         />
       )}
 
@@ -231,13 +209,6 @@ OperationListItem.propTypes = {
   suggestionChips: PropTypes.arrayOf(PropTypes.string),
   onApplySuggestion: PropTypes.func,
   onDismissSuggestion: PropTypes.func,
-  showUndo: PropTypes.bool,
-  undoToken: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  undoMessage: PropTypes.string,
-  undoActionLabel: PropTypes.string,
-  undoDuration: PropTypes.number,
-  onUndo: PropTypes.func,
-  onUndoClosed: PropTypes.func,
 };
 
 OperationListItem.defaultProps = {
@@ -246,13 +217,6 @@ OperationListItem.defaultProps = {
   suggestionChips: null,
   onApplySuggestion: () => {},
   onDismissSuggestion: () => {},
-  showUndo: false,
-  undoToken: 0,
-  undoMessage: '',
-  undoActionLabel: '',
-  undoDuration: 5000,
-  onUndo: () => {},
-  onUndoClosed: () => {},
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -73,12 +73,6 @@ const OperationsList = forwardRef(({
   pendingSuggestions,
   onApplySuggestion,
   onDismissSuggestion,
-  undoOperationId,
-  undoToken,
-  undoMessage,
-  undoActionLabel,
-  onUndo,
-  onUndoClosed,
 }, ref) => {
 
   // Format date label for the separator header.
@@ -338,16 +332,10 @@ const OperationsList = forwardRef(({
           suggestionChips={item.id === pendingSuggestionId ? pendingSuggestions : null}
           onApplySuggestion={onApplySuggestion}
           onDismissSuggestion={onDismissSuggestion}
-          showUndo={item.id === undoOperationId}
-          undoToken={undoToken}
-          undoMessage={undoMessage}
-          undoActionLabel={undoActionLabel}
-          onUndo={onUndo}
-          onUndoClosed={onUndoClosed}
         />
       </View>
     );
-  }, [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency, onEditOperation, pendingSuggestionId, pendingSuggestions, onApplySuggestion, onDismissSuggestion, undoOperationId, undoToken, undoMessage, undoActionLabel, onUndo, onUndoClosed]);
+  }, [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency, onEditOperation, pendingSuggestionId, pendingSuggestions, onApplySuggestion, onDismissSuggestion]);
 
   const keyExtractor = useCallback((item) => item.id, []);
 
@@ -380,7 +368,7 @@ const OperationsList = forwardRef(({
       renderSectionHeader={renderSectionHeader}
       renderSectionFooter={renderSectionFooter}
       keyExtractor={keyExtractor}
-      extraData={[accounts, categories, pendingSuggestionId, undoOperationId, undoToken]}
+      extraData={[accounts, categories, pendingSuggestionId]}
       getItemLayout={getItemLayout}
       ListHeaderComponent={
         (topInset > 0 || headerComponent)
@@ -438,9 +426,9 @@ const OperationsList = forwardRef(({
       // JS-side view list from SurfaceMountingManager's native one, crashing
       // with "IllegalStateException: addViewAt: failed to insert view ... at
       // index N" (IndexOutOfBoundsException) — see PENNY-16, caused by an
-      // earlier attempt to gate this on undoOperationId. The inline undo bar's
-      // visibility is guaranteed by UndoSnackbar mounting fully opaque instead
-      // (see its docblock), not by clipping tricks.
+      // earlier attempt to gate this on the (now removed) inline undo bar. The
+      // undo affordance now floats outside the list (OperationsScreen), so it is
+      // immune to this clipping entirely.
       removeClippedSubviews={true}
     />
   );
@@ -471,12 +459,6 @@ OperationsList.propTypes = {
   pendingSuggestions: PropTypes.arrayOf(PropTypes.string),
   onApplySuggestion: PropTypes.func,
   onDismissSuggestion: PropTypes.func,
-  undoOperationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  undoToken: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  undoMessage: PropTypes.string,
-  undoActionLabel: PropTypes.string,
-  onUndo: PropTypes.func,
-  onUndoClosed: PropTypes.func,
 };
 
 OperationsList.defaultProps = {
@@ -494,12 +476,6 @@ OperationsList.defaultProps = {
   pendingSuggestions: [],
   onApplySuggestion: () => {},
   onDismissSuggestion: () => {},
-  undoOperationId: null,
-  undoToken: 0,
-  undoMessage: '',
-  undoActionLabel: '',
-  onUndo: () => {},
-  onUndoClosed: () => {},
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/UndoSnackbar.js
+++ b/app/components/operations/UndoSnackbar.js
@@ -7,34 +7,34 @@ import {
   FONT_SIZE,
   DURATION,
   ICON_SIZE,
+  BORDER_RADIUS,
 } from '../../styles/designTokens';
 
 /**
  * UndoSnackbar
  *
- * A transient "just-added" bar that renders inline within the operations list,
- * directly beneath the operation it refers to (between that operation and the
- * one before it), offering a brief window to undo the last created operation. A
- * thin progress bar depletes over `duration`, giving the user a clear visual cue
- * for how much time remains.
+ * A transient "just-added" snackbar. It is rendered by OperationsScreen as a
+ * floating overlay pinned just above the tab bar — deliberately OUTSIDE the
+ * operations SectionList. Rendering it inline inside a virtualized list cell
+ * used to fight `getItemLayout` + `removeClippedSubviews`: the cell's reported
+ * height never accounted for the bar, so the clipping pass would slice it off a
+ * few frames after mount (see PENNY-16 for the crash the inline approach also
+ * caused). As a floating sibling of the list it is immune to virtualization.
+ *
+ * A thin progress bar depletes over `duration`, giving the user a clear visual
+ * cue for how much time remains.
  *
  * Lifecycle is intentionally split so the exit animation always plays:
  *  - `onUndo(operationId)` performs the undo (called before the fade-out).
- *  - `onClosed()` tells the parent to unmount, and fires only after the exit
- *    animation completes (whether dismissed by timeout or by the Undo tap).
+ *  - `onClosed(operationId)` tells the parent to unmount, and fires only after
+ *    the exit animation completes (whether dismissed by timeout or Undo tap).
  *
  * Mount this conditionally with a changing `key` (e.g. an incrementing token)
  * so each new operation restarts the entry animation and countdown cleanly.
- *
- * Visibility must NEVER depend on an animation successfully running: the bar is
- * inserted into an already-mounted virtualized list cell, where a native-driver
- * animation can fail to attach on its first frame. The container therefore
- * mounts fully opaque; animations only add polish (entry rise) or remove the
- * bar on the way out (exit fade), so their failure modes are benign.
  */
-// Shared with OperationsScreen's fallback cleanup: the parent must be able to
-// clear its undo state even when this component never gets to call onClosed
-// (cell unmounted by virtualization, exit animation never completing).
+// Shared with OperationsScreen's fallback cleanup: a belt-and-suspenders timer
+// that clears the parent's undo state even if this component's exit animation
+// never completes its callback.
 export const UNDO_DURATION_MS = 5000;
 
 const UndoSnackbar = ({
@@ -112,7 +112,7 @@ const UndoSnackbar = ({
         styles.container,
         {
           backgroundColor: colors.altRow || colors.surface,
-          borderTopColor: colors.border,
+          borderColor: colors.border,
           opacity: exitAnim,
           transform: [{ translateY }],
         },
@@ -167,9 +167,15 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
   container: {
-    borderTopWidth: 1,
-    // Clip the depleting progress fill to the bar's bounds.
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+    elevation: 6,
+    // Clip the depleting progress fill to the rounded bounds.
     overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
   },
   content: {
     alignItems: 'center',

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -3,6 +3,7 @@ import { View, StyleSheet, FlatList, TouchableOpacity, TextInput, Pressable, Mod
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import DateTimePicker from '@react-native-community/datetimepicker';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS, HEIGHTS } from '../styles/layout';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -22,7 +23,7 @@ import OperationsList from '../components/operations/OperationsList';
 import QuickAddForm from '../components/operations/QuickAddForm';
 import NotificationBindingStack, { deckPeekAllowance, deckCardHeight } from '../components/operations/NotificationBindingStack';
 import PickerModal from '../components/operations/PickerModal';
-import { UNDO_DURATION_MS } from '../components/operations/UndoSnackbar';
+import UndoSnackbar, { UNDO_DURATION_MS } from '../components/operations/UndoSnackbar';
 import SearchOverlay from '../components/search/SearchOverlay';
 import SearchBar from '../components/search/SearchBar';
 import FilterChipStrip from '../components/search/FilterChipStrip';
@@ -40,6 +41,7 @@ import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
 
 const OperationsScreen = () => {
   const { colors } = useThemeColors();
+  const insets = useSafeAreaInsets();
 
   const { t } = useLocalization();
   const { showDialog } = useDialog();
@@ -738,12 +740,10 @@ const OperationsScreen = () => {
     setUndoInfo(prev => (prev && operationId != null && prev.id !== operationId) ? prev : null);
   }, []);
 
-  // Fallback cleanup: the snackbar's onClosed is the normal path, but it never
-  // fires when the snackbar unmounts without animating out (its cell scrolled
-  // beyond the render window, a filter excluding the row) or when the exit
-  // animation drops its completion callback. Without this, a leaked undoInfo
-  // would keep offering an undo action for an operation whose window has long
-  // since passed.
+  // Fallback cleanup: the snackbar's onClosed is the normal path, but it won't
+  // fire if the exit animation drops its completion callback. Without this, a
+  // leaked undoInfo would keep offering an undo action for an operation whose
+  // window has long since passed.
   useEffect(() => {
     if (!undoInfo) return undefined;
     const timer = setTimeout(() => setUndoInfo(null), UNDO_DURATION_MS + 1500);
@@ -1047,13 +1047,28 @@ const OperationsScreen = () => {
         pendingSuggestions={pendingSuggestions}
         onApplySuggestion={handleApplySuggestion}
         onDismissSuggestion={handleDismissSuggestion}
-        undoOperationId={undoInfo ? undoInfo.id : null}
-        undoToken={undoInfo ? undoInfo.token : 0}
-        undoMessage={t('operation_added')}
-        undoActionLabel={t('undo')}
-        onUndo={handleUndoAdd}
-        onUndoClosed={handleUndoClosed}
       />
+
+      {/* Floating undo snackbar — pinned above the tab bar, OUTSIDE the list, so
+          virtualization / removeClippedSubviews can't clip it (see UndoSnackbar
+          docblock and PENNY-16). The token key restarts its countdown whenever a
+          newer operation replaces the one being offered for undo. */}
+      {undoInfo && (
+        <View
+          style={[styles.floatingUndoArea, { bottom: insets.bottom + HEIGHTS.tabBar }]}
+          pointerEvents="box-none"
+        >
+          <UndoSnackbar
+            key={undoInfo.token}
+            operationId={undoInfo.id}
+            message={t('operation_added')}
+            actionLabel={t('undo')}
+            colors={colors}
+            onUndo={handleUndoAdd}
+            onClosed={handleUndoClosed}
+          />
+        </View>
+      )}
 
       {/* Floating search area — overlays the list so its content scrolls behind
           it instead of being clipped by an opaque band. The matching topInset on
@@ -1163,6 +1178,14 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
     zIndex: 100,
+  },
+  floatingUndoArea: {
+    // `bottom` is applied inline (safe-area inset + tab bar height) so the
+    // snackbar floats just above the floating tab bar instead of behind it.
+    left: SPACING.lg,
+    position: 'absolute',
+    right: SPACING.lg,
+    zIndex: 90,
   },
   scrollToTopButton: {
     alignItems: 'center',


### PR DESCRIPTION
## Проблема

Панель отмены только что добавленной операции («operation added» + **Undo**) мелькала буквально долю секунды и пропадала, хотя окно отмены должно жить 5 секунд.

## Корневая причина

Снекбар рендерился **внутри виртуализированной ячейки** `SectionList`. Список отдаёт `getItemLayout`, который считает высоту строки по фиксированной константе `ITEM_ROW_HEIGHT` и **не учитывает высоту инлайн-бара**. При `removeClippedSubviews={true}` (Fabric/New Arch) RN доверяет `getItemLayout` как источнику истины для clip-прямоугольников ячеек, поэтому через пару кадров после монтирования проход клиппинга срезал бар — он оказывался «ниже» вычисленной границы ячейки.

Предыдущие заплатки (opaque-mount, fallback-cleanup) лечили симптомы (прозрачность / утечку state), но не рассинхрон высоты.

## Фикс

Снекбар вынесен из списка в **floating overlay** в `OperationsScreen`, absolute-плашкой над таб-баром — вне виртуализации, поэтому `removeClippedSubviews`/`getItemLayout` на него больше не влияют. Это убирает весь класс багов, включая краш **PENNY-16** (попытка гейтить клиппинг по undo-состоянию).

- `UndoSnackbar` получил вид floating-плашки: скругление, hairline-border, elevation/тень.
- Позиционирование `bottom = insets.bottom + HEIGHTS.tabBar` — по паттерну проекта (`CategoriesScreen`, `SettingsScreen`), т.к. таб-бар здесь floating pill поверх экрана (`screen: height 100%`); иначе бар оказался бы **за** таб-баром.
- Убрана вся undo-проводка пропов из `OperationsList` → `OperationListItem`.

## Тесты

- Полная сюита: **155 suites, 4435 passed, 0 failed**. ESLint чистый.
- Удалены 3 теста inline-проводки undo в `OperationListItem` и inline-bar тест в `OperationsList` (поведение, которого больше нет).
- Тест на **константность** `removeClippedSubviews` (регрессия PENNY-16) сохранён.
- Поведение самого снекбара (5с, undo, auto-dismiss, opaque-mount) остаётся покрытым `UndoSnackbar.test.js`.

## Примечание

Первый коммит (`refactor: move undo bar outside operation list`) — авто-коммит из claude-manager; его сообщение описывает причину неточно (упирает в toggling removeClippedSubviews). Точная причина — рассинхрон высоты в `getItemLayout`, описанная выше и в докблоке `UndoSnackbar`.
