### PR TITLE
perf(search): defer heavy filtering with useDeferredValue

### DIFF
--- a/__tests__/contexts/OperationsDataContext-search.test.js
+++ b/__tests__/contexts/OperationsDataContext-search.test.js
@@ -1096,5 +1096,75 @@ describe('OperationsDataContext - Search API', () => {
         });
       });
     });
+
+    // The text query is deferred via React 19's useDeferredValue (issue #1353) so a
+    // heavy filter commit does not block typing on large histories. These tests pin
+    // the guarantee that deferral is CORRECTNESS-NEUTRAL: the final filtered set for a
+    // query must be identical to filtering synchronously — only the scheduling changes.
+    describe('deferred text filtering is correctness-neutral (issue #1353)', () => {
+      it('a text query settles on the exact same set the synchronous filter would produce', async () => {
+        const result = await setupWithOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(5);
+        });
+
+        await act(async () => {
+          result.current.actions.setSearchText('bank');
+        });
+
+        // Once the deferred render flushes, the result must equal the reference set
+        // (same assertion as the non-deferred "filters by account name match" case).
+        await waitFor(() => {
+          expect(result.current.data.operations.map(op => op.id).sort())
+            .toEqual(['op-2', 'op-4', 'op-5']);
+        });
+      });
+
+      it('rapid successive queries converge on the final query result, not an intermediate one', async () => {
+        const result = await setupWithOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(5);
+        });
+
+        // Simulate the debounce delivering several committed values in quick
+        // succession; the deferred value must ultimately reflect the LAST query.
+        await act(async () => {
+          result.current.actions.setSearchText('coffee');
+          result.current.actions.setSearchText('bus');
+          result.current.actions.setSearchText('food');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations.map(op => op.id).sort())
+            .toEqual(['op-1', 'op-5']);
+        });
+      });
+
+      it('clearing the query restores the full unfiltered set', async () => {
+        const result = await setupWithOperations();
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(5);
+        });
+
+        await act(async () => {
+          result.current.actions.setSearchText('coffee');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(1);
+        });
+
+        await act(async () => {
+          result.current.actions.setSearchText('');
+        });
+
+        await waitFor(() => {
+          expect(result.current.data.operations).toHaveLength(5);
+        });
+      });
+    });
   });
 });

--- a/app/contexts/OperationsDataContext.js
+++ b/app/contexts/OperationsDataContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef, useDeferredValue } from 'react';
 import PropTypes from 'prop-types';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { getJsonPreference, PREF_KEYS } from '../services/PreferencesDB';
@@ -134,6 +134,18 @@ export const OperationsDataProvider = ({ children }) => {
   const accountNamesKey = accounts.map(a => `${a.id}:${a.name}`).join('|');
   const accountNameById = useMemo(() => new Map(accounts.map(a => [a.id, a.name])), [accountNamesKey]);
 
+  // Defer ONLY the free-text query that drives the heavy in-memory text scan.
+  // Typing already flows through SearchBar's 300ms debounce before it lands in
+  // searchState.text, so this does not add a second lag on keystrokes: the debounce
+  // gates HOW OFTEN the query commits, and useDeferredValue keeps each committed
+  // recompute non-blocking. When searchState.text changes, React first renders with
+  // the previous deferredSearchText (filteredOperations stays cached → no scan on the
+  // urgent pass), then schedules an interruptible background render where
+  // deferredSearchText catches up and the O(n) filter runs. The structural filters
+  // (types/accounts/categories/labels/date/amount) are discrete toggles, not typed,
+  // so they stay urgent — only the text scan is deferred.
+  const deferredSearchText = useDeferredValue(searchState.text);
+
   // Filtered operations based on search state
   const filteredOperations = useMemo(() => {
     let result = operations;
@@ -143,7 +155,7 @@ export const OperationsDataProvider = ({ children }) => {
     // case-insensitive AND treats Russian ё/е as equivalent (a Russian keyboard's
     // autocomplete frequently swaps one for the other, so "Самолет" must find "Самолёт"
     // and vice versa). This is the same normalization SEARCH_NORM applies in SQL.
-    const trimmedText = searchState.text ? searchState.text.trim() : '';
+    const trimmedText = deferredSearchText ? deferredSearchText.trim() : '';
     if (trimmedText) {
       const searchLower = normalizeSearchText(trimmedText);
       result = result.filter(op => {
@@ -249,7 +261,26 @@ export const OperationsDataProvider = ({ children }) => {
     }
 
     return result;
-  }, [operations, searchState, accountNameById, getCategoryPath, t]);
+    // Depend on the deferred text (not searchState.text) plus each structural filter
+    // field individually. setSearchText spreads prev, so the structural arrays/objects
+    // keep their identity across a text-only change — during the urgent render that
+    // commits new text, every dep here is unchanged (deferredSearchText still holds the
+    // previous value), so the memo returns its cached result and the O(n) scan is skipped
+    // until the deferred background render. Referencing the whole searchState object
+    // instead would invalidate the memo on the urgent pass and defeat the deferral.
+  }, [
+    operations,
+    deferredSearchText,
+    searchState.types,
+    searchState.accountIds,
+    searchState.categoryIds,
+    searchState.labels,
+    searchState.dateRange,
+    searchState.amountRange,
+    accountNameById,
+    getCategoryPath,
+    t,
+  ]);
 
   // Count active filter groups (excluding text search)
   const getSearchFilterCount = useCallback(() => {


### PR DESCRIPTION
## Summary

With active search text, `filteredOperations` scans the entire in-memory operations cache on the JS thread on every committed keystroke.

Wrap the free-text query in React 19's `useDeferredValue` so the O(n) text scan runs in an interruptible background render while typing stays responsive. The `useMemo` deps reference `deferredSearchText` + each structural filter field individually (not the whole `searchState` object), so a text-only change doesn't invalidate the memo on the urgent pass — the scan is skipped until the deferred render.

**Composes with the existing 300ms SearchBar debounce:** the debounce gates how often the query commits; `useDeferredValue` keeps each committed recompute non-blocking. No double-lag — the deferred value only affects the (already-debounced) text, and structural toggles stay urgent.

**Correctness-neutral:** the final filtered set for a given query is identical to before; only scheduling changes. The win shows under profiling on large histories. Adds a test asserting result-set equivalence.

Closes #1353
