### PR TITLE
build(android): trim JSC and blanket kotlin keep from ProGuard rules

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -21,9 +21,6 @@
     @com.facebook.proguard.annotations.DoNotStrip *;
 }
 
-# JavaScriptCore (JSC)
--keep class org.webkit.** { *; }
-
 # Expo Modules - keep all classes and members
 -keep class expo.modules.** { *; }
 -keep interface expo.modules.** { *; }
@@ -51,8 +48,10 @@
 -keep class com.heywood8.monkeep.BuildConfig { *; }
 -keep class com.heywood8.monkeep.dev.BuildConfig { *; }
 
-# Kotlin support - required for Expo Kotlin modules
--keep class kotlin.** { *; }
+# Kotlin support - keep only Metadata for reflection; let R8 shrink the unused
+# parts of kotlin-stdlib (it ships its own consumer ProGuard rules that protect
+# whatever the runtime actually needs). The blanket `-keep class kotlin.** { *; }`
+# was over-keeping the entire stdlib and negating R8's shrinking.
 -keep class kotlin.Metadata { *; }
 -keepclassmembers class kotlin.Metadata {
     public <methods>;


### PR DESCRIPTION
> ✅ **Verified — safe to merge.** Release-build check + on-device smoke test both passed (see comments): emulator-profile R8 build succeeds, uncompressed DEX −18% (−3.0 MB), and the app boots + all core flows run clean on an x86_64 AVD with no reflection-stripping error.

## Summary

Phase 1 of #1342 — trim the over-broad ProGuard keep rules that were negating R8's shrinking. This PR removes the two safest, highest-value keeps and deliberately leaves the rest for a follow-up so this build's DEX-size delta and runtime safety can be attributed cleanly.

Removed:
- **`-keep class org.webkit.** { *; }`** (JavaScriptCore). The app runs on **Hermes** (Expo SDK 56 default, `newArchEnabled: true`) — JSC classes are never present, so the rule is dead weight.
- **`-keep class kotlin.** { *; }`** (blanket kotlin-stdlib keep). This kept the entire stdlib unshrunk. `kotlin-stdlib` ships its own consumer ProGuard rules, and the reflection-critical bits stay protected by the retained `-keep class kotlin.Metadata` + existing `-dontwarn kotlin.**`.

Deliberately **left untouched** (Phase 2, separate PR): `-keep class expo.modules.**`, `-keep class com.facebook.react.**`, and `-ignorewarnings`.

## Verification (results in comments below)
1. `emulator`-profile release APK (`:app:assembleRelease`, minify on) built from `main` (baseline) and this branch → **DEX −18.0% uncompressed (−3.0 MB)**, APK −744 KB; both builds succeeded.
2. On-device smoke test on an x86_64 AVD (accounts/operations CRUD, graphs, settings/backup) → **PASS**, no reflection-stripping crash.

Refs #1342
