### PR TITLE
perf(bundle): enable react-native-paper babel plugin to strip unused components

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,10 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    env: {
+      production: {
+        plugins: ['react-native-paper/babel'],
+      },
+    },
   };
 };


### PR DESCRIPTION
## What changed

Enabled the `react-native-paper/babel` plugin in the **production** babel env in `babel.config.js`:

```js
env: {
  production: {
    plugins: ['react-native-paper/babel'],
  },
},
```

No source files were touched. The rewrite happens at build time.

## Why

`react-native-paper` is barrel-imported (`import { Button, Card, ... } from 'react-native-paper'`) across ~20 files. Without the Paper babel plugin, the barrel pulls the entire component set into the bundle even though only a subset is used. Enabling the plugin trims the dead components out, for an expected **~100-200KB minified** reduction in the JS bundle.

## How the plugin works

The plugin rewrites barrel imports into direct module paths, e.g.:

```js
import { Button } from 'react-native-paper';
// becomes
import Button from 'react-native-paper/src/components/Button';
```

This lets the bundler drop the unused components instead of bundling the whole index. It is the officially documented optimization for react-native-paper.

## Scope / caveats

- The plugin is gated to the `production` env only — it relies on `NODE_ENV=production` and must not run in dev (keeps fast refresh and dev DX untouched).
- Because it is production-only, the bundle-size win materializes **only in production/release builds**, not in dev or under jest (jest runs in the test env, so the plugin stays inert there — expected).
- Best confirmed with a before/after `source-map-explorer` run on a release bundle.

## Test results

`npx jest --silent` — all green, before and after the change:

```
Test Suites: 157 passed, 157 total
Tests:       4535 passed, 4535 total
```

Jest runs in the test env, so the plugin does not activate under tests; the goal here is only to confirm nothing regresses.

Closes #1343
