### PR TITLE
feat(operations): inline validation flash for QuickAdd (QoL-12)

### DIFF
--- a/.claude/feature-backlog.md
+++ b/.claude/feature-backlog.md
@@ -62,9 +62,10 @@ Findings from a code-level UX audit. Each item is small-scope (no major rework) 
 **Fix**: placeholder text for year-view balance card, top-level `EmptyState` when no visible accounts, init `loading: true`.
 
 ### QoL-12. QuickAdd validation feedback is inconsistent
-**Status**: Not Started
+**Status**: ✅ Completed
 **Problem**: a missing category gets a lightweight non-blocking red flash, but a missing account / zero amount / same-account transfer pops a blocking dialog needing an extra OK tap (`OperationsScreen.js:618-626`).
 **Fix**: extend the flash/inline treatment to the other one-field omissions.
+**Implementation**: `handleQuickAdd` now maps each single-field validation failure to the offending field via `getQuickAddFlashField` and flashes it red inline instead of opening a dialog. The category-only `flashCategoryError` prop was generalized to `flashError={{ field, token }}`, threaded through `QuickAddForm` → `OperationFormFields`, which flashes the source-account picker, target-account picker/chips, category chips, or the `Calculator` amount display (new `flashError` bool → red display border). The blocking dialog remains only for non-field errors (missing type/date). Same behaviour is unchanged in `OperationModal` (no `flashError` passed).
 
 ### QoL-13. Settings polish (small items)
 **Status**: Not Started

--- a/__tests__/components/OperationFormFields.test.js
+++ b/__tests__/components/OperationFormFields.test.js
@@ -721,7 +721,7 @@ describe('OperationFormFields', () => {
     });
   });
 
-  describe('Category Error Flash Animation', () => {
+  describe('Field Error Flash Animation', () => {
     const mockTopCategories = [
       { id: 'cat1', name: 'Food', icon: 'food', type: 'entry', categoryType: 'expense' },
       { id: 'cat2', name: 'Transport', icon: 'car', type: 'entry', categoryType: 'expense' },
@@ -731,7 +731,7 @@ describe('OperationFormFields', () => {
       return { name: cat?.name || 'Unknown', icon: cat?.icon || 'tag', parentName: null };
     };
 
-    it('renders category chips without error when flashCategoryError is 0', async () => {
+    it('renders without error when flashError is null', async () => {
       const props = {
         ...defaultProps,
         topCategoriesForType: mockTopCategories,
@@ -741,28 +741,55 @@ describe('OperationFormFields', () => {
       await render(<OperationFormFields {...props} />);
     });
 
-    it('triggers flash animation branch when flashCategoryError is non-zero', async () => {
+    it('triggers flash branch for a category omission', async () => {
       const props = {
         ...defaultProps,
         topCategoriesForType: mockTopCategories,
         getCategoryInfo,
         values: { ...defaultProps.values, categoryId: '' },
-        flashCategoryError: 1,
+        flashError: { field: 'category', token: 1 },
       };
       await render(<OperationFormFields {...props} />);
     });
 
-    it('re-triggers animation when flashCategoryError increments again', async () => {
+    it('triggers flash branch for a missing source account', async () => {
+      const props = {
+        ...defaultProps,
+        values: { ...defaultProps.values, accountId: '' },
+        flashError: { field: 'account', token: 1 },
+      };
+      await render(<OperationFormFields {...props} />);
+    });
+
+    it('triggers flash branch for a zero amount', async () => {
+      const props = {
+        ...defaultProps,
+        values: { ...defaultProps.values, amount: '' },
+        flashError: { field: 'amount', token: 1 },
+      };
+      await render(<OperationFormFields {...props} />);
+    });
+
+    it('triggers flash branch for a missing transfer target account', async () => {
+      const props = {
+        ...defaultProps,
+        values: { ...defaultProps.values, type: 'transfer', toAccountId: '' },
+        flashError: { field: 'toAccount', token: 1 },
+      };
+      await render(<OperationFormFields {...props} />);
+    });
+
+    it('re-triggers animation when the token changes for the same field', async () => {
       const props = {
         ...defaultProps,
         topCategoriesForType: mockTopCategories,
         getCategoryInfo,
         values: { ...defaultProps.values, categoryId: '' },
-        flashCategoryError: 0,
+        flashError: null,
       };
       const { rerender } = await render(<OperationFormFields {...props} />);
-      expect(() => rerender(<OperationFormFields {...props} flashCategoryError={1} />)).not.toThrow();
-      expect(() => rerender(<OperationFormFields {...props} flashCategoryError={2} />)).not.toThrow();
+      expect(() => rerender(<OperationFormFields {...props} flashError={{ field: 'category', token: 1 }} />)).not.toThrow();
+      expect(() => rerender(<OperationFormFields {...props} flashError={{ field: 'category', token: 2 }} />)).not.toThrow();
     });
   });
 });

--- a/__tests__/screens/OperationsScreen.test.js
+++ b/__tests__/screens/OperationsScreen.test.js
@@ -2397,75 +2397,119 @@ describe('OperationsScreen', () => {
     });
   });
 
-  describe('Category Validation Flash', () => {
+  // Pure mapping from a validation failure to the field that should flash red.
+  // Kept as a unit test (no render) so the core QoL-12 logic is covered directly
+  // and without the render flakiness the integration tests below are prone to.
+  describe('getQuickAddFlashField', () => {
+    const { getQuickAddFlashField } = require('../../app/screens/OperationsScreen');
+
+    it('maps a zero / empty / non-numeric amount to the amount field', () => {
+      expect(getQuickAddFlashField({ type: 'expense', amount: '', accountId: 'a', categoryId: 'c' })).toBe('amount');
+      expect(getQuickAddFlashField({ type: 'expense', amount: '0', accountId: 'a', categoryId: 'c' })).toBe('amount');
+      expect(getQuickAddFlashField({ type: 'expense', amount: 'abc', accountId: 'a', categoryId: 'c' })).toBe('amount');
+    });
+
+    it('maps a missing source account to the account field (amount takes precedence)', () => {
+      expect(getQuickAddFlashField({ type: 'expense', amount: '100', accountId: '', categoryId: 'c' })).toBe('account');
+      // Amount is checked first, so a bad amount wins even when the account is also missing.
+      expect(getQuickAddFlashField({ type: 'expense', amount: '', accountId: '', categoryId: 'c' })).toBe('amount');
+    });
+
+    it('maps a missing or duplicate transfer target to the toAccount field', () => {
+      expect(getQuickAddFlashField({ type: 'transfer', amount: '100', accountId: 'a', toAccountId: '' })).toBe('toAccount');
+      expect(getQuickAddFlashField({ type: 'transfer', amount: '100', accountId: 'a', toAccountId: 'a' })).toBe('toAccount');
+    });
+
+    it('maps a missing category (non-transfer) to the category field', () => {
+      expect(getQuickAddFlashField({ type: 'expense', amount: '100', accountId: 'a', categoryId: '' })).toBe('category');
+    });
+
+    it('returns null for a fully valid operation', () => {
+      expect(getQuickAddFlashField({ type: 'expense', amount: '100', accountId: 'a', categoryId: 'c' })).toBeNull();
+      expect(getQuickAddFlashField({ type: 'transfer', amount: '100', accountId: 'a', toAccountId: 'b' })).toBeNull();
+    });
+
+    it('returns null for errors not tied to a single visible field (missing type/date)', () => {
+      // type/date failures still fall back to the blocking dialog rather than a flash.
+      expect(getQuickAddFlashField({ amount: '100', accountId: 'a', categoryId: 'c' })).toBeNull();
+    });
+  });
+
+  describe('QuickAdd Validation Flash wiring', () => {
     const { act } = require('@testing-library/react-native');
 
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    it('flashes category chips instead of showing dialog when category is missing on expense', async () => {
-      const OperationsScreen = require('../../app/screens/OperationsScreen').default;
-      const { useDialog } = require('../../app/contexts/DialogContext');
+    // Mock the form hook with a given set of QuickAdd values. handleQuickAdd is
+    // reached through the PickerModal's onAutoAddWithCategory shortcut (the
+    // QuickAddForm itself is a list-header mock and not rendered here), so field
+    // mapping is verified separately by the getQuickAddFlashField unit tests; these
+    // two only prove the flash-vs-dialog routing.
+    const mockQuickAddValues = (values) => {
+      const useQuickAddForm = require('../../app/hooks/useQuickAddForm');
+      useQuickAddForm.mockReturnValue({
+        quickAddValues: { description: '', exchangeRate: '', destinationAmount: '', toAccountId: '', categoryId: '', ...values },
+        setQuickAddValues: jest.fn(),
+        getAccountName: jest.fn(() => 'Cash'),
+        getAccountBalance: jest.fn(() => '$1000.00'),
+        getCategoryInfo: jest.fn(() => ({ name: 'Food', icon: 'food' })),
+        getCategoryName: jest.fn(() => 'Food'),
+        filteredCategories: [],
+        resetForm: jest.fn(),
+      });
+    };
+
+    const mockActions = (validateOperation) => {
       const { useOperationsActions } = require('../../app/contexts/OperationsActionsContext');
-
-      const mockShowDialog = jest.fn();
-      const mockValidateOperation = jest.fn((op) =>
-        op.type !== 'transfer' && !op.categoryId ? 'category_required' : null,
-      );
-
-      useDialog.mockReturnValue({ showDialog: mockShowDialog });
       useOperationsActions.mockReturnValue({
         loadMoreOperations: jest.fn(),
         addOperation: jest.fn(),
         updateOperation: jest.fn(),
         deleteOperation: jest.fn(),
-        validateOperation: mockValidateOperation,
+        validateOperation,
         setSearchText: jest.fn(),
         updateSearchFilters: jest.fn(),
         jumpToDate: jest.fn(),
       });
+    };
+
+    it('flashes inline instead of showing a dialog for a single-field omission', async () => {
+      const OperationsScreen = require('../../app/screens/OperationsScreen').default;
+      const { useDialog } = require('../../app/contexts/DialogContext');
+
+      const mockShowDialog = jest.fn();
+      useDialog.mockReturnValue({ showDialog: mockShowDialog });
+      // Valid amount + account so the deciding omission is the (empty) category.
+      mockQuickAddValues({ type: 'expense', amount: '100', accountId: 'acc-1', categoryId: '' });
+      const validateOperation = jest.fn(() => 'category_required');
+      mockActions(validateOperation);
 
       const { getByTestId } = await render(<OperationsScreen />);
-      // onAutoAddWithCategory is exposed on the PickerModal mock and routes through handleQuickAdd
-      const pickerModal = getByTestId('picker-modal');
-
-      // Passing empty string: no categoryId → category error → flash (no dialog)
+      // Passing '' keeps the category empty → getQuickAddFlashField → 'category' → flash.
       await act(async () => {
-        await pickerModal.props.onAutoAddWithCategory('');
+        await getByTestId('picker-modal').props.onAutoAddWithCategory('');
       });
 
+      expect(validateOperation).toHaveBeenCalled();
       expect(mockShowDialog).not.toHaveBeenCalled();
-      expect(mockValidateOperation).toHaveBeenCalled();
     });
 
-    it('shows dialog for non-category validation errors when category is present', async () => {
+    it('still shows a blocking dialog for errors not tied to a single field', async () => {
       const OperationsScreen = require('../../app/screens/OperationsScreen').default;
       const { useDialog } = require('../../app/contexts/DialogContext');
-      const { useOperationsActions } = require('../../app/contexts/OperationsActionsContext');
 
       const mockShowDialog = jest.fn();
-      // Error unrelated to category (amount missing)
-      const mockValidateOperation = jest.fn(() => 'valid_amount_required');
-
       useDialog.mockReturnValue({ showDialog: mockShowDialog });
-      useOperationsActions.mockReturnValue({
-        loadMoreOperations: jest.fn(),
-        addOperation: jest.fn(),
-        updateOperation: jest.fn(),
-        deleteOperation: jest.fn(),
-        validateOperation: mockValidateOperation,
-        setSearchText: jest.fn(),
-        updateSearchFilters: jest.fn(),
-        jumpToDate: jest.fn(),
-      });
+      // All single fields valid, but validation still fails (e.g. a date problem)
+      // → getQuickAddFlashField returns null → fall back to the dialog.
+      mockQuickAddValues({ type: 'expense', amount: '100', accountId: 'acc-1', categoryId: 'cat-1' });
+      mockActions(jest.fn(() => 'date_required'));
 
       const { getByTestId } = await render(<OperationsScreen />);
-      const pickerModal = getByTestId('picker-modal');
-
-      // Passing a real categoryId: category check passes → dialog shown for other error
       await act(async () => {
-        await pickerModal.props.onAutoAddWithCategory('cat-1');
+        await getByTestId('picker-modal').props.onAutoAddWithCategory('cat-1');
       });
 
       expect(mockShowDialog).toHaveBeenCalled();

--- a/app/components/Calculator.js
+++ b/app/components/Calculator.js
@@ -163,7 +163,7 @@ CalcButton.propTypes = {
  * - Shows "=" button when expression contains operations
  * - Evaluates expression and replaces with result
  */
-export default function Calculator({ value = '', onValueChange = () => {}, colors, placeholder = '0', onAdd = null, containerBackground = null, compact = false, currencyCode, onCurrencyPress }) {
+export default function Calculator({ value = '', onValueChange = () => {}, colors, placeholder = '0', onAdd = null, containerBackground = null, compact = false, currencyCode, onCurrencyPress, flashError = false }) {
   const [expression, setExpression] = useState(value || '');
   const syncedFromPropRef = useRef(false);
 
@@ -285,7 +285,7 @@ export default function Calculator({ value = '', onValueChange = () => {}, color
     // Use provided containerBackground or fallback to altRow for compatibility
     <View style={[styles.container, compact && styles.containerCompact, { backgroundColor: containerBackground || colors.altRow }]}>
       {/* Display */}
-      <View style={styles.display}>
+      <View style={[styles.display, flashError && { borderColor: '#ef4444' }]}>
         {onCurrencyPress ? (
           <Pressable
             onPress={onCurrencyPress}
@@ -478,6 +478,7 @@ Calculator.propTypes = {
   compact: PropTypes.bool,
   currencyCode: PropTypes.string,
   onCurrencyPress: PropTypes.func,
+  flashError: PropTypes.bool,
 };
 
 const styles = StyleSheet.create({
@@ -529,6 +530,11 @@ const styles = StyleSheet.create({
   },
   display: {
     alignItems: 'center',
+    // Transparent border reserved so the validation flash (red border) can toggle
+    // in without shifting the keypad below by a pixel.
+    borderColor: 'transparent',
+    borderRadius: BORDER_RADIUS.sm,
+    borderWidth: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginBottom: SPACING.xs,

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -19,6 +19,9 @@ import currencies from '../../../assets/currencies.json';
 
 const getCurrencySymbol = (code) => currencies[code]?.symbol || code;
 
+// Red outline used to flash a field that failed validation on a QuickAdd attempt.
+const FLASH_ERROR_COLOR = '#ef4444';
+
 import { hasOperation as checkHasOperation, evaluateExpression } from '../../utils/calculatorUtils';
 import { SPACING, BORDER_RADIUS } from '../../styles/layout';
 import { FONT_SIZE } from '../../styles/designTokens';
@@ -98,28 +101,31 @@ const OperationFormFields = memo(({
   foreignRateSource,
   foreignExchangeRate,
   foreignCurrencyEditable = false,
-  flashCategoryError = 0,
+  flashError = null,
 }) => {
   const { hideBalances } = useDisplaySettings();
 
   // Local state for currency picker visibility
   const [showCurrencyPicker, setShowCurrencyPicker] = useState(false);
 
-  // Category chip error flash: briefly outline the category chips in red when
-  // the user tries to add without selecting a category. Driven by state (not an
-  // animated value) so each chip stays a single Pressable — wrapping a chip in
-  // an extra view to host an animated border collapses its height and hides the
-  // label.
-  const [categoryFlashing, setCategoryFlashing] = useState(false);
+  // Field error flash: briefly outline the offending field in red when the user
+  // tries to add with a one-field omission (missing category / source account /
+  // target account / zero amount). Driven by state (not an animated value) so
+  // each chip stays a single Pressable — wrapping a chip in an extra view to
+  // host an animated border collapses its height and hides the label.
+  // `flashError` carries { field, token }; the token changes on every failed
+  // attempt so repeating the same omission re-triggers the flash.
+  const [flashingField, setFlashingField] = useState(null);
 
   useEffect(() => {
-    if (!flashCategoryError) return undefined;
-    setCategoryFlashing(true);
-    const timer = setTimeout(() => setCategoryFlashing(false), 1500);
+    if (!flashError || !flashError.field) return undefined;
+    setFlashingField(flashError.field);
+    const timer = setTimeout(() => setFlashingField(null), 1500);
     return () => clearTimeout(timer);
-  }, [flashCategoryError]);
+  }, [flashError?.field, flashError?.token]);
 
-  const chipBorderColor = categoryFlashing ? '#ef4444' : colors.border;
+  const chipBorderColor = flashingField === 'category' ? FLASH_ERROR_COLOR : colors.border;
+  const toAccountChipBorderColor = flashingField === 'toAccount' ? FLASH_ERROR_COLOR : colors.border;
 
   // Inline "All categories" browser state — replaces the bottom-sheet picker in
   // QuickAdd. We render the category hierarchy in-place using chips that look
@@ -248,6 +254,15 @@ const OperationFormFields = memo(({
     borderColor: colors.border,
   }), [colors]);
 
+  // Per-field border overrides — flash red when that field is the one that
+  // failed validation, otherwise fall back to the normal group border.
+  const accountBorderStyle = flashingField === 'account'
+    ? { borderColor: FLASH_ERROR_COLOR }
+    : groupBorderStyle;
+  const toAccountBorderStyle = flashingField === 'toAccount'
+    ? { borderColor: FLASH_ERROR_COLOR }
+    : groupBorderStyle;
+
   const disabledStyle = useMemo(() =>
     disabled ? styles.disabledInput : null
   , [disabled]);
@@ -352,9 +367,10 @@ const OperationFormFields = memo(({
     iconName = 'wallet',
     style = styles.formInput,
     testID,
+    borderStyle = groupBorderStyle,
   ) => (
     <Pressable
-      style={[style, compact && styles.formInputCompact, inputStyle, groupBorderStyle, disabledStyle]}
+      style={[style, compact && styles.formInputCompact, inputStyle, borderStyle, disabledStyle]}
       onPress={onPress}
       disabled={disabled}
       testID={testID}
@@ -388,6 +404,10 @@ const OperationFormFields = memo(({
         values.accountId,
         () => !disabled && openPicker('account', accounts),
         t('select_account'),
+        'wallet',
+        styles.formInput,
+        undefined,
+        accountBorderStyle,
       );
     } else if (values.type === 'transfer' && transferLayout === 'stacked') {
       // Stacked layout for OperationModal
@@ -397,6 +417,10 @@ const OperationFormFields = memo(({
             values.accountId,
             () => !disabled && openPicker('account', accounts),
             t('select_account'),
+            'wallet',
+            styles.formInput,
+            undefined,
+            accountBorderStyle,
           )}
           {renderAccountPicker(
             values.toAccountId,
@@ -405,6 +429,7 @@ const OperationFormFields = memo(({
             'wallet',
             styles.formInput,
             'to-account-picker',
+            toAccountBorderStyle,
           )}
         </>
       );
@@ -414,6 +439,10 @@ const OperationFormFields = memo(({
         values.accountId,
         () => !disabled && openPicker('account', accounts),
         t('select_account'),
+        'wallet',
+        styles.formInput,
+        undefined,
+        accountBorderStyle,
       );
     }
   };
@@ -750,7 +779,7 @@ const OperationFormFields = memo(({
               compact && styles.accountShortcutButtonCompact,
               {
                 backgroundColor: isSelected ? colors.primary : colors.inputBackground,
-                borderColor: colors.border,
+                borderColor: isSelected ? colors.primary : toAccountChipBorderColor,
               },
               disabledStyle,
             ]}
@@ -786,7 +815,7 @@ const OperationFormFields = memo(({
           <View style={styles.categoryButtonsContainer}>
             {showAllAccountsButton && (
               <Pressable
-                style={[styles.categoryPickerButton, inputStyle, groupBorderStyle, disabledStyle]}
+                style={[styles.categoryPickerButton, inputStyle, toAccountBorderStyle, disabledStyle]}
                 onPress={() => !disabled && openPicker('toAccount', accounts.filter(acc => acc.id !== values.accountId))}
                 disabled={disabled}
               >
@@ -833,6 +862,7 @@ const OperationFormFields = memo(({
       'swap-horizontal',
       styles.formInput,
       'to-account-picker',
+      toAccountBorderStyle,
     );
   };
 
@@ -851,6 +881,7 @@ const OperationFormFields = memo(({
           compact={compact}
           currencyCode={compact && values.type !== 'transfer' && onOperationCurrencyChange ? getCurrencySymbol(values.operationCurrency) : undefined}
           onCurrencyPress={compact && values.type !== 'transfer' && onOperationCurrencyChange ? () => setShowCurrencyPicker(true) : undefined}
+          flashError={flashingField === 'amount'}
         />
       </View>
       {isForeignCurrencyOp && sourceAccount && !foreignCurrencyEditable && (
@@ -954,7 +985,10 @@ OperationFormFields.propTypes = {
   foreignRateSource: PropTypes.oneOf(['loading', 'live', 'offline']),
   foreignExchangeRate: PropTypes.string,
   foreignCurrencyEditable: PropTypes.bool,
-  flashCategoryError: PropTypes.number,
+  flashError: PropTypes.shape({
+    field: PropTypes.oneOf(['category', 'account', 'toAccount', 'amount']),
+    token: PropTypes.number,
+  }),
 };
 
 const styles = StyleSheet.create({

--- a/app/components/operations/QuickAddForm.js
+++ b/app/components/operations/QuickAddForm.js
@@ -42,7 +42,7 @@ const QuickAddForm = memo(({
   onOperationCurrencyChange,
   foreignRateSource,
   foreignExchangeRate,
-  flashCategoryError,
+  flashError,
 }) => {
   const containerThemed = React.useMemo(() => ({
     backgroundColor: colors.background,
@@ -88,7 +88,7 @@ const QuickAddForm = memo(({
           onOperationCurrencyChange={onOperationCurrencyChange}
           foreignRateSource={foreignRateSource}
           foreignExchangeRate={foreignExchangeRate}
-          flashCategoryError={flashCategoryError}
+          flashError={flashError}
         />
       </View>
     </View>
@@ -122,7 +122,10 @@ QuickAddForm.propTypes = {
   onOperationCurrencyChange: PropTypes.func,
   foreignRateSource: PropTypes.oneOf(['loading', 'live', 'offline']),
   foreignExchangeRate: PropTypes.string,
-  flashCategoryError: PropTypes.number,
+  flashError: PropTypes.shape({
+    field: PropTypes.oneOf(['category', 'account', 'toAccount', 'amount']),
+    token: PropTypes.number,
+  }),
 };
 
 const styles = StyleSheet.create({

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -44,7 +44,7 @@ import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
 // missing-category case already had (instead of a blocking OK dialog). The
 // order mirrors validateOperation; returns null for anything not tied to a
 // single visible field (e.g. missing type/date), which falls back to a dialog.
-const getQuickAddFlashField = (op) => {
+export const getQuickAddFlashField = (op) => {
   if (!op.amount || isNaN(parseFloat(op.amount)) || parseFloat(op.amount) <= 0) return 'amount';
   if (!op.accountId) return 'account';
   if (op.type === 'transfer') {

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -39,6 +39,22 @@ import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
 
 // Note: dynamic createStyles removed to keep linting stable.
 
+// Map a QuickAdd validation failure to the form field that should flash red,
+// so single-field omissions get the same lightweight inline treatment the
+// missing-category case already had (instead of a blocking OK dialog). The
+// order mirrors validateOperation; returns null for anything not tied to a
+// single visible field (e.g. missing type/date), which falls back to a dialog.
+const getQuickAddFlashField = (op) => {
+  if (!op.amount || isNaN(parseFloat(op.amount)) || parseFloat(op.amount) <= 0) return 'amount';
+  if (!op.accountId) return 'account';
+  if (op.type === 'transfer') {
+    if (!op.toAccountId || op.accountId === op.toAccountId) return 'toAccount';
+  } else if (!op.categoryId) {
+    return 'category';
+  }
+  return null;
+};
+
 const OperationsScreen = () => {
   const { colors } = useThemeColors();
   const insets = useSafeAreaInsets();
@@ -94,7 +110,10 @@ const OperationsScreen = () => {
   // Seeded with an estimate of the collapsed search-pill area so the list's top
   // inset is roughly right on first paint; the real value arrives via onLayout.
   const [searchBarAreaHeight, setSearchBarAreaHeight] = useState(48);
-  const [flashCategoryErrorCount, setFlashCategoryErrorCount] = useState(0);
+  // Which QuickAdd field failed validation, if any. `token` bumps on every failed
+  // attempt so re-omitting the same field re-triggers the red flash.
+  const [quickAddFlash, setQuickAddFlash] = useState(null);
+  const quickAddFlashTokenRef = useRef(0);
 
   const { searchMode, filtersExpanded, openSearch, closeSearch, reopenSearch, toggleFilters } = useSearch();
   const scrollOffsetRef = useRef(0);
@@ -656,8 +675,14 @@ const OperationsScreen = () => {
 
     const error = validateOperation(operationData, t);
     if (error) {
-      if (operationData.type !== 'transfer' && !operationData.categoryId) {
-        setFlashCategoryErrorCount(c => c + 1);
+      // Prefer the lightweight inline flash over a blocking dialog for the common
+      // one-field omissions (zero amount / missing account / missing or duplicate
+      // target account / missing category). The order mirrors validateOperation so
+      // the flashed field matches the error that would have been shown.
+      const flashField = getQuickAddFlashField(operationData);
+      if (flashField) {
+        quickAddFlashTokenRef.current += 1;
+        setQuickAddFlash({ field: flashField, token: quickAddFlashTokenRef.current });
         return;
       }
       showDialog(t('error'), error, [{ text: 'OK' }]);
@@ -972,7 +997,7 @@ const OperationsScreen = () => {
                 onOperationCurrencyChange={handleOperationCurrencyChange}
                 foreignRateSource={foreignRateSource}
                 foreignExchangeRate={foreignExchangeRate}
-                flashCategoryError={flashCategoryErrorCount}
+                flashError={quickAddFlash}
               />
             </View>
             {hasSuggestions && quickAddHeight > 0 && (
@@ -995,7 +1020,7 @@ const OperationsScreen = () => {
       </Animated.View>
       {filtersExpanded && filterPanelHeight > 0 && <View style={{ height: filterPanelHeight }} />}
     </>
-  ), [animatedQuickAddClipStyle, animatedQuickAddSlideStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, handleOperationCurrencyChange, foreignRateSource, foreignExchangeRate, filterPanelHeight, filtersExpanded, flashCategoryErrorCount, operationSuggestions, hasSuggestions, quickAddHeight, handleQuickAddLayout, accounts, categories, suggestionSaveErrors, suggestionChoices, setSuggestionChoice, acceptSuggestion, dismissSuggestion]);
+  ), [animatedQuickAddClipStyle, animatedQuickAddSlideStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, handleOperationCurrencyChange, foreignRateSource, foreignExchangeRate, filterPanelHeight, filtersExpanded, quickAddFlash, operationSuggestions, hasSuggestions, quickAddHeight, handleQuickAddLayout, accounts, categories, suggestionSaveErrors, suggestionChoices, setSuggestionChoice, acceptSuggestion, dismissSuggestion]);
 
   // Auto-scroll to top when filter panel closes, but only if the user is still
   // near the top (hasn't scrolled into past dates). The threshold is filterPanelHeight:


### PR DESCRIPTION
## QoL-12 — QuickAdd validation feedback is inconsistent

**Problem:** in QuickAdd a missing category got a lightweight non-blocking red flash, but a missing account / zero amount / missing-or-duplicate transfer target popped a **blocking dialog** needing an extra OK tap.

**Fix:** extend the flash/inline treatment to every single-field omission. The blocking dialog now only appears for errors not tied to a single visible field (e.g. missing type/date).

### What changed
- `handleQuickAdd` maps each single-field validation failure to the offending field via a new pure helper `getQuickAddFlashField(op)` (order mirrors `validateOperation`) and flashes that field red inline instead of opening a dialog.
- The category-only `flashCategoryError` (number) prop was generalized to `flashError={{ field, token }}`, threaded `QuickAddForm` → `OperationFormFields`, which flashes the source-account picker, target-account picker/chips, category chips, or the `Calculator` amount display.
- `Calculator` gained a `flashError` boolean → red border on the amount display (a permanent transparent border is reserved so the flash never shifts the keypad).
- `OperationModal` is unchanged (it passes no `flashError`).

### Tests
- New unit tests for `getQuickAddFlashField` covering amount/account/toAccount/category precedence, same-account transfers, and the null fallbacks (missing type/date, fully-valid ops).
- Two wiring tests: a single-field omission flashes inline (no dialog); a non-field error still opens the dialog.
- Extended `OperationFormFields` flash tests for the account/amount/toAccount fields.
- Replaces two stale `Category Validation Flash` tests that encoded the old dialog-on-amount-error behavior this PR intentionally changes.
- `OperationsScreen.test.js` + `OperationFormFields.test.js`: **120 passed, 0 failed**.

Reviewed with `/code-review` (high effort) before opening.
