### PR TITLE
fix(db): prevent startup fast path from bricking after reset or half-migration

### DIFF
--- a/__tests__/services/db.fastpath.test.js
+++ b/__tests__/services/db.fastpath.test.js
@@ -41,8 +41,57 @@ jest.mock('../../drizzle/migrations', () => ({
 
 const SCHEMA_VERSION = 3; // must equal the journal entry count above
 
-import { getDatabase, closeDatabase } from '../../app/services/db';
+import { getDatabase, closeDatabase, dropAllTables } from '../../app/services/db';
 import * as SQLite from 'expo-sqlite';
+
+// The nine tables isSchemaComplete() expects, plus per-table columns that satisfy
+// every column check in it. Used to simulate a genuinely complete post-migration
+// schema so the fast-path fingerprint is stamped (the stamp is now gated on
+// isSchemaComplete — a half-applied migration must NOT be stamped).
+const COMPLETE_TABLES = [
+  'accounts', 'categories', 'operations', 'budgets', 'app_metadata',
+  'accounts_balance_history', 'planned_operations',
+  'notification_merchant_rules', 'pending_notifications',
+];
+const mockSchemaComplete = (db, storedUserVersion) => {
+  db.getFirstAsync.mockImplementation((q) => {
+    if (typeof q === 'string' && q.includes('user_version')) {
+      return Promise.resolve({ user_version: storedUserVersion });
+    }
+    if (typeof q === 'string' && q.includes('trg_operations_type_insert')) {
+      return Promise.resolve({ name: 'trg_operations_type_insert' });
+    }
+    return Promise.resolve(null);
+  });
+  db.getAllAsync.mockImplementation((q) => {
+    if (typeof q !== 'string') return Promise.resolve([]);
+    if (q.includes("type='table'") && !q.includes('name=') && !q.includes('__drizzle')) {
+      return Promise.resolve(COMPLETE_TABLES.map((name) => ({ name })));
+    }
+    if (q.includes('table_info(accounts)')) {
+      return Promise.resolve([
+        { name: 'id', type: 'INTEGER' }, { name: 'deleted_at', type: 'TEXT' },
+        { name: 'card_mask', type: 'TEXT' }, { name: 'auto_txn_rounding', type: 'INTEGER' },
+        { name: 'auto_txn_rounding_mode', type: 'TEXT' }, { name: 'show_in_main_menu', type: 'INTEGER' },
+      ]);
+    }
+    if (q.includes('table_info(operations)')) {
+      return Promise.resolve([
+        { name: 'original_balance', type: 'TEXT' }, { name: 'latitude', type: 'REAL' },
+        { name: 'longitude', type: 'REAL' }, { name: 'account_id', type: 'INTEGER' },
+        { name: 'exclude_from_avg', type: 'INTEGER' },
+      ]);
+    }
+    if (q.includes('table_info(categories)')) return Promise.resolve([{ name: 'id', type: 'INTEGER' }]);
+    if (q.includes('table_info(notification_merchant_rules)')) {
+      return Promise.resolve([{ name: 'label_override', type: 'TEXT' }, { name: 'last_matched_at', type: 'TEXT' }]);
+    }
+    if (q.includes('table_info(pending_notifications)')) {
+      return Promise.resolve([{ name: 'latitude', type: 'REAL' }, { name: 'longitude', type: 'REAL' }]);
+    }
+    return Promise.resolve([]);
+  });
+};
 
 describe('DB startup schema-version fast path (#1341)', () => {
   let mockDb;
@@ -126,9 +175,21 @@ describe('DB startup schema-version fast path (#1341)', () => {
       expect(mockDb.getAllAsync).toHaveBeenCalled();
     });
 
-    it('writes the fingerprint after a successful full init', async () => {
+    it('writes the fingerprint after a successful full init (schema complete)', async () => {
+      // The stamp is gated on isSchemaComplete(), so simulate a genuinely complete
+      // post-migration schema — that is what a successful fresh install produces.
+      mockSchemaComplete(mockDb, 0);
       await getDatabase();
       expect(mockDb.runAsync).toHaveBeenCalledWith(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    });
+
+    it('does NOT stamp the fingerprint when the schema is still incomplete after init', async () => {
+      // Bare mock: getAllAsync returns [] so isSchemaComplete() is false — the state a
+      // half-applied migration leaves behind (applyPendingMigrations swallows per-statement
+      // errors). The fast-path fingerprint must NOT be written, so the next launch re-runs
+      // the full inspection and self-heals instead of locking in a broken schema forever.
+      await getDatabase();
+      expect(mockDb.runAsync).not.toHaveBeenCalledWith(`PRAGMA user_version = ${SCHEMA_VERSION}`);
     });
 
     it('sets per-connection PRAGMAs on the full path too', async () => {
@@ -169,8 +230,22 @@ describe('DB startup schema-version fast path (#1341)', () => {
     });
 
     it('re-stamps the fingerprint to the current SCHEMA_VERSION afterward', async () => {
+      // Older stored version + a complete schema after migrating -> stamp is renewed.
+      mockSchemaComplete(mockDb, SCHEMA_VERSION - 1);
       await getDatabase();
       expect(mockDb.runAsync).toHaveBeenCalledWith(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    });
+  });
+
+  describe('reset via dropAllTables clears the fingerprint (#1376 review regression)', () => {
+    it('resets PRAGMA user_version to 0 so the next open rebuilds the schema', async () => {
+      // Settings -> Reset database drops every table but keeps the same DB file.
+      // user_version is a header value that survives DROP TABLE, so if it kept its
+      // stamped value the next getDatabase() would take the fast path and skip
+      // recreating the tables -> "no such table: accounts", bricked until reinstall.
+      mockDb.getAllAsync.mockResolvedValue([{ name: 'accounts' }, { name: 'operations' }]);
+      await dropAllTables();
+      expect(mockDb.runAsync).toHaveBeenCalledWith('PRAGMA user_version = 0');
     });
   });
 

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -785,12 +785,21 @@ const initializeDatabase = async (rawDb, db) => {
     await rawDb.runAsync('PRAGMA foreign_keys = ON');
     await rawDb.runAsync('PRAGMA journal_mode = WAL');
 
-    // Stamp the schema fingerprint now that init has fully succeeded, so the next
-    // cold start can take the fast path above. Written only here (after the whole
-    // slow path completed without throwing) — never on a partial/failed init.
-    await setStoredSchemaVersion(rawDb, SCHEMA_VERSION);
-
-    console.log('Database migrations completed successfully');
+    // Stamp the schema fingerprint ONLY if the schema is actually complete.
+    // applyPendingMigrations() swallows per-statement errors and does not throw
+    // (an ADD COLUMN can fail transiently on a locked DB / disk pressure), so
+    // "init did not throw" is NOT proof the schema is whole. Verifying
+    // completeness here means a half-applied migration leaves user_version
+    // unstamped, so the next launch takes the full path and self-heals — instead
+    // of the fast path locking in a broken schema forever ("no such column" on
+    // every launch). This check runs only on the slow path (the fast path
+    // returns early above), so it adds no cost to warm cold starts.
+    if (await isSchemaComplete(rawDb)) {
+      await setStoredSchemaVersion(rawDb, SCHEMA_VERSION);
+      console.log('Database migrations completed successfully');
+    } else {
+      console.warn('[DB] Schema incomplete after init — not stamping the fast-path fingerprint; next launch will re-verify and heal');
+    }
   } catch (error) {
     console.error('Failed to initialize database:', error);    console.error('Error details:', {
       message: error.message,
@@ -986,6 +995,14 @@ export const dropAllTables = async () => {
 
     // Re-enable foreign keys
     await raw.runAsync('PRAGMA foreign_keys = ON');
+
+    // CRITICAL: clear the schema fingerprint. user_version is a DB-header value
+    // that survives table drops, so leaving it at its stamped SCHEMA_VERSION
+    // would make the next getDatabase() take the startup fast path and skip
+    // recreating the tables we just dropped — bricking the install with
+    // "no such table" until reinstall. Zeroing it forces the full init path
+    // (fresh-install branch) on the next open, which recreates the schema.
+    await raw.runAsync('PRAGMA user_version = 0');
 
     console.log('All tables dropped successfully');
 


### PR DESCRIPTION
> 🔴 **P0 — two install-bricking regressions in the merged #1341/#1368 schema-version fast path.** Surfaced by a high-effort code review. Please prioritize.

## Bug 1 — Settings → Reset database bricks the install (deterministic)
`dropAllTables()` drops every table, but `PRAGMA user_version` is a DB-header value that **survives `DROP TABLE`**, so it keeps its stamped `SCHEMA_VERSION`. The reset flow (`utils/resetDatabase.js`: `dropAllTables()` → `getDatabase()`) then reads a matching fingerprint, takes the startup **fast path**, and returns **without recreating any tables**. The next query throws `no such table: accounts`; the empty schema also survives restarts (fingerprint still matches) → bricked until reinstall.

**Fix:** reset `PRAGMA user_version = 0` in `dropAllTables()`, forcing the full init (fresh-install branch) on the next open. (`emergencyReset` deletes the DB file outright, so it was already safe.)

## Bug 2 — a half-applied migration gets a "healthy" fingerprint (permanent, no self-heal)
`applyPendingMigrations()` **swallows per-statement errors and never throws** (an `ADD COLUMN` can fail transiently on a locked DB / disk pressure), but `setStoredSchemaVersion()` was stamped **unconditionally** at the end of init. So a partially-applied migration is locked in: every later launch sees the matching fingerprint, takes the fast path, and **never re-runs the `isSchemaComplete` self-heal** → `no such column` on every launch forever.

**Fix:** gate the stamp on `isSchemaComplete(rawDb)`. An incomplete schema leaves `user_version` unstamped, so the next launch re-verifies and heals. This check runs **only on the slow path** (the fast path returns early), so warm cold starts are unaffected.

## Tests
- New: `dropAllTables` resets `user_version` to 0.
- New: an incomplete schema after init does **not** stamp the fingerprint.
- Updated: the fresh-install "writes fingerprint" and stale "re-stamps" tests now simulate a genuinely complete post-migration schema (the stamp is gated on completeness). Added a `mockSchemaComplete` helper for that.

Both bugs are confirmed against the merged code (`dropAllTables` at db.js; `resetDatabase.js` reset flow; `applyPendingMigrations` error swallowing; unconditional stamp).
