### PR TITLE
feat(planned): add execute action to long-press menu for discoverability (QoL-6)

### DIFF
--- a/__tests__/screens/PlannedOperationsScreen.test.js
+++ b/__tests__/screens/PlannedOperationsScreen.test.js
@@ -26,8 +26,9 @@ jest.mock('../../app/contexts/LocalizationContext', () => ({
   useLocalization: () => ({ t: (k) => k }),
 }));
 
+const mockShowDialog = jest.fn();
 jest.mock('../../app/contexts/DialogContext', () => ({
-  useDialog: () => ({ showDialog: jest.fn() }),
+  useDialog: () => ({ showDialog: mockShowDialog }),
 }));
 
 const mockExecute = jest.fn();
@@ -211,6 +212,52 @@ describe('PlannedOperationsScreen', () => {
       mockIsExecuted.mockReturnValue(false);
       const { queryByTestId } = await renderScreen();
       expect(queryByTestId('undo-action-r1')).toBeNull();
+    });
+  });
+
+  describe('Long-press action menu (QoL-6)', () => {
+    it('offers Execute and Mark-as-executed for an un-executed operation', async () => {
+      mockIsExecuted.mockReturnValue(false);
+      const { getByTestId } = await renderScreen();
+
+      fireEvent(getByTestId('planned-row-r1'), 'longPress');
+
+      expect(mockShowDialog).toHaveBeenCalled();
+      const actions = mockShowDialog.mock.calls[0][2];
+      const labels = actions.map((a) => a.text);
+      expect(labels).toEqual(
+        expect.arrayContaining(['execute', 'mark_as_executed', 'edit', 'delete', 'cancel']),
+      );
+      expect(labels).not.toContain('undo');
+    });
+
+    it('runs executePlannedOperation when the menu Execute item is chosen', async () => {
+      mockIsExecuted.mockReturnValue(false);
+      const { getByTestId } = await renderScreen();
+
+      fireEvent(getByTestId('planned-row-r1'), 'longPress');
+      const execute = mockShowDialog.mock.calls[0][2].find((a) => a.text === 'execute');
+      execute.onPress();
+
+      await waitFor(() => {
+        expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ id: 'r1' }));
+      });
+    });
+
+    it('offers Undo instead of Execute for an already-executed operation', async () => {
+      mockIsExecuted.mockReturnValue(true);
+      const { getByTestId } = await renderScreen();
+
+      fireEvent(getByTestId('planned-row-r1'), 'longPress');
+      const actions = mockShowDialog.mock.calls[0][2];
+      const labels = actions.map((a) => a.text);
+      expect(labels).toContain('undo');
+      expect(labels).not.toContain('execute');
+
+      actions.find((a) => a.text === 'undo').onPress();
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith('r1', { lastExecutedMonth: null });
+      });
     });
   });
 });

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -260,10 +260,24 @@ export default function PlannedOperationsScreen() {
   }, [updatePlannedOperation, t]);
 
   const handleLongPress = useCallback((op) => {
+    const executed = isExecutedThisMonth(op);
+
+    // Execute / mark-executed were previously reachable only by swiping the row —
+    // an invisible affordance. Surface them in the long-press menu too so the
+    // primary action is discoverable without a gesture (QoL-6). An already-executed
+    // operation offers Undo instead, mirroring the swipe behaviour.
+    const executionActions = executed
+      ? [{ text: t('undo'), onPress: () => handleUndoExecuted(op) }]
+      : [
+        { text: t('execute'), onPress: () => handleExecute(op) },
+        { text: t('mark_as_executed'), onPress: () => handleMarkExecuted(op) },
+      ];
+
     showDialog(
       t('select_action'),
       op.name,
       [
+        ...executionActions,
         {
           text: t('edit'),
           onPress: () => handleEdit(op),
@@ -289,7 +303,7 @@ export default function PlannedOperationsScreen() {
         { text: t('cancel'), style: 'cancel' },
       ],
     );
-  }, [showDialog, t, handleEdit, deletePlannedOperation]);
+  }, [showDialog, t, handleEdit, handleExecute, handleMarkExecuted, handleUndoExecuted, isExecutedThisMonth, deletePlannedOperation]);
 
   const renderRightActions = useCallback((item) => (
     <View style={styles.swipeActionsContainer}>
@@ -354,6 +368,7 @@ export default function PlannedOperationsScreen() {
         style={styles.itemContainer}
         onPress={() => handleEdit(item)}
         onLongPress={() => handleLongPress(item)}
+        testID={`planned-row-${item.id}`}
       >
         {/* Left: Category icon with optional checkmark badge */}
         <View style={[styles.iconContainer, { backgroundColor: typeColor + '1A' }]}>


### PR DESCRIPTION
## Problem
On the Planned screen, **Execute** and **Mark as executed** were reachable only by swiping a row's right actions. A swipe is an invisible affordance — there is no visual hint that the primary action (executing a planned operation) exists, so users could miss it entirely.

## Change
Surface the execution actions in the existing long-press menu (`handleLongPress`), alongside Edit and Delete:
- Un-executed operation → **Execute** and **Mark as executed**.
- Already-executed operation → **Undo** (mirrors the swipe behaviour), gated on `isExecutedThisMonth`.

Swipe actions are untouched — this is an additive, discoverable path, not a replacement. No new i18n keys (labels already exist for the swipe actions). Added a `planned-row-${id}` testID to the row for long-press testing.

## Tests
New `Long-press action menu (QoL-6)` suite: menu offers Execute/Mark for un-executed rows and Undo (not Execute) for executed rows, and choosing the item invokes the right handler. Full suite green (4471 tests).
