### PR TITLE
perf(operations): memoize SectionList extraData and wrap OperationsList in React.memo

### DIFF
--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, forwardRef, useRef, useImperativeHandle } from 'react';
+import React, { memo, useMemo, useCallback, forwardRef, useRef, useImperativeHandle } from 'react';
 import { View, Text, StyleSheet, SectionList, ActivityIndicator } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
@@ -371,6 +371,14 @@ const OperationsList = forwardRef(({
 
   const keyExtractor = useCallback((item) => item.id, []);
 
+  // Stable identity for the SectionList's extraData. An inline array literal
+  // allocates anew every render, so the list's shallow-compare bailout never
+  // holds and rows re-render even when nothing they depend on changed.
+  const listExtraData = useMemo(
+    () => [accounts, categories, pendingSuggestionId],
+    [accounts, categories, pendingSuggestionId]
+  );
+
   const sectionListRef = useRef(null);
 
   // Expose FlatList-compatible scroll methods so OperationsScreen can call
@@ -400,7 +408,7 @@ const OperationsList = forwardRef(({
       renderSectionHeader={renderSectionHeader}
       renderSectionFooter={renderSectionFooter}
       keyExtractor={keyExtractor}
-      extraData={[accounts, categories, pendingSuggestionId]}
+      extraData={listExtraData}
       getItemLayout={getItemLayout}
       ListHeaderComponent={
         (topInset > 0 || headerComponent)
@@ -468,7 +476,14 @@ const OperationsList = forwardRef(({
 
 OperationsList.displayName = 'OperationsList';
 
-OperationsList.propTypes = {
+// Wrapped in memo so a parent re-render with unchanged props skips re-rendering
+// the whole list. Paired with the stable extraData above, this keeps the
+// SectionList from redoing work when nothing it depends on has changed.
+const MemoizedOperationsList = memo(OperationsList);
+
+MemoizedOperationsList.displayName = 'OperationsList';
+
+MemoizedOperationsList.propTypes = {
   groupedOperations: PropTypes.arrayOf(PropTypes.object).isRequired,
   accounts: PropTypes.arrayOf(PropTypes.object).isRequired,
   categories: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -548,4 +563,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default OperationsList;
+export default MemoizedOperationsList;

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -376,7 +376,7 @@ const OperationsList = forwardRef(({
   // holds and rows re-render even when nothing they depend on changed.
   const listExtraData = useMemo(
     () => [accounts, categories, pendingSuggestionId],
-    [accounts, categories, pendingSuggestionId]
+    [accounts, categories, pendingSuggestionId],
   );
 
   const sectionListRef = useRef(null);
@@ -476,14 +476,7 @@ const OperationsList = forwardRef(({
 
 OperationsList.displayName = 'OperationsList';
 
-// Wrapped in memo so a parent re-render with unchanged props skips re-rendering
-// the whole list. Paired with the stable extraData above, this keeps the
-// SectionList from redoing work when nothing it depends on has changed.
-const MemoizedOperationsList = memo(OperationsList);
-
-MemoizedOperationsList.displayName = 'OperationsList';
-
-MemoizedOperationsList.propTypes = {
+OperationsList.propTypes = {
   groupedOperations: PropTypes.arrayOf(PropTypes.object).isRequired,
   accounts: PropTypes.arrayOf(PropTypes.object).isRequired,
   categories: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -508,6 +501,13 @@ MemoizedOperationsList.propTypes = {
   onApplySuggestion: PropTypes.func,
   onDismissSuggestion: PropTypes.func,
 };
+
+// Wrapped in memo so a parent re-render with unchanged props skips re-rendering
+// the whole list. Paired with the stable extraData above, this keeps the
+// SectionList from redoing work when nothing it depends on has changed.
+const MemoizedOperationsList = memo(OperationsList);
+
+MemoizedOperationsList.displayName = 'OperationsList';
 
 const styles = StyleSheet.create({
   cardBottom: {


### PR DESCRIPTION
## Root cause

`OperationsList` passed an inline array literal to the `SectionList`'s
`extraData` prop:

```js
extraData={[accounts, categories, pendingSuggestionId]}
```

A fresh array is allocated on every render, so its reference identity always
changes. `SectionList`/`VirtualizedList` shallow-compares `extraData` to decide
whether it can bail out of re-rendering cells; with a new array each time, that
bailout can never hold and the list re-renders rows even when nothing they
depend on actually changed.

On top of that, `OperationsList` was exported as a bare `forwardRef` component
with no `React.memo`, so any parent re-render re-rendered the whole list
regardless of whether its props changed.

## Fix

1. Memoize the `extraData` array so its identity is stable across renders and
   only changes when `accounts`, `categories`, or `pendingSuggestionId` change:

   ```js
   const listExtraData = useMemo(
     () => [accounts, categories, pendingSuggestionId],
     [accounts, categories, pendingSuggestionId]
   );
   ```

   and pass `extraData={listExtraData}`.

2. Wrap the component export in `React.memo` (preserving the existing
   `forwardRef` ref forwarding, `displayName`, and `propTypes`) so an unchanged
   parent re-render skips the list entirely.

Scope is intentionally limited to these two changes. The `renderItem`
`onEdit` handler (#1355) and the `DateSeparator` inline `onPress` (#1354) are
handled in their own PRs and are untouched here.

## Test results

`npx jest --testPathIgnorePatterns=/node_modules/ __tests__/components/operations/OperationsList.test.js`
— all tests pass. Full suite green.

Closes #1345
