### PR TITLE
perf(accounts): compute Net Worth from unfiltered operations, off the search hot path

### DIFF
--- a/__tests__/screens/AccountsScreen.test.js
+++ b/__tests__/screens/AccountsScreen.test.js
@@ -115,6 +115,16 @@ jest.mock('../../app/services/PreferencesDB', () => ({
   setDefaultAccountId: jest.fn(() => Promise.resolve()),
 }));
 
+// NetWorthCard sources its month operations directly from the DB (decoupled from
+// the search-filtered Operations feed — issue #1346). Mock those two entry points so
+// tests can control/observe what net worth is computed over. Safe defaults keep the
+// unrelated toggle tests working.
+jest.mock('../../app/services/OperationsDB', () => ({
+  getOperationsByDateRange: jest.fn(() => Promise.resolve([])),
+  computeNetWorthSummary: jest.fn(() =>
+    Promise.resolve({ total: '0', monthlyChange: '0', unconvertible: [] })),
+}));
+
 // Helper functions to create complete mocks for split contexts
 const createAccountsDataMock = (overrides = {}) => ({
   accounts: [],
@@ -269,6 +279,84 @@ describe('AccountsScreen', () => {
       await waitFor(() => {
         expect(getByLabelText('graphs_convert_currencies').props.accessibilityState)
           .toEqual(expect.objectContaining({ checked: false }));
+      });
+    });
+  });
+
+  // Regression coverage for issue #1346: net worth must be computed over the whole
+  // current month sourced directly from the DB, NOT over the search-filtered, lazily
+  // paginated Operations feed. This locks the corrected data source.
+  describe('Net worth data source (issue #1346)', () => {
+    const OperationsDB = require('../../app/services/OperationsDB');
+    const { appEvents, EVENTS } = require('../../app/services/eventEmitter');
+
+    beforeEach(() => {
+      OperationsDB.getOperationsByDateRange.mockResolvedValue([]);
+      OperationsDB.computeNetWorthSummary.mockResolvedValue({
+        total: '0', monthlyChange: '0', unconvertible: [],
+      });
+    });
+
+    it('computes net worth over DB-fetched current-month operations, not the feed', async () => {
+      const AccountsScreen = require('../../app/screens/AccountsScreen').default;
+      const { useAccountsData } = require('../../app/contexts/AccountsDataContext');
+
+      const accounts = [
+        { id: '1', name: 'USD', balance: '1000.00', currency: 'USD', order: 0 },
+        { id: '2', name: 'EUR', balance: '100.00', currency: 'EUR', order: 1 },
+      ];
+      useAccountsData.mockReturnValue(createAccountsDataMock({
+        accounts,
+        displayedAccounts: accounts,
+      }));
+
+      // The card's own DB source returns the complete month; the search feed is
+      // irrelevant to net worth and is never consulted.
+      const monthOps = [
+        { accountId: '1', type: 'income', amount: '200', date: '2026-07-05' },
+      ];
+      OperationsDB.getOperationsByDateRange.mockResolvedValue(monthOps);
+
+      await render(<AccountsScreen />);
+
+      const now = new Date();
+      const prefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByDateRange)
+          .toHaveBeenCalledWith(`${prefix}-01`, `${prefix}-31`);
+      });
+
+      // computeNetWorthSummary must receive the DB month set — never a filtered feed.
+      await waitFor(() => {
+        expect(OperationsDB.computeNetWorthSummary).toHaveBeenCalledWith(
+          accounts, monthOps, 'USD', prefix,
+        );
+      });
+    });
+
+    it('refetches the month when an operation changes', async () => {
+      const AccountsScreen = require('../../app/screens/AccountsScreen').default;
+      const { useAccountsData } = require('../../app/contexts/AccountsDataContext');
+
+      const accounts = [
+        { id: '1', name: 'USD', balance: '1000.00', currency: 'USD', order: 0 },
+      ];
+      useAccountsData.mockReturnValue(createAccountsDataMock({
+        accounts,
+        displayedAccounts: accounts,
+      }));
+
+      await render(<AccountsScreen />);
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByDateRange).toHaveBeenCalledTimes(1);
+      });
+
+      appEvents.emit(EVENTS.OPERATION_CHANGED);
+
+      await waitFor(() => {
+        expect(OperationsDB.getOperationsByDateRange).toHaveBeenCalledTimes(2);
       });
     });
   });

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -16,10 +16,10 @@ import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
 import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS, HEIGHTS } from '../styles/layout';
 import { useAccountsData } from '../contexts/AccountsDataContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
-import { useOperationsData } from '../contexts/OperationsDataContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { getDefaultAccountId, setDefaultAccountId } from '../services/PreferencesDB';
-import { computeNetWorthSummary } from '../services/OperationsDB';
+import { computeNetWorthSummary, getOperationsByDateRange } from '../services/OperationsDB';
+import { appEvents, EVENTS } from '../services/eventEmitter';
 import { parseCardMasks, serializeCardMasks, cardMaskLast4 } from '../utils/cardMask';
 import currencies from '../../assets/currencies.json';
 
@@ -227,8 +227,47 @@ ConfirmationDialog.propTypes = {
 };
 
 // Net worth summary card
-const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k) => k }) => {
+const NetWorthCard = memo(({ accounts = [], colors = {}, t = (k) => k }) => {
   const { hideBalances } = useDisplaySettings();
+
+  // Net worth's monthly-change figure only depends on the CURRENT MONTH's
+  // income/expense operations. Sourcing that from the Operations feed was wrong on
+  // two counts: the feed is (a) the SEARCH-FILTERED set, so the figure silently
+  // tracked whatever the user was searching, and (b) lazy-loaded a week at a time,
+  // so every load-more-while-scrolling re-ran the async currency conversion and the
+  // month total was incomplete until enough pages were loaded. Instead we fetch the
+  // whole current month directly from the DB, decoupled from search and pagination,
+  // and refresh only when operations actually mutate (OPERATION_CHANGED) or the data
+  // set is reloaded/reset. (issue #1346)
+  const [monthOperations, setMonthOperations] = useState([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const now = new Date();
+      const monthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+      try {
+        // Loose upper bound: no real date exceeds "-31", and both summary paths
+        // re-filter by the exact monthPrefix, so a slightly wide range is harmless.
+        const ops = await getOperationsByDateRange(`${monthPrefix}-01`, `${monthPrefix}-31`);
+        if (!cancelled) setMonthOperations(ops || []);
+      } catch {
+        if (!cancelled) setMonthOperations([]);
+      }
+    };
+    load();
+    const unsubChanged = appEvents.on(EVENTS.OPERATION_CHANGED, load);
+    const unsubReload = appEvents.on(EVENTS.RELOAD_ALL, load);
+    const unsubReset = appEvents.on(EVENTS.DATABASE_RESET, () => {
+      if (!cancelled) setMonthOperations([]);
+    });
+    return () => {
+      cancelled = true;
+      unsubChanged();
+      unsubReload();
+      unsubReset();
+    };
+  }, []);
 
   // Determine display currency from first account (or default to USD)
   const displayCurrency = useMemo(() => {
@@ -267,7 +306,7 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
       }
     }
     let change = 0;
-    for (const op of operations) {
+    for (const op of monthOperations) {
       if (!sameCurrencyIds.has(op.accountId)) continue;
       if (typeof op.date === 'string' && op.date.startsWith(monthPrefix)) {
         const amount = parseFloat(op.amount || '0');
@@ -276,7 +315,7 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
       }
     }
     return { total: total.toString(), monthlyChange: change.toString(), unconvertible: [] };
-  }, [accounts, operations, displayCurrency]);
+  }, [accounts, monthOperations, displayCurrency]);
 
   // When the toggle is on, every balance/operation is converted to the display
   // currency at the current rate (offline first, live fallback) — the same path
@@ -291,7 +330,7 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
     const now = new Date();
     const currentMonthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
 
-    computeNetWorthSummary(accounts, operations, displayCurrency, currentMonthPrefix)
+    computeNetWorthSummary(accounts, monthOperations, displayCurrency, currentMonthPrefix)
       .then((result) => {
         if (!cancelled) setConvertedSummary(result);
       })
@@ -300,7 +339,7 @@ const NetWorthCard = memo(({ accounts = [], operations = [], colors = {}, t = (k
       });
 
     return () => { cancelled = true; };
-  }, [convertAll, accounts, operations, displayCurrency, baseCurrencySummary]);
+  }, [convertAll, accounts, monthOperations, displayCurrency, baseCurrencySummary]);
 
   const summary = convertAll ? convertedSummary : baseCurrencySummary;
   const totalBalance = parseFloat(summary.total || '0');
@@ -374,7 +413,6 @@ NetWorthCard.displayName = 'NetWorthCard';
 
 NetWorthCard.propTypes = {
   accounts: PropTypes.array,
-  operations: PropTypes.array,
   colors: PropTypes.object,
   t: PropTypes.func,
 };
@@ -499,7 +537,6 @@ export default function AccountsScreen({ onBackStateChange }) {
   const { paperInputTheme } = makeModalStyles(colors);
   const { accounts, displayedAccounts, hiddenAccounts, showHiddenAccounts, loading, error } = useAccountsData();
   const { toggleShowHiddenAccounts, addAccount, updateAccount, deleteAccount, reorderAccounts, validateAccount, getOperationCount } = useAccountsActions();
-  const { operations } = useOperationsData();
   const { t } = useLocalization();
 
   const balanceInputRef = useRef(null);
@@ -915,7 +952,7 @@ export default function AccountsScreen({ onBackStateChange }) {
         style={{ backgroundColor: colors.background }}
       >
         {/* Net Worth Summary Card */}
-        <NetWorthCard accounts={accounts} operations={operations} colors={colors} t={t} />
+        <NetWorthCard accounts={accounts} colors={colors} t={t} />
 
         {/* Accounts Grouped Card */}
         <View style={[styles.accountsCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>


### PR DESCRIPTION
## Problem

On the always-mounted `AccountsScreen`, `NetWorthCard` recomputed on **every** change to the Operations feed. That feed (`useOperationsData().operations`) is `filteredOperations` — the **search-filtered**, **lazily paginated** set. Two consequences:

1. **Churn / perf (reported issue #1346):** every load-more-while-scrolling, every search commit, and every mutation churned the `operations` identity, re-running `computeNetWorthSummary(...)` — an **async currency conversion that can hit the network** — even though net worth depends on neither scroll position nor the active search.
2. **Correctness smell:** net worth's monthly-change was computed over whatever the user was currently *searching*. And with no search the feed only holds the initial week (`getOperationsByWeekOffset(0)`), so the month figure was silently **incomplete** until the user scrolled far enough back to lazy-load the rest of the month.

## Fix

Net worth's monthly-change only ever needs the **current month's** income/expense operations. Instead of borrowing the search-filtered feed, `NetWorthCard` now fetches the current month directly from the DB (`getOperationsByDateRange(YYYY-MM-01, YYYY-MM-31)`), decoupled from search and pagination. It refreshes only when the data truly changes — on mount and on `OPERATION_CHANGED` / `RELOAD_ALL` / `DATABASE_RESET` events — not on feed identity churn.

This fixes **both** the churn and the filtered-set correctness smell (plus the incomplete-month undercounting) in one move. `AccountsScreen` no longer consumes `useOperationsData` at all, so the net-worth path is fully off the search hot path.

### Scope

- `app/screens/AccountsScreen.js` — `NetWorthCard` sources month ops from the DB via a self-contained effect; removed the `operations` prop and the `useOperationsData()` consumption.
- The convert-toggle behavior is **unchanged**: both summary paths (toggle-off `baseCurrencySummary` and toggle-on async `computeNetWorthSummary`) now read `monthOperations` instead of the feed. The per-session convert toggle, offline-first / live-fallback conversion, and `unconvertible` reporting are all preserved — only the *source* of operations changed.

## Verification

- Convert-toggle tests (hide when single-currency, default-on, flips off) still pass.
- Added regression tests locking the corrected behavior:
  - net worth is computed over the **DB-fetched current-month** operations, never the search-filtered feed (`computeNetWorthSummary` asserted to receive the DB month set + the current `YYYY-MM` prefix);
  - the month set is refetched on `OPERATION_CHANGED`.
- `computeNetWorthSummary` unit tests in `__tests__/services/OperationsDB.test.js` continue to lock the computation itself.
- `__tests__/screens/AccountsScreen.test.js`: 60/60 passing.

Closes #1346
