### PR TITLE
feat(search): unify expanded filters panel with the search bar

### DIFF
--- a/__tests__/integration/SearchLayout.test.js
+++ b/__tests__/integration/SearchLayout.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
-import SearchOverlay from '../../app/components/search/SearchOverlay';
+import SearchOverlay, { PANEL_OVERLAP } from '../../app/components/search/SearchOverlay';
 
 // Mock ExpandableFilters to simplify test
 jest.mock('../../app/components/search/ExpandableFilters', () => {
@@ -100,8 +100,10 @@ describe('SearchLayout integration', () => {
     }
     const styles = StyleSheet.flatten(current.props.style);
 
-    // top comes from topOffset prop so overlay clears the SearchBar
-    expect(styles.top).toBe(50);
+    // top is topOffset pulled up by PANEL_OVERLAP so the panel tucks behind the
+    // search area and reads as one unit with the bar (its content padding keeps
+    // the first section clear of the pill).
+    expect(styles.top).toBe(50 - PANEL_OVERLAP);
   });
 
   it('SearchOverlay has proper zIndex for layering', async () => {

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -3,7 +3,6 @@ import { View, Text, ScrollView, TouchableOpacity, TextInput, StyleSheet } from 
 import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import PropTypes from 'prop-types';
-import { HORIZONTAL_PADDING } from '../../styles/layout';
 import { formatDate } from '../../services/BalanceHistoryDB';
 import currencies from '../../../assets/currencies.json';
 
@@ -200,8 +199,6 @@ const ExpandableFilters = ({
 
   return (
     <View testID="expandable-filters" style={styles.container}>
-      {/* Thin light edge along the top sells the frosted-glass layering. */}
-      <View style={[styles.topHighlight, { backgroundColor: colors.glassHighlight }]} />
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Type Section */}
         <View style={tileStyle}>
@@ -448,7 +445,6 @@ ExpandableFilters.propTypes = {
     glassSurface: PropTypes.string,
     glassSurfaceStrong: PropTypes.string,
     glassBorder: PropTypes.string,
-    glassHighlight: PropTypes.string,
   }).isRequired,
   t: PropTypes.func.isRequired,
   isExpanded: PropTypes.bool,
@@ -548,7 +544,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingBottom: 12,
-    paddingHorizontal: HORIZONTAL_PADDING,
+    paddingHorizontal: 12,
     paddingTop: 10,
   },
   footerCount: {
@@ -563,8 +559,10 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingBottom: 8,
-    paddingHorizontal: HORIZONTAL_PADDING,
-    paddingTop: 10,
+    paddingHorizontal: 12,
+    // Clears the search area that overlaps the panel's tucked-in top edge so the
+    // first section label isn't hidden behind the pill (see PANEL_OVERLAP).
+    paddingTop: 20,
   },
   scrollView: {
     flex: 1,
@@ -585,10 +583,6 @@ const styles = StyleSheet.create({
   },
   sectionLast: {
     marginBottom: 0,
-  },
-  topHighlight: {
-    height: StyleSheet.hairlineWidth,
-    width: '100%',
   },
 });
 

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -5,6 +5,7 @@ import {
 } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
 import PropTypes from 'prop-types';
+import { HORIZONTAL_PADDING } from '../../styles/layout';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
 import { useOperationsActions } from '../../contexts/OperationsActionsContext';
@@ -12,6 +13,11 @@ import { useAccountsData } from '../../contexts/AccountsDataContext';
 import { useSearch } from '../../contexts/SearchContext';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
+
+// The panel is pulled up under the search area (which sits at a higher zIndex)
+// so its rounded top tucks behind the pill/chip strip and the sheet reads as a
+// continuation of the search bar rather than a detached card below it.
+const PANEL_OVERLAP = 14;
 
 const SearchOverlay = ({ colors, t, visible, onHeightChange = null, topOffset = 0 }) => {
   const { searchState = { text: '', types: [], accountIds: [], categoryIds: [], dateRange: { startDate: null, endDate: null }, amountRange: { min: null, max: null } } } = useOperationsData();
@@ -58,7 +64,7 @@ const SearchOverlay = ({ colors, t, visible, onHeightChange = null, topOffset = 
         {
           backgroundColor: colors.glassSurface || colors.background,
           borderColor: colors.glassBorder || colors.border,
-          top: topOffset,
+          top: Math.max(0, topOffset - PANEL_OVERLAP),
         },
         animatedStyle,
       ]}
@@ -92,17 +98,16 @@ SearchOverlay.propTypes = {
 
 const styles = StyleSheet.create({
   filtersContainer: {
-    borderBottomLeftRadius: 18,
-    borderBottomRightRadius: 18,
-    // Hairline glass edge along the bottom + sides of the sheet.
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderLeftWidth: StyleSheet.hairlineWidth,
-    borderRightWidth: StyleSheet.hairlineWidth,
+    // Rounded on all corners and inset to the open search pill's width so the
+    // sheet reads as one floating unit with the bar. The top tucks behind the
+    // search area (see PANEL_OVERLAP), hiding the seam.
+    borderRadius: 18,
+    borderWidth: StyleSheet.hairlineWidth,
     elevation: 8,
-    left: 0,
+    left: HORIZONTAL_PADDING,
     maxHeight: SCREEN_HEIGHT * 0.62,
     position: 'absolute',
-    right: 0,
+    right: HORIZONTAL_PADDING,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 6 },
     shadowOpacity: 0.35,

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -17,7 +17,8 @@ const SCREEN_HEIGHT = Dimensions.get('window').height;
 // The panel is pulled up under the search area (which sits at a higher zIndex)
 // so its rounded top tucks behind the pill/chip strip and the sheet reads as a
 // continuation of the search bar rather than a detached card below it.
-const PANEL_OVERLAP = 14;
+// Exported so layout tests can assert the tucked position without a magic number.
+export const PANEL_OVERLAP = 14;
 
 const SearchOverlay = ({ colors, t, visible, onHeightChange = null, topOffset = 0 }) => {
   const { searchState = { text: '', types: [], accountIds: [], categoryIds: [], dateRange: { startDate: null, endDate: null }, amountRange: { min: null, max: null } } } = useOperationsData();

--- a/app/contexts/ThemeColorsContext.js
+++ b/app/contexts/ThemeColorsContext.js
@@ -29,13 +29,13 @@ const lightTheme = {
     expenseBackground: '#f5f0f0',
     incomeBackground: '#e5ffe5',
     transferBackground: '#e5e5ff',
-    // Frosted-glass surfaces for the search filters panel. No real backdrop
-    // blur on Android, so the panel stays fairly opaque for legibility while
-    // the highlight/border/tile cues sell the layered "glass" look.
-    glassSurface: 'rgba(250,250,250,0.90)',
+    // Frosted-glass surfaces for the search filters panel. The panel reads as a
+    // continuation of the search pill, so glassSurface matches `surface` at a
+    // high alpha (near-opaque to avoid list bleed-through, no real backdrop blur
+    // on Android). glassSurfaceStrong tints the inner section tiles.
+    glassSurface: 'rgba(255,255,255,0.97)',
     glassSurfaceStrong: 'rgba(120,120,120,0.08)',
     glassBorder: 'rgba(0,0,0,0.06)',
-    glassHighlight: 'rgba(255,255,255,0.85)',
   },
 };
 
@@ -64,12 +64,11 @@ const darkTheme = {
     expenseBackground: '#2a2020',
     incomeBackground: '#204a20',
     transferBackground: '#20204a',
-    // See lightTheme note. Dark variant keeps a near-opaque plate so filter
-    // labels stay readable over whatever operations sit behind the panel.
-    glassSurface: 'rgba(20,20,20,0.90)',
+    // See lightTheme note. Dark variant matches `surface` (#1a1a1a) at a high
+    // alpha so filter labels stay readable over the operations behind the panel.
+    glassSurface: 'rgba(26,26,26,0.97)',
     glassSurfaceStrong: 'rgba(120,120,120,0.12)',
     glassBorder: 'rgba(255,255,255,0.08)',
-    glassHighlight: 'rgba(255,255,255,0.14)',
   },
 };
 


### PR DESCRIPTION
## What

Second-iteration polish on the glass search-filters panel (the first iteration — glass tiles, section plates, sticky footer + active-filter counter — already landed on `main`). This makes the expanded panel read as **one floating unit with the search bar** and reduces list bleed-through.

## Changes

- **Unified with the search bar.** The panel is now inset to the open search pill's width (`HORIZONTAL_PADDING`), rounded on all corners, and pulled up by `PANEL_OVERLAP` (14px) so its top tucks **behind** the higher-`zIndex` search area — the seam disappears and the sheet looks like it grows out from under the bar. Works whether or not the active-filter chip strip is present.
- **Raised opacity.** `glassSurface` `0.90 → 0.97`, rebased onto the exact `surface` color so the panel is the same material as the search pill. Near-opaque kills the muddy operations-list bleed-through (there is no real backdrop blur on Android).
- **Content padding.** `scrollContent.paddingTop → 20` so the first section label clears the overlapping search area; inner gutters aligned to the new inset (12px).
- **Cleanup.** Removed the now-unnecessary top-highlight cue and the unused `glassHighlight` theme token + prop.

## Testing

- `npx jest` — all suites green (151 suites / 4462 tests).
- ESLint clean (0 warnings, per CI's zero-warning gate).
- `/code-review` (high) on the delta — no correctness findings.

Screenshots verified in-app by the owner across both iterations.
