### PR TITLE
perf(navigation): defer initial mount of background tabs to after first frame

### DIFF
--- a/__tests__/navigation/SimpleTabs.test.js
+++ b/__tests__/navigation/SimpleTabs.test.js
@@ -326,13 +326,15 @@ describe('SimpleTabs Component Rendering', () => {
     mockShowAccountsTab = false;
   });
 
-  it('mounts all four screens immediately (no lazy mount)', async () => {
-    // Every screen stays mounted so a swipe never reveals an unmounted
-    // (blank/black) screen — no tab press or data load required.
+  it('keeps the active screen real from frame 1 and mounts the rest after interactions', async () => {
+    // The active Operations screen is real on the first commit; the background
+    // tabs mount one idle tick later (requestIdleCallback → setImmediate in
+    // tests) — proactively, before any swipe could reveal them — so a swipe
+    // still never lands on an unmounted (blank/black) screen.
     const { getByText } = await render(<SimpleTabs />);
 
     expect(getByText('Operations Screen')).toBeTruthy();
-    expect(getByText('Graphs Screen')).toBeTruthy();
+    await waitFor(() => expect(getByText('Graphs Screen')).toBeTruthy());
     expect(getByText('Planned Screen')).toBeTruthy();
   });
 
@@ -362,8 +364,10 @@ describe('SimpleTabs Component Rendering', () => {
 
     const { getByTestId } = await render(<SimpleTabs />);
 
+    // The tab button is present from frame 1 (TABS is unaffected by deferral);
+    // the Accounts screen is a background slot, so it mounts after the idle flip.
     expect(getByTestId('tab-accounts')).toBeTruthy();
-    expect(getByTestId('accounts-screen')).toBeTruthy();
+    await waitFor(() => expect(getByTestId('accounts-screen')).toBeTruthy());
     // The rest of the tabs are still present alongside it.
     expect(getByTestId('tab-Operations')).toBeTruthy();
     expect(getByTestId('tab-Graphs')).toBeTruthy();
@@ -545,12 +549,13 @@ describe('SimpleTabs Component Rendering', () => {
     });
   });
 
-  it('keeps every screen mounted on cold start (no lazy mount)', async () => {
+  it('mounts every background screen shortly after cold start (no lazy-on-reveal)', async () => {
     const { getByText } = await render(<SimpleTabs />);
 
-    // All screens are mounted up front so a swipe never reveals a blank screen.
+    // Operations is real immediately; the rest mount proactively one idle tick
+    // later so a swipe never reveals a blank screen.
     expect(getByText('Operations Screen')).toBeTruthy();
-    expect(getByText('Graphs Screen')).toBeTruthy();
+    await waitFor(() => expect(getByText('Graphs Screen')).toBeTruthy());
     expect(getByText('Planned Screen')).toBeTruthy();
   });
 

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -246,6 +246,25 @@ export default function SimpleTabs() {
   const [subPanelActive, setSubPanelActive] = React.useState(false);
   const [tabBarWidth, setTabBarWidth] = React.useState(SCREEN_WIDTH);
 
+  // Cold-start optimization: only the active Operations screen is real on the
+  // first commit; the background tab slots render lightweight placeholders so
+  // their (heavy) mount — GraphsScreen's chart-data pipeline in particular —
+  // stays off the cold-start critical path. A single idle callback then flips
+  // this true, mounting every screen for the rest of the session. This does NOT
+  // reintroduce the blank/black-on-swipe bug that forced screens to stay
+  // mounted: the flip fires one idle tick after the first interactive frame —
+  // before a user could physically start a swipe — so by the time any tab can
+  // be revealed every screen is already mounted. After the flip all screens
+  // stay mounted permanently, exactly as before; only the initial mount is
+  // delayed by a moment.
+  const [backgroundMounted, setBackgroundMounted] = React.useState(false);
+  React.useEffect(() => {
+    // requestIdleCallback is the app's deferral primitive (see OperationsScreen /
+    // OperationsActionsContext); InteractionManager is deprecated per jest.setup.
+    const handle = requestIdleCallback(() => setBackgroundMounted(true));
+    return () => cancelIdleCallback(handle);
+  }, []);
+
   // Guard ref — updated synchronously so handleTabPress never reads stale state.
   const isTransitioningRef = useRef(false);
   // Shared value mirror — readable on the worklet thread inside panGesture
@@ -485,24 +504,51 @@ export default function SimpleTabs() {
     };
   });
 
-  // All four screens stay mounted for the whole session. Navigation only ever
+  // All screens stay mounted for the whole session once backgroundMounted flips
+  // (one idle tick after the first interactive frame). Navigation only ever
   // moves the strip (swipe to a neighbour, tap to any tab), so every screen
-  // must already be on-screen — lazy mounting left a not-yet-mounted screen
-  // blank/black when a swipe revealed it before its mount committed.
+  // must already be on-screen — lazy mounting ON reveal left a not-yet-mounted
+  // screen blank/black when a swipe uncovered it before its mount committed.
+  // The deferral below is not lazy-on-reveal: it mounts every background screen
+  // proactively before any swipe is possible, so the invariant still holds.
   //
   // Each screen element is memoized so SimpleTabs re-renders (active-tab
   // highlight, tab-bar layout) don't re-render the heavy screen subtrees: a
   // stable element reference lets React skip reconciling them, which avoids a
   // frame drop / stutter as a switch animation settles.
+  // Placeholder shown in a background tab slot until backgroundMounted flips.
+  // It only ever occupies an off-screen strip position on the very first frame
+  // (the Operations strip is the one on screen), so it is never actually seen;
+  // the theme background keeps it from flashing if a strip edge peeks during a
+  // fast first-frame swipe. Reused across every deferred slot — the keyed
+  // Animated.View wrappers keep the instances distinct.
+  const backgroundPlaceholder = useMemo(
+    () => <View style={[styles.screenPlaceholder, { backgroundColor: colors.background }]} />,
+    [colors.background],
+  );
+
   const operationsScreen = useMemo(() => <OperationsScreen />, []);
   // The Accounts tab reuses the same accounts screen as a full-screen duplicate
   // (all accounts, no subpanel header). Mounted only when the tab is enabled.
-  const accountsScreen = useMemo(() => <AccountsScreen />, []);
-  const graphsScreen = useMemo(() => <GraphsScreen />, []);
-  const plannedScreen = useMemo(() => <PlannedOperationsScreen />, []);
+  // Background screens render a placeholder until backgroundMounted flips true,
+  // then swap to the real screen once and stay mounted for the session.
+  const accountsScreen = useMemo(
+    () => (backgroundMounted ? <AccountsScreen /> : backgroundPlaceholder),
+    [backgroundMounted, backgroundPlaceholder],
+  );
+  const graphsScreen = useMemo(
+    () => (backgroundMounted ? <GraphsScreen /> : backgroundPlaceholder),
+    [backgroundMounted, backgroundPlaceholder],
+  );
+  const plannedScreen = useMemo(
+    () => (backgroundMounted ? <PlannedOperationsScreen /> : backgroundPlaceholder),
+    [backgroundMounted, backgroundPlaceholder],
+  );
   const settingsScreen = useMemo(
-    () => <SettingsScreen setSubPanelActive={setSubPanelActive} />,
-    [setSubPanelActive],
+    () => (backgroundMounted
+      ? <SettingsScreen setSubPanelActive={setSubPanelActive} />
+      : backgroundPlaceholder),
+    [backgroundMounted, backgroundPlaceholder, setSubPanelActive],
   );
 
   // Screens in strip order — matches TABS. Keyed by identity so instances are
@@ -653,6 +699,9 @@ const styles = StyleSheet.create({
   screen: {
     height: '100%',
     width: SCREEN_WIDTH,
+  },
+  screenPlaceholder: {
+    flex: 1,
   },
   screensContainer: {
     flex: 1,


### PR DESCRIPTION
> ⚠️ **Needs on-device swipe smoke test** — the no-blank-screen guarantee rests on a timing assumption (the idle-flip fires before a user could physically swipe) that only a device can confirm.

## Summary

All 5 tab screens mounted eagerly at startup, including GraphsScreen's chart-data pipeline — mount cost on the cold-start critical path. The always-mounted invariant exists for a real reason (documented in code): lazy-mounting-on-reveal left a background screen blank/black when a swipe uncovered it before its mount committed.

This does **not** reintroduce that bug. Only the active Operations screen is real on the first commit; the background tab slots render a lightweight theme-colored placeholder. A single `requestIdleCallback` then flips `backgroundMounted` true — one idle tick after the first interactive frame, before a user could physically start a swipe — mounting every screen for the rest of the session. After the flip, all screens stay mounted permanently, exactly as before; only the initial mount is delayed by a moment. This is proactive deferral, **not** lazy-on-reveal.

Tests adapted: still assert Operations is real from frame 1, and that the background screens do mount (via `waitFor`, after the idle flip) — preserving the invariant coverage.

Closes #1347
