### PR TITLE
fix: convert foreign-currency accounts into Net Worth on Accounts

### DIFF
--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1159,6 +1159,61 @@ describe('OperationsDB Service', () => {
         expect(result).toEqual(['XYZ']); // AMD resolves via the live mock, EUR offline, USD is target
       });
 
+      describe('computeNetWorthSummary', () => {
+        beforeEach(() => {
+          // Decimal helpers used only by this function — mirror them with floats;
+          // the RATES-based convertAmount above already returns 2dp strings.
+          Currency.add.mockImplementation((a, b) => (parseFloat(a) + parseFloat(b)).toString());
+          Currency.subtract.mockImplementation((a, b) => (parseFloat(a) - parseFloat(b)).toString());
+        });
+
+        it('includes foreign-currency accounts, converted to the display currency', async () => {
+          // Seed-data repro: three USD accounts + one EUR account (1.1 → USD).
+          const accounts = [
+            { id: 'a1', currency: 'USD', balance: '858' },
+            { id: 'a2', currency: 'USD', balance: '5100' },
+            { id: 'a3', currency: 'USD', balance: '100' },
+            { id: 'a4', currency: 'EUR', balance: '100' }, // 100 * 1.1 = 110
+          ];
+
+          const result = await OperationsDB.computeNetWorthSummary(accounts, [], 'USD', '2025-12');
+
+          // 858 + 5100 + 100 + 110 = 6168 — the EUR account is no longer dropped.
+          expect(parseFloat(result.total)).toBeCloseTo(6168);
+          expect(result.unconvertible).toEqual([]);
+        });
+
+        it('converts foreign-account operations into the monthly change', async () => {
+          const accounts = [
+            { id: 'usd', currency: 'USD', balance: '1000' },
+            { id: 'eur', currency: 'EUR', balance: '0' },
+          ];
+          const operations = [
+            { accountId: 'usd', type: 'income', amount: '200', date: '2025-12-10' },
+            { accountId: 'eur', type: 'expense', amount: '50', date: '2025-12-11' }, // 50 * 1.1 = 55
+            { accountId: 'usd', type: 'transfer', amount: '999', date: '2025-12-12' }, // ignored
+            { accountId: 'usd', type: 'income', amount: '10', date: '2025-11-30' }, // wrong month
+          ];
+
+          const result = await OperationsDB.computeNetWorthSummary(accounts, operations, 'USD', '2025-12');
+
+          // +200 (income) − 55 (converted expense) = 145
+          expect(parseFloat(result.monthlyChange)).toBeCloseTo(145);
+        });
+
+        it('excludes accounts whose currency has no rate and reports them', async () => {
+          const accounts = [
+            { id: 'a1', currency: 'USD', balance: '500' },
+            { id: 'a2', currency: 'XYZ', balance: '999' }, // no offline/live rate
+          ];
+
+          const result = await OperationsDB.computeNetWorthSummary(accounts, [], 'USD', '2025-12');
+
+          expect(parseFloat(result.total)).toBeCloseTo(500);
+          expect(result.unconvertible).toEqual(['XYZ']);
+        });
+      });
+
       it('category operations: converts foreign ops, tags account currency, drops unrateable', async () => {
         queryAll.mockResolvedValue([
           { id: '1', type: 'expense', amount: '100', category_id: 'cat1', date: '2025-12-05', account_currency: 'USD' },

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -19,6 +19,7 @@ import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useOperationsData } from '../contexts/OperationsDataContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { getDefaultAccountId, setDefaultAccountId } from '../services/PreferencesDB';
+import { computeNetWorthSummary } from '../services/OperationsDB';
 import { parseCardMasks, serializeCardMasks, cardMaskLast4 } from '../utils/cardMask';
 import currencies from '../../assets/currencies.json';
 
@@ -241,46 +242,43 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
   const decimals = currencyData?.decimal_digits ?? 2;
   const currencySymbol = currencyData?.symbol || displayCurrency;
 
-  // Filter accounts to only those matching display currency
-  const sameCurrencyAccounts = useMemo(() => {
-    return accounts.filter(acc => acc.currency === displayCurrency);
-  }, [accounts, displayCurrency]);
+  // Net worth converts every account's balance to the display currency at the
+  // current rate (offline first, live fallback) — same path Graphs uses — so
+  // foreign-currency accounts are included, not silently dropped. Conversion is
+  // async (may hit the network), so results land in state. Seed the initial
+  // state with the synchronous same-currency subtotal so the card shows a real
+  // figure on first paint instead of flashing $0 while the conversion resolves.
+  const [summary, setSummary] = useState(() => ({
+    total: accounts
+      .filter(acc => (acc.currency || displayCurrency) === displayCurrency)
+      .reduce((sum, acc) => sum + parseFloat(acc.balance || '0'), 0)
+      .toString(),
+    monthlyChange: '0',
+    unconvertible: [],
+  }));
 
-  // Create account ID set for quick lookup
-  const sameCurrencyAccountIds = useMemo(() => {
-    return new Set(sameCurrencyAccounts.map(acc => acc.id));
-  }, [sameCurrencyAccounts]);
-
-  const totalBalance = useMemo(() => {
-    return sameCurrencyAccounts.reduce((sum, acc) => sum + parseFloat(acc.balance || '0'), 0);
-  }, [sameCurrencyAccounts]);
-
-  // Calculate this month's change (only for accounts with matching currency)
-  const monthlyChange = useMemo(() => {
+  useEffect(() => {
+    let cancelled = false;
     const now = new Date();
     // Compare the YYYY-MM prefix of the stored local date string directly.
     // Parsing "YYYY-MM-DD" with new Date() yields UTC midnight, which shifts
     // ops dated the 1st into the previous month in UTC-negative timezones.
     const currentMonthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 
-    return operations.reduce((sum, op) => {
-      // Only count operations from accounts with matching currency
-      if (!sameCurrencyAccountIds.has(op.accountId)) {
-        return sum;
-      }
+    computeNetWorthSummary(accounts, operations, displayCurrency, currentMonthPrefix)
+      .then((result) => {
+        if (!cancelled) setSummary(result);
+      })
+      .catch(() => {
+        if (!cancelled) setSummary({ total: '0', monthlyChange: '0', unconvertible: [] });
+      });
 
-      if (typeof op.date === 'string' && op.date.startsWith(currentMonthPrefix)) {
-        const amount = parseFloat(op.amount || '0');
-        if (op.type === 'income') {
-          return sum + amount;
-        } else if (op.type === 'expense') {
-          return sum - amount;
-        }
-        // transfers don't affect net worth
-      }
-      return sum;
-    }, 0);
-  }, [operations, sameCurrencyAccountIds]);
+    return () => { cancelled = true; };
+  }, [accounts, operations, displayCurrency]);
+
+  const totalBalance = parseFloat(summary.total || '0');
+  const monthlyChange = parseFloat(summary.monthlyChange || '0');
+  const unconvertible = summary.unconvertible;
 
   const isNegative = totalBalance < 0;
   const abs = Math.abs(totalBalance);
@@ -310,6 +308,14 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
             <View style={styles.monthlyChangeRow}>
               <Text style={[styles.monthlyChangeText, { color: changeIsPositive ? colors.income : colors.expense }]}>
                 {changeIsPositive ? '↗' : '↘'} {changeIsPositive ? '+' : '-'}{currencySymbol}{formattedChange} {t('this_month') || 'this month'}
+              </Text>
+            </View>
+          )}
+          {unconvertible.length > 0 && (
+            <View style={styles.netWorthWarningRow}>
+              <Icon name="alert-outline" size={13} color={colors.mutedText} />
+              <Text style={[styles.netWorthWarningText, { color: colors.mutedText }]}>
+                {`${t('graphs_currencies_not_converted')}: ${unconvertible.join(', ')}`}
               </Text>
             </View>
           )}
@@ -1548,6 +1554,16 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: '600',
     letterSpacing: 0.8,
+  },
+  netWorthWarningRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 4,
+    marginTop: SPACING.sm,
+  },
+  netWorthWarningText: {
+    flex: 1,
+    fontSize: 12,
   },
   pickerAccountBalance: {
     fontSize: 14,

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -1172,6 +1172,61 @@ export const getUnconvertibleCurrencies = async (fromCurrencies, targetCurrency)
 };
 
 /**
+ * Compute a net-worth summary across ALL accounts, converting foreign-currency
+ * balances to `targetCurrency` at the current rate (offline first, live fallback)
+ * — the same conversion path the Graphs screen uses, so the two surfaces agree.
+ * A single rate map is built once and reused for both balances and the monthly
+ * change, so operations are converted from their own account's currency too.
+ *
+ * Accounts (and operations) whose currency has no available rate are excluded
+ * from the totals and their currency codes reported in `unconvertible`, so the
+ * UI can flag the omission instead of silently dropping them.
+ *
+ * @param {Array<{id: string, currency: string, balance: string}>} accounts
+ * @param {Array<{accountId: string, type: string, amount: string, date: string}>} operations
+ * @param {string} targetCurrency - display/base currency to express totals in
+ * @param {string} monthPrefix - `YYYY-MM` prefix selecting the current month's ops
+ * @returns {Promise<{ total: string, monthlyChange: string, unconvertible: string[] }>}
+ */
+export const computeNetWorthSummary = async (accounts, operations, targetCurrency, monthPrefix) => {
+  const accountList = accounts || [];
+  const rateByCurrency = await fetchRatesToTarget(
+    accountList.map(acc => acc.currency),
+    targetCurrency,
+  );
+  const currencyByAccountId = new Map(accountList.map(acc => [acc.id, acc.currency]));
+  const unconvertible = new Set();
+
+  let total = '0';
+  for (const acc of accountList) {
+    const currency = acc.currency || targetCurrency;
+    const converted = convertWithRateMap(String(acc.balance ?? '0'), currency, targetCurrency, rateByCurrency);
+    if (converted === null) {
+      unconvertible.add(currency);
+      continue;
+    }
+    total = Currency.add(total, converted);
+  }
+
+  let monthlyChange = '0';
+  for (const op of operations || []) {
+    if (op.type !== 'income' && op.type !== 'expense') continue; // transfers don't affect net worth
+    if (typeof op.date !== 'string' || !op.date.startsWith(monthPrefix)) continue;
+    const currency = currencyByAccountId.get(op.accountId);
+    if (!currency) continue; // op for an account not in the list
+    const converted = convertWithRateMap(String(op.amount ?? '0'), currency, targetCurrency, rateByCurrency);
+    // A null rate here means this account's currency is unrateable; the balance
+    // loop above already recorded it in `unconvertible`, so just skip the amount.
+    if (converted === null) continue;
+    monthlyChange = op.type === 'income'
+      ? Currency.add(monthlyChange, converted)
+      : Currency.subtract(monthlyChange, converted);
+  }
+
+  return { total, monthlyChange, unconvertible: [...unconvertible] };
+};
+
+/**
  * Get spending by category filtered by currency and date range
  * @param {string} currency - Currency code (e.g., 'USD', 'AMD')
  * @param {string} startDate - ISO date string


### PR DESCRIPTION
## Summary

Fixes #1332. On the **Accounts** screen, **Net Worth** summed only accounts whose currency matched the display currency, silently dropping foreign-currency accounts. With seed data it showed **$6,058.00** (the three USD accounts) while omitting the **€100 EUR** account entirely — not converted, just dropped.

Net Worth now converts **every** account balance to the display currency at the current rate, reusing the **same offline-first / live-fallback conversion path** the Graphs screen uses (`fetchRatesToTarget` + `convertWithRateMap`), so the two surfaces stay consistent. With seed data it now shows **~$6,168** (€100 → ~$110 at the current rate).

Behaviour decision (the issue left this open): **always convert**, no toggle — the obvious default for a summary card, matching Graphs' convert-on-by-default. If some account currency has no available rate, the card flags it inline (`alert-outline` + "Some currencies not converted: XYZ") instead of silently excluding it.

## Changes

- **`OperationsDB.js`** — new `computeNetWorthSummary(accounts, operations, targetCurrency, monthPrefix)`, reusing the existing conversion helpers. Converts both balances and the monthly-change operations from each op's own account currency, and returns `unconvertible` currency codes for the UI to flag.
- **`AccountsScreen.js`** — `NetWorthCard` now derives its total/monthly-change from `computeNetWorthSummary` (async). Initial state is seeded with the synchronous same-currency subtotal to avoid a `$0` flash before conversion resolves. Adds the inline unconvertible-currencies warning.
- **Tests** — unit coverage for the new helper (foreign-account inclusion, converted monthly change, unrateable-currency exclusion + reporting).

## Testing

- `npx jest` — **157 suites / 4530 tests passing**.
- Ran `/code-review` (high) on the diff; addressed the `$0`-flash regression, a redundant `unconvertible` add, and a missing `accounts` guard.
