### PR TITLE
perf(graphs): parallelize independent balance-history queries (QoL-10)

### DIFF
--- a/__tests__/hooks/useBalanceHistory.test.js
+++ b/__tests__/hooks/useBalanceHistory.test.js
@@ -113,6 +113,31 @@ describe('useBalanceHistory', () => {
       expect(result.current.balanceHistoryData.labels.length).toBe(31); // January has 31 days
     });
 
+    it('issues the four independent reads concurrently (QoL-10)', async () => {
+      // Gate every read behind one manually-released promise. Serial awaits would
+      // dispatch only the first read before the gate opens; concurrent dispatch
+      // via Promise.all puts all four reads in flight up front.
+      let releaseGate;
+      const gate = new Promise((resolve) => { releaseGate = resolve; });
+      BalanceHistoryDB.getBalanceHistory.mockImplementation(() => gate.then(() => []));
+      OperationsDB.getTotalExpenses.mockImplementation(() => gate.then(() => 0));
+
+      const { result } = await renderHook(() => useBalanceHistory(mockAccountId, mockYear, mockMonth));
+
+      await act(async () => {
+        const loadPromise = result.current.loadBalanceHistory();
+        // Flush the synchronous Promise.all dispatch without opening the gate.
+        await Promise.resolve();
+
+        // All four reads are in flight before any has resolved → concurrent.
+        expect(BalanceHistoryDB.getBalanceHistory).toHaveBeenCalledTimes(2);
+        expect(OperationsDB.getTotalExpenses).toHaveBeenCalledTimes(2);
+
+        releaseGate();
+        await loadPromise;
+      });
+    });
+
     it('should calculate trend line with linear regression', async () => {
       const mockHistory = [
         { date: '2024-01-01', balance: '1000' },

--- a/app/hooks/useBalanceHistory.js
+++ b/app/hooks/useBalanceHistory.js
@@ -52,9 +52,6 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
       const startDateStr = formatDate(startDate);
       const endDateStr = formatDate(endDate);
 
-      // Get balance history from database
-      const history = await getBalanceHistory(selectedAccount, startDateStr, endDateStr);
-
       // Calculate previous month dates.
       // When selectedMonth is 0 (January), selectedMonth - 1 = -1 which JS rolls
       // to December of the *same* year instead of decrementing the year — fix explicitly.
@@ -65,21 +62,25 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
       const prevStartDateStr = formatDate(prevMonthStart);
       const prevEndDateStr = formatDate(prevMonthEnd);
 
-      // Get previous month's balance history and total expenses
-      const prevHistory = await getBalanceHistory(selectedAccount, prevStartDateStr, prevEndDateStr);
-      const prevMonthTotalExpenses = await getTotalExpenses(selectedAccount, prevStartDateStr, prevEndDateStr);
-
       // Get current day of month
       const now = new Date();
       const isCurrentMonth = selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
       const currentDay = isCurrentMonth ? now.getDate() : endDate.getDate();
 
-      // Get current month's total expenses for the selected account (used for
-      // spending prediction). For the current month, cap the window at today —
-      // the prediction divides by elapsed days, so future-dated operations
-      // (e.g. scheduled rent later this month) must not inflate the average.
+      // Current month's total expenses feed the spending prediction. For the
+      // current month, cap the window at today — the prediction divides by
+      // elapsed days, so future-dated operations (e.g. scheduled rent later this
+      // month) must not inflate the average.
       const expenseEndStr = isCurrentMonth ? formatDate(now) : endDateStr;
-      const currentMonthTotalExpenses = await getTotalExpenses(selectedAccount, startDateStr, expenseEndStr);
+
+      // These four reads are mutually independent — only the date strings above
+      // gate them — so issue them concurrently instead of awaiting in series.
+      const [history, prevHistory, prevMonthTotalExpenses, currentMonthTotalExpenses] = await Promise.all([
+        getBalanceHistory(selectedAccount, startDateStr, endDateStr),
+        getBalanceHistory(selectedAccount, prevStartDateStr, prevEndDateStr),
+        getTotalExpenses(selectedAccount, prevStartDateStr, prevEndDateStr),
+        getTotalExpenses(selectedAccount, startDateStr, expenseEndStr),
+      ]);
 
       // Transform history data for chart
       const dataPoints = history.map(item => ({


### PR DESCRIPTION
## Problem
`loadBalanceHistory` in `useBalanceHistory` issued four mutually independent database reads sequentially — current-month balance history, previous-month balance history, previous-month total expenses, and current-month total expenses. Each `await` blocked the next even though none depends on another's result (only the precomputed date strings gate them), so the hook paid the sum of four round-trips on every Graphs balance-history load.

## Fix
Hoist all pure date math above the reads and issue the four queries with a single `Promise.all`, so wall-clock cost drops to the slowest single query. Call order in the array is preserved (current before previous for `getBalanceHistory`), keeping the existing `mockResolvedValueOnce`-ordered tests valid. Error handling (`setBalanceHistoryData({ labels: [] })`) and the `finally` loading reset are unchanged.

## Tests
Added a concurrency test that gates every read behind one manually-released promise and asserts all four are in flight before any resolves. Full suite green (4463 tests).
