### PR TITLE
feat(graphs): anchor balance-history burndown max to day-1 balance + monthly flows

### DIFF
--- a/__tests__/hooks/useBalanceHistory.test.js
+++ b/__tests__/hooks/useBalanceHistory.test.js
@@ -6,6 +6,7 @@ import * as OperationsDB from '../../app/services/OperationsDB';
 // Mock the BalanceHistoryDB service
 jest.mock('../../app/services/BalanceHistoryDB', () => ({
   getBalanceHistory: jest.fn(),
+  getAccountBalanceOnOrBeforeDate: jest.fn(),
   upsertBalanceHistory: jest.fn(),
   deleteBalanceHistory: jest.fn(),
   formatDate: jest.fn((date) => {
@@ -19,6 +20,8 @@ jest.mock('../../app/services/BalanceHistoryDB', () => ({
 // Mock the OperationsDB service
 jest.mock('../../app/services/OperationsDB', () => ({
   getTotalExpenses: jest.fn(),
+  getTotalIncome: jest.fn(),
+  getTransferTotals: jest.fn(),
 }));
 
 describe('useBalanceHistory', () => {
@@ -30,6 +33,11 @@ describe('useBalanceHistory', () => {
     jest.clearAllMocks();
     // Default: no expenses in previous month
     OperationsDB.getTotalExpenses.mockResolvedValue(0);
+    // Defaults for the burndown-anchor (plainAvgMax) reads: no income, no transfers,
+    // and no known day-1 balance unless a test overrides them.
+    OperationsDB.getTotalIncome.mockResolvedValue('0');
+    OperationsDB.getTransferTotals.mockResolvedValue({ incoming: '0', outgoing: '0' });
+    BalanceHistoryDB.getAccountBalanceOnOrBeforeDate.mockResolvedValue(null);
     // Mock console.error to suppress error logs in tests
     jest.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -236,6 +244,68 @@ describe('useBalanceHistory', () => {
         expect(result.current.loadingBalanceHistory).toBe(false);
         expect(result.current.balanceHistoryData).toEqual({ labels: [] });
         expect(console.error).toHaveBeenCalledWith('Failed to load balance history:', expect.any(Error));
+      });
+    });
+  });
+
+  describe('plainAvgMax (burndown anchor)', () => {
+    it('computes plainAvgMax as day-1 balance + post-day-1 inflows − outgoing transfers', async () => {
+      BalanceHistoryDB.getBalanceHistory
+        .mockResolvedValueOnce([
+          { date: '2024-01-01', balance: '1000' },
+          { date: '2024-01-20', balance: '900' },
+        ])
+        .mockResolvedValueOnce([]);
+      BalanceHistoryDB.getAccountBalanceOnOrBeforeDate.mockResolvedValue('1000'); // end of day 1
+      OperationsDB.getTransferTotals.mockResolvedValue({ incoming: '300', outgoing: '50' });
+      OperationsDB.getTotalIncome.mockResolvedValue('200');
+
+      const { result } = await renderHook(() => useBalanceHistory(mockAccountId, mockYear, mockMonth));
+
+      await act(async () => {
+        await result.current.loadBalanceHistory();
+      });
+
+      await waitFor(() => {
+        // 1000 (day-1 balance) + 300 (incoming) − 50 (outgoing) + 200 (income) = 1450
+        expect(result.current.balanceHistoryData.plainAvgMax).toBe(1450);
+      });
+    });
+
+    it('queries inflows/outflows from day 2 and anchors the balance on day 1 (excludes the first day)', async () => {
+      BalanceHistoryDB.getBalanceHistory
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const { result } = await renderHook(() => useBalanceHistory(mockAccountId, mockYear, mockMonth));
+
+      await act(async () => {
+        await result.current.loadBalanceHistory();
+      });
+
+      // January 2024: post-day-1 window is 2024-01-02 … 2024-01-31
+      expect(OperationsDB.getTransferTotals).toHaveBeenCalledWith(mockAccountId, '2024-01-02', '2024-01-31');
+      expect(OperationsDB.getTotalIncome).toHaveBeenCalledWith(mockAccountId, '2024-01-02', '2024-01-31');
+      // The anchor is the balance on (or before) the first of the month
+      expect(BalanceHistoryDB.getAccountBalanceOnOrBeforeDate).toHaveBeenCalledWith(mockAccountId, '2024-01-01');
+    });
+
+    it('leaves plainAvgMax null when the day-1 balance is unknown', async () => {
+      BalanceHistoryDB.getBalanceHistory
+        .mockResolvedValueOnce([{ date: '2024-01-10', balance: '500' }])
+        .mockResolvedValueOnce([]);
+      BalanceHistoryDB.getAccountBalanceOnOrBeforeDate.mockResolvedValue(null);
+      OperationsDB.getTransferTotals.mockResolvedValue({ incoming: '300', outgoing: '50' });
+      OperationsDB.getTotalIncome.mockResolvedValue('200');
+
+      const { result } = await renderHook(() => useBalanceHistory(mockAccountId, mockYear, mockMonth));
+
+      await act(async () => {
+        await result.current.loadBalanceHistory();
+      });
+
+      await waitFor(() => {
+        expect(result.current.balanceHistoryData.plainAvgMax).toBeNull();
       });
     });
   });

--- a/__tests__/services/BalanceHistoryDB.test.js
+++ b/__tests__/services/BalanceHistoryDB.test.js
@@ -188,6 +188,58 @@ describe('BalanceHistoryDB', () => {
     });
   });
 
+  describe('getAccountBalanceOnOrBeforeDate', () => {
+    it('returns the most recent balance on or before the date', async () => {
+      queryAll.mockResolvedValue([{ balance: '1000.00' }]);
+
+      const result = await BalanceHistoryDB.getAccountBalanceOnOrBeforeDate(1, '2024-02-01');
+
+      expect(queryAll).toHaveBeenCalledWith(
+        expect.stringContaining('date(date) <= date(?)'),
+        [1, '2024-02-01'],
+      );
+      expect(result).toBe('1000.00');
+    });
+
+    it('orders by the normalized date so a same-day timestamped row cannot outrank the latest calendar day (#773)', async () => {
+      queryAll.mockResolvedValue([{ balance: '1000.00' }]);
+
+      await BalanceHistoryDB.getAccountBalanceOnOrBeforeDate(1, '2024-02-01');
+
+      // Must sort by date(date), not the raw text column, or a raw DESC sort could
+      // place '2024-01-15T06:00:00' ahead of '2024-01-31' and pick the wrong row.
+      const sql = queryAll.mock.calls[0][0];
+      expect(sql).toContain('ORDER BY date(date) DESC');
+    });
+
+    it('returns null when no snapshot exists on or before the date', async () => {
+      queryAll.mockResolvedValue([]);
+
+      const result = await BalanceHistoryDB.getAccountBalanceOnOrBeforeDate(1, '2024-02-01');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when query returns null', async () => {
+      queryAll.mockResolvedValue(null);
+
+      const result = await BalanceHistoryDB.getAccountBalanceOnOrBeforeDate(1, '2024-02-01');
+
+      expect(result).toBeNull();
+    });
+
+    it('throws error on database failure', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      queryAll.mockRejectedValue(new Error('DB error'));
+
+      await expect(BalanceHistoryDB.getAccountBalanceOnOrBeforeDate(1, '2024-02-01'))
+        .rejects.toThrow('DB error');
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to get account balance on or before date:', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe('getLastSnapshotDate', () => {
     it('returns most recent snapshot date for account', async () => {
       queryAll.mockResolvedValue([{ date: '2024-01-20' }]);

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -954,6 +954,43 @@ describe('OperationsDB Service', () => {
       expect(result).toBe('1200');
     });
 
+    describe('getTransferTotals', () => {
+      it('splits transfers into incoming (destination_amount) and outgoing (amount)', async () => {
+        queryAll.mockResolvedValue([
+          { account_id: 'acc1', to_account_id: 'acc2', amount: '100', destination_amount: null },  // out 100
+          { account_id: 'acc3', to_account_id: 'acc1', amount: '50', destination_amount: '5000' },  // in 5000 (multi-currency)
+          { account_id: 'acc3', to_account_id: 'acc1', amount: '25', destination_amount: null },     // in 25 (same currency)
+        ]);
+
+        const result = await OperationsDB.getTransferTotals('acc1', '2025-12-02', '2025-12-31');
+
+        expect(queryAll).toHaveBeenCalledWith(
+          expect.stringContaining("type = 'transfer'"),
+          ['2025-12-02', '2025-12-31', 'acc1', 'acc1'],
+        );
+        // Incoming credits the destination_amount when present (5000), else amount (25).
+        expect(result).toEqual({ incoming: '5025', outgoing: '100' });
+      });
+
+      it('counts a self-transfer in both buckets so it nets to zero', async () => {
+        queryAll.mockResolvedValue([
+          { account_id: 'acc1', to_account_id: 'acc1', amount: '75', destination_amount: null },
+        ]);
+
+        const result = await OperationsDB.getTransferTotals('acc1', '2025-12-02', '2025-12-31');
+
+        expect(result).toEqual({ incoming: '75', outgoing: '75' });
+      });
+
+      it('returns zero totals when there are no transfers', async () => {
+        queryAll.mockResolvedValue([]);
+
+        const result = await OperationsDB.getTransferTotals('acc1', '2025-12-02', '2025-12-31');
+
+        expect(result).toEqual({ incoming: '0', outgoing: '0' });
+      });
+    });
+
     it('gets spending by category', async () => {
       const mockResults = [
         { category_id: 'cat1', total: 100.5 },

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -169,8 +169,17 @@ const BalanceHistoryCard = ({
     const maxBalance = actualValues.length > 0 ? Math.max(...actualValues) : 0;
     const daysInMonth = balanceHistoryData.labels[balanceHistoryData.labels.length - 1];
 
+    // Burndown ("plain avg") line starts from the month's spendable ceiling
+    // (day-1 balance + post-day-1 inflows − outgoing transfers), computed in the
+    // hook. Fall back to the peak-actual max when it's unavailable so older data /
+    // accounts younger than the month keep the previous behaviour.
+    const rawPlainAvgMax = balanceHistoryData.plainAvgMax;
+    const plainAvgMax = (rawPlainAvgMax != null && Number.isFinite(rawPlainAvgMax))
+      ? rawPlainAvgMax
+      : maxBalance;
+
     const plainAvgData = balanceHistoryData.labels.map(day =>
-      maxBalance * (1 - (day - 1) / (daysInMonth - 1)),
+      plainAvgMax * (1 - (day - 1) / (daysInMonth - 1)),
     );
 
     const forecastValues = combinedActualForecast.filter(v => v !== undefined);
@@ -219,8 +228,8 @@ const BalanceHistoryCard = ({
       }
     }
 
-    const plainAvgDaily = daysInMonth > 1 ? -maxBalance / (daysInMonth - 1) : 0;
-    const plainAvgCurrent = displayDay ? maxBalance * (1 - (displayDay - 1) / (daysInMonth - 1)) : null;
+    const plainAvgDaily = daysInMonth > 1 ? -plainAvgMax / (daysInMonth - 1) : 0;
+    const plainAvgCurrent = displayDay ? plainAvgMax * (1 - (displayDay - 1) / (daysInMonth - 1)) : null;
 
     let forecastEnd = null;
     let forecastDailyAvg = null;
@@ -267,6 +276,7 @@ const BalanceHistoryCard = ({
       combinedActualForecast,
       actualValues,
       maxBalance,
+      plainAvgMax,
       daysInMonth,
       plainAvgData,
       hasNegativeValues,
@@ -502,7 +512,7 @@ const BalanceHistoryCard = ({
                       <View style={[styles.legendDot, styles.legendDotPlainAvg]} />
                       <Text style={[styles.legendTableLabel, { color: colors.text }]}>{t('plain_avg') || 'Plain avg'}</Text>
                     </View>
-                    <Text style={[styles.legendTableValue, { color: colors.text }]}>{formatCompact(chartComputed.maxBalance, currency)}</Text>
+                    <Text style={[styles.legendTableValue, { color: colors.text }]}>{formatCompact(chartComputed.plainAvgMax, currency)}</Text>
                     <Text style={[styles.legendTableValue, { color: colors.text }]}>{formatCompact(chartComputed.plainAvgCurrent, currency)}</Text>
                     <Text style={[styles.legendTableValue, { color: colors.text }]}>{formatCompact(chartComputed.plainAvgDaily, currency)}</Text>
                     <Text style={[styles.legendTableValue, { color: colors.text }]}>{formatCompact(0, currency)}</Text>
@@ -552,6 +562,7 @@ BalanceHistoryCard.propTypes = {
     prevMonth: PropTypes.array,
     prevMonthTotalExpenses: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     prevMonthDaysCount: PropTypes.number,
+    plainAvgMax: PropTypes.number,
   }).isRequired,
   selectedYear: PropTypes.number.isRequired,
   selectedMonth: PropTypes.number,

--- a/app/hooks/useBalanceHistory.js
+++ b/app/hooks/useBalanceHistory.js
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
-import { getBalanceHistory, upsertBalanceHistory, deleteBalanceHistory, formatDate } from '../services/BalanceHistoryDB';
-import { getTotalExpenses } from '../services/OperationsDB';
+import { getBalanceHistory, getAccountBalanceOnOrBeforeDate, upsertBalanceHistory, deleteBalanceHistory, formatDate } from '../services/BalanceHistoryDB';
+import { getTotalExpenses, getTotalIncome, getTransferTotals } from '../services/OperationsDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 
 /**
@@ -78,14 +78,48 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
       // month) must not inflate the average.
       const expenseEndStr = isCurrentMonth ? formatDate(now) : endDateStr;
 
-      // These four reads are mutually independent — only the date strings above
-      // gate them — so issue them concurrently instead of awaiting in series.
-      const [history, prevHistory, prevMonthTotalExpenses, currentMonthTotalExpenses] = await Promise.all([
+      // Burndown ("plain avg") max is anchored to the balance at end of day 1 plus
+      // every inflow/outflow *after* day 1 — day-1 activity is already baked into
+      // that anchor, so the post-day-1 window starts on the 2nd (see plainAvgMax).
+      const secondDayStr = formatDate(new Date(selectedYear, selectedMonth, 2));
+
+      // These reads are mutually independent — only the date strings above gate
+      // them — so issue them concurrently instead of awaiting in series.
+      const [
+        history,
+        prevHistory,
+        prevMonthTotalExpenses,
+        currentMonthTotalExpenses,
+        firstDayBalance,
+        transferTotals,
+        incomeAfterDay1,
+      ] = await Promise.all([
         getBalanceHistory(selectedAccount, startDateStr, endDateStr),
         getBalanceHistory(selectedAccount, prevStartDateStr, prevEndDateStr),
         getTotalExpenses(selectedAccount, prevStartDateStr, prevEndDateStr),
         getTotalExpenses(selectedAccount, startDateStr, expenseEndStr),
+        getAccountBalanceOnOrBeforeDate(selectedAccount, startDateStr),
+        getTransferTotals(selectedAccount, secondDayStr, endDateStr),
+        getTotalIncome(selectedAccount, secondDayStr, endDateStr),
       ]);
+
+      // Burndown line anchor (a.k.a. "plain avg" max): the ceiling of money
+      // available to spend across the month. Start from the balance at end of day 1,
+      // add every post-day-1 inflow (incoming transfers + income) and remove
+      // outgoing transfers. Expenses are intentionally excluded — the burndown line
+      // is precisely the depiction of that ceiling being spent down to zero. Null
+      // when the day-1 balance is unknown (e.g. an account younger than the month);
+      // the card then falls back to the peak-actual max.
+      let plainAvgMax = null;
+      if (firstDayBalance !== null && firstDayBalance !== undefined) {
+        const computed = parseFloat(firstDayBalance)
+          + parseFloat(transferTotals.incoming)
+          - parseFloat(transferTotals.outgoing)
+          + parseFloat(incomeAfterDay1);
+        if (Number.isFinite(computed)) {
+          plainAvgMax = computed;
+        }
+      }
 
       // Transform history data for chart
       const dataPoints = history.map(item => ({
@@ -214,6 +248,7 @@ const useBalanceHistory = (selectedAccount, selectedYear, selectedMonth) => {
         prevMonthTotalExpenses,
         prevMonthDaysCount: prevMonthDays,
         currentMonthTotalExpenses,
+        plainAvgMax,
         labels: allDays,
       });
     } catch (error) {

--- a/app/services/BalanceHistoryDB.js
+++ b/app/services/BalanceHistoryDB.js
@@ -280,9 +280,15 @@ export const getAccountBalanceOnDate = async (accountId, date) => {
  *
  * Unlike getAccountBalanceOnDate (which requires an exact-date row), this carries
  * the last known balance forward when the requested day itself has no snapshot —
- * mirroring how the chart forward-fills. Used to anchor the burndown line's start
+ * mirroring how the chart forward-fills, and keeping this anchor consistent with the
+ * (same-snapshot-sourced) actual line. Used to anchor the burndown line's start
  * ("balance at end of the first day") so a sparse snapshot history doesn't leave it
  * undefined.
+ *
+ * Caveat: when no row exists exactly on `date` the carried-forward value predates
+ * any activity dated on `date` itself. For the burndown anchor that only matters for
+ * back-dated / import-dated day-1 operations (a real-time op always writes its own
+ * day's snapshot); the caller accepts that approximation.
  *
  * @param {number} accountId
  * @param {string} date - YYYY-MM-DD format
@@ -290,12 +296,16 @@ export const getAccountBalanceOnDate = async (accountId, date) => {
  */
 export const getAccountBalanceOnOrBeforeDate = async (accountId, date) => {
   try {
+    // ORDER BY date(date), not the raw column: the WHERE clause already normalises
+    // with date(), and since LIMIT 1 makes the ordering pick the single result, a
+    // raw-text sort could otherwise return a same-day timestamped import row ahead
+    // of the true latest calendar-day snapshot (#773).
     const result = await queryAll(
       `SELECT balance
        FROM accounts_balance_history
        WHERE account_id = ?
          AND date(date) <= date(?) -- date() normalises non-ISO formats from CSV import (#773)
-       ORDER BY date DESC
+       ORDER BY date(date) DESC
        LIMIT 1`,
       [accountId, date],
     );

--- a/app/services/BalanceHistoryDB.js
+++ b/app/services/BalanceHistoryDB.js
@@ -276,6 +276,37 @@ export const getAccountBalanceOnDate = async (accountId, date) => {
 };
 
 /**
+ * Get an account's most recent balance snapshot on or before a date.
+ *
+ * Unlike getAccountBalanceOnDate (which requires an exact-date row), this carries
+ * the last known balance forward when the requested day itself has no snapshot —
+ * mirroring how the chart forward-fills. Used to anchor the burndown line's start
+ * ("balance at end of the first day") so a sparse snapshot history doesn't leave it
+ * undefined.
+ *
+ * @param {number} accountId
+ * @param {string} date - YYYY-MM-DD format
+ * @returns {Promise<string|null>} Balance as string, or null if no snapshot on/before the date
+ */
+export const getAccountBalanceOnOrBeforeDate = async (accountId, date) => {
+  try {
+    const result = await queryAll(
+      `SELECT balance
+       FROM accounts_balance_history
+       WHERE account_id = ?
+         AND date(date) <= date(?) -- date() normalises non-ISO formats from CSV import (#773)
+       ORDER BY date DESC
+       LIMIT 1`,
+      [accountId, date],
+    );
+    return result && result.length > 0 ? result[0].balance : null;
+  } catch (error) {
+    console.error('Failed to get account balance on or before date:', error);
+    throw error;
+  }
+};
+
+/**
  * Get most recent snapshot date for an account
  *
  * @param {number} accountId

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1002,6 +1002,53 @@ export const getTotalIncome = async (accountId, startDate, endDate) => {
 };
 
 /**
+ * Get transfer totals for an account in a date range, split into money moved IN
+ * (this account was the destination) and OUT (this account was the source).
+ *
+ * Incoming transfers use destination_amount when present — a multi-currency
+ * transfer credits the destination the converted amount, not the source amount —
+ * falling back to amount for same-currency transfers. Outgoing transfers always use
+ * amount (the debited value). This mirrors the debit/credit split in
+ * calculateBalanceChanges so the totals reconcile with how balances actually move.
+ *
+ * A self-transfer (same account on both sides) lands in both buckets; the +in and
+ * −out cancel wherever the caller nets them, which is the correct zero effect.
+ *
+ * @param {string} accountId
+ * @param {string} startDate - YYYY-MM-DD (inclusive)
+ * @param {string} endDate - YYYY-MM-DD (inclusive)
+ * @returns {Promise<{incoming: string, outgoing: string}>} Decimal-safe string totals
+ */
+export const getTransferTotals = async (accountId, startDate, endDate) => {
+  try {
+    const results = await queryAll(
+      `SELECT account_id, to_account_id, amount, destination_amount
+       FROM operations
+       WHERE type = 'transfer'
+         AND date >= ? AND date <= ?
+         AND (account_id = ? OR to_account_id = ?)`,
+      [startDate, endDate, accountId, accountId],
+    );
+
+    let incoming = '0';
+    let outgoing = '0';
+    for (const row of results || []) {
+      if (String(row.to_account_id) === String(accountId)) {
+        const credit = row.destination_amount || row.amount || '0';
+        incoming = Currency.add(incoming, String(credit));
+      }
+      if (String(row.account_id) === String(accountId)) {
+        outgoing = Currency.add(outgoing, String(row.amount || '0'));
+      }
+    }
+    return { incoming, outgoing };
+  } catch (error) {
+    console.error('Failed to get transfer totals:', error);
+    throw error;
+  }
+};
+
+/**
  * Get spending by category for date range
  * @param {string} startDate
  * @param {string} endDate


### PR DESCRIPTION
## What

Reworks how the **max** (starting value) of the burndown / "plain avg" line on the balance-history chart is computed. Previously it reused the peak of the actual balance (`maxBalance`); now it reflects the month's spendable ceiling:

```
plainAvgMax = (balance at end of day 1)
            + (incoming transfers after day 1)
            − (outgoing transfers after day 1)
            + (income after day 1)
```

Expenses are intentionally excluded — the burndown line is precisely the depiction of that ceiling being spent down to zero. "After day 1" = the 2nd through end of month, because the day-1 balance anchor already includes everything dated on the 1st (no double counting).

## Changes

- **`services/OperationsDB.js`** — new `getTransferTotals(accountId, start, end)` returning `{ incoming, outgoing }`. Incoming uses `destination_amount` when present (multi-currency transfers credit the converted amount), falling back to `amount`; outgoing uses `amount` — mirroring the debit/credit split in `calculateBalanceChanges`.
- **`services/BalanceHistoryDB.js`** — new `getAccountBalanceOnOrBeforeDate(accountId, date)`: the most recent snapshot on/before a date (forward-fill), used as the day-1 anchor. Orders by `date(date)` to stay consistent with the normalized `WHERE` (avoids a same-day timestamped import row outranking the true latest calendar day, #773).
- **`hooks/useBalanceHistory.js`** — three new reads folded into the existing `Promise.all`; computes `plainAvgMax` (null when the day-1 balance is unknown) and exposes it on `balanceHistoryData`.
- **`components/graphs/BalanceHistoryCard.js`** — the burndown line, its daily/current values, and the "Plain avg" legend Max cell now use `plainAvgMax`. The **Actual** row is unchanged (still peak-actual `maxBalance`). Falls back to `maxBalance` when `plainAvgMax` is unavailable, preserving prior behaviour for accounts younger than the month.

## Behaviour notes

- The day-1 anchor is read from the balance snapshot (same source as the actual line) rather than a full per-op reversal — fast and visually consistent, exact for real-time-entered operations. There is a minor `max` imprecision only for back-dated day-1 operations or a migration-collapsed old month; accepted as a deliberate trade-off.

## Tests

- New unit tests for `getTransferTotals` (incoming/outgoing split, multi-currency, self-transfer, empty) and `getAccountBalanceOnOrBeforeDate` (incl. a regression test for `ORDER BY date(date)`).
- New hook tests for `plainAvgMax` (formula, day-2 window boundaries, null when day-1 balance unknown).
- Full suite green: 153 suites / 4155 tests.
