### PR TITLE
feat(operations): non-blocking add of notification suggestions

### DIFF
--- a/__tests__/components/operations/NotificationBindingStack.test.js
+++ b/__tests__/components/operations/NotificationBindingStack.test.js
@@ -65,7 +65,6 @@ const makeSuggestions = (count) =>
 const defaultProps = {
   suggestions: [EXPENSE],
   choices: { p1: { accountId: 1, categoryId: 'c1', toAccountId: null, labelOverride: '' } },
-  savingIds: {},
   quickAddHeight: 320,
   colors: COLORS,
   t,
@@ -211,13 +210,6 @@ describe('NotificationBindingStack', () => {
     const { getByText } = await renderStack({ onDismiss });
     fireEvent.press(getByText('dismiss'));
     expect(onDismiss).toHaveBeenCalledWith(EXPENSE);
-  });
-
-  it('collapses a saving card into the progress row without action buttons', async () => {
-    const { getByTestId, queryByText } = await renderStack({ savingIds: { p1: true } });
-    expect(getByTestId('notification-binding-card-saving')).toBeTruthy();
-    expect(queryByText('save')).toBeNull();
-    expect(queryByText('dismiss')).toBeNull();
   });
 
   it('shows an inline error when the front card has a save error', async () => {

--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -480,4 +480,31 @@ describe('OperationListItem', () => {
       expect(getByText('Weekly shop')).toBeTruthy();
     });
   });
+
+  describe('Pending (in-flight) operation', () => {
+    it('does not open the editor while the write is still in flight', async () => {
+      const onPress = jest.fn();
+      const { getByTestId } = await render(
+        <OperationListItem
+          {...baseProps}
+          testID="pending-row"
+          operation={{ ...baseOperation, _pending: true }}
+          onPress={onPress}
+        />,
+      );
+      await fireEvent.press(getByTestId('pending-row'));
+      // A placeholder row carries a temp id with no DB row behind it; tapping it
+      // must not open an editor.
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    it('opens the editor once the operation is settled (not pending)', async () => {
+      const onPress = jest.fn();
+      const { getByTestId } = await render(
+        <OperationListItem {...baseProps} testID="settled-row" onPress={onPress} />,
+      );
+      await fireEvent.press(getByTestId('settled-row'));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/__tests__/hooks/usePendingOperationSuggestions.test.js
+++ b/__tests__/hooks/usePendingOperationSuggestions.test.js
@@ -293,7 +293,7 @@ describe('usePendingOperationSuggestions', () => {
       // labelOverride is omitted so the resolver keeps the learned merchant label.
       expect(pipeline.resolvePendingNotification).toHaveBeenCalledWith('p1', EXPENSE_RESOLVE);
       expect(result.current.suggestions).toEqual([]);
-      expect(result.current.savingIds).toEqual({});
+      expect(result.current.committingIds).toEqual({});
     });
 
     it('does not send a label override even when a label was seeded from the learned name', async () => {
@@ -365,7 +365,7 @@ describe('usePendingOperationSuggestions', () => {
         result.current.accept(EXPENSE);
       });
       expect(pipeline.resolvePendingNotification).toHaveBeenCalledTimes(1);
-      await waitFor(() => expect(result.current.savingIds).toEqual({ p1: true }));
+      await waitFor(() => expect(result.current.committingIds).toEqual({ p1: true }));
 
       PendingNotificationsDB.getPendingNotifications.mockResolvedValue([]);
       await act(async () => {
@@ -382,7 +382,7 @@ describe('usePendingOperationSuggestions', () => {
       await act(async () => {
         await result.current.accept(EXPENSE);
       });
-      expect(result.current.savingIds).toEqual({});
+      expect(result.current.committingIds).toEqual({});
       expect(result.current.suggestions).toEqual([EXPENSE]);
       // The failure is surfaced, not swallowed, so the card can show an error.
       expect(result.current.saveErrors).toEqual({ p1: true });
@@ -418,7 +418,70 @@ describe('usePendingOperationSuggestions', () => {
         await result.current.accept(EXPENSE);
       });
       expect(result.current.suggestions).toEqual([]);
-      expect(result.current.savingIds).toEqual({});
+      expect(result.current.committingIds).toEqual({});
+    });
+  });
+
+  describe('non-blocking optimistic insert', () => {
+    it('inserts a placeholder row and hides the card the instant the save starts', async () => {
+      let resolveSave;
+      pipeline.resolvePendingNotification.mockImplementation(
+        () => new Promise((resolve) => { resolveSave = resolve; }),
+      );
+      const onOptimisticAdd = jest.fn(() => '_temp_1');
+      const onOptimisticSettle = jest.fn();
+      const onOptimisticRemove = jest.fn();
+      const { result } = await renderHook(() =>
+        usePendingOperationSuggestions({ onOptimisticAdd, onOptimisticSettle, onOptimisticRemove }));
+      await waitFor(() => expect(result.current.choices.p1).toEqual(EXPENSE_CHOICE));
+
+      await act(async () => { result.current.accept(EXPENSE); });
+      // The row is handed to the list, and the card leaves the deck without waiting
+      // on the write.
+      expect(onOptimisticAdd).toHaveBeenCalledWith(EXPENSE, EXPENSE_CHOICE);
+      await waitFor(() => expect(result.current.committingIds).toEqual({ p1: true }));
+      expect(result.current.suggestions).toEqual([]);
+
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([]);
+      await act(async () => { resolveSave({ id: 'op1' }); });
+      await waitFor(() => expect(result.current.suggestions).toEqual([]));
+      // On success the placeholder is swapped for the persisted row, never rolled back.
+      expect(onOptimisticSettle).toHaveBeenCalledWith('_temp_1', { id: 'op1' });
+      expect(onOptimisticRemove).not.toHaveBeenCalled();
+    });
+
+    it('rolls back the placeholder row and restores the card when the save fails', async () => {
+      pipeline.resolvePendingNotification.mockRejectedValue(new Error('no exchange rate'));
+      const onOptimisticAdd = jest.fn(() => '_temp_1');
+      const onOptimisticSettle = jest.fn();
+      const onOptimisticRemove = jest.fn();
+      const { result } = await renderHook(() =>
+        usePendingOperationSuggestions({ onOptimisticAdd, onOptimisticSettle, onOptimisticRemove }));
+      await waitFor(() => expect(result.current.choices.p1).toEqual(EXPENSE_CHOICE));
+
+      await act(async () => { await result.current.accept(EXPENSE); });
+      expect(onOptimisticRemove).toHaveBeenCalledWith('_temp_1');
+      expect(onOptimisticSettle).not.toHaveBeenCalled();
+      expect(result.current.suggestions).toEqual([EXPENSE]);
+      expect(result.current.saveErrors).toEqual({ p1: true });
+      expect(result.current.committingIds).toEqual({});
+    });
+
+    it('rolls back the placeholder when the pending row had already vanished', async () => {
+      // resolve returns null when the row is gone (e.g. resolved elsewhere); nothing
+      // was booked, so the placeholder must be removed, not settled.
+      pipeline.resolvePendingNotification.mockResolvedValue(null);
+      const onOptimisticAdd = jest.fn(() => '_temp_1');
+      const onOptimisticSettle = jest.fn();
+      const onOptimisticRemove = jest.fn();
+      const { result } = await renderHook(() =>
+        usePendingOperationSuggestions({ onOptimisticAdd, onOptimisticSettle, onOptimisticRemove }));
+      await waitFor(() => expect(result.current.choices.p1).toEqual(EXPENSE_CHOICE));
+
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([]);
+      await act(async () => { await result.current.accept(EXPENSE); });
+      expect(onOptimisticRemove).toHaveBeenCalledWith('_temp_1');
+      expect(onOptimisticSettle).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/screens/OperationsScreen.test.js
+++ b/__tests__/screens/OperationsScreen.test.js
@@ -170,7 +170,7 @@ jest.mock('../../app/hooks/usePendingOperationSuggestions', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     suggestions: [],
-    savingIds: {},
+    committingIds: {},
     saveErrors: {},
     choices: {},
     setChoice: jest.fn(),

--- a/app/components/operations/NotificationBindingCard.js
+++ b/app/components/operations/NotificationBindingCard.js
@@ -6,7 +6,6 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  ActivityIndicator,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import SimplePicker from '../SimplePicker';
@@ -45,7 +44,6 @@ const NotificationBindingCard = ({
   t,
   accounts,
   categories,
-  saving = false,
   saveError = false,
   height,
   onChoiceChange,
@@ -91,35 +89,6 @@ const NotificationBindingCard = ({
   // A screen reader hears each card's identical buttons ("Dismiss"/"Save")
   // otherwise; naming the merchant + amount disambiguates them.
   const itemContext = `${item.merchant || item.kind}, ${item.amount} ${item.currency}`;
-
-  // Mid-save: swap the body for a compact progress row, keeping the deck frame
-  // (its geometry is pinned to the quick-add panel) and dropping the action
-  // buttons so the up-to-8s save can't be double-tapped into duplicates.
-  if (saving) {
-    return (
-      <View
-        testID="notification-binding-card-saving"
-        style={[styles.card, frameStyle]}
-        accessibilityRole="progressbar"
-        accessibilityLabel={t('bank_notifications_adding') || 'Adding operation…'}
-      >
-        <View style={styles.savingRow}>
-          <ActivityIndicator size="small" color={colors.primary} />
-          <View style={styles.savingBody}>
-            <Text style={[styles.merchant, { color: colors.text }]} numberOfLines={1}>
-              {item.merchant || item.kind}
-            </Text>
-            <Text style={[styles.metaText, { color: colors.mutedText }]} numberOfLines={1}>
-              {t('bank_notifications_adding') || 'Adding operation…'}
-            </Text>
-          </View>
-          <Text style={[styles.amount, { color: colors.mutedText }]}>
-            {item.amount} {item.currency}
-          </Text>
-        </View>
-      </View>
-    );
-  }
 
   return (
     <View testID="notification-binding-card" style={[styles.card, frameStyle]}>
@@ -278,7 +247,6 @@ NotificationBindingCard.propTypes = {
   t: PropTypes.func.isRequired,
   accounts: PropTypes.array.isRequired,
   categories: PropTypes.array.isRequired,
-  saving: PropTypes.bool,
   saveError: PropTypes.bool,
   height: PropTypes.number.isRequired,
   onChoiceChange: PropTypes.func.isRequired,
@@ -369,26 +337,12 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '700',
   },
-  metaText: {
-    fontSize: 12,
-    marginTop: 2,
-  },
   nameInput: {
     marginTop: SPACING.sm,
   },
   pickerWrap: {
     borderRadius: BORDER_RADIUS.sm,
     borderWidth: StyleSheet.hairlineWidth,
-  },
-  savingBody: {
-    flex: 1,
-  },
-  savingRow: {
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-    gap: SPACING.md,
-    paddingHorizontal: SPACING.md,
   },
   selectedCategoryRow: {
     alignItems: 'center',

--- a/app/components/operations/NotificationBindingStack.js
+++ b/app/components/operations/NotificationBindingStack.js
@@ -93,7 +93,6 @@ DeckSlot.propTypes = {
 const NotificationBindingStack = memo(function NotificationBindingStack({
   suggestions = [],
   choices = {},
-  savingIds = {},
   saveErrors = {},
   quickAddHeight,
   colors,
@@ -156,7 +155,6 @@ const NotificationBindingStack = memo(function NotificationBindingStack({
                 t={t}
                 accounts={accounts}
                 categories={categories}
-                saving={!!savingIds[item.id]}
                 saveError={!!saveErrors[item.id]}
                 height={cardHeight}
                 onChoiceChange={(patch) => onChoiceChange(item.id, patch)}
@@ -187,7 +185,6 @@ NotificationBindingStack.displayName = 'NotificationBindingStack';
 NotificationBindingStack.propTypes = {
   suggestions: PropTypes.arrayOf(PropTypes.object),
   choices: PropTypes.object,
-  savingIds: PropTypes.object,
   saveErrors: PropTypes.object,
   quickAddHeight: PropTypes.number.isRequired,
   colors: PropTypes.object.isRequired,

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { TouchableRipple } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import PropTypes from 'prop-types';
@@ -36,6 +36,11 @@ const OperationListItem = ({
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
   const isTransfer = operation.type === 'transfer';
+
+  // A placeholder row for an operation whose write (from a notification
+  // suggestion) is still in flight: it shows a spinner in the icon slot, dims,
+  // and can't be opened for editing until the persisted row replaces it.
+  const isPending = !!operation._pending;
 
   const isMultiCurrencyTransfer = isTransfer && operation.exchangeRate && operation.destinationAmount;
 
@@ -103,16 +108,22 @@ const OperationListItem = ({
     <>
       <TouchableRipple
         testID={testID}
-        onPress={onPress}
+        onPress={isPending ? undefined : onPress}
+        disabled={isPending}
         rippleColor="rgba(0, 0, 0, .08)"
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={t('edit_operation_hint')}
+        accessibilityState={{ disabled: isPending, busy: isPending }}
       >
-        <View style={styles.row}>
-          {/* Icon */}
+        <View style={[styles.row, isPending && styles.rowPending]}>
+          {/* Icon — a spinner while the operation is still being written. */}
           <View style={styles.iconContainer}>
-            <Icon name={categoryInfo.icon} size={ICON_SIZE.md} color={amountColor} />
+            {isPending ? (
+              <ActivityIndicator size="small" color={amountColor} />
+            ) : (
+              <Icon name={categoryInfo.icon} size={ICON_SIZE.md} color={amountColor} />
+            )}
           </View>
 
           {/* Text */}
@@ -196,6 +207,7 @@ OperationListItem.propTypes = {
     sourceCurrency: PropTypes.string,
     destinationCurrency: PropTypes.string,
     description: PropTypes.string,
+    _pending: PropTypes.bool,
   }).isRequired,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
@@ -254,6 +266,9 @@ const styles = StyleSheet.create({
     minHeight: HEIGHTS.listItem,
     paddingHorizontal: SPACING.lg,
     paddingVertical: SPACING.xs,
+  },
+  rowPending: {
+    opacity: 0.6,
   },
   separator: {
     height: 1,

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -433,6 +433,42 @@ export const OperationsActionsProvider = ({ children }) => {
     }
   }, [reloadAccounts, showDialog, loadInitialOperations, _setSaveError, _setOperations]);
 
+  // Insert a placeholder operation into the list immediately, before its DB write
+  // completes. Used by the notification-suggestion flow so the binding card can
+  // advance to the next suggestion without waiting on the (up-to-several-second)
+  // write: the row carries `_pending` so it renders an in-flight spinner. A
+  // RELOAD_ALL — emitted by the resolver when the write lands — wholesale-replaces
+  // the list, swapping this placeholder for the persisted row and dropping the
+  // spinner. No-ops if a row with the same id is already present.
+  const addOptimisticOperation = useCallback((operation) => {
+    _setOperations(prev => (
+      prev.some(op => op.id === operation.id)
+        ? prev
+        : [{ ...operation, _pending: true }, ...prev]
+    ));
+  }, [_setOperations]);
+
+  // Roll back a placeholder operation whose background write failed, so a booking
+  // that never persisted doesn't linger in the list.
+  const removeOptimisticOperation = useCallback((id) => {
+    _setOperations(prev => prev.filter(op => op.id !== id));
+  }, [_setOperations]);
+
+  // Replace a placeholder with the persisted row the write returned, in place.
+  // Deterministic cleanup for the optimistic path: it doesn't depend on the
+  // RELOAD_ALL reload landing (which silently no-ops if its read fails, otherwise
+  // stranding a permanent spinner). A no-op if the placeholder is already gone —
+  // e.g. a RELOAD_ALL reload beat us to it.
+  const replaceOptimisticOperation = useCallback((tempId, operation) => {
+    _setOperations(prev => {
+      const idx = prev.findIndex(op => op.id === tempId);
+      if (idx === -1) return prev;
+      const next = [...prev];
+      next[idx] = operation;
+      return next;
+    });
+  }, [_setOperations]);
+
   const splitOperation = useCallback(async (id, updates, newOperationData) => {
     try {
       await OperationsDB.splitOperation(id, updates, newOperationData);
@@ -689,6 +725,9 @@ export const OperationsActionsProvider = ({ children }) => {
 
   const value = useMemo(() => ({
     addOperation,
+    addOptimisticOperation,
+    removeOptimisticOperation,
+    replaceOptimisticOperation,
     splitOperation,
     updateOperation,
     deleteOperation,
@@ -710,6 +749,9 @@ export const OperationsActionsProvider = ({ children }) => {
     clearAllSearch: _clearAllSearch,
   }), [
     addOperation,
+    addOptimisticOperation,
+    removeOptimisticOperation,
+    replaceOptimisticOperation,
     splitOperation,
     updateOperation,
     deleteOperation,

--- a/app/hooks/usePendingOperationSuggestions.js
+++ b/app/hooks/usePendingOperationSuggestions.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { LayoutAnimation, Platform, UIManager } from 'react-native';
 import { getPendingNotifications } from '../services/PendingNotificationsDB';
 import {
@@ -63,12 +63,26 @@ export const canSaveSuggestion = (item, choice = {}) => {
  * There is intentionally no polling here — the pipeline already runs on app
  * open/foreground (AppInitializer) and on the pull-to-refresh gesture (refresh),
  * so the main page stays cheap while idle.
+ *
+ * Saving is non-blocking: on accept the card leaves the deck at once (revealing
+ * the next suggestion, or the quick-add form) while the booking runs in the
+ * background. The host injects `onOptimisticAdd(item, choice) => placeholderId`,
+ * `onOptimisticSettle(placeholderId, operation)`, and
+ * `onOptimisticRemove(placeholderId)` so the just-accepted operation appears in
+ * the list immediately (carrying its own in-flight spinner), is swapped for the
+ * persisted row once the write lands, or is rolled back on failure. All default
+ * to no-ops, so the hook stays usable — and testable — standalone.
  */
-export default function usePendingOperationSuggestions() {
+export default function usePendingOperationSuggestions({
+  onOptimisticAdd = null,
+  onOptimisticSettle = null,
+  onOptimisticRemove = null,
+} = {}) {
   const [suggestions, setSuggestions] = useState([]);
-  // Per-item accept-in-flight flags, so the card can collapse into an
-  // "Adding operation…" row and repeat taps can't book duplicates.
-  const [savingIds, setSavingIds] = useState({});
+  // Per-item "commit in flight" flags. The accepted card is hidden from the deck
+  // (its operation now lives in the list) while its background write runs, and
+  // repeat taps can't book duplicates. Kept until the item leaves the queue.
+  const [committingIds, setCommittingIds] = useState({});
   // Per-item save-failure flags (e.g. no exchange rate for a cross-currency
   // booking), so the card can show an inline error instead of failing silently.
   const [saveErrors, setSaveErrors] = useState({});
@@ -82,8 +96,11 @@ export default function usePendingOperationSuggestions() {
   const choicesRef = useRef(choices);
   useEffect(() => { choicesRef.current = choices; }, [choices]);
   // Synchronous mirror of the in-flight set — state updates are async, so the
-  // double-tap guard must not rely on `savingIds` alone.
+  // double-tap guard must not rely on `committingIds` alone.
   const savingRef = useRef(new Set());
+  // pending id -> placeholder operation id, so a failed background write can roll
+  // back the exact optimistic row it inserted.
+  const optimisticIdsRef = useRef(new Map());
   // Guards async setters from firing after unmount.
   const mountedRef = useRef(true);
   useEffect(() => () => { mountedRef.current = false; }, []);
@@ -221,10 +238,18 @@ export default function usePendingOperationSuggestions() {
       });
       return changed ? next : prev;
     };
-    setSavingIds(prune);
+    setCommittingIds(prune);
     setChoices(prune);
     setSaveErrors(prune);
   }, [suggestions]);
+
+  // The deck shows only suggestions that aren't mid-commit: an accepted card is
+  // hidden the instant its background write starts, so the next suggestion (or the
+  // quick-add form, when the queue empties) surfaces without waiting on the write.
+  const visibleSuggestions = useMemo(
+    () => suggestions.filter((s) => !committingIds[s.id]),
+    [suggestions, committingIds],
+  );
 
   /**
    * Pull-to-refresh entry point: re-run the ingestion pipeline (a no-op when the
@@ -251,14 +276,32 @@ export default function usePendingOperationSuggestions() {
     if (!canSaveSuggestion(item, choice)) return;
     if (savingRef.current.has(item.id)) return;
     savingRef.current.add(item.id);
-    setSavingIds((prev) => ({ ...prev, [item.id]: true }));
-    // Clear any stale error from a prior failed attempt on this card.
+
+    // Optimistically drop the operation into the list so the user can act on the
+    // next suggestion immediately; its row shows an in-flight spinner until the
+    // background write lands. Track the placeholder id so a failure can roll back
+    // the exact row it inserted.
+    let optimisticId = null;
+    if (onOptimisticAdd) {
+      try {
+        optimisticId = onOptimisticAdd(item, choice);
+      } catch (error) {
+        optimisticId = null;
+      }
+    }
+    if (optimisticId != null) optimisticIdsRef.current.set(item.id, optimisticId);
+
+    // Hide the card from the deck (it now lives in the list) and clear any stale
+    // error, revealing the next suggestion — or the quick-add form — beneath it.
+    LayoutAnimation.configureNext(CARD_LEAVE_ANIMATION);
+    setCommittingIds((prev) => ({ ...prev, [item.id]: true }));
     setSaveErrors((prev) => {
       if (!prev[item.id]) return prev;
       const next = { ...prev };
       delete next[item.id];
       return next;
     });
+
     try {
       const resolveChoices = {
         accountId: choice.accountId,
@@ -272,13 +315,20 @@ export default function usePendingOperationSuggestions() {
       if (choice.labelDirty) {
         resolveChoices.labelOverride = choice.labelOverride ?? '';
       }
-      await resolvePendingNotification(item.id, resolveChoices);
-      // The operation is booked and the pending row deleted. Drop the card from
-      // the stack optimistically: reload() below swallows its own errors, so a
-      // transient post-write read failure must not strand the card in the
-      // buttonless "Adding…" state (the saving flag is only pruned when the item
-      // actually leaves `suggestions`). Animate the collapse.
-      LayoutAnimation.configureNext(CARD_LEAVE_ANIMATION);
+      const created = await resolvePendingNotification(item.id, resolveChoices);
+      // Booked: swap the placeholder for the persisted row deterministically, so a
+      // silently-failing RELOAD_ALL reload can't strand a permanent spinner (and
+      // the exact booked amount replaces the offline estimate at once). Roll back
+      // instead if nothing was created (the pending row had already vanished).
+      const placeholderId = optimisticIdsRef.current.get(item.id);
+      optimisticIdsRef.current.delete(item.id);
+      if (placeholderId != null) {
+        if (created && onOptimisticSettle) onOptimisticSettle(placeholderId, created);
+        else if (!created && onOptimisticRemove) onOptimisticRemove(placeholderId);
+      }
+      // Drop the item from the queue so the card is gone even if the reload below
+      // (which swallows its own errors) can't reach the DB; pruning then clears
+      // its committing flag and choices.
       if (mountedRef.current) {
         setSuggestions((prev) => prev.filter((s) => s.id !== item.id));
       }
@@ -287,10 +337,21 @@ export default function usePendingOperationSuggestions() {
       await reload();
     } catch (error) {
       // The save failed (e.g. no exchange rate for a cross-currency booking) —
-      // restore the card and surface an inline error so the user can adjust their
-      // choices and retry instead of tapping Save into a silent void.
+      // roll back the placeholder row, un-hide the card, and surface an inline
+      // error so the user can adjust their choices and retry instead of losing the
+      // suggestion into a silent void.
+      const placeholderId = optimisticIdsRef.current.get(item.id);
+      optimisticIdsRef.current.delete(item.id);
+      if (placeholderId != null && onOptimisticRemove) {
+        try {
+          onOptimisticRemove(placeholderId);
+        } catch (removeError) {
+          // Best-effort rollback — a stuck placeholder is preferable to a throw here.
+        }
+      }
       if (mountedRef.current) {
-        setSavingIds((prev) => {
+        LayoutAnimation.configureNext(CARD_LEAVE_ANIMATION);
+        setCommittingIds((prev) => {
           const next = { ...prev };
           delete next[item.id];
           return next;
@@ -300,7 +361,7 @@ export default function usePendingOperationSuggestions() {
     } finally {
       savingRef.current.delete(item.id);
     }
-  }, [reload]);
+  }, [reload, onOptimisticAdd, onOptimisticSettle, onOptimisticRemove]);
 
   /** Dismiss a suggestion without creating an operation. */
   const dismiss = useCallback(async (item) => {
@@ -318,8 +379,8 @@ export default function usePendingOperationSuggestions() {
   }, [reload]);
 
   return {
-    suggestions,
-    savingIds,
+    suggestions: visibleSuggestions,
+    committingIds,
     saveErrors,
     choices,
     setChoice,

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -57,6 +57,9 @@ const OperationsScreen = () => {
   const {
     deleteOperation,
     addOperation,
+    addOptimisticOperation,
+    removeOptimisticOperation,
+    replaceOptimisticOperation,
     updateOperation,
     validateOperation,
     loadMoreOperations,
@@ -167,19 +170,55 @@ const OperationsScreen = () => {
     navigateBack,
   } = useOperationPicker(t);
 
+  // Insert a placeholder row for a just-accepted notification suggestion so the
+  // binding card can leave the deck immediately while its write runs in the
+  // background. The amount is an offline-rate estimate in the account currency;
+  // the persisted row (arriving via RELOAD_ALL) replaces it with the exact value.
+  const insertOptimisticSuggestion = useCallback((item, choice) => {
+    const account = accounts.find((a) => a.id === choice.accountId);
+    const accountCurrency = account?.currency;
+    let amount = item.amount;
+    if (account && item.currency && accountCurrency && accountCurrency !== item.currency) {
+      const converted = Currency.convertAmount(item.amount, item.currency, accountCurrency);
+      if (converted) amount = converted;
+    }
+    amount = Currency.formatAmount(amount, accountCurrency ?? 2);
+    const trimmedLabel = typeof choice.labelOverride === 'string' ? choice.labelOverride.trim() : '';
+    const label = trimmedLabel || item.merchant || '';
+    const isTransfer = item.type === 'transfer';
+    const opId = `_pending_notif_${item.id}`;
+    addOptimisticOperation({
+      id: opId,
+      type: item.type,
+      accountId: choice.accountId,
+      toAccountId: isTransfer ? (choice.toAccountId ?? null) : null,
+      categoryId: isTransfer ? null : (choice.categoryId ?? null),
+      amount: String(amount),
+      date: item.date || (item.createdAt ? item.createdAt.slice(0, 10) : toDateString(new Date())),
+      description: label ? serializeLabels([label]) : null,
+    });
+    return opId;
+  }, [accounts, addOptimisticOperation]);
+
   // Suggested operations parsed from bank notifications (the same pending queue
   // the settings review panel manages), surfaced as a deck of full binding
   // cards laid over the quick-add form so nothing requires a trip to settings.
+  // Accepting is non-blocking: the card leaves the deck at once (revealing the
+  // next suggestion or the quick-add form) and the operation lands in the list
+  // with an in-flight spinner via the optimistic add/remove pair.
   const {
     suggestions: operationSuggestions,
-    savingIds: suggestionSavingIds,
     saveErrors: suggestionSaveErrors,
     choices: suggestionChoices,
     setChoice: setSuggestionChoice,
     refresh: refreshSuggestions,
     accept: acceptSuggestion,
     dismiss: dismissSuggestion,
-  } = usePendingOperationSuggestions();
+  } = usePendingOperationSuggestions({
+    onOptimisticAdd: insertOptimisticSuggestion,
+    onOptimisticSettle: replaceOptimisticOperation,
+    onOptimisticRemove: removeOptimisticOperation,
+  });
 
   // Measured height of the quick-add wrapper — the binding cards pin their frame
   // to it so the deck reads as cards stacked over the form. Rounded, and only
@@ -940,7 +979,6 @@ const OperationsScreen = () => {
               <NotificationBindingStack
                 suggestions={operationSuggestions}
                 choices={suggestionChoices}
-                savingIds={suggestionSavingIds}
                 saveErrors={suggestionSaveErrors}
                 quickAddHeight={quickAddHeight}
                 colors={colors}
@@ -957,7 +995,7 @@ const OperationsScreen = () => {
       </Animated.View>
       {filtersExpanded && filterPanelHeight > 0 && <View style={{ height: filterPanelHeight }} />}
     </>
-  ), [animatedQuickAddClipStyle, animatedQuickAddSlideStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, handleOperationCurrencyChange, foreignRateSource, foreignExchangeRate, filterPanelHeight, filtersExpanded, flashCategoryErrorCount, operationSuggestions, hasSuggestions, quickAddHeight, handleQuickAddLayout, accounts, categories, suggestionSavingIds, suggestionSaveErrors, suggestionChoices, setSuggestionChoice, acceptSuggestion, dismissSuggestion]);
+  ), [animatedQuickAddClipStyle, animatedQuickAddSlideStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, handleOperationCurrencyChange, foreignRateSource, foreignExchangeRate, filterPanelHeight, filtersExpanded, flashCategoryErrorCount, operationSuggestions, hasSuggestions, quickAddHeight, handleQuickAddLayout, accounts, categories, suggestionSaveErrors, suggestionChoices, setSuggestionChoice, acceptSuggestion, dismissSuggestion]);
 
   // Auto-scroll to top when filter panel closes, but only if the user is still
   // near the top (hasn't scrolled into past dates). The threshold is filterPanelHeight:


### PR DESCRIPTION
## Что и зачем

Добавление операции из предложений банковских уведомлений (колода binding-карточек над quick-add формой) было **синхронным и блокирующим**: по «Save» карточка схлопывалась в спиннер «Adding operation…» на всю панель, пряча кнопки, и пользователь ждал до нескольких секунд (например, живой запрос курса), прежде чем перейти к следующему предложению.

Теперь процесс **неблокирующий**:

- по «Save» карточка сразу уходит из колоды, открывая следующее предложение — либо quick-add панель, если очередь кончилась;
- сама операция мгновенно попадает в список операций со спиннером **на строке** (иконка категории → `ActivityIndicator`, строка приглушена и не открывается на редактирование);
- запись в БД идёт в фоне; по завершении плейсхолдер **детерминированно** заменяется реальной операцией (сумма/округление становятся точными сразу, не дожидаясь события `RELOAD_ALL`);
- при ошибке — строка откатывается, карточка возвращается с инлайн-ошибкой (прежнее поведение сохранено).

## Реализация

- **`app/hooks/usePendingOperationSuggestions.js`** — `accept` переписан на неблокирующий поток: `committingIds` прячет карточку из колоды, а вставка/замена/откат оптимистичной строки делегированы инъектируемым колбэкам `onOptimisticAdd` / `onOptimisticSettle` / `onOptimisticRemove` (по умолчанию no-op, хук остаётся самодостаточным и тестируемым). `savingIds` → `committingIds`, добавлен derived `visibleSuggestions`.
- **`app/contexts/OperationsActionsContext.js`** — новые экшены `addOptimisticOperation` / `replaceOptimisticOperation` / `removeOptimisticOperation` поверх общего `_setOperations`.
- **`app/screens/OperationsScreen.js`** — построение плейсхолдера операции из `item`+`choice` (оценка суммы по офлайн-курсу) и проброс колбэков в хук.
- **`app/components/operations/OperationListItem.js`** — спиннер/приглушение/блокировка нажатия для строки с флагом `_pending`.
- **`NotificationBindingCard.js` / `NotificationBindingStack.js`** — удалён устаревший блокирующий `saving`-режим карточки (защита от двойного тапа сохранена через синхронный `savingRef` + мгновенный уход карточки из колоды).

## Тесты

- Обновлены тесты хука/стека/экрана под новый API; добавлено покрытие оптимистичного пути (insert → settle / rollback, включая `resolve → null`) и `_pending`-строки в `OperationListItem`.
- Полный прогон: **4455 тестов, 155 сьютов — зелёные**. ESLint по затронутым файлам чист.
- Перед PR прогнан `/code-review` (high): застрявший спиннер при сбое пост-reload и неточная сумма плейсхолдера устранены детерминированной заменой на возвращённую операцию; добавлен недостающий тест.

