### PR TITLE
build(metro): enable experimental tree shaking for production

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -41,7 +41,9 @@
         "gradleCommand": ":app:bundleRelease"
       },
       "env": {
-        "APP_VARIANT": "production"
+        "APP_VARIANT": "production",
+        "EXPO_UNSTABLE_TREE_SHAKING": "1",
+        "EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH": "1"
       },
       "channel": "production"
     }

--- a/metro.config.js
+++ b/metro.config.js
@@ -46,12 +46,16 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
   return context.resolveRequest(context, moduleName, platform);
 };
 
-// Add transformer options for web
+// Transformer options.
+// experimentalImportSupport is required for Expo's experimental tree shaking
+// (paired with EXPO_UNSTABLE_TREE_SHAKING + EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH,
+// set on the production EAS build). It rewrites ESM imports so Metro can
+// statically analyze and drop unused exports. inlineRequires keeps startup fast.
 config.transformer = {
   ...config.transformer,
   getTransformOptions: async () => ({
     transform: {
-      experimentalImportSupport: false,
+      experimentalImportSupport: true,
       inlineRequires: true,
     },
   }),


### PR DESCRIPTION
> ✅ **Measured — safe to merge** (see comment): production export shrinks the Android JS bundle **−13.1%** (6.06 MB → 5.26 MB) and bundles cleanly. Recommend one EAS production/preview build sanity-check before shipping, since the flags are production-only.

## Summary

`metro.config.js` set `experimentalImportSupport: false` (stale "for web" comment on an Android-only app), and the tree-shaking env flags were unset. Expo SDK 56 supports experimental tree shaking. This is also the mechanism that finally shrinks react-native-paper's footprint (the Paper babel plugin was measured to NOT help because Metro doesn't tree-shake by default — see closed #1343).

Changes:
- `metro.config.js`: `experimentalImportSupport: true` (kept `inlineRequires: true`).
- `eas.json` production `env`: `EXPO_UNSTABLE_TREE_SHAKING=1`, `EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH=1`.

## Measurement (same base, local production export)
| | Android JS bundle |
|---|---|
| before (off) | 6,055,876 B |
| after (on) | 5,259,616 B |
| **Δ** | **−796,260 B (−13.1%)** |

Bundled with no error — the CJS-heavy paths (drizzle-orm, decimal.js) did not break under `experimentalImportSupport`.

## Residual risk
Experimental, production-only. The authoritative check is a real EAS production build (Sentry Metro wrapper + full pipeline); local export is strong but not identical. Recommend a production/preview build sanity-check before shipping.

Closes #1350
