### PR TITLE
perf(operations): pass stable onEdit handler to OperationListItem

### DIFF
--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -41,7 +41,7 @@ const baseProps = {
   getAccountName: () => 'Checking',
   formatCurrency: (_, amount) => `$${amount}`,
   isLast: false,
-  onPress: jest.fn(),
+  onEdit: jest.fn(),
 };
 
 describe('OperationListItem', () => {
@@ -504,28 +504,32 @@ describe('OperationListItem', () => {
 
   describe('Pending (in-flight) operation', () => {
     it('does not open the editor while the write is still in flight', async () => {
-      const onPress = jest.fn();
+      const onEdit = jest.fn();
       const { getByTestId } = await render(
         <OperationListItem
           {...baseProps}
           testID="pending-row"
           operation={{ ...baseOperation, _pending: true }}
-          onPress={onPress}
+          onEdit={onEdit}
         />,
       );
       await fireEvent.press(getByTestId('pending-row'));
       // A placeholder row carries a temp id with no DB row behind it; tapping it
       // must not open an editor.
-      expect(onPress).not.toHaveBeenCalled();
+      expect(onEdit).not.toHaveBeenCalled();
     });
 
     it('opens the editor once the operation is settled (not pending)', async () => {
-      const onPress = jest.fn();
+      const onEdit = jest.fn();
+      const operation = { ...baseOperation };
       const { getByTestId } = await render(
-        <OperationListItem {...baseProps} testID="settled-row" onPress={onPress} />,
+        <OperationListItem {...baseProps} testID="settled-row" operation={operation} onEdit={onEdit} />,
       );
       await fireEvent.press(getByTestId('settled-row'));
-      expect(onPress).toHaveBeenCalledTimes(1);
+      // The row binds its own operation to the stable onEdit handler (#1339),
+      // so the pressed operation is forwarded to the caller.
+      expect(onEdit).toHaveBeenCalledTimes(1);
+      expect(onEdit).toHaveBeenCalledWith(operation);
     });
   });
 });

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -27,7 +27,7 @@ const OperationListItem = ({
   getAccountName,
   formatCurrency,
   isLast = false,
-  onPress,
+  onEdit,
   onLongPress = () => {},
   testID,
   suggestionChips = null,
@@ -37,6 +37,13 @@ const OperationListItem = ({
   // Measure the row in window coordinates on long-press so the caller can float
   // an action menu / lifted clone exactly over it (see OperationActionMenu).
   const rowRef = useRef(null);
+  // Bind the operation to the edit handler INSIDE the row so the stable `onEdit`
+  // prop can flow down unchanged. This keeps OperationListItem's React.memo
+  // compare stable — the list no longer hands each row a fresh inline
+  // `() => onEditOperation(item)` closure on every parent render (see #1339).
+  const handlePress = useCallback(() => {
+    onEdit(operation);
+  }, [onEdit, operation]);
   const handleLongPress = useCallback(() => {
     const node = rowRef.current;
     if (!node || typeof node.measureInWindow !== 'function') {
@@ -122,7 +129,7 @@ const OperationListItem = ({
     <>
       <TouchableRipple
         testID={testID}
-        onPress={isPending ? undefined : onPress}
+        onPress={isPending ? undefined : handlePress}
         onLongPress={isPending ? undefined : handleLongPress}
         disabled={isPending}
         rippleColor="rgba(0, 0, 0, .08)"
@@ -231,7 +238,7 @@ OperationListItem.propTypes = {
   getAccountName: PropTypes.func.isRequired,
   formatCurrency: PropTypes.func.isRequired,
   isLast: PropTypes.bool,
-  onPress: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
   onLongPress: PropTypes.func,
   testID: PropTypes.string,
   suggestionChips: PropTypes.arrayOf(PropTypes.string),

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -326,7 +326,7 @@ const OperationsList = forwardRef(({
       getAccountName={getAccountName}
       formatCurrency={formatCurrency}
       isLast
-      onPress={NOOP}
+      onEdit={NOOP}
     />
   ), [colors, t, categories, getCategoryInfo, getAccountName, formatCurrency]);
 
@@ -359,7 +359,7 @@ const OperationsList = forwardRef(({
           getAccountName={getAccountName}
           formatCurrency={formatCurrency}
           isLast={isLast}
-          onPress={() => onEditOperation(item)}
+          onEdit={onEditOperation}
           onLongPress={handleItemLongPress}
           suggestionChips={item.id === pendingSuggestionId ? pendingSuggestions : null}
           onApplySuggestion={onApplySuggestion}


### PR DESCRIPTION
## Summary

Fixes a critical perf regression in the operations list: every mounted row re-rendered on each digit tap / search commit, defeating the `React.memo` on `OperationListItem`.

## Root cause

`renderItem` in `OperationsList.js` created a fresh inline closure `onPress={() => onEditOperation(item)}` for every row on every render. Because the closure has a new function identity each render, `OperationListItem`'s `React.memo` shallow-compare never matched on the `onPress` prop, so all mounted rows re-rendered whenever the parent re-rendered (which happens on every keystroke in the calculator / search).

## The fix

Pass the stable `onEditOperation` reference down as a new `onEdit` prop and bind the operation argument **inside** the row via a `useCallback` `handlePress`, mirroring the existing `handleLongPress` pattern already in the component. With a stable prop reference, the memo compare stays stable and row re-renders collapse to cheap bail-outs.

- `OperationListItem.js`: `onPress` prop replaced by stable `onEdit`; new `handlePress` (useCallback) binds the row's own `operation` and feeds `onEdit`. PropTypes updated.
- `OperationsList.js`: `renderItem` now passes `onEdit={onEditOperation}` (no inline closure); the long-press clone passes `onEdit={NOOP}`.
- `onEditOperation` is already a stable `useCallback` (`handleEditOperation`) at the `OperationsScreen` level — no inline wrapping anywhere in the chain.

Scope is limited to the row edit handler. The separate `DateSeparator` inline `onPress` (#1354) is intentionally left untouched.

## Tests

Full suite green: **154 suites passed, 4454 tests passed, 0 failures.**

Updated `OperationListItem.test.js` to use the new `onEdit` prop and to assert the row forwards its own operation to the handler (`onEdit` called once with the pressed operation).

Closes #1339
