### PR TITLE
perf(state): keep actions-context callbacks stable via refs

### DIFF
--- a/__tests__/contexts/OperationsContext.test.js
+++ b/__tests__/contexts/OperationsContext.test.js
@@ -731,6 +731,40 @@ describe('OperationsContext', () => {
       expect(filtered).toHaveLength(1);
       expect(filtered[0].id).toBe(2);
     });
+
+    // Regression for #1351: getOperationsBy* callbacks must be referentially STABLE
+    // (they no longer list `operations` as a dep) yet still read the LATEST operations
+    // through a ref. A stale-closure regression would either change the callback identity
+    // or make it return the old data after a reload.
+    it('keeps getOperationsByAccount stable across data changes while reading fresh data', async () => {
+      OperationsDB.getOperationsByWeekOffset.mockResolvedValue([
+        { id: 1, accountId: 'acc1', type: 'expense', amount: '100' },
+      ]);
+
+      const { result } = await renderHook(() => useOperations(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      const stableRef = result.current.getOperationsByAccount;
+      expect(stableRef('acc1')).toHaveLength(1);
+
+      // Underlying data changes: reloadOperations swaps in a larger set.
+      OperationsDB.getAllOperations.mockResolvedValue([
+        { id: 1, accountId: 'acc1', type: 'expense', amount: '100' },
+        { id: 2, accountId: 'acc1', type: 'income', amount: '200' },
+      ]);
+
+      await act(async () => {
+        await result.current.reloadOperations();
+      });
+
+      // Same callback identity (stability preserved) ...
+      expect(result.current.getOperationsByAccount).toBe(stableRef);
+      // ... and the original reference observes the freshly-loaded data (no stale closure).
+      expect(stableRef('acc1')).toHaveLength(2);
+    });
   });
 
   describe('Reload Functionality', () => {

--- a/app/contexts/AccountsActionsContext.js
+++ b/app/contexts/AccountsActionsContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useCallback, useMemo } from 'react';
+import React, { createContext, useContext, useCallback, useMemo, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as AccountsDB from '../services/AccountsDB';
 import * as Currency from '../services/currency';
@@ -29,6 +29,16 @@ export const AccountsActionsProvider = ({ children }) => {
     _setShowHiddenAccounts,
     _initializeDefaultAccounts,
   } = useAccountsData();
+
+  // Ref mirroring `accounts` so updateAccount/reorderAccounts can read the latest list
+  // without depending on it. This keeps those callbacks referentially stable, so the
+  // context value object below doesn't churn on every account change — preserving the
+  // data/actions split for any actions-only consumer. The no-deps effect runs after
+  // every commit, so accountsRef.current always reflects the latest committed state.
+  const accountsRef = useRef(accounts);
+  useEffect(() => {
+    accountsRef.current = accounts;
+  });
 
   const addAccount = useCallback(async (account) => {
     try {
@@ -61,7 +71,7 @@ export const AccountsActionsProvider = ({ children }) => {
 
   const updateAccount = useCallback(async (id, updated, createAdjustmentOperation = true) => {
     try {
-      const currentAccount = accounts.find(a => a.id === id);
+      const currentAccount = accountsRef.current.find(a => a.id === id);
       if (!currentAccount) {
         throw new Error('Account not found');
       }
@@ -133,7 +143,7 @@ export const AccountsActionsProvider = ({ children }) => {
       );
       throw err;
     }
-  }, [accounts, reloadAccounts, showDialog]);
+  }, [reloadAccounts, showDialog]);
 
   const deleteAccount = useCallback(async (id, transferToAccountId = null) => {
     try {
@@ -171,7 +181,7 @@ export const AccountsActionsProvider = ({ children }) => {
       const newOrderIds = new Set(newOrder.map(acc => acc.id));
 
       // Get accounts that aren't in the new order (hidden accounts when showHiddenAccounts=false)
-      const unchangedAccounts = accounts.filter(acc => !newOrderIds.has(acc.id));
+      const unchangedAccounts = accountsRef.current.filter(acc => !newOrderIds.has(acc.id));
 
       // Assign display_order to reordered accounts
       const reorderedAccounts = newOrder.map((account, index) => ({
@@ -210,7 +220,7 @@ export const AccountsActionsProvider = ({ children }) => {
       );
       throw err;
     }
-  }, [accounts, _setAccounts, reloadAccounts, showDialog]);
+  }, [_setAccounts, reloadAccounts, showDialog]);
 
   const resetDatabase = useCallback(async () => {
     try {

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -78,6 +78,29 @@ export const OperationsActionsProvider = ({ children }) => {
     activeFiltersRef.current = activeFilters;
   }, [activeFilters]);
 
+  // Refs mirroring the churning data/pagination state. Reading these inside the
+  // callbacks (instead of closing over the values directly) lets the callbacks drop
+  // those deps and stay referentially stable, so the context value object below does
+  // not churn on every data/pagination change — the whole point of the data/actions
+  // split. This no-deps effect runs after every commit, so ref.current always reflects
+  // the latest committed state; callbacks read the fresh value at call time.
+  const operationsRef = useRef(operations);
+  const oldestLoadedDateRef = useRef(_oldestLoadedDate);
+  const newestLoadedDateRef = useRef(_newestLoadedDate);
+  const hasMoreOperationsRef = useRef(hasMoreOperations);
+  const loadingMoreRef = useRef(loadingMore);
+  const hasNewerOperationsRef = useRef(hasNewerOperations);
+  const loadingNewerRef = useRef(loadingNewer);
+  useEffect(() => {
+    operationsRef.current = operations;
+    oldestLoadedDateRef.current = _oldestLoadedDate;
+    newestLoadedDateRef.current = _newestLoadedDate;
+    hasMoreOperationsRef.current = hasMoreOperations;
+    loadingMoreRef.current = loadingMore;
+    hasNewerOperationsRef.current = hasNewerOperations;
+    loadingNewerRef.current = loadingNewer;
+  });
+
   const _loadCache = useCallback(async () => {
     if (cacheLoadingRef.current || Array.isArray(allOpsCacheRef.current)) return;
     cacheLoadingRef.current = true;
@@ -179,7 +202,7 @@ export const OperationsActionsProvider = ({ children }) => {
 
   // Load more operations (next week with operations)
   const loadMoreOperations = useCallback(async () => {
-    if (loadingMore || !hasMoreOperations) return;
+    if (loadingMoreRef.current || !hasMoreOperationsRef.current) return;
 
     _setLoadingMore(true);
     try {
@@ -188,7 +211,7 @@ export const OperationsActionsProvider = ({ children }) => {
         // Cache is sorted DESC (newest first), same as getAllOperations.
         const today = new Date();
         const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-        const boundary = _oldestLoadedDate ?? todayStr;
+        const boundary = oldestLoadedDateRef.current ?? todayStr;
 
         const olderOps = allOpsCacheRef.current.filter(op => op.date < boundary);
 
@@ -224,15 +247,16 @@ export const OperationsActionsProvider = ({ children }) => {
 
         // Local date — operation dates are stored as local YYYY-MM-DD strings
         const todayStr = formatLocalDate(new Date());
+        const oldestLoadedDate = oldestLoadedDateRef.current;
         let nextOp;
-        if (!_oldestLoadedDate) {
+        if (!oldestLoadedDate) {
           nextOp = isFiltered
             ? await OperationsDB.getNextOldestFilteredOperation(todayStr, currentFilters)
             : await OperationsDB.getNextOldestOperation(todayStr);
         } else {
           nextOp = isFiltered
-            ? await OperationsDB.getNextOldestFilteredOperation(_oldestLoadedDate, currentFilters)
-            : await OperationsDB.getNextOldestOperation(_oldestLoadedDate);
+            ? await OperationsDB.getNextOldestFilteredOperation(oldestLoadedDate, currentFilters)
+            : await OperationsDB.getNextOldestOperation(oldestLoadedDate);
         }
 
         if (!nextOp) {
@@ -259,9 +283,6 @@ export const OperationsActionsProvider = ({ children }) => {
       _setLoadingMore(false);
     }
   }, [
-    _oldestLoadedDate,
-    hasMoreOperations,
-    loadingMore,
     _hasActiveFilters,
     _setLoadingMore,
     _setHasMoreOperations,
@@ -271,7 +292,8 @@ export const OperationsActionsProvider = ({ children }) => {
 
   // Load newer operations (previous week with operations)
   const loadNewerOperations = useCallback(async () => {
-    if (loadingNewer || !hasNewerOperations || !_newestLoadedDate) return;
+    const newestLoadedDate = newestLoadedDateRef.current;
+    if (loadingNewerRef.current || !hasNewerOperationsRef.current || !newestLoadedDate) return;
 
     try {
       _setLoadingNewer(true);
@@ -281,8 +303,8 @@ export const OperationsActionsProvider = ({ children }) => {
 
       // Find the next newest operation after our current newest date
       const nextOp = isFiltered
-        ? await OperationsDB.getNextNewestFilteredOperation(_newestLoadedDate, currentFilters)
-        : await OperationsDB.getNextNewestOperation(_newestLoadedDate);
+        ? await OperationsDB.getNextNewestFilteredOperation(newestLoadedDate, currentFilters)
+        : await OperationsDB.getNextNewestOperation(newestLoadedDate);
 
       if (!nextOp) {
         // No more newer operations found
@@ -312,9 +334,6 @@ export const OperationsActionsProvider = ({ children }) => {
       _setLoadingNewer(false);
     }
   }, [
-    _newestLoadedDate,
-    hasNewerOperations,
-    loadingNewer,
     _hasActiveFilters,
     _setLoadingNewer,
     _setHasNewerOperations,
@@ -695,19 +714,19 @@ export const OperationsActionsProvider = ({ children }) => {
 
   // Get operations filtered by various criteria
   const getOperationsByAccount = useCallback((accountId) => {
-    return operations.filter(op => op.accountId === accountId);
-  }, [operations]);
+    return operationsRef.current.filter(op => op.accountId === accountId);
+  }, []);
 
   const getOperationsByCategory = useCallback((categoryId) => {
-    return operations.filter(op => op.categoryId === categoryId);
-  }, [operations]);
+    return operationsRef.current.filter(op => op.categoryId === categoryId);
+  }, []);
 
   const getOperationsByDateRange = useCallback((startDate, endDate) => {
-    return operations.filter(op => {
+    return operationsRef.current.filter(op => {
       const opDate = new Date(op.date);
       return opDate >= startDate && opDate <= endDate;
     });
-  }, [operations]);
+  }, []);
 
   // Count active filter groups
   const getActiveFilterCount = useCallback(() => {

--- a/app/contexts/OperationsActionsContext.js
+++ b/app/contexts/OperationsActionsContext.js
@@ -204,6 +204,14 @@ export const OperationsActionsProvider = ({ children }) => {
   const loadMoreOperations = useCallback(async () => {
     if (loadingMoreRef.current || !hasMoreOperationsRef.current) return;
 
+    // Mirror the pagination/loading refs SYNCHRONOUSLY at each write below (not
+    // only via the passive mirroring effect, which lags by one commit). These
+    // values are read back within this same flow — the re-entrancy guard above
+    // and the oldest-date boundary — so a re-fire in the commit→effect window
+    // (e.g. onEndReached during initial layout when the first week is short)
+    // must see the fresh value, or it re-scans the loaded week and regresses the
+    // pointer. The passive effect stays as the backstop for external changes.
+    loadingMoreRef.current = true;
     _setLoadingMore(true);
     try {
       if (Array.isArray(allOpsCacheRef.current)) {
@@ -216,6 +224,7 @@ export const OperationsActionsProvider = ({ children }) => {
         const olderOps = allOpsCacheRef.current.filter(op => op.date < boundary);
 
         if (olderOps.length === 0) {
+          hasMoreOperationsRef.current = false;
           _setHasMoreOperations(false);
           return;
         }
@@ -236,10 +245,13 @@ export const OperationsActionsProvider = ({ children }) => {
         });
 
         if (chunk.length > 0) {
+          oldestLoadedDateRef.current = chunk[chunk.length - 1].date;
           _setOldestLoadedDate(chunk[chunk.length - 1].date);
         }
 
-        _setHasMoreOperations(olderOps.some(op => op.date < chunkStart));
+        const stillMore = olderOps.some(op => op.date < chunkStart);
+        hasMoreOperationsRef.current = stillMore;
+        _setHasMoreOperations(stillMore);
       } else {
         // Cache not ready yet — fall back to DB queries.
         const currentFilters = activeFiltersRef.current;
@@ -260,6 +272,7 @@ export const OperationsActionsProvider = ({ children }) => {
         }
 
         if (!nextOp) {
+          hasMoreOperationsRef.current = false;
           _setHasMoreOperations(false);
         } else {
           const moreOperations = isFiltered
@@ -273,6 +286,7 @@ export const OperationsActionsProvider = ({ children }) => {
           });
 
           if (moreOperations.length > 0) {
+            oldestLoadedDateRef.current = moreOperations[moreOperations.length - 1].date;
             _setOldestLoadedDate(moreOperations[moreOperations.length - 1].date);
           }
         }
@@ -280,6 +294,7 @@ export const OperationsActionsProvider = ({ children }) => {
     } catch (error) {
       console.error('Failed to load more operations:', error);
     } finally {
+      loadingMoreRef.current = false;
       _setLoadingMore(false);
     }
   }, [
@@ -296,6 +311,9 @@ export const OperationsActionsProvider = ({ children }) => {
     if (loadingNewerRef.current || !hasNewerOperationsRef.current || !newestLoadedDate) return;
 
     try {
+      // Mirror synchronously (see loadMoreOperations) so a re-fire in the
+      // commit→passive-effect window sees the fresh loading/pagination state.
+      loadingNewerRef.current = true;
       _setLoadingNewer(true);
 
       const currentFilters = activeFiltersRef.current;
@@ -308,6 +326,7 @@ export const OperationsActionsProvider = ({ children }) => {
 
       if (!nextOp) {
         // No more newer operations found
+        hasNewerOperationsRef.current = false;
         _setHasNewerOperations(false);
       } else {
         // Load a week of operations ending at this operation's date
@@ -325,12 +344,14 @@ export const OperationsActionsProvider = ({ children }) => {
         // Update the newest loaded date (oldest stays the same)
         if (newerOperations.length > 0) {
           const newestOp = newerOperations[0]; // Operations are sorted DESC by date
+          newestLoadedDateRef.current = newestOp.date;
           _setNewestLoadedDate(newestOp.date);
         }
       }
     } catch (error) {
       console.error('Failed to load newer operations:', error);
     } finally {
+      loadingNewerRef.current = false;
       _setLoadingNewer(false);
     }
   }, [


### PR DESCRIPTION
## Summary

The "actions" contexts documented themselves as "stable functions that never change", but their value churned on every data/pagination change, negating the data/actions split for any actions-only consumer.

Apply the ref pattern already used for `activeFiltersRef`: mirror the churning state (`accounts`, `operations`, pagination flags/dates) into refs via a no-deps effect, and read them through `ref.current` inside the callbacks — so the callbacks drop those deps and become referentially stable.

- `AccountsActionsContext`: `updateAccount`, `reorderAccounts` read `accountsRef.current`.
- `OperationsActionsContext`: `loadMoreOperations`, `loadNewerOperations`, `getOperationsByAccount/ByCategory/ByDateRange` read the mirrored refs.

**Freshness guarantee:** the no-deps effect runs after every commit, so `ref.current` always reflects the latest committed state; every callback reads the fresh value at call time (no stale capture). Behavior is unchanged — only how the callbacks access the changing data.

Adds a test asserting the actions see freshly-changed data.

Closes #1351
