### PR TITLE
fix(operations): keep the undo bar on screen for its full 5s window

### DIFF
--- a/__tests__/components/operations/UndoSnackbar.test.js
+++ b/__tests__/components/operations/UndoSnackbar.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Animated, StyleSheet } from 'react-native';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import UndoSnackbar from '../../../app/components/operations/UndoSnackbar';
+import UndoSnackbar, { UNDO_DURATION_MS } from '../../../app/components/operations/UndoSnackbar';
 
 const mockColors = {
   surface: '#1e1e1e',
@@ -107,6 +107,39 @@ describe('UndoSnackbar', () => {
     // Well within the 10s window — the dismiss timer has not fired.
     await flush(50);
     expect(onClosed).not.toHaveBeenCalled();
+  });
+
+  describe('Regression Tests', () => {
+    // The bar's real caller (OperationsScreen) does NOT pass `duration`, but every
+    // test above did — which hid the bug through two attempted fixes. React 19
+    // removed defaultProps for function components, so the omitted prop arrived as
+    // undefined: setTimeout(fn, undefined) fired on the next tick and the bar
+    // vanished in a couple of frames. These tests mount it exactly as the screen
+    // does — no `duration` — so the default can never silently break again.
+    const propsWithoutDuration = () => {
+      const { duration, ...rest } = baseProps;
+      return rest;
+    };
+
+    it('falls back to the 5s window when the parent omits duration', async () => {
+      const onClosed = jest.fn();
+      await render(<UndoSnackbar {...propsWithoutDuration()} onClosed={onClosed} />);
+
+      // Far past the couple of frames the broken default collapsed to, and far
+      // short of the real 5s window.
+      await flush(150);
+      expect(onClosed).not.toHaveBeenCalled();
+    });
+
+    it('runs the countdown animation over the full default duration', async () => {
+      await render(<UndoSnackbar {...propsWithoutDuration()} />);
+
+      // The depleting progress bar must span the same window as the dismiss timer,
+      // not Animated's own 500ms fallback for an undefined duration.
+      const durations = Animated.timing.mock.calls.map(([, config]) => config.duration);
+      expect(durations).toContain(UNDO_DURATION_MS);
+      expect(durations).not.toContain(undefined);
+    });
   });
 
   it('clears its auto-dismiss timer on unmount', async () => {

--- a/app/components/operations/UndoSnackbar.js
+++ b/app/components/operations/UndoSnackbar.js
@@ -41,7 +41,11 @@ const UndoSnackbar = ({
   operationId,
   message,
   actionLabel,
-  duration,
+  // Must be an ES6 default, not defaultProps: React 19 removed defaultProps for
+  // function components, so an omitted `duration` would arrive as undefined and
+  // collapse the visible window to a couple of frames (setTimeout(fn, undefined)
+  // fires on the next tick; Animated.timing falls back to its own 500ms).
+  duration = UNDO_DURATION_MS,
   colors,
   onUndo,
   onClosed,
@@ -215,10 +219,6 @@ UndoSnackbar.propTypes = {
   }).isRequired,
   onUndo: PropTypes.func.isRequired,
   onClosed: PropTypes.func.isRequired,
-};
-
-UndoSnackbar.defaultProps = {
-  duration: UNDO_DURATION_MS,
 };
 
 export default memo(UndoSnackbar);


### PR DESCRIPTION
## The bug

The undo bar for a just-added operation vanished a few frames after appearing — the third report of this. Neither previous fix (#1249 moving it out of the list, and the one before that) touched the cause. It was never about layout, clipping, or where the bar lived in the tree.

`UndoSnackbar` declared its 5s window via `defaultProps`:

```js
UndoSnackbar.defaultProps = { duration: UNDO_DURATION_MS };  // 5000
```

`OperationsScreen` is its only caller and does not pass `duration` — it relies on that default. We are on **React 19.2.3**, and [React 19 removed `defaultProps` for function components](https://react.dev/blog/2024/04/25/react-19-upgrade-guide): they are silently ignored. So the prop arrived as `undefined`:

```js
setTimeout(() => animateOut(), undefined)              // undefined -> 0ms, dismisses on the next tick
Animated.timing(progressAnim, { duration: undefined }) // -> Animated's own 500ms fallback
```

The dismiss timer fired immediately while the progress bar animated over 500ms. That is exactly the half-second flash users saw.

The earlier inline version failed for the identical reason: `undoDuration` was defaulted on `OperationListItem`, and `OperationsList` never passed it. Same `undefined`, different address — which is why moving the bar around never helped.

## The fix

An ES6 default parameter, which React 19 does honour:

```js
const UndoSnackbar = ({ ..., duration = UNDO_DURATION_MS, ... }) => {
```

## Why it survived two fixes

Every test passed `duration` explicitly (`baseProps` has `duration: 5000`), while the only real caller never does. The tested path did not exist in production.

The regression tests mount the bar **exactly as `OperationsScreen` does** — no `duration`. Both were verified to fail against the pre-fix component; the second one reported `Received array: [300, undefined]`, catching the countdown running on an undefined duration.

## Testing

- `npx jest --silent` — 155 suites, 4449 tests, all passing.
- Both new regression tests confirmed red before the fix, green after.

## Follow-up (separate PR)

The other 26 components still declare `defaultProps`, all inert under React 19. An audit traced every call site: no live crashes or broken behaviour today — saved by defensive guards in the bodies, falsy-equivalent defaults, and ES6 defaults already present alongside the redundant `defaultProps`. That is luck, not design; each one is a footgun waiting for a call site that omits a prop. Migration to ES6 defaults will follow separately.
