### PR TITLE
build(android): replace -ignorewarnings with targeted -dontwarn rules

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -2,8 +2,15 @@
 # These rules are applied during EAS Build for production releases
 # Place this file in your project root and it will be copied to android/app/proguard-rules.pro
 
-# Allow R8 to continue despite missing class references (canary SDK compatibility)
--ignorewarnings
+# Suppress R8 "missing class reference" warnings for dependency namespaces that
+# emit them under a canary Expo SDK. Replaces the previous blanket `-ignorewarnings`,
+# which masked ALL R8 warnings and could hide real config errors. These targeted
+# `-dontwarn` rules only silence the expected missing-class noise from these deps.
+-dontwarn expo.modules.**
+-dontwarn com.facebook.react.**
+-dontwarn com.facebook.hermes.**
+-dontwarn com.swmansion.**
+-dontwarn org.webkit.**
 
 # React Native Reanimated
 -keep class com.swmansion.reanimated.** { *; }


### PR DESCRIPTION
>  ⚠️ Needs release-build verification (R8-only change, not covered by Jest)

ProGuard/R8 only runs during release builds, so Jest cannot validate this change. A maintainer must run a release build to confirm R8 still completes cleanly. If removing `-ignorewarnings` surfaces a warning that breaks the build, that's expected iteration — the build log will name the exact missing class, and the specific `-dontwarn` for it can be appended.

## Rationale

Phase 2 of R8 keep-rule trimming (#1342). This phase does one thing only: replace the blanket `-ignorewarnings` in `proguard-rules.pro` with targeted `-dontwarn` rules.

`-ignorewarnings` suppresses **every** R8 warning globally, including warnings about genuine misconfiguration. That defeats the purpose of R8's static checks — a real "missing class" or broken keep rule would be silently swallowed. Swapping it for scoped `-dontwarn` rules keeps the noise down for the dependency namespaces that legitimately emit missing-class warnings under a canary Expo SDK, while letting any *unexpected* warning surface and fail loudly.

The chosen namespaces mirror the dependencies already `-keep`-ed in this file (Expo modules, React Native, Hermes, Reanimated/swmansion, JSC/webkit). The existing `kotlin.**` / `kotlinx.**` / `expo.modules.kotlin.**` / `expo.modules.filesystem.**` `-dontwarn` lines are left untouched.

## Scope

This phase is **only** the `-ignorewarnings` → targeted `-dontwarn` swap. It does **not** narrow the `-keep class expo.modules.**` or `-keep class com.facebook.react.**` rules — that's a later phase. Phase 1 (#1367) already dropped the JSC keep and the blanket `-keep class kotlin.** { *; }`; those are not touched here.

## Before / after

```diff
-# Allow R8 to continue despite missing class references (canary SDK compatibility)
--ignorewarnings
+# Suppress R8 "missing class reference" warnings for dependency namespaces that
+# emit them under a canary Expo SDK. Replaces the previous blanket `-ignorewarnings`,
+# which masked ALL R8 warnings and could hide real config errors. These targeted
+# `-dontwarn` rules only silence the expected missing-class noise from these deps.
+-dontwarn expo.modules.**
+-dontwarn com.facebook.react.**
+-dontwarn com.facebook.hermes.**
+-dontwarn com.swmansion.**
+-dontwarn org.webkit.**
```

Refs #1342
