### PR TITLE
ci: fail the test job when tests fail (unmask jest exit code)

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -109,7 +109,13 @@ jobs:
 
       - name: Run tests
         id: test
-        run: bun run test -- --coverage 2>&1 | tee test-output.txt
+        # pipefail keeps jest's exit code from being masked by tee, so the final
+        # step below can fail the job on a test failure. continue-on-error lets
+        # us post the results comment before the job is failed. Mirrors the lint
+        # job's pattern above.
+        run: |
+          set -o pipefail
+          bun run test -- --coverage 2>&1 | tee test-output.txt
         continue-on-error: true
 
       - name: Post test results
@@ -173,6 +179,7 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@v3.0.5
         id: sticky-comment
+        if: always()
         with:
           header: "Test Results"
           message: ${{ steps.set-results.outputs.message }}


### PR DESCRIPTION
## Problem

The `Run Tests` job reported a **green check even when a test failed**. On PR #1313 the sticky comment showed `Tests: 1 failed, 4525 passed` while the check itself passed and the PR looked mergeable.

Root cause: the test step piped jest into `tee` **without `pipefail`**:

```yaml
run: bun run test -- --coverage 2>&1 | tee test-output.txt
```

The pipeline's exit code comes from the last command (`tee`, always `0`), so jest's non-zero exit was masked. As a result `steps.test.outcome` was always `success`, and the already-present `Fail if tests failed` gate (`if: steps.test.outcome != 'success'`) never fired. Tests were effectively **not gating merges**.

The sibling `lint` job in the same file already does this correctly (`set -o pipefail` + block `run:`), so the test job was just missing the same guard.

## Fix

- Add `set -o pipefail` (block form) to the `Run tests` step so jest's exit code propagates. This makes `steps.test.outcome` reflect real failures and lets the existing `Fail if tests failed` step fail the job.
- Add `if: always()` to the `sticky-pull-request-comment` step (matching the `lint` job) so the **Test Results comment is still posted** even when the job is about to fail.

Net effect: a failing test now turns the check red **and** the sticky comment is preserved — no behavior change on green runs.

## Testing

Config-only change to `.github/workflows/npm-test.yml`; validated by mirroring the proven `lint` job pattern in the same file. Will be exercised by this PR's own CI run.
