### PR TITLE
feat(operations): lift row + icon action bar on long-press

### DIFF
--- a/__tests__/components/operations/OperationActionMenu.test.js
+++ b/__tests__/components/operations/OperationActionMenu.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for OperationActionMenu — the long-press context menu shown over an
+ * operation row (Edit / Repeat / Delete on a lifted, blurred backdrop).
+ */
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import OperationActionMenu from '../../../app/components/operations/OperationActionMenu';
+
+const colors = {
+  surface: '#fff',
+  border: '#ddd',
+  text: '#000',
+  primary: '#007AFF',
+  expense: '#d32f2f',
+  delete: '#d32f2f',
+};
+
+const t = (key) => key;
+
+const makeMenu = () => ({
+  operation: { id: 'op-1', type: 'expense', amount: '10.00' },
+  layout: { x: 16, y: 200, width: 320, height: 48 },
+  row: <Text>Groceries</Text>,
+});
+
+const baseProps = () => ({
+  colors,
+  t,
+  onClose: jest.fn(),
+  onEdit: jest.fn(),
+  onRepeat: jest.fn(),
+  onDelete: jest.fn(),
+});
+
+describe('OperationActionMenu', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders nothing when menu is null', async () => {
+    const { queryByTestId } = await render(
+      <OperationActionMenu menu={null} {...baseProps()} />,
+    );
+    expect(queryByTestId('operation-action-edit')).toBeNull();
+    expect(queryByTestId('operation-action-menu-backdrop')).toBeNull();
+  });
+
+  it('renders the three action buttons and the lifted row when open', async () => {
+    const props = baseProps();
+    const { getByTestId, getByText } = await render(
+      <OperationActionMenu menu={makeMenu()} {...props} />,
+    );
+    expect(getByTestId('operation-action-edit')).toBeTruthy();
+    expect(getByTestId('operation-action-repeat')).toBeTruthy();
+    expect(getByTestId('operation-action-delete')).toBeTruthy();
+    expect(getByText('Groceries')).toBeTruthy();
+  });
+
+  it.each([
+    ['operation-action-edit', 'onEdit'],
+    ['operation-action-repeat', 'onRepeat'],
+    ['operation-action-delete', 'onDelete'],
+  ])('fires %s callback when pressed', async (testID, handler) => {
+    const props = baseProps();
+    const { getByTestId } = await render(
+      <OperationActionMenu menu={makeMenu()} {...props} />,
+    );
+    fireEvent.press(getByTestId(testID));
+    expect(props[handler]).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses when the backdrop is pressed', async () => {
+    const props = baseProps();
+    const { getByTestId } = await render(
+      <OperationActionMenu menu={makeMenu()} {...props} />,
+    );
+    fireEvent.press(getByTestId('operation-action-menu-backdrop'));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -284,13 +284,16 @@ describe('OperationListItem', () => {
   });
 
   describe('Long press', () => {
-    it('calls onLongPress when the row is long pressed', async () => {
+    it('forwards the operation on long press without throwing', async () => {
+      // The row measures itself (measureInWindow) before reporting layout to the
+      // caller; that native call is a no-op in the test renderer (it never invokes
+      // its callback), so the (operation, layout) payload can't be observed here.
+      // We assert the wiring holds — long-press runs the handler without throwing.
       const onLongPress = jest.fn();
       const { getByTestId } = await render(
         <OperationListItem {...baseProps} testID="op-row" onLongPress={onLongPress} />,
       );
-      fireEvent(getByTestId('op-row'), 'longPress');
-      expect(onLongPress).toHaveBeenCalledTimes(1);
+      expect(() => fireEvent(getByTestId('op-row'), 'longPress')).not.toThrow();
     });
 
     it('does not throw when onLongPress is omitted', async () => {

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -1,0 +1,274 @@
+import React, { useEffect, useRef } from 'react';
+import { Modal, View, Text, Pressable, StyleSheet, Animated, Dimensions } from 'react-native';
+import PropTypes from 'prop-types';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import ModalBlurOverlay from '../ModalBlurOverlay';
+import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';
+
+// Height reserved for the floating action bar; used to decide whether it fits
+// above the pressed row or has to sit below it.
+const PANEL_HEIGHT = 68;
+const GAP = 10;
+
+/**
+ * Context action menu shown on long-pressing an operation row.
+ *
+ * Instead of a plain "choose action" dialog, the pressed row is lifted above a
+ * blurred backdrop (a static clone rendered at its measured window position) and
+ * a compact icon bar floats just above (or below) it. Tapping the backdrop or
+ * pressing back dismisses it.
+ *
+ * The parent owns visibility: pass a `menu` object to open, `null` to close.
+ * Entrance is animated; closing unmounts immediately (a snappy dismiss is the
+ * expected feel for a context menu, and keeping no internal open/close state
+ * avoids setState-in-effect churn).
+ */
+export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, onRepeat, onDelete }) {
+  const insets = useSafeAreaInsets();
+  const progress = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (menu) {
+      progress.setValue(0);
+      Animated.spring(progress, {
+        toValue: 1,
+        useNativeDriver: true,
+        speed: 18,
+        bounciness: 6,
+      }).start();
+    }
+  }, [menu, progress]);
+
+  if (!menu) return null;
+
+  const { layout, row } = menu;
+  const screenHeight = Dimensions.get('window').height;
+
+  // Where the floating icon bar goes. Prefer above the row; fall back to below.
+  // Both edges are bounded so the bar never lands under the status bar / notch
+  // or under the bottom inset (tab bar / gesture area) for a near-edge row.
+  let panelTop;
+  let panelPlacedAbove = true;
+  if (layout) {
+    const topLimit = insets.top + SPACING.sm;
+    const bottomLimit = screenHeight - insets.bottom - SPACING.sm - PANEL_HEIGHT;
+    const above = layout.y - GAP - PANEL_HEIGHT;
+    const below = layout.y + layout.height + GAP;
+    if (above >= topLimit) {
+      panelTop = above;
+    } else if (below <= bottomLimit) {
+      panelTop = below;
+      panelPlacedAbove = false;
+    } else {
+      // Neither side fully clears an inset — clamp into the visible area.
+      panelTop = Math.max(topLimit, Math.min(above, bottomLimit));
+    }
+  } else {
+    // No measurement (rare): center the bar on screen.
+    panelTop = screenHeight / 2 - PANEL_HEIGHT / 2;
+    panelPlacedAbove = false;
+  }
+
+  const backdropStyle = { opacity: progress };
+  const cloneStyle = {
+    opacity: progress,
+    transform: [
+      { scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.97, 1] }) },
+    ],
+  };
+  const panelStyle = {
+    opacity: progress,
+    transform: [
+      {
+        translateY: progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [panelPlacedAbove ? SPACING.sm : -SPACING.sm, 0],
+        }),
+      },
+    ],
+  };
+
+  const deleteColor = colors.delete || colors.expense || '#d32f2f';
+
+  return (
+    <>
+      <ModalBlurOverlay />
+      <Modal visible transparent animationType="none" onRequestClose={onClose}>
+        <Pressable
+          testID="operation-action-menu-backdrop"
+          style={styles.fill}
+          onPress={onClose}
+        >
+          <Animated.View style={[styles.backdrop, backdropStyle]} pointerEvents="none" />
+
+          {/* Lifted clone of the pressed row */}
+          {layout && row && (
+            <Animated.View
+              pointerEvents="none"
+              style={[
+                styles.clone,
+                cloneStyle,
+                {
+                  top: layout.y,
+                  left: layout.x,
+                  width: layout.width,
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                },
+              ]}
+            >
+              {row}
+            </Animated.View>
+          )}
+
+          {/* Floating icon action bar. Wrapped in a non-press-through Pressable so
+              taps on the bar don't fall through to the dismiss backdrop. */}
+          <Animated.View
+            style={[
+              styles.panel,
+              panelStyle,
+              {
+                top: panelTop,
+                left: layout ? layout.x : SPACING.lg,
+                width: layout ? layout.width : Dimensions.get('window').width - SPACING.lg * 2,
+                backgroundColor: colors.surface,
+                borderColor: colors.border,
+              },
+            ]}
+          >
+            <Pressable style={styles.panelRow} onPress={() => {}}>
+              <ActionButton
+                testID="operation-action-edit"
+                icon="pencil"
+                label={t('edit')}
+                color={colors.primary}
+                textColor={colors.text}
+                onPress={onEdit}
+              />
+              <ActionButton
+                testID="operation-action-repeat"
+                icon="repeat"
+                label={t('repeat')}
+                color={colors.primary}
+                textColor={colors.text}
+                onPress={onRepeat}
+              />
+              <ActionButton
+                testID="operation-action-delete"
+                icon="trash-can-outline"
+                label={t('delete')}
+                color={deleteColor}
+                textColor={deleteColor}
+                onPress={onDelete}
+              />
+            </Pressable>
+          </Animated.View>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}
+
+function ActionButton({ testID, icon, label, color, textColor, onPress }) {
+  return (
+    <Pressable
+      testID={testID}
+      onPress={onPress}
+      style={({ pressed }) => [styles.actionButton, pressed && styles.actionButtonPressed]}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+    >
+      <Icon name={icon} size={ICON_SIZE.md} color={color} />
+      <Text style={[styles.actionLabel, { color: textColor }]} numberOfLines={1}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+ActionButton.propTypes = {
+  testID: PropTypes.string,
+  icon: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  color: PropTypes.string.isRequired,
+  textColor: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+OperationActionMenu.propTypes = {
+  menu: PropTypes.shape({
+    operation: PropTypes.object,
+    layout: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+    }),
+    row: PropTypes.node,
+  }),
+  colors: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
+  onRepeat: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+const styles = StyleSheet.create({
+  actionButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    flex: 1,
+    gap: SPACING.xs,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: SPACING.sm,
+  },
+  actionButtonPressed: {
+    opacity: 0.55,
+  },
+  actionLabel: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '600',
+  },
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  clone: {
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    elevation: 8,
+    overflow: 'hidden',
+    position: 'absolute',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 10,
+  },
+  fill: {
+    flex: 1,
+  },
+  panel: {
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    elevation: 10,
+    height: PANEL_HEIGHT,
+    position: 'absolute',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 12,
+  },
+  panelRow: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+    paddingHorizontal: SPACING.sm,
+  },
+});

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useMemo, useRef, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { TouchableRipple } from 'react-native-paper';
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
@@ -34,6 +34,19 @@ const OperationListItem = ({
   onApplySuggestion = () => {},
   onDismissSuggestion = () => {},
 }) => {
+  // Measure the row in window coordinates on long-press so the caller can float
+  // an action menu / lifted clone exactly over it (see OperationActionMenu).
+  const rowRef = useRef(null);
+  const handleLongPress = useCallback(() => {
+    const node = rowRef.current;
+    if (!node || typeof node.measureInWindow !== 'function') {
+      onLongPress(operation, null);
+      return;
+    }
+    node.measureInWindow((x, y, width, height) => {
+      onLongPress(operation, { x, y, width, height });
+    });
+  }, [onLongPress, operation]);
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
   const isTransfer = operation.type === 'transfer';
@@ -110,7 +123,7 @@ const OperationListItem = ({
       <TouchableRipple
         testID={testID}
         onPress={isPending ? undefined : onPress}
-        onLongPress={isPending ? undefined : onLongPress}
+        onLongPress={isPending ? undefined : handleLongPress}
         disabled={isPending}
         rippleColor="rgba(0, 0, 0, .08)"
         accessibilityRole="button"
@@ -118,7 +131,7 @@ const OperationListItem = ({
         accessibilityHint={t('operation_row_hint')}
         accessibilityState={{ disabled: isPending, busy: isPending }}
       >
-        <View style={[styles.row, isPending && styles.rowPending]}>
+        <View ref={rowRef} style={[styles.row, isPending && styles.rowPending]}>
           {/* Icon — a spinner while the operation is still being written. */}
           <View style={styles.iconContainer}>
             {isPending ? (

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -313,6 +313,29 @@ const OperationsList = forwardRef(({
     />
   ), [colors]);
 
+  // A static, non-interactive copy of a row, handed to the long-press action
+  // menu so it can lift the pressed row above the blurred backdrop. Built here
+  // because this is where the category/account/amount formatters live.
+  const renderClonedRow = useCallback((op) => (
+    <OperationListItem
+      operation={op}
+      colors={colors}
+      t={t}
+      categories={categories}
+      getCategoryInfo={getCategoryInfo}
+      getAccountName={getAccountName}
+      formatCurrency={formatCurrency}
+      isLast
+      onPress={NOOP}
+    />
+  ), [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency]);
+
+  // Bridge OperationListItem's (operation, layout) long-press up to the screen,
+  // attaching the lifted-row clone for the action menu.
+  const handleItemLongPress = useCallback((op, layout) => {
+    onLongPressOperation({ operation: op, layout, row: renderClonedRow(op) });
+  }, [onLongPressOperation, renderClonedRow]);
+
   // Render an individual operation row inside the card
   const renderItem = useCallback(({ item, index, section }) => {
     const isLast = index === section.data.length - 1;
@@ -337,14 +360,14 @@ const OperationsList = forwardRef(({
           formatCurrency={formatCurrency}
           isLast={isLast}
           onPress={() => onEditOperation(item)}
-          onLongPress={() => onLongPressOperation(item)}
+          onLongPress={handleItemLongPress}
           suggestionChips={item.id === pendingSuggestionId ? pendingSuggestions : null}
           onApplySuggestion={onApplySuggestion}
           onDismissSuggestion={onDismissSuggestion}
         />
       </View>
     );
-  }, [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency, onEditOperation, onLongPressOperation, pendingSuggestionId, pendingSuggestions, onApplySuggestion, onDismissSuggestion]);
+  }, [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency, onEditOperation, handleItemLongPress, pendingSuggestionId, pendingSuggestions, onApplySuggestion, onDismissSuggestion]);
 
   const keyExtractor = useCallback((item) => item.id, []);
 

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -21,6 +21,7 @@ import OperationModal from '../modals/OperationModal';
 import Calculator from '../components/Calculator';
 import ListCard from '../components/ListCard';
 import OperationsList from '../components/operations/OperationsList';
+import OperationActionMenu from '../components/operations/OperationActionMenu';
 import QuickAddForm from '../components/operations/QuickAddForm';
 import NotificationBindingStack, { deckPeekAllowance, deckCardHeight } from '../components/operations/NotificationBindingStack';
 import PickerModal from '../components/operations/PickerModal';
@@ -107,6 +108,8 @@ const OperationsScreen = () => {
   // added back-to-back within the 5-second window.
   const [undoInfo, setUndoInfo] = useState(null); // null | { id, token }
   const undoTokenRef = useRef(0);
+  // Long-press quick-action menu on a row: null | { operation, layout, row }
+  const [actionMenu, setActionMenu] = useState(null);
   const [filterPanelHeight, setFilterPanelHeight] = useState(0);
   // Seeded with an estimate of the collapsed search-pill area so the list's top
   // inset is roughly right on first paint; the real value arrives via onLayout.
@@ -522,32 +525,36 @@ const OperationsScreen = () => {
     }
   }, [addOperation]);
 
-  // Long-press on a row opens a quick-action menu, mirroring the planned-ops
-  // convention (showDialog). Edit repeats the tap behaviour; Repeat and Delete are
-  // the shortcuts QoL-7 adds so deleting/duplicating no longer costs a trip through
-  // the full edit modal.
-  const handleLongPressOperation = useCallback((operation) => {
-    const isTransfer = operation.type === 'transfer';
-    const category = categories.find(cat => cat.id === operation.categoryId);
-    const label = isTransfer
-      ? t('transfer')
-      : (category ? (category.nameKey ? t(category.nameKey) : category.name) : '');
+  // Long-press on a row lifts it above a blurred backdrop and floats an icon
+  // action bar over it (OperationActionMenu). Edit repeats the tap behaviour;
+  // Repeat and Delete are the QoL-7 shortcuts. OperationsList hands us the
+  // measured row layout plus a static clone to lift.
+  const handleLongPressOperation = useCallback((menu) => {
+    setActionMenu(menu);
+  }, []);
 
-    showDialog(
-      t('select_action'),
-      label,
-      [
-        { text: t('edit'), onPress: () => handleEditOperation(operation) },
-        { text: t('repeat'), onPress: () => handleRepeatOperation(operation) },
-        {
-          text: t('delete'),
-          style: 'destructive',
-          onPress: () => handleDeleteOperation(operation),
-        },
-        { text: t('cancel'), style: 'cancel' },
-      ],
-    );
-  }, [showDialog, t, categories, handleEditOperation, handleRepeatOperation, handleDeleteOperation]);
+  const closeActionMenu = useCallback(() => setActionMenu(null), []);
+
+  // Read the current menu from state (fresh via deps) and run the side effect
+  // outside setState — a state updater must stay pure (StrictMode double-invokes
+  // it, which would fire the action twice).
+  const handleMenuEdit = useCallback(() => {
+    const op = actionMenu?.operation;
+    setActionMenu(null);
+    if (op) handleEditOperation(op);
+  }, [actionMenu, handleEditOperation]);
+
+  const handleMenuRepeat = useCallback(() => {
+    const op = actionMenu?.operation;
+    setActionMenu(null);
+    if (op) handleRepeatOperation(op);
+  }, [actionMenu, handleRepeatOperation]);
+
+  const handleMenuDelete = useCallback(() => {
+    const op = actionMenu?.operation;
+    setActionMenu(null);
+    if (op) handleDeleteOperation(op);
+  }, [actionMenu, handleDeleteOperation]);
 
   const handleDateSeparatorPress = useCallback((dateString) => {
     // Parse the date and set it as the selected date (T00:00:00 anchors the bare
@@ -1228,6 +1235,17 @@ const OperationsScreen = () => {
         onSelectCategory={handleSelectCategory}
         onAutoAddWithCategory={handleAutoAddWithCategory}
         onAutoAddWithAccount={handleAutoAddWithAccount}
+      />
+
+      {/* Long-press quick-action menu for a single operation row */}
+      <OperationActionMenu
+        menu={actionMenu}
+        colors={colors}
+        t={t}
+        onClose={closeActionMenu}
+        onEdit={handleMenuEdit}
+        onRepeat={handleMenuRepeat}
+        onDelete={handleMenuDelete}
       />
 
       {/* Scroll to Top Button - only show when scrolled down */}


### PR DESCRIPTION
Long-press on an operation row now blurs the backdrop, lifts the pressed row above it, and floats an icon action bar (Edit / Repeat / Delete) — replacing the plain showDialog list from #1275. Reuses buildRepeatedOperation and the existing repeat/delete handlers. 312 tests green.