### PR TITLE
fix(navigation): block taps only beside and below the tab bar

### DIFF
--- a/__tests__/navigation/SimpleTabs.test.js
+++ b/__tests__/navigation/SimpleTabs.test.js
@@ -115,13 +115,15 @@ jest.mock('react-native-safe-area-context', () => {
   const { View } = require('react-native');
   const PropTypes = require('prop-types');
 
-  function SafeAreaView({ children, style }) {
-    return React.createElement(View, { style }, children);
+  // Forwards every prop but `edges` (inset-only) to a real View, so testID and
+  // pointerEvents stay assertable the way the real SafeAreaView renders them.
+  function SafeAreaView({ children, edges: _edges, ...props }) {
+    return React.createElement(View, props, children);
   }
 
   SafeAreaView.propTypes = {
     children: PropTypes.node,
-    style: PropTypes.any,
+    edges: PropTypes.array,
   };
 
   function SafeAreaProvider({ children }) { return children; }
@@ -400,6 +402,37 @@ describe('SimpleTabs Component Rendering', () => {
   it('renders header component', async () => {
     const { getByTestId } = await render(<SimpleTabs />);
     expect(getByTestId('mock-header')).toBeTruthy();
+  });
+
+  describe('Tab bar touch blocking', () => {
+    // Regression: the gradient used to be a plain touch-absorbing View spanning
+    // TAB_OVERLAY_HEIGHT (130px), far taller than the bar itself. That killed
+    // taps on anything anchored just above the bar — most visibly the undo
+    // snackbar, pinned at insets.bottom + HEIGHTS.tabBar. Blocking must come
+    // from the bar wrapper (bar height + margin + inset), never the gradient.
+    it('lets touches pass through the gradient above the bar', async () => {
+      const { getByTestId } = await render(<SimpleTabs />);
+
+      expect(getByTestId('tab-gradient').props.pointerEvents).toBe('none');
+    });
+
+    it('absorbs taps in the empty space around the pill via the bar wrapper', async () => {
+      const { getByTestId } = await render(<SimpleTabs />);
+
+      // Default pointerEvents ('auto'): the wrapper itself is a touch target,
+      // while the tab buttons nested inside it still receive their own taps.
+      // 'box-none' here would let taps beside the pill fall through to content.
+      expect(getByTestId('tab-bar-wrapper').props.pointerEvents).toBeUndefined();
+      expect(getByTestId('tab-Operations')).toBeTruthy();
+    });
+
+    it('keeps the tab buttons tappable through the blocking wrapper', async () => {
+      const { getByTestId } = await render(<SimpleTabs />);
+
+      await act(async () => { fireEvent(getByTestId('tab-Graphs'), 'pressIn'); });
+
+      await waitFor(() => expect(getByTestId('graphs-screen')).toBeTruthy());
+    });
   });
 
   it('renders a Settings tab button', async () => {

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -217,13 +217,14 @@ const gradientStepColors = Array.from({ length: GRADIENT_STEPS }, (_, i) => {
   return `rgba(0, 0, 0, ${opacity})`;
 });
 
-// Covers the tab bar region, blocks accidental touches falling through
-// to the list content below, and shows a darkening gradient as a visual cue.
-// Rendered before floatingBarWrapper so tab buttons (higher z-order) remain clickable.
-const TabGradientBlocker = memo(() => {
+// Darkening gradient behind the tab bar region. Purely visual: it must not
+// swallow touches, because it extends well above the bar and would make
+// elements anchored just above the bar (undo bar, FABs) untappable. Touch
+// blocking around the pill lives on floatingBarWrapper instead.
+const TabGradient = memo(() => {
   const stepHeight = TAB_OVERLAY_HEIGHT / GRADIENT_STEPS;
   return (
-    <View style={styles.tabGradientOverlay}>
+    <View style={styles.tabGradientOverlay} pointerEvents="none" testID="tab-gradient">
       {gradientStepColors.map((color, i) => (
         <View key={i} style={{ height: stepHeight, backgroundColor: color }} />
       ))}
@@ -231,7 +232,7 @@ const TabGradientBlocker = memo(() => {
   );
 });
 
-TabGradientBlocker.displayName = 'TabGradientBlocker';
+TabGradient.displayName = 'TabGradient';
 
 export default function SimpleTabs() {
   const { colors } = useThemeColors();
@@ -547,46 +548,44 @@ export default function SimpleTabs() {
           </Animated.View>
         </GestureDetector>
       </View>
-      {/* Gradient touch blocker — rendered before floatingBarWrapper so the
-          tab buttons (higher z-order, box-none wrapper) remain clickable while
-          the empty space around the pill catches accidental taps */}
-      <TabGradientBlocker />
-      {/* Floating bar overlays content so screen shows through behind it */}
-      <SafeAreaView edges={['bottom']} style={styles.floatingBarWrapper} pointerEvents="box-none">
-        <View
-          pointerEvents="box-none"
-          style={styles.floatingBarPositioner}
-        >
-          <View style={[
-            styles.floatingBar,
-            // Widen the bar for the extra tab so labels don't get cramped.
-            TABS.length >= 5 && styles.floatingBarWide,
-            {
-              backgroundColor: withAlpha(colors.surface, 0.87),
-              borderColor: withAlpha(colors.border, 0.5),
-            },
-          ]}>
-            <Animated.View
-              style={[
-                styles.activePill,
-                { backgroundColor: colors.primary + '1A' },
-                pillAnimatedStyle,
-              ]}
-            />
-            <View style={styles.tabsRow} onLayout={handleTabBarLayout}>
-              {TABS.map(tab => (
-                <TabButton
-                  key={tab.key}
-                  tab={tab}
-                  isActive={displayedTab === tab.key}
-                  colors={colors}
-                  onPress={handleTabPress}
-                  isUpdating={tab.key === 'Settings' && isDownloading}
-                  updatePhase={downloadPhase}
-                  updateProgress={downloadProgress}
-                />
-              ))}
-            </View>
+      {/* Visual gradient only — rendered before floatingBarWrapper so the tab
+          buttons stay on top */}
+      <TabGradient />
+      {/* Floating bar overlays content so screen shows through behind it.
+          The wrapper is exactly as tall as the bar plus its bottom margin and
+          safe-area inset, and it uses the default pointerEvents so the empty
+          space beside and below the pill absorbs accidental taps — without
+          reaching any higher than the bar itself. */}
+      <SafeAreaView edges={['bottom']} style={styles.floatingBarWrapper} testID="tab-bar-wrapper">
+        <View style={[
+          styles.floatingBar,
+          // Widen the bar for the extra tab so labels don't get cramped.
+          TABS.length >= 5 && styles.floatingBarWide,
+          {
+            backgroundColor: withAlpha(colors.surface, 0.87),
+            borderColor: withAlpha(colors.border, 0.5),
+          },
+        ]}>
+          <Animated.View
+            style={[
+              styles.activePill,
+              { backgroundColor: colors.primary + '1A' },
+              pillAnimatedStyle,
+            ]}
+          />
+          <View style={styles.tabsRow} onLayout={handleTabBarLayout}>
+            {TABS.map(tab => (
+              <TabButton
+                key={tab.key}
+                tab={tab}
+                isActive={displayedTab === tab.key}
+                colors={colors}
+                onPress={handleTabPress}
+                isUpdating={tab.key === 'Settings' && isDownloading}
+                updatePhase={downloadPhase}
+                updateProgress={downloadProgress}
+              />
+            ))}
           </View>
         </View>
       </SafeAreaView>
@@ -628,15 +627,16 @@ const styles = StyleSheet.create({
       },
     }),
   },
-  floatingBarPositioner: {
-    flex: 1,
-    justifyContent: 'flex-end',
-  },
   floatingBarWide: {
     width: '84%',
   },
   floatingBarWrapper: {
     bottom: 0,
+    // Carries the same elevation the gradient overlay uses, so the empty space
+    // beside the pill keeps absorbing taps even above an elevated subpanel
+    // (e.g. the Settings sub-screens). No backgroundColor, so this only affects
+    // z-ordering on Android and casts no shadow.
+    elevation: 8,
     left: 0,
     position: 'absolute',
     right: 0,


### PR DESCRIPTION
## Проблема

Блокировка тапов вокруг таббара была навешена на сам градиентный оверлей — обычный `View` высотой `TAB_OVERLAY_HEIGHT` (130px) от низа экрана. Но бар вместе с `marginBottom` и safe-area инсетом занимает всего ~74px. То есть оверлей выпирал примерно на 56px над баром и глотал тапы в полосе, где градиент уже практически прозрачный (альфа ~0.075 на этой высоте).

Всё, что приклеено к меню сверху, попадало в эту мёртвую зону. Ярче всего — undo-бар, прибитый к `insets.bottom + HEIGHTS.tabBar`: он был нетапабельным все свои 5 секунд, что обесценивало #1253.

## Решение

Развожу две роли, которые совмещал оверлей:

- **Градиент** теперь чисто визуальный — `pointerEvents="none"`.
- **`floatingBarWrapper`** взял на себя блокировку. Его высота задаётся контентом (бар + `marginBottom` + инсет), поэтому он покрывает ровно полосу слева, справа и снизу от пилюли и никогда не лезет выше бара. Дефолтный `pointerEvents` делает его тач-таргетом, при этом вложенные кнопки табов продолжают получать свои тапы. Забрал себе `elevation: 8` от градиента, чтобы полоса продолжала глотать тапы поверх поднятого сабпанеля (Settings sub-screens).

Заодно выпилен `floatingBarPositioner`: `flex: 1` + `justifyContent: 'flex-end'` ничего не делают внутри absolute-родителя с авто-высотой, так что это была пустая View, притворяющаяся несущей раскладкой.

Приятный побочный эффект: свайп переключения табов снова работает в полосе над баром — раньше блокер его там съедал.

## Тесты

- `npx jest` — 155 suites, 4454 теста, все зелёные.
- Добавлен регрессионный блок `Tab bar touch blocking`. Проверен мутацией: если вернуть баг (убрать `pointerEvents="none"` с градиента), тест краснеет.
- Локальный мок `SafeAreaView` в тест-файле теперь форвардит пропсы в `View` (кроме `edges`), иначе `testID`/`pointerEvents` не доходили до дерева.

## Известный нюанс (не в этом PR)

Зазор между верхом обёртки (~74px + инсет) и якорем undo-бара (`HEIGHTS.tabBar` = 80) — 6px. Это предсуществующий дрейф токена относительно фактической высоты бара: на сильно увеличенном системном шрифте бар может подрасти и снова задеть undo-бар. Нормальное лечение — считать якорь undo-бара от той же величины, что и высота бара, а не от захардкоженной константы. Отдельной задачей.
