### PR TITLE
ci: build emulator-installable APK artifacts on demand

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -100,6 +100,20 @@ jobs:
           echo "checksum_path=${APK}.sha256" >> $GITHUB_OUTPUT
           echo "SHA-256: $(cat ${APK}.sha256)"
 
+      # Makes the APK downloadable from every run — including manual
+      # workflow_dispatch runs off a branch, where there is no release/tag to
+      # attach it to. Without this, a dispatched build produces an APK that is
+      # discarded when the runner is torn down.
+      - name: 📦 Upload APK as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: penny-apk
+          path: |
+            ${{ steps.find_apk.outputs.apk_path }}
+            ${{ steps.checksum.outputs.checksum_path }}
+          retention-days: 7
+          if-no-files-found: error
+
       - name: 📤 Upload APK and checksum to Release
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -2,6 +2,15 @@ name: Build Android APK (EAS)
 
 on:
   workflow_dispatch:
+    inputs:
+      profile:
+        description: 'EAS profile (preview = arm64 only; emulator = arm64 + x86_64 for AVDs)'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - emulator
   push:
     tags:
       - 'penny-v*'
@@ -66,8 +75,9 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          BUILD_PROFILE: ${{ github.event.inputs.profile || 'preview' }}
         run: |
-          eas build --platform android --local --profile preview --non-interactive
+          eas build --platform android --local --profile "$BUILD_PROFILE" --non-interactive
 
       - name: 📦 Find and rename APK
         id: find_apk

--- a/app.config.js
+++ b/app.config.js
@@ -1,6 +1,14 @@
-// Architecture filtering: Only arm64-v8a for preview builds to speed up build time
+// Architecture filtering to speed up build time:
+//  - preview:  arm64-v8a only (real devices; ~75% faster than all-ABI)
+//  - emulator: arm64-v8a + x86_64 (installable on x86_64 AVDs for UI testing)
+//  - other:    all architectures
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
-const ANDROID_ARCHITECTURES = IS_PREVIEW ? ['arm64-v8a'] : undefined; // undefined = all architectures
+const IS_EMULATOR = process.env.APP_VARIANT === 'emulator';
+const ANDROID_ARCHITECTURES = IS_PREVIEW
+  ? ['arm64-v8a']
+  : IS_EMULATOR
+    ? ['arm64-v8a', 'x86_64']
+    : undefined; // undefined = all architectures
 
 module.exports = {
   expo: {

--- a/eas.json
+++ b/eas.json
@@ -21,6 +21,18 @@
       },
       "channel": "preview"
     },
+    "emulator": {
+      "distribution": "internal",
+      "node": "22.12.0",
+      "android": {
+        "buildType": "apk",
+        "gradleCommand": ":app:preBuild :app:assembleRelease"
+      },
+      "env": {
+        "APP_VARIANT": "emulator"
+      },
+      "channel": "preview"
+    },
     "production": {
       "autoIncrement": true,
       "node": "22.12.0",

--- a/plugins/withR8Config.js
+++ b/plugins/withR8Config.js
@@ -26,11 +26,16 @@ const withR8Config = (config) => {
       'org.gradle.daemon': 'true',
     };
 
-    // For preview builds, restrict to arm64-v8a only for faster builds
-    // This is a more reliable method than expo-build-properties buildArchs (known issues)
+    // Restrict native ABIs to speed up builds. This gradle property is a more
+    // reliable method than expo-build-properties buildArchs (known issues).
+    //  - preview:  arm64-v8a only (real devices)
+    //  - emulator: arm64-v8a + x86_64 (installable on x86_64 AVDs for UI testing)
     if (process.env.APP_VARIANT === 'preview') {
       properties['reactNativeArchitectures'] = 'arm64-v8a';
       console.log('🏗️  Building for arm64-v8a only (preview build)');
+    } else if (process.env.APP_VARIANT === 'emulator') {
+      properties['reactNativeArchitectures'] = 'arm64-v8a,x86_64';
+      console.log('🏗️  Building for arm64-v8a + x86_64 (emulator build)');
     }
 
     // Update or add each property


### PR DESCRIPTION
## What

Makes the `build-release-apk` workflow able to produce a downloadable APK that runs on an **x86_64 Android emulator**, from any branch via manual dispatch.

### Changes
- **Upload artifact on every run** — the APK/checksum were only attached to a GitHub Release on tag pushes, so manual `workflow_dispatch` runs discarded the APK. Added an `actions/upload-artifact` step (`penny-apk`, ungated).
- **New `emulator` build profile** — the `preview` profile builds **arm64-v8a only**, so its APK crashes on boot on an x86_64 emulator (`SoLoader` → `MainApplication.onCreate`, process dies). The `emulator` variant (`APP_VARIANT=emulator`) also bundles **x86_64**. Wired through `app.config.js`, `plugins/withR8Config.js`, and a new `emulator` profile in `eas.json` (APK output).
- **Profile input** on the workflow (`preview` | `emulator`), default `preview`. Tag/release builds stay arm64-only.

## Why
Enables installing and UI-testing real release builds on the emulator (no dev-client, no `Tools` dev overlay), and — once on main — from any branch.

## Testing
Dispatched with `profile=emulator`, downloaded the artifact (62 MB, contains `lib/arm64-v8a/` + `lib/x86_64/`), installed on an x86_64 AVD — app launches and runs clean.
