### PR TITLE
feat: add per-session convert toggle to Net Worth card

### DIFF
--- a/__tests__/screens/AccountsScreen.test.js
+++ b/__tests__/screens/AccountsScreen.test.js
@@ -225,6 +225,54 @@ describe('AccountsScreen', () => {
     });
   });
 
+  describe('Net worth currency conversion toggle', () => {
+    it('hides the convert toggle when all accounts share one currency', async () => {
+      const AccountsScreen = require('../../app/screens/AccountsScreen').default;
+      const { useAccountsData } = require('../../app/contexts/AccountsDataContext');
+
+      const singleCurrency = [
+        { id: '1', name: 'Cash', balance: '100.00', currency: 'USD', order: 0 },
+        { id: '2', name: 'Bank', balance: '200.00', currency: 'USD', order: 1 },
+      ];
+      useAccountsData.mockReturnValue(createAccountsDataMock({
+        accounts: singleCurrency,
+        displayedAccounts: singleCurrency,
+      }));
+
+      const { queryByLabelText } = await render(<AccountsScreen />);
+
+      expect(queryByLabelText('graphs_convert_currencies')).toBeNull();
+    });
+
+    it('shows the convert toggle (default on) and flips it off when pressed', async () => {
+      const AccountsScreen = require('../../app/screens/AccountsScreen').default;
+      const { useAccountsData } = require('../../app/contexts/AccountsDataContext');
+
+      const multiCurrency = [
+        { id: '1', name: 'USD', balance: '100.00', currency: 'USD', order: 0 },
+        { id: '2', name: 'EUR', balance: '100.00', currency: 'EUR', order: 1 },
+      ];
+      useAccountsData.mockReturnValue(createAccountsDataMock({
+        accounts: multiCurrency,
+        displayedAccounts: multiCurrency,
+      }));
+
+      const { getByLabelText } = await render(<AccountsScreen />);
+
+      const toggle = getByLabelText('graphs_convert_currencies');
+      expect(toggle.props.accessibilityState).toEqual(
+        expect.objectContaining({ checked: true }),
+      );
+
+      fireEvent.press(toggle);
+
+      await waitFor(() => {
+        expect(getByLabelText('graphs_convert_currencies').props.accessibilityState)
+          .toEqual(expect.objectContaining({ checked: false }));
+      });
+    });
+  });
+
   describe('Component Logic', () => {
     it('initializes with modal closed', async () => {
       const AccountsScreen = require('../../app/screens/AccountsScreen').default;

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -242,43 +242,70 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
   const decimals = currencyData?.decimal_digits ?? 2;
   const currencySymbol = currencyData?.symbol || displayCurrency;
 
-  // Net worth converts every account's balance to the display currency at the
-  // current rate (offline first, live fallback) — same path Graphs uses — so
-  // foreign-currency accounts are included, not silently dropped. Conversion is
-  // async (may hit the network), so results land in state. Seed the initial
-  // state with the synchronous same-currency subtotal so the card shows a real
-  // figure on first paint instead of flashing $0 while the conversion resolves.
-  const [summary, setSummary] = useState(() => ({
-    total: accounts
-      .filter(acc => (acc.currency || displayCurrency) === displayCurrency)
-      .reduce((sum, acc) => sum + parseFloat(acc.balance || '0'), 0)
-      .toString(),
-    monthlyChange: '0',
-    unconvertible: [],
-  }));
+  // Only worth offering a convert toggle when accounts span more than one currency.
+  const hasMultipleCurrencies = useMemo(
+    () => new Set(accounts.map(acc => acc.currency || displayCurrency)).size > 1,
+    [accounts, displayCurrency],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
+  // Same-currency-only summary (the pre-conversion behaviour): sums just the
+  // display-currency accounts and their operations. Used when the toggle is off,
+  // and as the seed for the converted state so the card never flashes $0 before
+  // the async conversion resolves.
+  const baseCurrencySummary = useMemo(() => {
     const now = new Date();
     // Compare the YYYY-MM prefix of the stored local date string directly.
     // Parsing "YYYY-MM-DD" with new Date() yields UTC midnight, which shifts
     // ops dated the 1st into the previous month in UTC-negative timezones.
+    const monthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const sameCurrencyIds = new Set();
+    let total = 0;
+    for (const acc of accounts) {
+      if ((acc.currency || displayCurrency) === displayCurrency) {
+        sameCurrencyIds.add(acc.id);
+        total += parseFloat(acc.balance || '0');
+      }
+    }
+    let change = 0;
+    for (const op of operations) {
+      if (!sameCurrencyIds.has(op.accountId)) continue;
+      if (typeof op.date === 'string' && op.date.startsWith(monthPrefix)) {
+        const amount = parseFloat(op.amount || '0');
+        if (op.type === 'income') change += amount;
+        else if (op.type === 'expense') change -= amount; // transfers don't affect net worth
+      }
+    }
+    return { total: total.toString(), monthlyChange: change.toString(), unconvertible: [] };
+  }, [accounts, operations, displayCurrency]);
+
+  // When the toggle is on, every balance/operation is converted to the display
+  // currency at the current rate (offline first, live fallback) — the same path
+  // Graphs uses — so foreign-currency accounts are included, not silently dropped.
+  // Conversion is async (may hit the network), so results land in state.
+  const [convertAll, setConvertAll] = useState(true);
+  const [convertedSummary, setConvertedSummary] = useState(baseCurrencySummary);
+
+  useEffect(() => {
+    if (!convertAll) return undefined;
+    let cancelled = false;
+    const now = new Date();
     const currentMonthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 
     computeNetWorthSummary(accounts, operations, displayCurrency, currentMonthPrefix)
       .then((result) => {
-        if (!cancelled) setSummary(result);
+        if (!cancelled) setConvertedSummary(result);
       })
       .catch(() => {
-        if (!cancelled) setSummary({ total: '0', monthlyChange: '0', unconvertible: [] });
+        if (!cancelled) setConvertedSummary(baseCurrencySummary);
       });
 
     return () => { cancelled = true; };
-  }, [accounts, operations, displayCurrency]);
+  }, [convertAll, accounts, operations, displayCurrency, baseCurrencySummary]);
 
+  const summary = convertAll ? convertedSummary : baseCurrencySummary;
   const totalBalance = parseFloat(summary.total || '0');
   const monthlyChange = parseFloat(summary.monthlyChange || '0');
-  const unconvertible = summary.unconvertible;
+  const unconvertible = convertAll ? summary.unconvertible : [];
 
   const isNegative = totalBalance < 0;
   const abs = Math.abs(totalBalance);
@@ -294,6 +321,24 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
 
   return (
     <View style={[styles.netWorthCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+      {hasMultipleCurrencies && !hideBalances && (
+        <TouchableOpacity
+          style={[
+            styles.netWorthConvertToggle,
+            {
+              backgroundColor: convertAll ? colors.primary : colors.surface,
+              borderColor: convertAll ? colors.primary : colors.border,
+            },
+          ]}
+          onPress={() => setConvertAll(v => !v)}
+          activeOpacity={0.7}
+          accessibilityRole="switch"
+          accessibilityState={{ checked: convertAll }}
+          accessibilityLabel={t('graphs_convert_currencies')}
+        >
+          <Icon name="cash-sync" size={16} color={convertAll ? colors.surface : colors.mutedText} />
+        </TouchableOpacity>
+      )}
       <Text style={[styles.netWorthLabel, { color: colors.mutedText }]}>
         {(t('net_worth') || 'NET WORTH').toUpperCase()}
       </Text>
@@ -1549,6 +1594,18 @@ const styles = StyleSheet.create({
     marginHorizontal: SPACING.lg,
     marginTop: SPACING.sm,
     padding: SPACING.xl,
+  },
+  netWorthConvertToggle: {
+    alignItems: 'center',
+    borderRadius: 16,
+    borderWidth: 1,
+    height: 32,
+    justifyContent: 'center',
+    position: 'absolute',
+    right: SPACING.md,
+    top: SPACING.md,
+    width: 32,
+    zIndex: 1,
   },
   netWorthLabel: {
     fontSize: 11,


### PR DESCRIPTION
## Summary

Follow-up to #1333. That PR made the Accounts **Net Worth** always convert foreign-currency accounts, with no way to turn conversion off. This adds a **session-local toggle** so the behaviour can be switched at runtime, mirroring the existing toggle on the Graphs screen.

- **`cash-sync` badge** tucked into the Net Worth card's top-right corner. Tapping it flips between the converted total and the previous **same-currency-only** total.
- **Default on** (matches Graphs' convert-on-by-default). Session-local — resets to on across app restarts, exactly like the Graphs toggle.
- **Shown only when accounts span more than one currency** (nothing to convert otherwise), and hidden while balances are hidden.
- When off, the card shows the base-currency subtotal and suppresses the "some currencies not converted" warning.

## Implementation

`NetWorthCard` now keeps two summaries:
- a synchronous **same-currency** summary (`useMemo`) — used when the toggle is off, and as the anti-`$0`-flash seed for the converted state;
- the async **converted** summary from `computeNetWorthSummary` — used when the toggle is on (the effect skips work entirely when off).

## Testing

- `npx jest` — **157 suites / 4532 tests passing**.
- New component tests: toggle hidden for a single-currency portfolio; visible + defaults on + flips off on press for a multi-currency one.
- Ran `/code-review` (high) on the diff; the two surfaced findings (a one-frame stale value when re-enabling, a duplicated month-prefix computation) are cosmetic/trivial and consciously left as-is.
