### PR TITLE
perf(db): fast-path startup schema check via stored schema version

### DIFF
--- a/__tests__/services/db.fastpath.test.js
+++ b/__tests__/services/db.fastpath.test.js
@@ -1,0 +1,224 @@
+/**
+ * Tests for the startup schema-version fast path (issue #1341).
+ *
+ * The fast path stores the schema fingerprint in `PRAGMA user_version` after a
+ * successful init, then on subsequent cold starts reads that one value and skips
+ * the expensive schema-inspection + migration-detection sweep when it matches.
+ *
+ * These tests lock the safety invariants:
+ *   - up-to-date DB (fingerprint matches)  -> fast path, no inspection queries
+ *   - fresh install (no fingerprint)        -> full path, fingerprint written after
+ *   - stale DB (older fingerprint)           -> full path, migrations applied
+ *   - corrupted DB                           -> recovery still triggered
+ *   - per-connection PRAGMAs run on EVERY open (both paths)
+ *
+ * This file overrides the global (empty) migrations mock from jest.setup.js with a
+ * synthetic journal of 3 entries, so SCHEMA_VERSION resolves to 3 and the fast
+ * path is actually reachable (it is inert when SCHEMA_VERSION === 0).
+ */
+
+// Override the empty migrations mock from jest.setup.js. Three journal entries →
+// SCHEMA_VERSION (migrations.journal.entries.length) === 3.
+jest.mock('../../drizzle/migrations', () => ({
+  __esModule: true,
+  default: {
+    journal: {
+      version: '7',
+      dialect: 'sqlite',
+      entries: [
+        { idx: 0, version: '6', when: 1, tag: '0000_a', breakpoints: true },
+        { idx: 1, version: '6', when: 2, tag: '0001_b', breakpoints: true },
+        { idx: 2, version: '6', when: 3, tag: '0002_c', breakpoints: true },
+      ],
+    },
+    migrations: {
+      m0000: 'CREATE TABLE t0 (id integer);',
+      m0001: 'CREATE TABLE t1 (id integer);',
+      m0002: 'CREATE TABLE t2 (id integer);',
+    },
+  },
+}));
+
+const SCHEMA_VERSION = 3; // must equal the journal entry count above
+
+import { getDatabase, closeDatabase } from '../../app/services/db';
+import * as SQLite from 'expo-sqlite';
+
+describe('DB startup schema-version fast path (#1341)', () => {
+  let mockDb;
+
+  const makeMockDb = () => ({
+    execAsync: jest.fn(() => Promise.resolve()),
+    runAsync: jest.fn(() => Promise.resolve({ changes: 1, lastInsertRowId: 1 })),
+    getFirstAsync: jest.fn(() => Promise.resolve(null)),
+    getAllAsync: jest.fn(() => Promise.resolve([])),
+    closeAsync: jest.fn(() => Promise.resolve()),
+    withTransactionAsync: jest.fn((cb) => cb()),
+    createCustomFunctionAsync: jest.fn(() => Promise.resolve()),
+    createFunctionAsync: jest.fn(() => Promise.resolve()),
+  });
+
+  beforeEach(async () => {
+    await closeDatabase();
+    jest.clearAllMocks();
+    mockDb = makeMockDb();
+    SQLite.openDatabaseAsync.mockResolvedValue(mockDb);
+  });
+
+  afterEach(async () => {
+    try {
+      await closeDatabase();
+    } catch (_) {
+      // ignore
+    }
+  });
+
+  describe('up-to-date DB (fingerprint matches)', () => {
+    beforeEach(() => {
+      mockDb.getFirstAsync.mockImplementation((q) => {
+        if (typeof q === 'string' && q.includes('user_version')) {
+          return Promise.resolve({ user_version: SCHEMA_VERSION });
+        }
+        return Promise.resolve(null);
+      });
+    });
+
+    it('reads the fingerprint via PRAGMA user_version', async () => {
+      await getDatabase();
+      expect(mockDb.getFirstAsync).toHaveBeenCalledWith('PRAGMA user_version');
+    });
+
+    it('takes the fast path: NO schema-inspection queries run', async () => {
+      await getDatabase();
+      // The entire inspection sweep (isSchemaComplete, detectAppliedMigrations,
+      // corruption re-scan, __drizzle_migrations SELECTs) goes through getAllAsync.
+      // On the fast path none of it runs.
+      expect(mockDb.getAllAsync).not.toHaveBeenCalled();
+      // No migrations applied either.
+      expect(mockDb.execAsync).not.toHaveBeenCalled();
+    });
+
+    it('still sets per-connection PRAGMAs (foreign_keys + WAL) on the fast path', async () => {
+      await getDatabase();
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA foreign_keys = ON');
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA journal_mode = WAL');
+    });
+
+    it('does not re-write the fingerprint on the fast path', async () => {
+      await getDatabase();
+      expect(mockDb.runAsync).not.toHaveBeenCalledWith(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    });
+  });
+
+  describe('fresh install (no fingerprint)', () => {
+    beforeEach(() => {
+      // Fresh DB: user_version defaults to 0, no tables.
+      mockDb.getFirstAsync.mockImplementation((q) => {
+        if (typeof q === 'string' && q.includes('user_version')) {
+          return Promise.resolve({ user_version: 0 });
+        }
+        return Promise.resolve(null);
+      });
+    });
+
+    it('runs the full path (inspection queries execute)', async () => {
+      await getDatabase();
+      expect(mockDb.getAllAsync).toHaveBeenCalled();
+    });
+
+    it('writes the fingerprint after a successful full init', async () => {
+      await getDatabase();
+      expect(mockDb.runAsync).toHaveBeenCalledWith(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    });
+
+    it('sets per-connection PRAGMAs on the full path too', async () => {
+      await getDatabase();
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA foreign_keys = ON');
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA journal_mode = WAL');
+    });
+
+    it('applies migrations on a fresh (no-tables) database', async () => {
+      await getDatabase();
+      // No tables exist -> all 3 synthetic migrations are pending -> applied via execAsync.
+      expect(mockDb.execAsync).toHaveBeenCalledWith('CREATE TABLE t0 (id integer);');
+      expect(mockDb.execAsync).toHaveBeenCalledWith('CREATE TABLE t1 (id integer);');
+      expect(mockDb.execAsync).toHaveBeenCalledWith('CREATE TABLE t2 (id integer);');
+    });
+  });
+
+  describe('stale DB (older fingerprint than SCHEMA_VERSION)', () => {
+    beforeEach(() => {
+      // Stored version 2 < SCHEMA_VERSION 3 — an install from an older build.
+      mockDb.getFirstAsync.mockImplementation((q) => {
+        if (typeof q === 'string' && q.includes('user_version')) {
+          return Promise.resolve({ user_version: SCHEMA_VERSION - 1 });
+        }
+        return Promise.resolve(null);
+      });
+    });
+
+    it('does NOT take the fast path (inspection runs) — migration-skip invariant', async () => {
+      await getDatabase();
+      // Proof the fast path was bypassed: the inspection sweep touched getAllAsync.
+      expect(mockDb.getAllAsync).toHaveBeenCalled();
+    });
+
+    it('runs the migrate path (pending migrations applied)', async () => {
+      await getDatabase();
+      expect(mockDb.execAsync).toHaveBeenCalled();
+    });
+
+    it('re-stamps the fingerprint to the current SCHEMA_VERSION afterward', async () => {
+      await getDatabase();
+      expect(mockDb.runAsync).toHaveBeenCalledWith(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    });
+  });
+
+  describe('corrupted DB (text account id — migration 0002 not applied)', () => {
+    beforeEach(() => {
+      // Fingerprint absent so the full path runs and can reach corruption recovery.
+      mockDb.getFirstAsync.mockImplementation((q) => {
+        if (typeof q === 'string' && q.includes('user_version')) {
+          return Promise.resolve({ user_version: 0 });
+        }
+        return Promise.resolve(null);
+      });
+      // accounts table exists with a TEXT id -> isDatabaseCorrupted() === true.
+      mockDb.getAllAsync.mockImplementation((q) => {
+        if (typeof q !== 'string') return Promise.resolve([]);
+        if (q.includes("name='accounts'")) {
+          return Promise.resolve([{ name: 'accounts' }]);
+        }
+        if (q.includes('PRAGMA table_info(accounts)')) {
+          return Promise.resolve([{ name: 'id', type: 'TEXT' }]);
+        }
+        if (q.includes("name NOT LIKE 'sqlite_%'")) {
+          // tables to drop during recovery
+          return Promise.resolve([{ name: 'accounts' }]);
+        }
+        return Promise.resolve([]);
+      });
+    });
+
+    it('still triggers corruption recovery (drops tables) despite the fingerprint feature', async () => {
+      await getDatabase();
+      // Recovery path disables FKs, then drops the corrupted table.
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA foreign_keys = OFF');
+      expect(mockDb.runAsync).toHaveBeenCalledWith('DROP TABLE IF EXISTS "accounts"');
+    });
+  });
+
+  describe('PRAGMAs run on every open regardless of path', () => {
+    it('fast path sets foreign_keys ON and journal_mode WAL', async () => {
+      mockDb.getFirstAsync.mockImplementation((q) => {
+        if (typeof q === 'string' && q.includes('user_version')) {
+          return Promise.resolve({ user_version: SCHEMA_VERSION });
+        }
+        return Promise.resolve(null);
+      });
+      await getDatabase();
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA foreign_keys = ON');
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA journal_mode = WAL');
+    });
+  });
+});

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -6,6 +6,71 @@ import { normalizeSearchText } from './searchNormalize';
 
 const DB_NAME = 'penny.db';
 
+/**
+ * Schema fingerprint for the startup fast path.
+ *
+ * This is the number of migrations this build ships, read straight from the
+ * Drizzle journal. It is DERIVED, not hand-maintained, on purpose: adding a
+ * migration means adding a journal entry, which increments this value
+ * automatically. There is no separate integer to remember to bump.
+ *
+ * How the fast path uses it (see initializeDatabase):
+ *   - After a fully successful init we store this value in `PRAGMA user_version`.
+ *   - On the next cold start we read `user_version` (a single SQLite header read,
+ *     no table access) and, if it equals SCHEMA_VERSION, skip the expensive
+ *     schema-inspection + migration-detection sweep entirely.
+ *
+ * MIGRATION-SAFETY INVARIANT (do not break): because this value tracks the
+ * journal length, ANY new migration raises SCHEMA_VERSION. An existing install
+ * carries the OLDER value it was stamped with, so `stored !== SCHEMA_VERSION`
+ * and the full migrate path runs — a pending migration can never be skipped by
+ * the fast path. This is why the fingerprint is bound to the journal rather than
+ * a manually-edited constant. When you add a migration you do NOT touch this
+ * line; adding the journal entry is what bumps it.
+ *
+ * Note: any build predating this feature never wrote `user_version` (defaults to
+ * 0), so its first launch after upgrade sees 0 !== SCHEMA_VERSION and runs the
+ * full path once, then stamps the fingerprint — identical to today's behavior,
+ * just with a fast path unlocked for every subsequent launch.
+ */
+const SCHEMA_VERSION = migrations.journal.entries.length;
+
+/**
+ * Read the persisted schema fingerprint from `PRAGMA user_version`.
+ * One SQLite header read — no table access, so it is safe and cheap to call
+ * before any schema inspection. Returns 0 on any error or when unset (0 is the
+ * SQLite default), which forces the full init path — the safe direction.
+ */
+const getStoredSchemaVersion = async (rawDb) => {
+  try {
+    const row = await rawDb.getFirstAsync('PRAGMA user_version');
+    // expo-sqlite returns the pragma as a single-column row, e.g. { user_version: 18 }.
+    const value = row
+      ? (row.user_version ?? row.userVersion ?? Object.values(row)[0])
+      : 0;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  } catch (error) {
+    console.warn('[DB] Could not read schema fingerprint (user_version):', error.message);
+    return 0;
+  }
+};
+
+/**
+ * Persist the schema fingerprint into `PRAGMA user_version`.
+ * NOTE: PRAGMA user_version does not accept bound parameters, so the integer is
+ * inlined. `version` is always SCHEMA_VERSION (derived from the journal), never
+ * user input, and is coerced to a 32-bit int — no injection surface.
+ * Failures are non-fatal: the worst case is the next start re-runs the full path.
+ */
+const setStoredSchemaVersion = async (rawDb, version) => {
+  try {
+    await rawDb.runAsync(`PRAGMA user_version = ${Number(version) | 0}`);
+  } catch (error) {
+    console.warn('[DB] Could not persist schema fingerprint (user_version):', error.message);
+  }
+};
+
 let dbInstance = null;
 let drizzleInstance = null;
 let initPromise = null;
@@ -566,6 +631,33 @@ const isDatabaseCorrupted = async (rawDb) => {
  */
 const initializeDatabase = async (rawDb, db) => {
   try {
+    // FAST PATH: read the stored schema fingerprint first (one header read, no
+    // table access). If it equals the schema this build ships, the database was
+    // already brought fully up to date by a previous successful init — the
+    // fingerprint is ONLY ever written at the very end of that init — so we can
+    // skip the whole inspection/migration-detection sweep (isSchemaComplete's
+    // ~10 PRAGMA queries, the __drizzle_migrations SELECTs, the corruption
+    // re-scan). This is the up-to-date cold-start path that gates first paint.
+    //
+    // The `SCHEMA_VERSION > 0` guard keeps the fast path inert in the unit-test
+    // environment (empty migrations journal → SCHEMA_VERSION 0), where the full
+    // path is exercised. In production there is always ≥1 migration.
+    //
+    // Corruption safety: the only corruption isDatabaseCorrupted() detects is a
+    // text-typed accounts.id (migration 0002 never applied). That state is
+    // impossible when user_version === SCHEMA_VERSION, because that value is only
+    // stamped after a run in which 0002 (and every later migration) completed. So
+    // the fast path cannot bypass a corruption this codebase can actually detect.
+    const storedVersion = await getStoredSchemaVersion(rawDb);
+    if (SCHEMA_VERSION > 0 && storedVersion === SCHEMA_VERSION) {
+      console.log(`[DB] Schema fingerprint matches (user_version=${SCHEMA_VERSION}) — fast startup, skipping inspection`);
+      // Per-connection PRAGMAs are connection-scoped, NOT schema state — they must
+      // run on every open regardless of the fast path.
+      await rawDb.runAsync('PRAGMA foreign_keys = ON');
+      await rawDb.runAsync('PRAGMA journal_mode = WAL');
+      return;
+    }
+
     console.log('Running Drizzle migrations...');
     console.log('Available migrations:', migrations.journal.entries.map(e => e.tag).join(', '));
 
@@ -692,6 +784,11 @@ const initializeDatabase = async (rawDb, db) => {
     // Enable foreign keys and WAL mode (always, regardless of migration path)
     await rawDb.runAsync('PRAGMA foreign_keys = ON');
     await rawDb.runAsync('PRAGMA journal_mode = WAL');
+
+    // Stamp the schema fingerprint now that init has fully succeeded, so the next
+    // cold start can take the fast path above. Written only here (after the whole
+    // slow path completed without throwing) — never on a partial/failed init.
+    await setStoredSchemaVersion(rawDb, SCHEMA_VERSION);
 
     console.log('Database migrations completed successfully');
   } catch (error) {

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -379,6 +379,25 @@ Drizzle automatically tracks applied migrations in the `__drizzle_migrations` ta
 - Inconsistent schema states
 - Manual version tracking
 
+### Startup Fast Path (schema fingerprint)
+
+To keep the up-to-date cold start cheap, `initializeDatabase` (`app/services/db.js`)
+stores a schema fingerprint in `PRAGMA user_version` after every fully successful
+init, and on the next start reads that one value first. If it equals
+`SCHEMA_VERSION`, the expensive schema-inspection + migration-detection sweep
+(`isSchemaComplete`, `detectAppliedMigrations`, corruption re-scan) is skipped.
+
+`SCHEMA_VERSION` is **derived** from the migrations journal
+(`migrations.journal.entries.length`), so **adding a migration bumps it
+automatically — there is nothing to hand-edit.** An existing install carries the
+older fingerprint it was stamped with, so `stored !== SCHEMA_VERSION` and the full
+migrate path runs; a pending migration can never be skipped by the fast path.
+
+When you add a migration you still MUST keep `isSchemaComplete` and
+`detectAppliedMigrations` in sync with the new column/table markers (they gate the
+*slow* path that actually applies the migration for older installs). The fast path
+only decides whether that slow path needs to run at all.
+
 ### Database Studio (Limited Support)
 
 Drizzle Kit includes a browser-based database viewer:


### PR DESCRIPTION
## Root cause

First paint is gated on `getPreference(LANGUAGE)`, which awaits the full
`initializeDatabase()` chain (`app/services/db.js`). Even on an up-to-date
install, the existing "skip migrate" fast branch still paid for the whole
inspection sweep on every cold start:

- `isSchemaComplete()` — ~10 sequential `PRAGMA table_info` / `sqlite_master`
  queries,
- the `__drizzle_migrations` SELECTs,
- the corruption re-scan (`isDatabaseCorrupted`),

i.e. ~20 sequential SQLite round-trips before the app can read one preference.

## Design — a schema-version fast path

- **Fingerprint:** `PRAGMA user_version`. Chosen over an `app_metadata` row
  because it is a single SQLite header read (no table access, safe to call
  before any inspection) and it travels with the database file, so a restored
  `.db` backup carries the fingerprint of the schema physically in it.
- **`SCHEMA_VERSION`** is **derived** from the migrations journal
  (`migrations.journal.entries.length`) — not a hand-maintained integer.
- **On successful init** (end of the slow path, after PRAGMAs, only if nothing
  threw) we stamp `user_version = SCHEMA_VERSION`.
- **On startup** we read `user_version` first. If it equals `SCHEMA_VERSION`,
  the DB is already fully migrated, so we set the per-connection PRAGMAs and
  return — skipping the inspection sweep. Otherwise today's full path runs
  **unchanged**, then stamps the fingerprint at the end.

## Migration-safety invariant (the #1 risk) and how it is guaranteed

An install must **never** skip a pending migration. This is guaranteed
structurally rather than by discipline:

- `SCHEMA_VERSION = migrations.journal.entries.length`. Adding a migration adds
  a journal entry, so `SCHEMA_VERSION` **increments automatically** — there is
  no constant to forget to bump.
- An install stamped by an older build carries the older value. When the new
  build (higher `SCHEMA_VERSION`) starts, `stored !== SCHEMA_VERSION`, so the
  fast path is bypassed and the full `applyPendingMigrations` path runs, exactly
  as today. Only after it completes is the new fingerprint written.
- A build predating this feature never wrote `user_version` (SQLite default 0),
  so `0 !== SCHEMA_VERSION` → full path once on first launch after upgrade →
  then stamp. Identical to current behavior, just with the fast path unlocked
  for subsequent launches.

Covered by a dedicated test (stale fingerprint → full path → migrations
applied → re-stamp).

### Other invariants preserved

- **Per-connection PRAGMAs run on every open.** `PRAGMA foreign_keys = ON` and
  `PRAGMA journal_mode = WAL` are set in *both* the fast and slow paths — they
  are connection-scoped, not schema state, and are never gated behind the
  fingerprint.
- **Fresh install** (no fingerprint, `user_version = 0`) → full path → stamp.
- **Corruption recovery still reachable.** The only corruption
  `isDatabaseCorrupted()` detects is a text-typed `accounts.id` (migration 0002
  never applied). That state is impossible when `user_version === SCHEMA_VERSION`,
  because the fingerprint is only ever stamped after a run in which 0002 (and
  every later migration) completed — so the fast path cannot bypass a corruption
  this codebase can actually detect. When the fingerprint does not match, the
  full path (including corruption recovery) runs untouched.
- **Single shared `initPromise`** and all slow-path behavior are unchanged.

## Test coverage added

New `__tests__/services/db.fastpath.test.js` (overrides the empty jest.setup
migrations mock with a 3-entry synthetic journal so `SCHEMA_VERSION === 3` and
the fast path is reachable):

- up-to-date DB (fingerprint matches) → reads `PRAGMA user_version`, takes the
  fast path (**asserts `getAllAsync` / `execAsync` are never called**), still
  sets both PRAGMAs, does not re-stamp.
- fresh install (`user_version = 0`) → full path runs, migrations applied,
  fingerprint written afterward, PRAGMAs set.
- stale DB (`user_version = SCHEMA_VERSION - 1`) → fast path bypassed,
  migrate path runs, fingerprint re-stamped to current.
- corrupted DB (text `accounts.id`) → corruption recovery still drops tables.
- PRAGMAs asserted on the fast path too.

The `SCHEMA_VERSION > 0` guard keeps the fast path inert under the default
empty-journal test mock, so all existing `db.test.js` behavior is preserved.

**Results:** full suite green — 158 suites, 4550 tests, 0 failures.

## Follow-up (cannot be measured in CI)

An on-device cold-start measurement (`nativeLaunchStart` → first interactive
frame) before/after is the recommended follow-up to quantify the TTI win. CI
mocks SQLite, so the wall-clock saving of dropping ~20 sequential round-trips
can only be observed on a real device/emulator.

Closes #1341
