### PR TITLE
feat: add close-search button to filter footer

### DIFF
--- a/__tests__/components/search/ExpandableFilters.test.js
+++ b/__tests__/components/search/ExpandableFilters.test.js
@@ -105,6 +105,38 @@ describe('ExpandableFilters', () => {
     });
   });
 
+  describe('Close button', () => {
+    it('does not render the close button when onCloseSearch is not provided', async () => {
+      const { queryByTestId } = await render(<ExpandableFilters {...defaultProps} />);
+      expect(queryByTestId('close-search-footer-button')).toBeNull();
+    });
+
+    it('renders the close button when onCloseSearch is provided', async () => {
+      const { getByTestId } = await render(
+        <ExpandableFilters {...defaultProps} onCloseSearch={jest.fn()} />,
+      );
+      expect(getByTestId('close-search-footer-button')).toBeTruthy();
+    });
+
+    it('calls onCloseSearch when the close button is pressed', async () => {
+      const onCloseSearch = jest.fn();
+      const { getByTestId } = await render(
+        <ExpandableFilters {...defaultProps} onCloseSearch={onCloseSearch} />,
+      );
+      await fireEvent.press(getByTestId('close-search-footer-button'));
+      expect(onCloseSearch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not clear filters when the close button is pressed', async () => {
+      const onCloseSearch = jest.fn();
+      const { getByTestId } = await render(
+        <ExpandableFilters {...defaultProps} onCloseSearch={onCloseSearch} />,
+      );
+      await fireEvent.press(getByTestId('close-search-footer-button'));
+      expect(defaultProps.onFilterChange).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Amount range input', () => {
     it('preserves decimal point mid-typing without calling onFilterChange', async () => {
       const { getByPlaceholderText } = await render(<ExpandableFilters {...defaultProps} />);

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -13,6 +13,7 @@ const ExpandableFilters = ({
   colors,
   t,
   isExpanded = true,
+  onCloseSearch = null,
 }) => {
   const [showStartDatePicker, setShowStartDatePicker] = useState(false);
   const [showEndDatePicker, setShowEndDatePicker] = useState(false);
@@ -283,8 +284,9 @@ const ExpandableFilters = ({
         </View>
       </ScrollView>
 
-      {/* Sticky footer: clear-all + active-filter count, always reachable
-          without scrolling to the end of the sections. */}
+      {/* Sticky footer: active-filter count on the left, clear-all + close on
+          the right so both stay reachable at the bottom without stretching a
+          thumb up to the search pill. */}
       <View style={[styles.footer, { borderTopColor: colors.glassBorder }]}>
         <View style={styles.footerCountWrap}>
           {activeCount > 0 && (
@@ -296,24 +298,38 @@ const ExpandableFilters = ({
             </>
           )}
         </View>
-        <TouchableOpacity
-          testID="clear-all-button"
-          style={[styles.clearAllButton, activeCount === 0 && styles.clearAllButtonDisabled]}
-          onPress={() => onFilterChange({
-            text: '',
-            types: [],
-            accountIds: [],
-            categoryIds: [],
-            labels: [],
-            dateRange: { startDate: null, endDate: null },
-            amountRange: { min: null, max: null },
-          })}
-        >
-          <Icon name="filter-remove-outline" size={16} color={colors.primary} />
-          <Text style={[styles.clearAllText, { color: colors.primary }]}>
-            {t('clear_all')}
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.footerActions}>
+          <TouchableOpacity
+            testID="clear-all-button"
+            style={[styles.footerButton, activeCount === 0 && styles.footerButtonDisabled]}
+            onPress={() => onFilterChange({
+              text: '',
+              types: [],
+              accountIds: [],
+              categoryIds: [],
+              labels: [],
+              dateRange: { startDate: null, endDate: null },
+              amountRange: { min: null, max: null },
+            })}
+          >
+            <Icon name="filter-remove-outline" size={16} color={colors.primary} />
+            <Text style={[styles.footerButtonText, { color: colors.primary }]}>
+              {t('clear_all')}
+            </Text>
+          </TouchableOpacity>
+          {onCloseSearch && (
+            <TouchableOpacity
+              testID="close-search-footer-button"
+              style={styles.footerButton}
+              onPress={onCloseSearch}
+            >
+              <Icon name="close" size={16} color={colors.primary} />
+              <Text style={[styles.footerButtonText, { color: colors.primary }]}>
+                {t('close')}
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
 
       {/* Date Pickers */}
@@ -367,6 +383,7 @@ ExpandableFilters.propTypes = {
   }).isRequired,
   t: PropTypes.func.isRequired,
   isExpanded: PropTypes.bool,
+  onCloseSearch: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
@@ -414,19 +431,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '500',
   },
-  clearAllButton: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 6,
-    paddingVertical: 6,
-  },
-  clearAllButtonDisabled: {
-    opacity: 0.4,
-  },
-  clearAllText: {
-    fontSize: 14,
-    fontWeight: '600',
-  },
   clearDateButton: {
     marginTop: 7,
   },
@@ -462,6 +466,24 @@ const styles = StyleSheet.create({
     paddingBottom: 12,
     paddingHorizontal: 12,
     paddingTop: 10,
+  },
+  footerActions: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 18,
+  },
+  footerButton: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 6,
+    paddingVertical: 6,
+  },
+  footerButtonDisabled: {
+    opacity: 0.4,
+  },
+  footerButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
   },
   footerCount: {
     fontSize: 13,

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -20,7 +20,7 @@ const SCREEN_HEIGHT = Dimensions.get('window').height;
 // Exported so layout tests can assert the tucked position without a magic number.
 export const PANEL_OVERLAP = 14;
 
-const SearchOverlay = ({ colors, t, visible, onHeightChange = null, topOffset = 0 }) => {
+const SearchOverlay = ({ colors, t, visible, onHeightChange = null, topOffset = 0, onClose = null }) => {
   const { searchState = { text: '', types: [], accountIds: [], categoryIds: [], dateRange: { startDate: null, endDate: null }, amountRange: { min: null, max: null } } } = useOperationsData();
   const { filtersExpanded } = useSearch();
   const { updateSearchFilters } = useOperationsActions();
@@ -79,6 +79,7 @@ const SearchOverlay = ({ colors, t, visible, onHeightChange = null, topOffset = 
         colors={colors}
         t={t}
         isExpanded={filtersExpanded}
+        onCloseSearch={onClose}
       />
     </Animated.View>
   );
@@ -95,6 +96,7 @@ SearchOverlay.propTypes = {
   t: PropTypes.func.isRequired,
   visible: PropTypes.bool.isRequired,
   topOffset: PropTypes.number,
+  onClose: PropTypes.func,
 };
 
 const styles = StyleSheet.create({

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -1293,6 +1293,7 @@ const OperationsScreen = () => {
         topOffset={searchBarAreaHeight}
         colors={colors}
         t={t}
+        onClose={handleCloseSearch}
       />
     </View>
   );


### PR DESCRIPTION
Adds an optional close button to ExpandableFilters footer that dismisses the search overlay without clearing active filters. The button appears alongside the existing clear-all action and is only shown when onCloseSearch callback is provided.
