### PR TITLE
perf(bundle): import @expo/vector-icons families directly instead of via barrel

### DIFF
--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -13,10 +13,11 @@ jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
   })),
 }));
 
-// Mock vector icons
+// Mock vector icons (barrel + per-family subpath used by the component)
 jest.mock('@expo/vector-icons', () => ({
   MaterialCommunityIcons: 'Icon',
 }));
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon');
 
 // Mock currencies
 jest.mock('../../../assets/currencies.json', () => ({

--- a/app/components/Calculator.js
+++ b/app/components/Calculator.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo, memo, useRef } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { BORDER_RADIUS, SPACING, HEIGHTS } from '../styles/designTokens';
 import { hasOperation as checkHasOperation, evaluateExpression as evalExpr } from '../utils/calculatorUtils';

--- a/app/components/CategoryGridSelector.js
+++ b/app/components/CategoryGridSelector.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 
 // Legacy (flat all-root) grid width vs. the quick-add-style suggestions grid,

--- a/app/components/EmptyState.js
+++ b/app/components/EmptyState.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Text } from 'react-native-paper';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { SPACING } from '../styles/layout';

--- a/app/components/FormInput.js
+++ b/app/components/FormInput.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, TextInput, Text, StyleSheet } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { BORDER_RADIUS, SPACING, HEIGHTS, FONT_SIZE, OPACITY } from '../styles/designTokens';

--- a/app/components/IconPicker.js
+++ b/app/components/IconPicker.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, TouchableOpacity, Modal, StyleSheet, FlatList, useWindowDimensions } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import ModalBlurOverlay from './ModalBlurOverlay';

--- a/app/components/ListCard.js
+++ b/app/components/ListCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Card, TouchableRipple } from 'react-native-paper';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { HEIGHTS, BORDER_RADIUS, SPACING, ICON_SIZE } from '../styles/designTokens';

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -13,7 +13,7 @@ import {
 } from 'react-native';
 import Reanimated from 'react-native-reanimated';
 import { Text, TouchableRipple } from 'react-native-paper';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '../contexts/ThemeColorsContext';

--- a/app/components/NotificationBindingsContentPanel.js
+++ b/app/components/NotificationBindingsContentPanel.js
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types';
 import { View, StyleSheet, ScrollView, ActivityIndicator, RefreshControl, TouchableOpacity } from 'react-native';
 import { Text } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';

--- a/app/components/NotificationFiltersContentPanel.js
+++ b/app/components/NotificationFiltersContentPanel.js
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types';
 import { View, StyleSheet, ScrollView, ActivityIndicator, RefreshControl, TouchableOpacity } from 'react-native';
 import { Text, Switch } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 import { Text } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';

--- a/app/components/NotificationsContentPanel.js
+++ b/app/components/NotificationsContentPanel.js
@@ -2,7 +2,7 @@ import React, { useRef, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, Animated, Easing, ScrollView, ActivityIndicator, RefreshControl, TouchableOpacity } from 'react-native';
 import { Text } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { parseBankNotification } from '../services/notifications/parseBankNotification';

--- a/app/components/SimplePicker.js
+++ b/app/components/SimplePicker.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, StyleSheet, TouchableOpacity, Pressable, Modal, FlatList, Platform } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import ModalBlurOverlay from './ModalBlurOverlay';
 

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -2,7 +2,7 @@ import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, TouchableOpacity, Animated, Easing, ScrollView, ActivityIndicator, Linking, RefreshControl } from 'react-native';
 import { Text, Divider } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
 import { LineChart } from 'react-native-chart-kit/v2';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import SimplePicker from '../SimplePicker';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Dimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import PropTypes from 'prop-types';
 import Svg, { Line, Rect, Text as SvgText, Path } from 'react-native-svg';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
 import useCategoryMonthlySpending from '../../hooks/useCategoryMonthlySpending';
 import { HORIZONTAL_PADDING } from '../../styles/layout';

--- a/app/components/graphs/ChartModal.js
+++ b/app/components/graphs/ChartModal.js
@@ -1,7 +1,7 @@
 import React, { useRef, useCallback } from 'react';
 import { View, Text, StyleSheet, Modal, TouchableOpacity, TouchableWithoutFeedback, ScrollView, PanResponder } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { HORIZONTAL_PADDING } from '../../styles/layout';
 import SimplePicker from '../SimplePicker';
 import ExpensePieChart from './ExpensePieChart';

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 

--- a/app/components/graphs/DonutChart.js
+++ b/app/components/graphs/DonutChart.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 
 export const SVG_SIZE = 140;

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';

--- a/app/components/graphs/SpendingPredictionCard.js
+++ b/app/components/graphs/SpendingPredictionCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
 
 const formatCurrency = (amount, currency) => {

--- a/app/components/modals/MultiCurrencyFields.js
+++ b/app/components/modals/MultiCurrencyFields.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, TextInput, StyleSheet, Keyboard } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { SPACING } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
 import * as Currency from '../../services/currency';

--- a/app/components/operations/CurrencyPickerModal.js
+++ b/app/components/operations/CurrencyPickerModal.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, memo } from 'react';
 import { View, Text, StyleSheet, FlatList, Modal, Pressable, TextInput } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import ModalBlurOverlay from '../ModalBlurOverlay';

--- a/app/components/operations/LabelInput.js
+++ b/app/components/operations/LabelInput.js
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   Animated,
 } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../../styles/designTokens';
 import { parseLabels, serializeLabels, addLabel, removeLabel, hasLabel, displayLabel } from '../../utils/labelUtils';

--- a/app/components/operations/NotificationBindingCard.js
+++ b/app/components/operations/NotificationBindingCard.js
@@ -7,7 +7,7 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import SimplePicker from '../SimplePicker';
 import FormInput from '../FormInput';
 import CategoryGridSelector from '../CategoryGridSelector';

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Modal, View, Text, Pressable, StyleSheet, Animated, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -10,7 +10,7 @@ import Reanimated, {
   Easing,
 } from 'react-native-reanimated';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import Calculator from '../Calculator';
 import MultiCurrencyFields from '../modals/MultiCurrencyFields';
 import CurrencyPickerModal from './CurrencyPickerModal';

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -1,7 +1,7 @@
 import React, { memo, useMemo, useRef, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { TouchableRipple } from 'react-native-paper';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';

--- a/app/components/operations/OperationLocationRow.js
+++ b/app/components/operations/OperationLocationRow.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
 
 /**

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback, forwardRef, useRef, useImperativeHandle } from 'react';
 import { View, Text, StyleSheet, SectionList, ActivityIndicator } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import DateSeparator from './DateSeparator';
 import OperationListItem from './OperationListItem';

--- a/app/components/operations/PickerModal.js
+++ b/app/components/operations/PickerModal.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, FlatList, Modal, Pressable, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import currencies from '../../../assets/currencies.json';
 import ModalBlurOverlay from '../ModalBlurOverlay';

--- a/app/components/operations/SplitOperationModal.js
+++ b/app/components/operations/SplitOperationModal.js
@@ -14,7 +14,7 @@ import {
   Dimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { SPACING, BORDER_RADIUS, HEIGHTS, FONT_SIZE } from '../../styles/designTokens';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 

--- a/app/components/operations/UndoSnackbar.js
+++ b/app/components/operations/UndoSnackbar.js
@@ -1,7 +1,7 @@
 import React, { memo, useEffect, useRef, useCallback } from 'react';
 import { View, Text, TouchableOpacity, Animated, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import {
   SPACING,
   FONT_SIZE,

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, TextInput, StyleSheet } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import PropTypes from 'prop-types';
 import { formatDate } from '../../services/BalanceHistoryDB';

--- a/app/components/search/FilterChipStrip.js
+++ b/app/components/search/FilterChipStrip.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { HORIZONTAL_PADDING } from '../../styles/layout';
 

--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { View, TextInput, TouchableOpacity, StyleSheet, Text, Keyboard, Platform, Animated, Easing, Dimensions } from 'react-native';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { HORIZONTAL_PADDING, SPACING } from '../../styles/layout';
 

--- a/app/modals/BudgetModal.js
+++ b/app/modals/BudgetModal.js
@@ -18,7 +18,7 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';

--- a/app/modals/CategoryModal.js
+++ b/app/modals/CategoryModal.js
@@ -11,7 +11,7 @@ import {
   Dimensions,
 } from 'react-native';
 import { TextInput as PaperTextInput, TouchableRipple } from 'react-native-paper';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';

--- a/app/modals/ImportProgressModal.js
+++ b/app/modals/ImportProgressModal.js
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import { View, StyleSheet, ScrollView, Platform } from 'react-native';
 import { Portal, Modal, Text, ActivityIndicator, Button } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import * as Updates from 'expo-updates';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useImportProgress } from '../contexts/ImportProgressContext';

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Switch } from 'react-native-paper';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';

--- a/app/modals/PlannedOperationModal.js
+++ b/app/modals/PlannedOperationModal.js
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { TextInput as PaperTextInput, TouchableRipple } from 'react-native-paper';
 import PropTypes from 'prop-types';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';

--- a/app/modals/UpdateAvailableModal.js
+++ b/app/modals/UpdateAvailableModal.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet, TouchableOpacity, ScrollView, useWindowDimensions, Modal } from 'react-native';
 import { Text, Divider } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { SPACING, BORDER_RADIUS } from '../styles/layout';

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -17,7 +17,7 @@ import { Svg, Circle } from 'react-native-svg';
 
 const SCREEN_TIMING = { duration: 300, easing: Easing.out(Easing.cubic) };
 const PILL_TIMING = { duration: 200, easing: Easing.out(Easing.quad) };
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import OperationsScreen from '../screens/OperationsScreen';
 import AccountsScreen from '../screens/AccountsScreen';
 import GraphsScreen from '../screens/GraphsScreen';

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -7,7 +7,7 @@ import AddFAB from '../components/AddFAB';
 import LoadingView from '../components/LoadingView';
 import EmptyState from '../components/EmptyState';
 import { NestableScrollContainer, NestableDraggableFlatList } from 'react-native-draggable-flatlist';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeConfig } from '../contexts/ThemeConfigContext';

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -14,7 +14,7 @@ import {
 } from 'react-native';
 import { Text, TouchableRipple, TextInput as PaperTextInput } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS } from '../styles/designTokens';
 import AddFAB from '../components/AddFAB';

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing, SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import WheelPicker from '@quidone/react-native-wheel-picker';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { View, StyleSheet, FlatList, TouchableOpacity, TextInput, Pressable, Modal, Keyboard, BackHandler } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '../contexts/ThemeColorsContext';

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -5,7 +5,7 @@ import { Text, Snackbar } from 'react-native-paper';
 import AddFAB from '../components/AddFAB';
 import LoadingView from '../components/LoadingView';
 import EmptyState from '../components/EmptyState';
-import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING } from '../styles/layout';
 import { BORDER_RADIUS, FONT_SIZE, HEIGHTS } from '../styles/designTokens';

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -7,7 +7,7 @@ import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, Acti
 import * as Clipboard from 'expo-clipboard';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
 import { Text, Divider, TouchableRipple, Menu } from 'react-native-paper';
-import { Ionicons } from '@expo/vector-icons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useSharedValue,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -696,7 +696,8 @@ jest.mock('react-native-paper', () => {
 });
 
 // Mock @expo/vector-icons
-jest.mock('@expo/vector-icons', () => {
+// Prefixed with `mock` so jest permits referencing it inside jest.mock factories.
+const mockCreateVectorIcon = () => {
   const React = require('react');
   const { Text } = require('react-native');
   const PropTypes = require('prop-types');
@@ -709,7 +710,12 @@ jest.mock('@expo/vector-icons', () => {
     color: PropTypes.string,
     testID: PropTypes.string,
   };
+  return MockIcon;
+};
 
+// Barrel entry point (kept for any test importing named families directly).
+jest.mock('@expo/vector-icons', () => {
+  const MockIcon = mockCreateVectorIcon();
   return {
     MaterialCommunityIcons: MockIcon,
     Ionicons: MockIcon,
@@ -718,6 +724,17 @@ jest.mock('@expo/vector-icons', () => {
     MaterialIcons: MockIcon,
   };
 });
+
+// Per-family subpath entry points. App code imports these directly so the
+// bundle no longer pulls in every icon font via the barrel (issue #1340).
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({
+  __esModule: true,
+  default: mockCreateVectorIcon(),
+}));
+jest.mock('@expo/vector-icons/Ionicons', () => ({
+  __esModule: true,
+  default: mockCreateVectorIcon(),
+}));
 
 // Mock react-native-safe-area-context
 jest.mock('react-native-safe-area-context', () => {


### PR DESCRIPTION
## Summary

`@expo/vector-icons` was imported through its barrel entry point in 49 files
(e.g. `import { MaterialCommunityIcons as Icon } from '@expo/vector-icons'`).
The barrel re-exports every icon family (~20 fonts + glyphmaps, ~4MB), so Metro
pulls all of them into the bundle even though the app only uses two families.

This PR converts every barrel import to a direct per-family subpath import so
only the families actually used get bundled, cutting the unnecessary font and
glyphmap weight.

## Transform applied

- `import { MaterialCommunityIcons as Icon } from '@expo/vector-icons'`
  → `import Icon from '@expo/vector-icons/MaterialCommunityIcons'`
- `import { MaterialCommunityIcons } from '@expo/vector-icons'`
  → `import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons'`
- `import { Ionicons } from '@expo/vector-icons'`
  → `import Ionicons from '@expo/vector-icons/Ionicons'`

Local binding names (including `as` aliases) are preserved — no JSX or icon-name
changes. Import statements only.

## Scope

- 49 app source files converted (0 barrel imports remain).
- Families involved: **MaterialCommunityIcons**, **Ionicons**.
- `jest.setup.js`: added per-family subpath mocks so the direct imports resolve
  under Jest (the barrel mock alone did not cover subpaths).
- `__tests__/components/graphs/CategorySpendingCard.test.js`: this suite used a
  string-typed local barrel mock (`MaterialCommunityIcons: 'Icon'`) and asserts
  on `n.type === 'Icon'`; added a matching subpath mock so its intent is preserved.

## Tests

`npx jest --silent` — **157 suites / 4532 tests passing**, before and after.

Closes #1340
