### PR TITLE
refactor: replace defaultProps with ES default parameters

### DIFF
--- a/__tests__/components/MaterialDialog.test.js
+++ b/__tests__/components/MaterialDialog.test.js
@@ -439,8 +439,13 @@ describe('MaterialDialog', () => {
 
   describe('Default Props', () => {
     it('uses default visible value', async () => {
-      // Default visible is false
-      expect(MaterialDialog.defaultProps.visible).toBe(false);
+      // Default visible is false, so the dialog renders nothing when omitted
+      const { queryByTestId } = await render(
+        <MaterialDialog title="Hidden" />,
+        { wrapper },
+      );
+
+      expect(queryByTestId('material-dialog-overlay')).toBeNull();
     });
 
     it('uses default buttons array', async () => {

--- a/__tests__/components/SimplePicker.test.js
+++ b/__tests__/components/SimplePicker.test.js
@@ -75,11 +75,27 @@ describe('SimplePicker', () => {
     });
 
     it('handles undefined items gracefully', async () => {
+      // undefined is filled in by the default parameter, so no warning is needed
       const { root } = await render(
         <SimplePicker
           value="opt1"
           onValueChange={jest.fn()}
           items={undefined}
+          colors={mockColors}
+        />,
+      );
+
+      expect(root).toBeTruthy();
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('handles null items gracefully', async () => {
+      // null bypasses the default parameter, so the defensive fallback catches it
+      const { root } = await render(
+        <SimplePicker
+          value="opt1"
+          onValueChange={jest.fn()}
+          items={null}
           colors={mockColors}
         />,
       );
@@ -438,11 +454,26 @@ describe('SimplePicker', () => {
 
   describe('Default Props', () => {
     it('uses default colors when not provided', async () => {
+      // The default parameter supplies colors, so the defensive fallback never trips
       const { root } = await render(
         <SimplePicker
           value="opt1"
           onValueChange={jest.fn()}
           items={mockItems}
+        />,
+      );
+
+      expect(root).toBeTruthy();
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('falls back to safe colors when colors is explicitly invalid', async () => {
+      const { root } = await render(
+        <SimplePicker
+          value="opt1"
+          onValueChange={jest.fn()}
+          items={mockItems}
+          colors={null}
         />,
       );
 
@@ -460,7 +491,7 @@ describe('SimplePicker', () => {
       );
 
       expect(root).toBeTruthy();
-      expect(console.warn).toHaveBeenCalledWith('SimplePicker: items prop is undefined or null. Using empty array.');
+      expect(console.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/Calculator.js
+++ b/app/components/Calculator.js
@@ -10,7 +10,7 @@ import { getDecimalPlaces } from '../services/currency';
  * Calculator button component - Memoized for performance
  * Executes on press down and repeats during long holds
  */
-const CalcButton = memo(({ value, onPress, style, textStyle, icon, colors }) => {
+const CalcButton = memo(({ value = '', onPress = () => {}, style = null, textStyle = null, icon = null, colors = {} }) => {
   const timeoutRef = useRef(null);
   const intervalRef = useRef(null);
   const isPressedRef = useRef(false);
@@ -153,15 +153,6 @@ CalcButton.propTypes = {
   colors: PropTypes.object,
 };
 
-CalcButton.defaultProps = {
-  value: '',
-  onPress: () => {},
-  style: null,
-  textStyle: null,
-  icon: null,
-  colors: {},
-};
-
 /**
  * Calculator component for amount input
  * Features:
@@ -172,7 +163,7 @@ CalcButton.defaultProps = {
  * - Shows "=" button when expression contains operations
  * - Evaluates expression and replaces with result
  */
-export default function Calculator({ value, onValueChange, colors, placeholder = '0', onAdd, containerBackground = null, compact = false, currencyCode, onCurrencyPress }) {
+export default function Calculator({ value = '', onValueChange = () => {}, colors, placeholder = '0', onAdd = null, containerBackground = null, compact = false, currencyCode, onCurrencyPress }) {
   const [expression, setExpression] = useState(value || '');
   const syncedFromPropRef = useRef(false);
 
@@ -487,14 +478,6 @@ Calculator.propTypes = {
   compact: PropTypes.bool,
   currencyCode: PropTypes.string,
   onCurrencyPress: PropTypes.func,
-};
-
-Calculator.defaultProps = {
-  value: '',
-  onValueChange: () => {},
-  placeholder: '0',
-  onAdd: null,
-  containerBackground: null,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/CategoryGridSelector.js
+++ b/app/components/CategoryGridSelector.js
@@ -42,11 +42,11 @@ const TOP_WITHOUT_ALL = 8;
 export default function CategoryGridSelector({
   categories,
   categoryType,
-  selectedCategoryId,
+  selectedCategoryId = null,
   onSelect,
   colors,
   t,
-  topCategoryIds,
+  topCategoryIds = null,
 }) {
   const suggestMode = Array.isArray(topCategoryIds);
   const columns = suggestMode ? SUGGEST_COLUMNS : LEGACY_COLUMNS;
@@ -282,11 +282,6 @@ CategoryGridSelector.propTypes = {
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   topCategoryIds: PropTypes.arrayOf(PropTypes.string),
-};
-
-CategoryGridSelector.defaultProps = {
-  selectedCategoryId: null,
-  topCategoryIds: null,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -2,7 +2,7 @@ import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 
-export default function Header({ rightContent }) {
+export default function Header({ rightContent = null }) {
   const { colors } = useThemeColors();
 
   if (!rightContent) return null;
@@ -21,10 +21,6 @@ export default function Header({ rightContent }) {
 
 Header.propTypes = {
   rightContent: PropTypes.node,
-};
-
-Header.defaultProps = {
-  rightContent: null,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/MaterialDialog.js
+++ b/app/components/MaterialDialog.js
@@ -17,7 +17,7 @@ import ModalBlurOverlay from './ModalBlurOverlay';
  * @param {function} onDismiss - Called when dialog is dismissed
  */
 export default function MaterialDialog({
-  visible,
+  visible = false,
   title,
   message,
   buttons = [],
@@ -120,14 +120,6 @@ MaterialDialog.propTypes = {
     }),
   ),
   onDismiss: PropTypes.func,
-};
-
-MaterialDialog.defaultProps = {
-  visible: false,
-  title: undefined,
-  message: undefined,
-  buttons: [],
-  onDismiss: undefined,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -39,17 +39,17 @@ export default function ModalShell({
   visible,
   onDismiss,
   title,
-  subtitle,
-  onSave,
+  subtitle = null,
+  onSave = null,
   onCancel,
-  saveLabel,
-  cancelLabel,
-  onDelete,
-  deleteLabel,
-  deleteDisabled,
-  extraActions,
-  scrollRef,
-  showBlurOverlay,
+  saveLabel = null,
+  cancelLabel = null,
+  onDelete = null,
+  deleteLabel = null,
+  deleteDisabled = false,
+  extraActions = null,
+  scrollRef = null,
+  showBlurOverlay = false,
   children,
 }) {
   const { colors } = useThemeColors();
@@ -298,19 +298,6 @@ ModalShell.propTypes = {
   scrollRef: PropTypes.object,
   showBlurOverlay: PropTypes.bool,
   children: PropTypes.node.isRequired,
-};
-
-ModalShell.defaultProps = {
-  subtitle: null,
-  onSave: null,
-  saveLabel: null,
-  cancelLabel: null,
-  onDelete: null,
-  deleteLabel: null,
-  deleteDisabled: false,
-  extraActions: null,
-  scrollRef: null,
-  showBlurOverlay: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/NotificationBindingsContentPanel.js
+++ b/app/components/NotificationBindingsContentPanel.js
@@ -45,7 +45,7 @@ import {
  * preference; category and name bindings share the notification_merchant_rules
  * table (one row may carry both). Each row can be re-pointed or removed.
  */
-export default function NotificationBindingsContentPanel({ bottomInset }) {
+export default function NotificationBindingsContentPanel({ bottomInset = 0 }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { accounts } = useAccountsData();
@@ -420,10 +420,6 @@ export default function NotificationBindingsContentPanel({ bottomInset }) {
 
 NotificationBindingsContentPanel.propTypes = {
   bottomInset: PropTypes.number,
-};
-
-NotificationBindingsContentPanel.defaultProps = {
-  bottomInset: 0,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/NotificationFiltersContentPanel.js
+++ b/app/components/NotificationFiltersContentPanel.js
@@ -40,7 +40,7 @@ import {
  *      checkbox. Apps are shown by default; unchecking one hides its
  *      notifications from the feed on the main processing page.
  */
-export default function NotificationFiltersContentPanel({ bottomInset }) {
+export default function NotificationFiltersContentPanel({ bottomInset = 0 }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
 
@@ -324,10 +324,6 @@ export default function NotificationFiltersContentPanel({ bottomInset }) {
 
 NotificationFiltersContentPanel.propTypes = {
   bottomInset: PropTypes.number,
-};
-
-NotificationFiltersContentPanel.defaultProps = {
-  bottomInset: 0,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -83,7 +83,7 @@ const CARD_COLLAPSE_ANIMATION = {
  *
  * The panel owns all of its async state so the host screen only has to mount it.
  */
-export default function NotificationProcessingContentPanel({ bottomInset }) {
+export default function NotificationProcessingContentPanel({ bottomInset = 0 }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { accounts } = useAccountsData();
@@ -666,10 +666,6 @@ export default function NotificationProcessingContentPanel({ bottomInset }) {
 
 NotificationProcessingContentPanel.propTypes = {
   bottomInset: PropTypes.number,
-};
-
-NotificationProcessingContentPanel.defaultProps = {
-  bottomInset: 0,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/NotificationsContentPanel.js
+++ b/app/components/NotificationsContentPanel.js
@@ -19,7 +19,7 @@ const formatPostTime = (postTime) => {
   return `${datePart} · ${timePart}`;
 };
 
-export function NotificationCard({ notification, colors, t, onReAdd, reAddState, animateIn }) {
+export function NotificationCard({ notification, colors, t, onReAdd = null, reAddState = undefined, animateIn = false }) {
   const { title, text, packageName, postTime } = notification;
   const timeLabel = formatPostTime(postTime);
   // A notification that parses into a bank transaction is surfaced with an
@@ -144,13 +144,7 @@ NotificationCard.propTypes = {
   animateIn: PropTypes.bool,
 };
 
-NotificationCard.defaultProps = {
-  onReAdd: null,
-  reAddState: undefined,
-  animateIn: false,
-};
-
-export default function NotificationsContentPanel({ isLoading, notifications, onRefresh, bottomInset }) {
+export default function NotificationsContentPanel({ isLoading = false, notifications = [], onRefresh = null, bottomInset = 0 }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const contentAnim = useRef(new Animated.Value(0)).current;
@@ -228,13 +222,6 @@ NotificationsContentPanel.propTypes = {
   ),
   onRefresh: PropTypes.func,
   bottomInset: PropTypes.number,
-};
-
-NotificationsContentPanel.defaultProps = {
-  isLoading: false,
-  notifications: [],
-  onRefresh: null,
-  bottomInset: 0,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/SimplePicker.js
+++ b/app/components/SimplePicker.js
@@ -5,11 +5,20 @@ import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import ModalBlurOverlay from './ModalBlurOverlay';
 
+// Module-level so the default `colors` prop keeps a stable identity across
+// renders (an inline object literal would break the safeColors useMemo).
+const DEFAULT_COLORS = {
+  text: '#000',
+  surface: '#fff',
+  border: '#e0e0e0',
+  selected: '#f5f5f5',
+};
+
 /**
  * SimplePicker - A picker component for Android
  * Uses native HTML select on web, custom modal picker on Android
  */
-const SimplePicker = ({ value, onValueChange, items, style, textStyle, colors, leftIcon, leftText, closeLabel }) => {
+const SimplePicker = ({ value, onValueChange, items = [], style, textStyle, colors = DEFAULT_COLORS, leftIcon, leftText, closeLabel = 'Close' }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   // Defensive check for undefined items with warning
@@ -252,17 +261,6 @@ SimplePicker.propTypes = {
   leftIcon: PropTypes.string,
   leftText: PropTypes.string,
   closeLabel: PropTypes.string,
-};
-
-SimplePicker.defaultProps = {
-  items: [],
-  closeLabel: 'Close',
-  colors: {
-    text: '#000',
-    surface: '#fff',
-    border: '#e0e0e0',
-    selected: '#f5f5f5',
-  },
 };
 
 export default SimplePicker;

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -370,7 +370,7 @@ const unmatchedApksFor = (downloadedApks, releases) => {
   return downloadedApks.filter((apk) => !apk.version || !shown.has(apk.version));
 };
 
-export default function UpdateContentPanel({ isChecking, updateResult, downloadedApks, onUpdate, onInstallApk, onRefresh, bottomInset }) {
+export default function UpdateContentPanel({ isChecking = false, updateResult = null, downloadedApks = [], onUpdate = () => {}, onInstallApk = () => {}, onRefresh = null, bottomInset = 0 }) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const contentAnim = useRef(new Animated.Value(0)).current;
@@ -683,16 +683,6 @@ UpdateContentPanel.propTypes = {
   onInstallApk: PropTypes.func,
   onRefresh: PropTypes.func,
   bottomInset: PropTypes.number,
-};
-
-UpdateContentPanel.defaultProps = {
-  isChecking: false,
-  updateResult: null,
-  downloadedApks: [],
-  onUpdate: () => {},
-  onInstallApk: () => {},
-  onRefresh: null,
-  bottomInset: 0,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/CategoryOperationsList.js
+++ b/app/components/graphs/CategoryOperationsList.js
@@ -34,7 +34,7 @@ const formatOpDate = (dateStr, language) => {
  * Views (no inner ScrollView) so the parent chart ScrollView measures and
  * animates its height.
  */
-const CategoryOperationsList = ({ operations, loading, currency, colors, language, emptyText }) => {
+const CategoryOperationsList = ({ operations = [], loading = false, currency, colors, language, emptyText = '' }) => {
   const { hideBalances } = useDisplaySettings();
 
   if (loading) {
@@ -112,13 +112,6 @@ CategoryOperationsList.propTypes = {
   colors: PropTypes.object.isRequired,
   language: PropTypes.string,
   emptyText: PropTypes.string,
-};
-
-CategoryOperationsList.defaultProps = {
-  operations: [],
-  loading: false,
-  language: undefined,
-  emptyText: '',
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -13,9 +13,9 @@ const ExpensePieChart = ({
   chartData,
   selectedCurrency,
   onLegendItemPress,
-  isLeafCategory,
-  operations,
-  loadingOperations,
+  isLeafCategory = false,
+  operations = [],
+  loadingOperations = false,
 }) => {
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
@@ -78,13 +78,6 @@ ExpensePieChart.propTypes = {
   isLeafCategory: PropTypes.bool,
   operations: PropTypes.array,
   loadingOperations: PropTypes.bool,
-};
-
-ExpensePieChart.defaultProps = {
-  language: undefined,
-  isLeafCategory: false,
-  operations: [],
-  loadingOperations: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -13,9 +13,9 @@ const IncomePieChart = ({
   incomeChartData,
   selectedCurrency,
   onLegendItemPress,
-  isLeafCategory,
-  operations,
-  loadingOperations,
+  isLeafCategory = false,
+  operations = [],
+  loadingOperations = false,
 }) => {
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
@@ -78,13 +78,6 @@ IncomePieChart.propTypes = {
   isLeafCategory: PropTypes.bool,
   operations: PropTypes.array,
   loadingOperations: PropTypes.bool,
-};
-
-IncomePieChart.defaultProps = {
-  language: undefined,
-  isLeafCategory: false,
-  operations: [],
-  loadingOperations: false,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/CurrencyPickerModal.js
+++ b/app/components/operations/CurrencyPickerModal.js
@@ -13,7 +13,7 @@ const alphabeticalList = Object.entries(currencies).map(([code, data]) => ({
   symbol: data.symbol,
 })).sort((a, b) => a.name.localeCompare(b.name));
 
-const CurrencyPickerModal = memo(({ visible, onClose, onSelect, selectedCurrency, colors, t }) => {
+const CurrencyPickerModal = memo(({ visible, onClose, onSelect, selectedCurrency = '', colors, t }) => {
   const [query, setQuery] = useState('');
   const [popularCodes, setPopularCodes] = useState([]);
 
@@ -129,10 +129,6 @@ CurrencyPickerModal.propTypes = {
   selectedCurrency: PropTypes.string,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
-};
-
-CurrencyPickerModal.defaultProps = {
-  selectedCurrency: '',
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -26,12 +26,12 @@ const OperationListItem = ({
   getCategoryInfo,
   getAccountName,
   formatCurrency,
-  isLast,
+  isLast = false,
   onPress,
   testID,
-  suggestionChips,
-  onApplySuggestion,
-  onDismissSuggestion,
+  suggestionChips = null,
+  onApplySuggestion = () => {},
+  onDismissSuggestion = () => {},
 }) => {
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
@@ -209,14 +209,6 @@ OperationListItem.propTypes = {
   suggestionChips: PropTypes.arrayOf(PropTypes.string),
   onApplySuggestion: PropTypes.func,
   onDismissSuggestion: PropTypes.func,
-};
-
-OperationListItem.defaultProps = {
-  isLast: false,
-  testID: undefined,
-  suggestionChips: null,
-  onApplySuggestion: () => {},
-  onDismissSuggestion: () => {},
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -42,6 +42,13 @@ const SECTION_FOOTER_HEIGHT = BORDER_RADIUS.md + SPACING.xs;
 // DateSeparator, plus the cardTop cap (BORDER_RADIUS.md).
 const SECTION_HEADER_HEIGHT_FALLBACK = SPACING.sm + 17 + SPACING.xs + BORDER_RADIUS.md;
 
+// Hoisted so an omitted prop keeps a stable identity across renders. Inline
+// `[]` / `() => {}` defaults would allocate anew on every render and, since
+// several of these feed the renderItem useCallback deps, would churn its
+// identity and defeat the list's row memoization.
+const NOOP = () => {};
+const NO_SUGGESTIONS = [];
+
 /**
  * OperationsList Component
  *
@@ -56,23 +63,23 @@ const OperationsList = forwardRef(({
   categories,
   colors,
   t,
-  initialLoading,
-  loadingMore,
-  hasMoreOperations,
+  initialLoading = false,
+  loadingMore = false,
+  hasMoreOperations = false,
   onLoadMore,
   onEditOperation,
   onDateSeparatorPress,
-  onScroll,
-  onScrollToIndexFailed,
-  onContentSizeChange,
-  refreshing,
-  onRefresh,
-  headerComponent,
-  topInset,
-  pendingSuggestionId,
-  pendingSuggestions,
-  onApplySuggestion,
-  onDismissSuggestion,
+  onScroll = NOOP,
+  onScrollToIndexFailed = NOOP,
+  onContentSizeChange = NOOP,
+  refreshing = false,
+  onRefresh = null,
+  headerComponent = null,
+  topInset = 0,
+  pendingSuggestionId = null,
+  pendingSuggestions = NO_SUGGESTIONS,
+  onApplySuggestion = NOOP,
+  onDismissSuggestion = NOOP,
 }, ref) => {
 
   // Format date label for the separator header.
@@ -459,23 +466,6 @@ OperationsList.propTypes = {
   pendingSuggestions: PropTypes.arrayOf(PropTypes.string),
   onApplySuggestion: PropTypes.func,
   onDismissSuggestion: PropTypes.func,
-};
-
-OperationsList.defaultProps = {
-  initialLoading: false,
-  loadingMore: false,
-  hasMoreOperations: false,
-  onScroll: () => {},
-  onScrollToIndexFailed: () => {},
-  onContentSizeChange: () => {},
-  refreshing: false,
-  onRefresh: null,
-  headerComponent: null,
-  topInset: 0,
-  pendingSuggestionId: null,
-  pendingSuggestions: [],
-  onApplySuggestion: () => {},
-  onDismissSuggestion: () => {},
 };
 
 const styles = StyleSheet.create({

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -12,7 +12,7 @@ const ExpandableFilters = ({
   accounts,
   colors,
   t,
-  isExpanded,
+  isExpanded = true,
 }) => {
   const [showStartDatePicker, setShowStartDatePicker] = useState(false);
   const [showEndDatePicker, setShowEndDatePicker] = useState(false);
@@ -304,10 +304,6 @@ ExpandableFilters.propTypes = {
   }).isRequired,
   t: PropTypes.func.isRequired,
   isExpanded: PropTypes.bool,
-};
-
-ExpandableFilters.defaultProps = {
-  isExpanded: true,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/search/FilterBadge.js
+++ b/app/components/search/FilterBadge.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-const FilterBadge = ({ count, colors }) => {
+const FilterBadge = ({ count = 0, colors }) => {
   if (!count || count === 0) {
     return null;
   }
@@ -22,10 +22,6 @@ FilterBadge.propTypes = {
   colors: PropTypes.shape({
     primary: PropTypes.string.isRequired,
   }).isRequired,
-};
-
-FilterBadge.defaultProps = {
-  count: 0,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -27,11 +27,11 @@ const SearchBar = ({
   onSearchTextChange,
   onToggleFilters,
   onClose,
-  filterCount,
+  filterCount = 0,
   colors,
   t,
-  collapsed,
-  onCollapsedPress,
+  collapsed = false,
+  onCollapsedPress = undefined,
 }) => {
   const [localText, setLocalText] = useState(searchText);
   // Track the last value we sent to the parent so we can distinguish
@@ -237,12 +237,6 @@ SearchBar.propTypes = {
   t: PropTypes.func.isRequired,
   collapsed: PropTypes.bool,
   onCollapsedPress: PropTypes.func,
-};
-
-SearchBar.defaultProps = {
-  filterCount: 0,
-  collapsed: false,
-  onCollapsedPress: undefined,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -13,7 +13,7 @@ import { useSearch } from '../../contexts/SearchContext';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 
-const SearchOverlay = ({ colors, t, visible, onHeightChange, topOffset }) => {
+const SearchOverlay = ({ colors, t, visible, onHeightChange = null, topOffset = 0 }) => {
   const { searchState = { text: '', types: [], accountIds: [], categoryIds: [], dateRange: { startDate: null, endDate: null }, amountRange: { min: null, max: null } } } = useOperationsData();
   const { filtersExpanded } = useSearch();
   const { updateSearchFilters } = useOperationsActions();
@@ -77,11 +77,6 @@ SearchOverlay.propTypes = {
   t: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
   topOffset: PropTypes.number,
-};
-
-SearchOverlay.defaultProps = {
-  onHeightChange: null,
-  topOffset: 0,
 };
 
 const styles = StyleSheet.create({

--- a/app/modals/BudgetModal.js
+++ b/app/modals/BudgetModal.js
@@ -29,7 +29,9 @@ import currencies from '../../assets/currencies.json';
 import ModalBlurOverlay from '../components/ModalBlurOverlay';
 import ModalHeader from '../components/ModalHeader';
 
-export default function BudgetModal({ visible, onClose, budget, categoryId, categoryName, isNew }) {
+export default function BudgetModal({
+  visible = false, onClose = () => {}, budget = null, categoryId = '', categoryName = '', isNew = true,
+}) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { showDialog } = useDialog();
@@ -678,15 +680,6 @@ BudgetModal.propTypes = {
   categoryId: PropTypes.string,
   categoryName: PropTypes.string,
   isNew: PropTypes.bool,
-};
-
-BudgetModal.defaultProps = {
-  visible: false,
-  onClose: () => {},
-  budget: null,
-  categoryId: '',
-  categoryName: '',
-  isNew: true,
 };
 
 const styles = StyleSheet.create({

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -106,7 +106,9 @@ const buildLocationOverrides = (attachLocation, location) => {
   return null;
 };
 
-export default function OperationModal({ visible, onClose, operation, isNew, onDelete }) {
+export default function OperationModal({
+  visible = false, onClose = () => {}, operation = null, isNew = false, onDelete = null,
+}) {
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { showDialog } = useDialog();
@@ -924,10 +926,3 @@ OperationModal.propTypes = {
   onDelete: PropTypes.func,
 };
 
-OperationModal.defaultProps = {
-  visible: false,
-  onClose: () => {},
-  operation: null,
-  isNew: false,
-  onDelete: null,
-};

--- a/app/modals/PlannedOperationModal.js
+++ b/app/modals/PlannedOperationModal.js
@@ -32,7 +32,9 @@ const TYPE_OPTIONS = [
   { key: 'transfer', icon: 'swap-horizontal', colorKey: 'transfer' },
 ];
 
-export default function PlannedOperationModal({ visible, onClose, plannedOperation, isNew }) {
+export default function PlannedOperationModal({
+  visible = false, onClose, plannedOperation = null, isNew = true,
+}) {
   const { colors } = useThemeColors();
   const { paperInputTheme } = makeModalStyles(colors);
   const { t } = useLocalization();
@@ -457,12 +459,6 @@ PlannedOperationModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   plannedOperation: PropTypes.object,
   isNew: PropTypes.bool,
-};
-
-PlannedOperationModal.defaultProps = {
-  visible: false,
-  plannedOperation: null,
-  isNew: true,
 };
 
 const styles = StyleSheet.create({

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -132,7 +132,7 @@ UpdateProgressIcon.propTypes = {
 };
 
 // Memoized tab button with icon + label, pill active state
-const TabButton = memo(({ tab, isActive, colors, onPress, isUpdating, updatePhase, updateProgress }) => {
+const TabButton = memo(({ tab, isActive = false, colors, onPress = () => {}, isUpdating = false, updatePhase = null, updateProgress = null }) => {
   const handlePress = useCallback(() => {
     onPress(tab.key);
   }, [onPress, tab.key]);
@@ -196,14 +196,6 @@ TabButton.propTypes = {
   isUpdating: PropTypes.bool,
   updatePhase: PropTypes.string,
   updateProgress: PropTypes.number,
-};
-
-TabButton.defaultProps = {
-  isActive: false,
-  onPress: () => {},
-  isUpdating: false,
-  updatePhase: null,
-  updateProgress: null,
 };
 
 // Pre-computed gradient steps: transparent → very dark black overlay

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -22,6 +22,10 @@ import { getDefaultAccountId, setDefaultAccountId } from '../services/Preference
 import { parseCardMasks, serializeCardMasks, cardMaskLast4 } from '../utils/cardMask';
 import currencies from '../../assets/currencies.json';
 
+// Alias for use as a prop default: a `currencies = currencies` destructuring
+// default would shadow the import and throw (TDZ), so default to this instead.
+const DEFAULT_CURRENCIES = currencies;
+
 // Rounding steps offered for operations auto-created from bank notifications.
 // `null` means no rounding (the default). Labels are static; the "Off" option is
 // localized at render time.
@@ -43,7 +47,7 @@ const ROUNDING_MODE_OPTIONS = [
 ];
 
 // Memoized currency picker modal component
-const CurrencyPickerModal = memo(({ visible, onClose, currencies, colors, t, onSelect }) => {
+const CurrencyPickerModal = memo(({ visible = false, onClose = () => {}, currencies = DEFAULT_CURRENCIES, colors = {}, t = (k) => k, onSelect = () => {} }) => {
   const renderCurrencyItem = useCallback(({ item }) => {
     const [code, cur] = item;
 
@@ -90,17 +94,8 @@ CurrencyPickerModal.propTypes = {
   onSelect: PropTypes.func,
 };
 
-CurrencyPickerModal.defaultProps = {
-  visible: false,
-  onClose: () => {},
-  currencies,
-  colors: {},
-  t: (k) => k,
-  onSelect: () => {},
-};
-
 // Memoized transfer account picker modal component
-const TransferAccountPickerModal = memo(({ visible, onClose, accounts, accountToDelete, accountCurrency, operationCount, colors, t, onSelect, currencies }) => {
+const TransferAccountPickerModal = memo(({ visible = false, onClose = () => {}, accounts = [], accountToDelete = null, accountCurrency = null, operationCount = 0, colors = {}, t = (k) => k, onSelect = () => {}, currencies = DEFAULT_CURRENCIES }) => {
   const { hideBalances } = useDisplaySettings();
   const availableAccounts = useMemo(() => {
     return accounts.filter(a => a.id !== accountToDelete && a.currency === accountCurrency);
@@ -176,21 +171,8 @@ TransferAccountPickerModal.propTypes = {
   currencies: PropTypes.object,
 };
 
-TransferAccountPickerModal.defaultProps = {
-  visible: false,
-  onClose: () => {},
-  accounts: [],
-  accountToDelete: null,
-  accountCurrency: null,
-  operationCount: 0,
-  colors: {},
-  t: (k) => k,
-  onSelect: () => {},
-  currencies,
-};
-
 // Memoized confirmation dialog component
-const ConfirmationDialog = memo(({ visible, onClose, title, message, cancelText, confirmText, onConfirm, colors, confirmColor }) => {
+const ConfirmationDialog = memo(({ visible = false, onClose = () => {}, title = '', message = '', cancelText = null, confirmText = 'OK', onConfirm = () => {}, colors = {}, confirmColor = null }) => {
   return (
     <Portal>
       <Modal
@@ -243,20 +225,8 @@ ConfirmationDialog.propTypes = {
   confirmColor: PropTypes.string,
 };
 
-ConfirmationDialog.defaultProps = {
-  visible: false,
-  onClose: () => {},
-  title: '',
-  message: '',
-  cancelText: null,
-  confirmText: 'OK',
-  onConfirm: () => {},
-  colors: {},
-  confirmColor: null,
-};
-
 // Net worth summary card
-const NetWorthCard = memo(({ accounts, operations, colors, t }) => {
+const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k) => k }) => {
   const { hideBalances } = useDisplaySettings();
 
   // Determine display currency from first account (or default to USD)
@@ -358,15 +328,8 @@ NetWorthCard.propTypes = {
   t: PropTypes.func,
 };
 
-NetWorthCard.defaultProps = {
-  accounts: [],
-  operations: [],
-  colors: {},
-  t: (k) => k,
-};
-
 // Memoized account row component
-const AccountRow = memo(({ item, colors, onPress, t, drag, isActive, isDefault }) => {
+const AccountRow = memo(({ item, colors = {}, onPress = () => {}, t = (k) => k, drag = () => {}, isActive = false, isDefault = false }) => {
   const { hideBalances } = useDisplaySettings();
   const decimals = currencies[item.currency]?.decimal_digits ?? 2;
   const balance = parseFloat(item.balance);
@@ -449,15 +412,6 @@ AccountRow.propTypes = {
   drag: PropTypes.func,
   isActive: PropTypes.bool,
   isDefault: PropTypes.bool,
-};
-
-AccountRow.defaultProps = {
-  colors: {},
-  onPress: () => {},
-  t: (k) => k,
-  drag: () => {},
-  isActive: false,
-  isDefault: false,
 };
 
 export default function AccountsScreen({ onBackStateChange }) {
@@ -1315,8 +1269,6 @@ export default function AccountsScreen({ onBackStateChange }) {
 AccountsScreen.propTypes = {
   onBackStateChange: PropTypes.func,
 };
-
-AccountsScreen.defaultProps = {};
 
 const styles = StyleSheet.create({
   accountBalance: {


### PR DESCRIPTION
## Что и зачем

React 19 игнорирует `defaultProps` у функциональных компонентов. То есть все блоки `Component.defaultProps = {...}` в кодовой базе были мёртвым кодом: пропущенный проп приходил как `undefined`, а задокументированный дефолт не применялся никогда. Переношу дефолты на деструктурируемые параметры, где они реально работают, и выпиливаю ставшие лишними блоки.

Затронуто 28 файлов, чистый кодмод: -311 строк.

## Нюанс со стабильностью идентити

Дефолты, попадающие в dep-массивы хуков, вынесены в модульные константы (`NOOP` / `NO_SUGGESTIONS` в `OperationsList`). Инлайновый `[]` или `() => {}` аллоцируется на каждом рендере, что ломало бы идентити `renderItem` в `useCallback` и убивало мемоизацию строк списка — единственное, что инертные `defaultProps` делали правильно, пусть и случайно.

Сейчас это латентно (единственный прод-колсайт в `OperationsScreen.js` передаёт все пропсы явно), но оставлять грабли под ногой смысла нет.

## Тесты

`npx jest` — 155 suites, 4451 тест, все зелёные.

## Найдено рядом, но не трогал

Ревью подсветило два места, где кодмод отмодернизировал то, что стоило бы удалить или свести. Не лезу в них здесь, потому что это уже не про `defaultProps`, и решение за автором:

- `app/screens/AccountsScreen.js:50` — локальный `CurrencyPickerModal` (~47 строк) не рендерится и не экспортируется, при этом дублирует живой `app/components/operations/CurrencyPickerModal.js`. Кодмод его аккуратно обновил, хотя кандидат на удаление.
- `app/components/SimplePicker.js:37` — инлайновый fallback-палитра в `safeColors` дублирует новую константу `DEFAULT_COLORS`, но с другими hex-значениями. В итоге «нет `colors`» и «`colors={null}`» рендерятся по-разному (`#e0e0e0`/`#f5f5f5` против `#cccccc`/`#e0e0e0`). Свести к `return DEFAULT_COLORS;` — но какая из двух палитр правильная, решать не мне.
