### PR TITLE
feat(graphs): add chevron period navigation and jump-to-current (QoL-9)

### DIFF
--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -357,6 +357,40 @@ describe('GraphsScreen', () => {
     });
   });
 
+  describe('Period chevron navigation (QoL-9)', () => {
+    it('reveals jump-to-current after stepping to an older period and hides it back at current', async () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getAvailableMonths } = require('../../app/services/OperationsDB');
+
+      const now = new Date();
+      // Current month must be present so the wheel starts at it; add an older year
+      // so there is at least one older period to step to.
+      getAvailableMonths.mockResolvedValue([
+        { year: now.getFullYear(), month: now.getMonth() },
+        { year: 2020, month: 0 },
+      ]);
+
+      const { queryByTestId, getByTestId, findByTestId } = await render(<GraphsScreen />);
+
+      // The wheel and its chevrons mount once available months load.
+      await findByTestId('period-chevron-older');
+
+      // Starts at the current period → jump-to-current hidden, newer chevron disabled.
+      expect(queryByTestId('period-jump-current')).toBeNull();
+      expect(getByTestId('period-chevron-newer').props.accessibilityState).toEqual(
+        expect.objectContaining({ disabled: true }),
+      );
+
+      // Step to an older period → jump-to-current appears.
+      fireEvent.press(getByTestId('period-chevron-older'));
+      expect(getByTestId('period-jump-current')).toBeTruthy();
+
+      // Jump back to the current period → the button hides again.
+      fireEvent.press(getByTestId('period-jump-current'));
+      expect(queryByTestId('period-jump-current')).toBeNull();
+    });
+  });
+
   describe('Combined Period Picker Logic', () => {
     describe('Period string parsing', () => {
       it('parses specific month period correctly', async () => {

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -875,22 +875,67 @@ const GraphsScreen = () => {
         </TouchableOpacity>
       )}
 
-      {/* Floating period wheel FAB */}
-      {periodItems.length > 0 && (
-        <View style={[styles.fabWheel, styles.fabWheelRight, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}>
-          <WheelPicker
-            data={periodItems}
-            value={selectedPeriod}
-            onValueChanged={({ item }) => item && setSelectedPeriod(item.value)}
-            itemHeight={28}
-            visibleItemCount={3}
-            itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
-            overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
-            enableScrollByTapOnItem
-            keyExtractor={(item, index) => `period-${index}`}
-          />
-        </View>
-      )}
+      {/* Floating period wheel FAB with chevron navigation (QoL-9) */}
+      {periodItems.length > 0 && (() => {
+        const currentIndex = periodItems.findIndex((i) => i.value === selectedPeriod);
+        const currentPeriodValue = `${now.getFullYear()}-${now.getMonth()}`;
+        // periodItems is sorted newest-first, so a newer period is a lower index
+        // and an older one a higher index. Chevron-up steps newer, down steps older.
+        const canGoNewer = currentIndex > 0;
+        const canGoOlder = currentIndex >= 0 && currentIndex < periodItems.length - 1;
+        const isCurrentPeriod = selectedPeriod === currentPeriodValue;
+        return (
+          <View style={[styles.fabWheel, styles.fabWheelRight, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}>
+            <TouchableOpacity
+              style={styles.periodChevron}
+              onPress={() => { if (canGoNewer) setSelectedPeriod(periodItems[currentIndex - 1].value); }}
+              disabled={!canGoNewer}
+              testID="period-chevron-newer"
+              accessibilityRole="button"
+              accessibilityLabel={t('next_period')}
+              accessibilityState={{ disabled: !canGoNewer }}
+            >
+              <Icon name="chevron-up" size={22} color={canGoNewer ? colors.text : colors.mutedText + '55'} />
+            </TouchableOpacity>
+
+            <WheelPicker
+              data={periodItems}
+              value={selectedPeriod}
+              onValueChanged={({ item }) => item && setSelectedPeriod(item.value)}
+              itemHeight={28}
+              visibleItemCount={3}
+              itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
+              overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
+              enableScrollByTapOnItem
+              keyExtractor={(item, index) => `period-${index}`}
+            />
+
+            <TouchableOpacity
+              style={styles.periodChevron}
+              onPress={() => { if (canGoOlder) setSelectedPeriod(periodItems[currentIndex + 1].value); }}
+              disabled={!canGoOlder}
+              testID="period-chevron-older"
+              accessibilityRole="button"
+              accessibilityLabel={t('previous_period')}
+              accessibilityState={{ disabled: !canGoOlder }}
+            >
+              <Icon name="chevron-down" size={22} color={canGoOlder ? colors.text : colors.mutedText + '55'} />
+            </TouchableOpacity>
+
+            {!isCurrentPeriod && (
+              <TouchableOpacity
+                style={[styles.periodTodayButton, { borderTopColor: colors.border + '80' }]}
+                onPress={() => setSelectedPeriod(currentPeriodValue)}
+                testID="period-jump-current"
+                accessibilityRole="button"
+                accessibilityLabel={t('jump_to_current_period')}
+              >
+                <Icon name="calendar-today" size={16} color={colors.primary} />
+              </TouchableOpacity>
+            )}
+          </View>
+        );
+      })()}
 
       {/* Long-press hint for the convert-currencies toggle */}
       {hintVisible && (
@@ -989,6 +1034,17 @@ const styles = StyleSheet.create({
     borderRadius: 40,
     right: 16,
     width: 120,
+  },
+  periodChevron: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 2,
+  },
+  periodTodayButton: {
+    alignItems: 'center',
+    borderTopWidth: 1,
+    justifyContent: 'center',
+    paddingVertical: 6,
   },
   scrollContent: {
     paddingBottom: 180,

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -320,6 +320,7 @@
   "current_period": "Aktueller Zeitraum",
   "next_period": "Nächster Zeitraum",
   "previous_period": "Vorheriger Zeitraum",
+  "jump_to_current_period": "Aktueller Monat",
   "all_budgets": "Alle Budgets",
   "total_budgeted": "Gesamt budgetiert",
   "total_spent": "Gesamt ausgegeben",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -322,6 +322,7 @@
   "current_period": "Current Period",
   "next_period": "Next Period",
   "previous_period": "Previous Period",
+  "jump_to_current_period": "Current month",
   "all_budgets": "All Budgets",
   "total_budgeted": "Total Budgeted",
   "total_spent": "Total Spent",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -320,6 +320,7 @@
   "current_period": "Periodo actual",
   "next_period": "Próximo periodo",
   "previous_period": "Periodo anterior",
+  "jump_to_current_period": "Mes actual",
   "all_budgets": "Todos los presupuestos",
   "total_budgeted": "Total presupuestado",
   "total_spent": "Total gastado",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -320,6 +320,7 @@
   "current_period": "Période actuelle",
   "next_period": "Période suivante",
   "previous_period": "Période précédente",
+  "jump_to_current_period": "Mois actuel",
   "all_budgets": "Tous les budgets",
   "total_budgeted": "Total budgétisé",
   "total_spent": "Total dépensé",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -320,6 +320,7 @@
   "current_period": "Ընթացիկ ժամանակահատված",
   "next_period": "Հաջորդ ժամանակահատված",
   "previous_period": "Նախորդ ժամանակահատված",
+  "jump_to_current_period": "Ընթացիկ ամիս",
   "all_budgets": "Բոլոր բյուջեները",
   "total_budgeted": "Ընդհանուր բյուջետավորված",
   "total_spent": "Ընդհանուր ծախսված",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -320,6 +320,7 @@
   "current_period": "Periodo corrente",
   "next_period": "Periodo successivo",
   "previous_period": "Periodo precedente",
+  "jump_to_current_period": "Mese corrente",
   "all_budgets": "Tutti i budget",
   "total_budgeted": "Totale preventivato",
   "total_spent": "Totale speso",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -320,6 +320,7 @@
   "current_period": "現在の期間",
   "next_period": "次の期間",
   "previous_period": "前の期間",
+  "jump_to_current_period": "今月",
   "all_budgets": "すべての予算",
   "total_budgeted": "予算合計",
   "total_spent": "支出合計",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -320,6 +320,7 @@
   "current_period": "현재 기간",
   "next_period": "다음 기간",
   "previous_period": "이전 기간",
+  "jump_to_current_period": "이번 달",
   "all_budgets": "모든 예산",
   "total_budgeted": "총 예산",
   "total_spent": "총 지출",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -320,6 +320,7 @@
   "current_period": "Período atual",
   "next_period": "Próximo período",
   "previous_period": "Período anterior",
+  "jump_to_current_period": "Mês atual",
   "all_budgets": "Todos os orçamentos",
   "total_budgeted": "Total orçado",
   "total_spent": "Total gasto",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -322,6 +322,7 @@
   "current_period": "Текущий период",
   "next_period": "Следующий период",
   "previous_period": "Предыдущий период",
+  "jump_to_current_period": "Текущий месяц",
   "all_budgets": "Все бюджеты",
   "total_budgeted": "Всего запланировано",
   "total_spent": "Всего потрачено",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -320,6 +320,7 @@
   "current_period": "当前期间",
   "next_period": "下一期间",
   "previous_period": "上一期间",
+  "jump_to_current_period": "本月",
   "all_budgets": "所有预算",
   "total_budgeted": "总预算",
   "total_spent": "总花费",


### PR DESCRIPTION
## Problem
On the Graphs screen the period could only be changed by scrolling the floating wheel picker — there were no discrete step controls and no quick way back to the current month once you'd scrolled away (QoL-9).

## Change
Wrap the floating period wheel with navigation controls:
- **Chevron up** steps to the newer adjacent period, **chevron down** to the older one (`periodItems` is sorted newest-first). Each chevron disables at its end of the list.
- A **calendar (current-month) button** appears below the wheel only when a non-current period is selected, and jumps straight back to the current month.

The wheel's own scroll behaviour is unchanged. New i18n key `jump_to_current_period` across all 11 locales (`next_period` / `previous_period` already existed).

## Tests
New `Period chevron navigation (QoL-9)` test: starts at the current period (jump button hidden, newer chevron disabled), stepping older reveals the jump button, and pressing it returns to the current period (button hides). Full suite green (4431 tests).
