### PR TITLE
feat: log level counts and visual hierarchy in logs viewer

### DIFF
--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -130,6 +130,7 @@ const mockGetExportText = jest.fn(() => 'log text');
 jest.mock('../../app/hooks/useLogEntries', () => ({
   useLogEntries: () => ({
     entries: [],
+    counts: { all: 0, error: 0, warn: 0, info: 0, debug: 0 },
     clearLogs: mockClearLogs,
     getExportText: mockGetExportText,
   }),

--- a/__tests__/services/LogService.test.js
+++ b/__tests__/services/LogService.test.js
@@ -166,6 +166,33 @@ describe('LogService', () => {
     it('returns empty string when no entries', async () => {
       expect(service.formatForExport()).toBe('');
     });
+
+    it('redacts monetary amounts and long digit runs from exported messages', async () => {
+      service._addEntry('info', ['Balance updated to 1234.56 for account 987654']);
+
+      const text = service.formatForExport();
+      expect(text).not.toContain('1234.56');
+      expect(text).not.toContain('987654');
+      expect(text).toContain('[redacted]');
+      // Timestamp/level structure is preserved.
+      expect(text).toMatch(/^\[.*\] \[INFO\] /);
+    });
+  });
+
+  describe('Counts', () => {
+    it('returns zeroed counts when empty', () => {
+      expect(service.getCounts()).toEqual({ all: 0, error: 0, warn: 0, info: 0, debug: 0 });
+    });
+
+    it('tallies entries per level and total', () => {
+      service._addEntry('info', ['a']);
+      service._addEntry('info', ['b']);
+      service._addEntry('error', ['c']);
+      service._addEntry('warn', ['d']);
+      service._addEntry('debug', ['e']);
+
+      expect(service.getCounts()).toEqual({ all: 5, error: 1, warn: 1, info: 2, debug: 1 });
+    });
   });
 
   describe('Install', () => {

--- a/app/hooks/useLogEntries.js
+++ b/app/hooks/useLogEntries.js
@@ -17,6 +17,7 @@ export function useLogEntries(levelFilter = 'all') {
   }, []);
 
   const entries = logService.getEntries(levelFilter);
+  const counts = logService.getCounts();
 
   const clearLogs = useCallback(() => {
     logService.clear();
@@ -26,5 +27,5 @@ export function useLogEntries(levelFilter = 'all') {
     return logService.formatForExport(filterRef.current);
   }, []);
 
-  return { entries, clearLogs, getExportText };
+  return { entries, counts, clearLogs, getExportText };
 }

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -190,7 +190,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
     setTheme(colorScheme === 'dark' ? 'light' : 'dark');
   }, [colorScheme, setTheme]);
 
-  const { entries, clearLogs, getExportText } = useLogEntries(logFilter);
+  const { entries, counts, clearLogs, getExportText } = useLogEntries(logFilter);
   const importPickInProgress = useRef(false);
 
   const handleToggleHideBalances = useCallback(async () => {
@@ -961,17 +961,26 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
   const renderLogEntry = useCallback(({ item }) => {
     const isExpanded = expandedLogIds.has(item.id);
+    const levelColor = LOG_LEVEL_COLORS[item.level];
+    // Tint the row background for the two levels that warrant attention so they
+    // stand out while scanning a wall of info/debug lines. `20` = ~12% alpha.
+    const rowBackground = item.level === 'error' || item.level === 'warn'
+      ? `${levelColor}20`
+      : 'transparent';
     return (
       <TouchableOpacity
         onPress={() => toggleLogExpand(item.id)}
         onLongPress={() => Clipboard.setStringAsync(`${item.timestamp} [${item.level.toUpperCase()}] ${item.message}`)}
         activeOpacity={0.7}
-        style={styles.logEntry}
+        style={[
+          styles.logEntry,
+          { borderLeftColor: levelColor, borderBottomColor: colors.border, backgroundColor: rowBackground },
+        ]}
       >
         <Text style={[styles.logTimestamp, { color: colors.mutedText }]}>
-          {item.timestamp.substring(11, 19)}
+          {isExpanded ? item.timestamp.substring(0, 19).replace('T', ' ') : item.timestamp.substring(11, 19)}
         </Text>
-        <Text style={[styles.logLevel, { color: LOG_LEVEL_COLORS[item.level] }]}>
+        <Text style={[styles.logLevel, { color: levelColor }]}>
           {item.level.toUpperCase()}
         </Text>
         <Text style={[styles.logMessage, { color: colors.text }]} numberOfLines={isExpanded ? undefined : 3}>
@@ -1519,10 +1528,19 @@ export default function SettingsScreen({ setSubPanelActive }) {
                   {LOG_FILTERS.map(f => {
                     const isSelected = f === logFilter;
                     const filterLabelKey = `log_level_${f}`;
+                    const label = t(filterLabelKey) || f;
+                    // Badge every level chip that has entries (skip "all"); the
+                    // absence of a badge on Error/Warn reads as "none", so a
+                    // zero count needs no badge.
+                    const count = f === 'all' ? 0 : (counts?.[f] || 0);
+                    const badgeColor = f === 'error' || f === 'warn' ? LOG_LEVEL_COLORS[f] : colors.mutedText;
                     return (
                       <TouchableOpacity
                         key={f}
                         onPress={() => setLogFilter(f)}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: isSelected }}
+                        accessibilityLabel={count > 0 ? `${label}, ${count}` : label}
                         style={[
                           styles.filterChip,
                           { borderColor: colors.border },
@@ -1533,8 +1551,21 @@ export default function SettingsScreen({ setSubPanelActive }) {
                           styles.filterChipText,
                           isSelected ? styles.filterChipTextSelected : { color: colors.text },
                         ]}>
-                          {t(filterLabelKey) || f}
+                          {label}
                         </Text>
+                        {count > 0 && (
+                          <View style={[
+                            styles.filterChipBadge,
+                            { backgroundColor: isSelected ? 'rgba(255,255,255,0.3)' : `${badgeColor}26` },
+                          ]}>
+                            <Text style={[
+                              styles.filterChipBadgeText,
+                              { color: isSelected ? '#fff' : badgeColor },
+                            ]}>
+                              {count}
+                            </Text>
+                          </View>
+                        )}
                       </TouchableOpacity>
                     );
                   })}
@@ -1542,7 +1573,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
                 <FlatList
                   data={entries.slice().reverse()}
-                  keyExtractor={(item) => item.id}
+                  keyExtractor={(item) => String(item.id)}
                   renderItem={renderLogEntry}
                   style={styles.flexList}
                   inverted
@@ -1920,10 +1951,24 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   filterChip: {
+    alignItems: 'center',
     borderRadius: 16,
     borderWidth: 1,
+    flexDirection: 'row',
+    gap: 5,
     paddingHorizontal: 12,
     paddingVertical: 6,
+  },
+  filterChipBadge: {
+    alignItems: 'center',
+    borderRadius: 8,
+    justifyContent: 'center',
+    minWidth: 16,
+    paddingHorizontal: 4,
+  },
+  filterChipBadgeText: {
+    fontSize: 10,
+    fontWeight: '700',
   },
   filterChipText: {
     fontSize: 12,
@@ -1971,10 +2016,13 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   logEntry: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderLeftWidth: 3,
     flexDirection: 'row',
     gap: 6,
     paddingHorizontal: HORIZONTAL_PADDING,
-    paddingVertical: 4,
+    paddingLeft: HORIZONTAL_PADDING - 3,
+    paddingVertical: 6,
   },
   logLevel: {
     fontFamily: 'monospace',

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -66,6 +66,10 @@ const LOG_LEVEL_COLORS = {
 
 const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 
+// Badge background on a selected (primary-filled) filter chip — translucent
+// white so the count reads on the blue fill.
+const SELECTED_BADGE_BG = 'rgba(255,255,255,0.3)';
+
 const SPRING_CONFIG = { mass: 1, damping: 20, stiffness: 200 };
 
 // Red used for the inline "location permission denied" hint under the toggle row.
@@ -1534,6 +1538,8 @@ export default function SettingsScreen({ setSubPanelActive }) {
                     // zero count needs no badge.
                     const count = f === 'all' ? 0 : (counts?.[f] || 0);
                     const badgeColor = f === 'error' || f === 'warn' ? LOG_LEVEL_COLORS[f] : colors.mutedText;
+                    const badgeBackground = isSelected ? SELECTED_BADGE_BG : `${badgeColor}26`;
+                    const badgeTextColor = isSelected ? '#fff' : badgeColor;
                     return (
                       <TouchableOpacity
                         key={f}
@@ -1556,11 +1562,11 @@ export default function SettingsScreen({ setSubPanelActive }) {
                         {count > 0 && (
                           <View style={[
                             styles.filterChipBadge,
-                            { backgroundColor: isSelected ? 'rgba(255,255,255,0.3)' : `${badgeColor}26` },
+                            { backgroundColor: badgeBackground },
                           ]}>
                             <Text style={[
                               styles.filterChipBadgeText,
-                              { color: isSelected ? '#fff' : badgeColor },
+                              { color: badgeTextColor },
                             ]}>
                               {count}
                             </Text>

--- a/app/services/LogService.js
+++ b/app/services/LogService.js
@@ -1,5 +1,5 @@
 import { writeTodayLogs, readAllLogs, pruneOldFiles, clearAllLogs } from './LogsFile';
-import { captureLog } from './sentry';
+import { captureLog, redactText } from './sentry';
 
 const MAX_ENTRIES = 500;
 
@@ -121,6 +121,19 @@ class LogService {
     return this._entries.filter(e => e.level === filter);
   }
 
+  /**
+   * Count entries per level in a single pass. Returns `{ all, error, warn,
+   * info, debug }` — used to badge the level filter chips without running
+   * `getEntries` once per level on every render.
+   */
+  getCounts() {
+    const counts = { all: this._entries.length, error: 0, warn: 0, info: 0, debug: 0 };
+    for (const e of this._entries) {
+      if (counts[e.level] !== undefined) counts[e.level] += 1;
+    }
+    return counts;
+  }
+
   clear() {
     if (this._flushTimer) {
       clearTimeout(this._flushTimer);
@@ -146,8 +159,12 @@ class LogService {
 
   formatForExport(filter) {
     const entries = this.getEntries(filter);
+    // Shared logs leave the device, so scrub monetary amounts / PII from each
+    // message with the same redactor used before shipping to Sentry. Timestamp
+    // and level are kept intact — they carry no sensitive data and redactText
+    // would otherwise mangle the ISO date's digit runs.
     return entries.map(e =>
-      `[${e.timestamp}] [${e.level.toUpperCase()}] ${e.message}`,
+      `[${e.timestamp}] [${e.level.toUpperCase()}] ${redactText(e.message)}`,
     ).join('\n');
   }
 }


### PR DESCRIPTION
## What

Reworks the Settings → Logs viewer to make it usable for scanning and debugging, without adding text search (deferred by request).

### Filter chips
- Badge counts per level on the filter chips (`Error 1`, `Info 131`, `Debug 79`). `All` shows no number; a level with zero entries shows no badge, so the absence of a badge on Error/Warn reads as "none".
- Added `accessibilityRole`, `accessibilityState={{ selected }}`, and count-aware `accessibilityLabel` to each chip.

### Log rows — visual hierarchy
- Level-colored 3px left border on every row (error=red, warn=orange, info=blue, debug=gray).
- Hairline divider between rows so multi-line entries no longer merge.
- Soft background tint on `error`/`warn` rows so problems stand out while scanning a wall of info/debug lines.
- Expanding a row now shows the full `YYYY-MM-DD HH:MM:SS` timestamp (collapsed rows still show `HH:MM:SS`).

### Correctness & privacy
- Fixed a non-string `FlatList` `keyExtractor` (`item.id` is a number → `String(item.id)`), which was emitting a React warning that fed back into the log itself.
- Exported/shared log text now runs each message through the same `redactText` used before shipping logs to Sentry, scrubbing monetary amounts and long digit runs. Timestamp/level are kept intact.

### Service layer
- New `LogService.getCounts()` tallies entries per level in a single pass; exposed via `useLogEntries`.

## Testing
- Added unit tests for `getCounts()` and for redaction in `formatForExport`.
- Updated the `useLogEntries` mock in `SettingsScreen.test.js` to include `counts`.
- All affected suites pass (`LogService`, `LogsFile`, `sentry`, `SettingsScreen`).
- Verified on an Android emulator: left borders, dividers, error-row tint, chip badges, and expanded full-timestamp all render as intended.

## Deferred (not in this PR)
Text search, duplicate collapsing (`×N`), and a session-start marker — they change log semantics and belong in a separate change.
