### PR TITLE
feat(notifications): persist ingestion location on pending notifications

### DIFF
--- a/__tests__/services/PendingNotificationsDB.test.js
+++ b/__tests__/services/PendingNotificationsDB.test.js
@@ -62,6 +62,28 @@ describe('PendingNotificationsDB', () => {
       expect(result.cardMask).toBeNull();
       expect(result.merchant).toBeNull();
       expect(result.accountId).toBeNull();
+      expect(result.latitude).toBeNull();
+      expect(result.longitude).toBeNull();
+    });
+
+    it('persists the ingestion-time coordinates', async () => {
+      const result = await PendingNotificationsDB.addPendingNotification({
+        kind: 'PURCHASE', type: 'expense', amount: '10', currency: 'AMD',
+        latitude: '40.1', longitude: '44.2',
+      });
+      expect(mockDb.executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('latitude, longitude'),
+        expect.arrayContaining(['40.1', '44.2']),
+      );
+      expect(result).toMatchObject({ latitude: '40.1', longitude: '44.2' });
+    });
+
+    it('preserves a 0.0 coordinate (does not coerce to null)', async () => {
+      const result = await PendingNotificationsDB.addPendingNotification({
+        kind: 'PURCHASE', type: 'expense', amount: '10', currency: 'AMD',
+        latitude: '0.0', longitude: '0.0',
+      });
+      expect(result).toMatchObject({ latitude: '0.0', longitude: '0.0' });
     });
   });
 

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -47,6 +47,7 @@ import * as PreferencesDB from '../../../app/services/PreferencesDB';
 // function so the merge-into-createOperation behavior is exercised.
 jest.mock('../../../app/services/operationLocation', () => ({
   captureLocationIfEnabled: jest.fn(),
+  isAttachLocationEnabled: jest.fn(),
   operationLocationFields: (loc) =>
     loc && loc.latitude != null && loc.longitude != null
       ? { latitude: loc.latitude, longitude: loc.longitude }
@@ -128,6 +129,9 @@ describe('processBankNotifications', () => {
     Currency.fetchLiveExchangeRate.mockResolvedValue({ rate: null, source: 'none' });
     // Location feature off by default — no coordinates attached.
     OperationLocation.captureLocationIfEnabled.mockResolvedValue(null);
+    // Opt-in on by default so the resolve path can reuse a stored fix; the tests
+    // that exercise the off case override this explicitly.
+    OperationLocation.isAttachLocationEnabled.mockResolvedValue(true);
   });
 
   it('does nothing when disabled', async () => {
@@ -203,8 +207,11 @@ describe('processBankNotifications', () => {
         expect.objectContaining({ latitude: '40.1', longitude: '44.2' }));
     });
 
-    it('does not capture a location when nothing is auto-created (all queued)', async () => {
-      // Untrusted source → the notification is queued, not booked, so no fix.
+    it('stores the ingestion-time location on a queued notification', async () => {
+      // Untrusted source → the notification is queued, not booked. The location is
+      // still captured now (near the shop) and stored on the pending row so it is
+      // reused when the user resolves it later.
+      OperationLocation.captureLocationIfEnabled.mockResolvedValue({ latitude: '40.1', longitude: '44.2' });
       NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]);
       AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
       NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
@@ -213,15 +220,73 @@ describe('processBankNotifications', () => {
       const summary = await pipeline.processBankNotifications();
 
       expect(summary).toEqual({ created: 0, pending: 1, skipped: 0 });
-      expect(OperationLocation.captureLocationIfEnabled).not.toHaveBeenCalled();
+      expect(OperationsDB.createOperation).not.toHaveBeenCalled();
+      expect(PendingNotificationsDB.addPendingNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: '40.1', longitude: '44.2' }),
+      );
     });
 
-    it('attaches the captured location when resolving a pending notification', async () => {
+    it('queues a notification without coordinates when the feature is off', async () => {
+      OperationLocation.captureLocationIfEnabled.mockResolvedValue(null);
+      NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [])(key));
+
+      await pipeline.processBankNotifications();
+
+      const arg = PendingNotificationsDB.addPendingNotification.mock.calls[0][0];
+      expect(arg).not.toHaveProperty('latitude');
+      expect(arg).not.toHaveProperty('longitude');
+    });
+
+    it('reuses the stored ingestion location when resolving a pending notification', async () => {
+      // The live capture would return the (wrong) current location; the stored fix
+      // from ingestion must win so a purchase reviewed at home keeps the shop's place.
+      OperationLocation.captureLocationIfEnabled.mockResolvedValue({ latitude: '55.7', longitude: '37.6' });
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        id: 'p1', type: 'expense', amount: '3900.00', currency: 'AMD',
+        cardMask: '4083***7027', merchant: 'NAREK MEHRABYAN', date: '2026-06-28',
+        accountId: null, categoryId: null, packageName: PKG,
+        latitude: '40.1', longitude: '44.2',
+        createdAt: '2026-06-28T10:15:00.000Z',
+      });
+
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-food' });
+
+      expect(OperationLocation.captureLocationIfEnabled).not.toHaveBeenCalled();
+      expect(OperationsDB.createOperation).toHaveBeenCalledWith(
+        expect.objectContaining({ latitude: '40.1', longitude: '44.2' }),
+      );
+    });
+
+    it('does not attach a stored location when the feature has since been turned off', async () => {
+      // Coords were captured at the shop while opted in, but the user has since
+      // opted out. Resolving creates a NEW operation, which the toggle governs, so
+      // nothing is attached — not even the stored fix.
+      OperationLocation.isAttachLocationEnabled.mockResolvedValue(false);
+      PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
+        id: 'p1', type: 'expense', amount: '3900.00', currency: 'AMD',
+        cardMask: '4083***7027', merchant: 'NAREK MEHRABYAN', date: '2026-06-28',
+        accountId: null, categoryId: null, packageName: PKG,
+        latitude: '40.1', longitude: '44.2',
+        createdAt: '2026-06-28T10:15:00.000Z',
+      });
+
+      await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-food' });
+
+      const arg = OperationsDB.createOperation.mock.calls[0][0];
+      expect(arg).not.toHaveProperty('latitude');
+      expect(arg).not.toHaveProperty('longitude');
+    });
+
+    it('falls back to a live capture when a pending notification carries no stored location', async () => {
       OperationLocation.captureLocationIfEnabled.mockResolvedValue({ latitude: '1.5', longitude: '2.5' });
       PendingNotificationsDB.getPendingNotificationById.mockResolvedValue({
         id: 'p1', type: 'expense', amount: '3900.00', currency: 'AMD',
         cardMask: '4083***7027', merchant: 'NAREK MEHRABYAN', date: '2026-06-28',
         accountId: null, categoryId: null, packageName: PKG,
+        latitude: null, longitude: null,
         createdAt: '2026-06-28T10:15:00.000Z',
       });
 

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -212,6 +212,11 @@ export const pendingNotifications = sqliteTable('pending_notifications', {
   categoryId: text('category_id').references(() => categories.id, { onDelete: 'set null' }),
   packageName: text('package_name'),
   raw: text('raw'),
+  // Location captured at ingestion time (near the shop), reused when the item is
+  // resolved so a notification reviewed later isn't stamped with the wrong place.
+  // Both nullable — only populated when the attach-location opt-in was on.
+  latitude: text('latitude'),
+  longitude: text('longitude'),
   createdAt: text('created_at').notNull(),
 }, (table) => ({
   createdIdx: index('idx_pending_notifications_created').on(table.createdAt),

--- a/app/services/PendingNotificationsDB.js
+++ b/app/services/PendingNotificationsDB.js
@@ -26,6 +26,8 @@ const mapPendingFields = (row) => {
     categoryId: row.category_id,
     packageName: row.package_name,
     raw: row.raw,
+    latitude: row.latitude,
+    longitude: row.longitude,
     createdAt: row.created_at,
   };
 };
@@ -33,7 +35,8 @@ const mapPendingFields = (row) => {
 /**
  * Insert a pending notification from a parsed descriptor + suggestions.
  * @param {Object} item - { kind, type, amount, currency, cardMask, merchant,
- *   country, date, time, accountId, categoryId, packageName, raw }
+ *   country, date, time, accountId, categoryId, packageName, raw, latitude,
+ *   longitude }
  * @returns {Promise<Object>} the stored pending item
  */
 export const addPendingNotification = async (item) => {
@@ -55,16 +58,20 @@ export const addPendingNotification = async (item) => {
       category_id: item.categoryId || null,
       package_name: item.packageName || null,
       raw: item.raw || null,
+      // ?? (not ||) so a valid 0.0 coordinate (equator / prime meridian) survives.
+      latitude: item.latitude ?? null,
+      longitude: item.longitude ?? null,
       created_at: now,
     };
     await executeQuery(
       `INSERT INTO pending_notifications
-        (id, kind, type, amount, currency, card_mask, merchant, country, date, time, account_id, category_id, package_name, raw, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, kind, type, amount, currency, card_mask, merchant, country, date, time, account_id, category_id, package_name, raw, latitude, longitude, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         row.id, row.kind, row.type, row.amount, row.currency, row.card_mask,
         row.merchant, row.country, row.date, row.time, row.account_id,
-        row.category_id, row.package_name, row.raw, row.created_at,
+        row.category_id, row.package_name, row.raw, row.latitude, row.longitude,
+        row.created_at,
       ],
     );
     return mapPendingFields(row);

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -186,6 +186,14 @@ const isSchemaComplete = async (rawDb) => {
     // would throw, wiping the category and name bindings from the UI.
     if (!merchantRuleCols.some(c => c.name === 'last_matched_at')) return false;
 
+    // Check pending_notifications has BOTH latitude and longitude (migration 0017).
+    // Both are checked for the same reason as operations' 0009 columns: a
+    // half-applied 0017 (latitude only) must not be mistaken for complete. Without
+    // this check, an install complete through 0016 would skip migrate() and never
+    // gain the columns.
+    const pendingCols = await rawDb.getAllAsync('PRAGMA table_info(pending_notifications)');
+    if (!pendingCols.some(c => c.name === 'latitude') || !pendingCols.some(c => c.name === 'longitude')) return false;
+
     return true;
   } catch (error) {
     console.warn('[DB] isSchemaComplete check failed:', error.message);
@@ -471,6 +479,16 @@ const detectAppliedMigrations = async (rawDb) => {
     const ruleCols = await getColumns('notification_merchant_rules');
     if (ruleCols.some(c => c.name === 'last_matched_at')) {
       applied.push(16);
+    }
+  }
+
+  // Migration 0017: Adds latitude/longitude columns to pending_notifications.
+  // Require BOTH columns — a half-applied 0017 (latitude only) must re-run so the
+  // missing longitude column is added.
+  if (await tableExists('pending_notifications')) {
+    const pnCols = await getColumns('pending_notifications');
+    if (pnCols.some(c => c.name === 'latitude') && pnCols.some(c => c.name === 'longitude')) {
+      applied.push(17);
     }
   }
 

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -18,7 +18,7 @@ import * as NotificationRulesDB from '../NotificationRulesDB';
 import * as PendingNotificationsDB from '../PendingNotificationsDB';
 import { serializeLabels, sanitizeLabel } from '../../utils/labelUtils';
 import { appEvents, EVENTS } from '../eventEmitter';
-import { captureLocationIfEnabled, operationLocationFields } from '../operationLocation';
+import { captureLocationIfEnabled, isAttachLocationEnabled, operationLocationFields } from '../operationLocation';
 import { parseBankNotification, kindRequiresCategory } from './parseBankNotification';
 import { resolveNotification } from './resolveNotification';
 import { learnAccountBinding } from './accountBindings';
@@ -40,6 +40,27 @@ const makeLocationProvider = () => {
     }
     return cached;
   };
+};
+
+/**
+ * Location to stamp on an operation booked from a pending notification. Prefers
+ * the fix captured when the notification was ingested (near the shop) so resolving
+ * the item later — e.g. after coming home — doesn't record the current (wrong)
+ * place. Falls back to a live capture for rows that carry no stored fix (queued
+ * before this feature, or ingested with the toggle off).
+ *
+ * Gated on the current opt-in either way: resolving a pending row creates a NEW
+ * operation, and the toggle governs new operations, so a user who has since opted
+ * out gets no location — not even the stored one.
+ * @param {{ latitude?: *, longitude?: * }} pending
+ * @returns {Promise<{ latitude: string, longitude: string }|null>}
+ */
+const resolvePendingLocation = async (pending) => {
+  if (pending && pending.latitude != null && pending.longitude != null) {
+    if (!(await isAttachLocationEnabled())) return null;
+    return { latitude: pending.latitude, longitude: pending.longitude };
+  }
+  return captureLocationIfEnabled();
 };
 
 // Cap on remembered signatures. The native side only ever keeps a handful of
@@ -377,6 +398,10 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
       }
     }
   } else {
+    // Capture the location NOW (at ingestion, near the shop) and store it on the
+    // pending row, so resolving the item later — e.g. after coming home — stamps
+    // the operation with where the purchase happened, not the current location.
+    const location = getLocation ? await getLocation() : null;
     await PendingNotificationsDB.addPendingNotification({
       ...descriptor,
       date,
@@ -389,6 +414,7 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
       // away a binding the user already trained — forcing them to re-pick it on
       // every notification even though it shows up in the bindings list.
       categoryId: resolution.categoryId,
+      ...operationLocationFields(location),
     });
     summary.pending += 1;
   }
@@ -456,12 +482,16 @@ const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages
     });
     summary.created += 1;
   } else {
+    // Capture the location NOW (at ingestion, near the ATM) and store it on the
+    // pending row, mirroring the expense/income queue path.
+    const location = getLocation ? await getLocation() : null;
     await PendingNotificationsDB.addPendingNotification({
       ...descriptor,
       date,
       accountId: resolution.accountId,
       // Transfers carry no category; the target account is chosen at review time.
       categoryId: null,
+      ...operationLocationFields(location),
     });
     summary.pending += 1;
   }
@@ -637,8 +667,9 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
     };
   }
 
-  // Best-effort location for this user-driven save (attached only when enabled).
-  const location = await captureLocationIfEnabled();
+  // Prefer the fix captured at ingestion (near the shop); fall back to a live,
+  // opt-in-gated capture only when the pending row carries no stored coordinates.
+  const location = await resolvePendingLocation(pending);
 
   const operation = await OperationsDB.createOperation({
     type: pending.type,
@@ -805,8 +836,9 @@ const resolvePendingTransfer = async (pending, choices = {}) => {
   const typedLabel = sanitizeLabel(choices.labelOverride);
   const label = typedLabel || pending.merchant;
 
-  // Best-effort location for this user-driven save (attached only when enabled).
-  const location = await captureLocationIfEnabled();
+  // Prefer the fix captured at ingestion (near the ATM); fall back to a live,
+  // opt-in-gated capture only when the pending row carries no stored coordinates.
+  const location = await resolvePendingLocation(pending);
 
   const operation = await OperationsDB.createOperation({
     type: 'transfer',

--- a/drizzle/0017_add_pending_notification_location.js
+++ b/drizzle/0017_add_pending_notification_location.js
@@ -1,0 +1,19 @@
+/**
+ * Migration 0017: Add latitude/longitude columns to pending_notifications
+ *
+ * A bank notification that can't be auto-matched waits in the review queue as a
+ * pending row. Its location is now captured when the notification is ingested
+ * (near the shop) rather than when the user finally resolves it — otherwise a
+ * notification reviewed later, e.g. after coming home, would be stamped with the
+ * wrong (current) location. Both columns are nullable text, mirroring
+ * operations.latitude/longitude (migration 0009): only populated when the
+ * attach-location opt-in is on at ingestion time.
+ *
+ * SQLite requires one ADD COLUMN per statement, so the two columns are added in
+ * separate statements (split on Drizzle's statement-breakpoint marker).
+ */
+
+const sql = `ALTER TABLE \`pending_notifications\` ADD COLUMN \`latitude\` text;--> statement-breakpoint
+ALTER TABLE \`pending_notifications\` ADD COLUMN \`longitude\` text;`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1767100000000,
       "tag": "0016_merchant_rule_last_matched",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1767200000000,
+      "tag": "0017_add_pending_notification_location",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -18,6 +18,7 @@ import m0013 from './0013_operation_exclude_from_avg.js';
 import m0014 from './0014_account_rounding_mode.js';
 import m0015 from './0015_account_show_in_main_menu.js';
 import m0016 from './0016_merchant_rule_last_matched.js';
+import m0017 from './0017_add_pending_notification_location.js';
 
 export default {
   journal,
@@ -39,6 +40,7 @@ export default {
     m0014,
     m0015,
     m0016,
+    m0017,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,


### PR DESCRIPTION
Store location coordinates captured at notification ingestion time and reuse them when resolving. Respects the location attachment feature toggle to avoid attaching coordinates if the feature has since been disabled.
