### PR TITLE
fix(db): применить миграцию 0016 для установок, полных до 0015

### DIFF
--- a/app/services/db.js
+++ b/app/services/db.js
@@ -179,6 +179,13 @@ const isSchemaComplete = async (rawDb) => {
     // and never gain the column.
     if (!accountsCols.some(c => c.name === 'show_in_main_menu')) return false;
 
+    // Check notification_merchant_rules has last_matched_at column (migration 0016).
+    // Same reasoning: an install complete through 0015 would otherwise report
+    // "schema complete" and skip migrate(), so 0016 would never add the column —
+    // and getAllMerchantRules (which ORDER BYs COALESCE(last_matched_at, ...))
+    // would throw, wiping the category and name bindings from the UI.
+    if (!merchantRuleCols.some(c => c.name === 'last_matched_at')) return false;
+
     return true;
   } catch (error) {
     console.warn('[DB] isSchemaComplete check failed:', error.message);
@@ -456,6 +463,14 @@ const detectAppliedMigrations = async (rawDb) => {
     const accCols = await getColumns('accounts');
     if (accCols.some(c => c.name === 'show_in_main_menu')) {
       applied.push(15);
+    }
+  }
+
+  // Migration 0016: Adds notification_merchant_rules.last_matched_at column.
+  if (await tableExists('notification_merchant_rules')) {
+    const ruleCols = await getColumns('notification_merchant_rules');
+    if (ruleCols.some(c => c.name === 'last_matched_at')) {
+      applied.push(16);
     }
   }
 


### PR DESCRIPTION
## Проблема

После мержа #1261 существующие установки (у кого схема была полной до 0015) **не получают** миграцию 0016, и экран «Привязки» теряет привязки категорий и имён — остаются только карты.

Подтверждено логом с устройства:
```
[ERROR] Failed to get merchant rules: Error: ... no such column: last_matched_at
```

## Причина

`isSchemaComplete()` в `app/services/db.js` пропускает `migrate()`, когда считает схему актуальной, поэтому обязана знать про каждую колоночную миграцию. Проверки на 0016 не было → БД, полная до 0015, отчитывалась «schema complete», `migrate()` пропускался, колонка `notification_merchant_rules.last_matched_at` не добавлялась. `getAllMerchantRules` сортирует по `COALESCE(last_matched_at, updated_at)`, поэтому запрос падал `no such column` на каждой загрузке, а `reload()` глотал ошибку в `[]` — категории и имена исчезали (карты берутся из `accounts` другим запросом, поэтому оставались).

## Фикс

Добавлен маркер `last_matched_at` в обе функции `db.js`:
- `isSchemaComplete()` — чтобы БД до 0015 больше не считалась актуальной и `migrate()` не пропускался;
- `detectAppliedMigrations()` — чтобы 0016 распознавалась как pending и применялась на следующем запуске.

Зеркалит уже существующие проверки для 0013–0015. Данные не теряются — правила лежат в таблице, просто не читались; после применения миграции привязки возвращаются.

## Проверки

`db.test` зелёный (690/690). Изменение — один файл, `app/services/db.js` (+15 строк).
