### PR TITLE
test: verify CI gate fails on a failing test (do not merge)

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -109,7 +109,13 @@ jobs:
 
       - name: Run tests
         id: test
-        run: bun run test -- --coverage 2>&1 | tee test-output.txt
+        # pipefail keeps jest's exit code from being masked by tee, so the final
+        # step below can fail the job on a test failure. continue-on-error lets
+        # us post the results comment before the job is failed. Mirrors the lint
+        # job's pattern above.
+        run: |
+          set -o pipefail
+          bun run test -- --coverage 2>&1 | tee test-output.txt
         continue-on-error: true
 
       - name: Post test results
@@ -173,6 +179,7 @@ jobs:
 
       - uses: marocchino/sticky-pull-request-comment@v3.0.5
         id: sticky-comment
+        if: always()
         with:
           header: "Test Results"
           message: ${{ steps.set-results.outputs.message }}

--- a/__tests__/ci-gate-verification.test.js
+++ b/__tests__/ci-gate-verification.test.js
@@ -1,0 +1,16 @@
+// TEMPORARY VERIFICATION ARTIFACT — DO NOT MERGE.
+//
+// This test fails on purpose to prove that the CI test gate (added in the
+// `fix/ci-gate-test-failures` branch, PR #1317) now turns the "Run Tests" check
+// RED when a test fails, instead of masking the failure and reporting green.
+//
+// Expected CI behavior on this PR:
+//   - "Run Tests" check: FAIL (red)
+//   - "Test Results" sticky comment: still posted, showing "1 failed"
+//
+// Delete this file before merging anything.
+describe('CI gate verification (intentional failure)', () => {
+  it('fails on purpose to confirm the test job now gates on failures', () => {
+    expect(true).toBe(false);
+  });
+});


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — verification only

This PR exists solely to **prove the CI test gate works**. It is branched off `fix/ci-gate-test-failures` (PR #1317) and adds a single test that fails on purpose (`expect(true).toBe(false)` in `__tests__/ci-gate-verification.test.js`).

## What to expect on this PR's CI

- **`Run Tests` check → RED (fail).** Before #1317 this same failure was masked by `tee` and reported green.
- **`Test Results` sticky comment → still posted**, showing `1 failed`. The comment must survive even though the job fails.

If both hold, the fix is confirmed: failing tests now block the check, and reporting is preserved.

## Cleanup

Close without merging (or delete `__tests__/ci-gate-verification.test.js`). Nothing here should reach `main`.
