### PR TITLE
chore: clear RN best-practices hygiene basket (6/9, 3 deferred)

### DIFF
--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -73,6 +73,17 @@ export default function ModalShell({
     // a JS-driven paddingBottom animation on every keyboard show/hide app-wide.
     // Only the visible modal needs keyboard avoidance.
     if (!visible) return undefined;
+
+    // If a keyboard is already open when this modal becomes visible (e.g. focus
+    // retained from a prior field / quick-add flow), keyboardDidShow has already
+    // fired and will not fire again for this subscription — so seed the offset from
+    // the current keyboard metrics, otherwise the sheet stays glued to the bottom
+    // and the keyboard overlaps its input until the user dismisses and refocuses.
+    const currentMetrics = Keyboard.metrics?.();
+    if (currentMetrics?.height) {
+      keyboardOffset.setValue(currentMetrics.height);
+    }
+
     const onShow = (e) => {
       Animated.timing(keyboardOffset, {
         toValue: e?.endCoordinates?.height ?? 0,

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -68,6 +68,11 @@ export default function ModalShell({
   // offset, the bug the old behavior="height" KeyboardAvoidingView left behind).
   const keyboardOffset = useRef(new Animated.Value(0)).current;
   useEffect(() => {
+    // ModalShell instances stay permanently mounted (e.g. OperationModal, and all
+    // tab screens mount eagerly), so without this gate every closed modal would run
+    // a JS-driven paddingBottom animation on every keyboard show/hide app-wide.
+    // Only the visible modal needs keyboard avoidance.
+    if (!visible) return undefined;
     const onShow = (e) => {
       Animated.timing(keyboardOffset, {
         toValue: e?.endCoordinates?.height ?? 0,
@@ -88,7 +93,7 @@ export default function ModalShell({
       showSub.remove();
       hideSub.remove();
     };
-  }, [keyboardOffset]);
+  }, [keyboardOffset, visible]);
   // Use a ref so the PanResponder closure always calls the latest onDismiss
   const onDismissRef = useRef(onDismiss);
   useEffect(() => { onDismissRef.current = onDismiss; }, [onDismiss]);

--- a/app/components/operations/DateSeparator.js
+++ b/app/components/operations/DateSeparator.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
@@ -13,10 +13,14 @@ const getCurrencySymbol = (currencyCode) => {
 const DateSeparator = ({ date, spendingSums, formatDate, colors, onPress }) => {
   const hasSpending = spendingSums && Object.keys(spendingSums).length > 0;
 
+  // Bind the date here so the parent can pass a STABLE onPress (onDateSeparatorPress)
+  // instead of a fresh `() => onPress(date)` per render — the latter pierces this memo.
+  const handlePress = useCallback(() => onPress?.(date), [onPress, date]);
+
   return (
     <Pressable
       style={({ pressed }) => [styles.container, pressed && styles.pressed]}
-      onPress={onPress}
+      onPress={handlePress}
       accessibilityRole="button"
       accessibilityLabel={`${formatDate(date)}, press to select date`}
       accessibilityHint="Opens date picker to jump to a specific date"

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -285,7 +285,7 @@ const OperationsList = forwardRef(({
         spendingSums={section.spendingSums}
         formatDate={formatDate}
         colors={colors}
-        onPress={() => onDateSeparatorPress(section.title)}
+        onPress={onDateSeparatorPress}
       />
       {/* Top of the card surface — provides border, radius, and background */}
       <View

--- a/app/hooks/useLogEntries.js
+++ b/app/hooks/useLogEntries.js
@@ -7,13 +7,24 @@ export function useLogEntries(levelFilter = 'all') {
   filterRef.current = levelFilter;
 
   useEffect(() => {
+    const pendingTimers = new Set();
     const unsubscribe = logService.subscribe(() => {
       // Defer setState to avoid updating during a render phase — LogService intercepts
       // console.*, which React calls internally during rendering (e.g. dev warnings),
       // so a synchronous setTick here causes "Cannot update a component while rendering".
-      setTimeout(() => setTick(t => t + 1), 0);
+      const id = setTimeout(() => {
+        pendingTimers.delete(id);
+        setTick(t => t + 1);
+      }, 0);
+      pendingTimers.add(id);
     });
-    return unsubscribe;
+    return () => {
+      unsubscribe();
+      // Cancel any deferred setTick so a log line arriving in the same tick as
+      // unmount doesn't fire setState on an unmounted component.
+      pendingTimers.forEach(clearTimeout);
+      pendingTimers.clear();
+    };
   }, []);
 
   const entries = logService.getEntries(levelFilter);

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -47,6 +47,10 @@ const ROUNDING_MODE_OPTIONS = [
   { value: 'down', labelKey: 'rounding_mode_down', fallback: 'Down' },
 ];
 
+// Static currency list is a module-level JSON import that never changes, so its
+// Object.entries() can be computed once and shared as a stable FlatList `data`.
+const CURRENCY_ENTRIES = Object.entries(currencies);
+
 // Memoized currency picker modal component
 const CurrencyPickerModal = memo(({ visible = false, onClose = () => {}, currencies = DEFAULT_CURRENCIES, colors = {}, t = (k) => k, onSelect = () => {} }) => {
   const renderCurrencyItem = useCallback(({ item }) => {
@@ -63,6 +67,9 @@ const CurrencyPickerModal = memo(({ visible = false, onClose = () => {}, currenc
     );
   }, [onSelect]);
 
+  // Stable array identity so the FlatList doesn't re-diff on every modal render.
+  const currencyEntries = useMemo(() => Object.entries(currencies), [currencies]);
+
   return (
     <Portal>
       <Modal
@@ -71,7 +78,7 @@ const CurrencyPickerModal = memo(({ visible = false, onClose = () => {}, currenc
         contentContainerStyle={[styles.pickerModalContent, { backgroundColor: colors.card }]}
       >
         <FlatList
-          data={Object.entries(currencies)}
+          data={currencyEntries}
           keyExtractor={([code]) => code}
           renderItem={renderCurrencyItem}
           style={styles.pickerList}
@@ -541,17 +548,20 @@ export default function AccountsScreen({ onBackStateChange }) {
 
   const balanceInputRef = useRef(null);
 
-  const SCREEN_WIDTH = Dimensions.get('window').width;
+  // Frozen at mount (portrait Android — the window width does not change), so the
+  // interpolations below keep a stable identity across re-renders.
+  const SCREEN_WIDTH = useMemo(() => Dimensions.get('window').width, []);
 
-  // Form panel interpolations
-  const formPanelTranslateX = formPanelAnim.interpolate({
+  // Form panel interpolations — memoized on the stable Animated value so a re-render
+  // of AccountsScreen doesn't allocate a fresh AnimatedInterpolation each time.
+  const formPanelTranslateX = useMemo(() => formPanelAnim.interpolate({
     inputRange: [0, 1],
     outputRange: [SCREEN_WIDTH, 0],
-  });
-  const formPanelOpacity = formPanelAnim.interpolate({
+  }), [formPanelAnim, SCREEN_WIDTH]);
+  const formPanelOpacity = useMemo(() => formPanelAnim.interpolate({
     inputRange: [0, 1],
     outputRange: [0, 1],
-  });
+  }), [formPanelAnim]);
 
   const openFormPanel = useCallback((id, values) => {
     setCurrencyPanelVisible(false);
@@ -1280,7 +1290,7 @@ export default function AccountsScreen({ onBackStateChange }) {
                 </Text>
               </View>
               <FlatList
-                data={Object.entries(currencies)}
+                data={CURRENCY_ENTRIES}
                 keyExtractor={([code]) => code}
                 renderItem={({ item: [code, cur] }) => (
                   <TouchableRipple

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -67,9 +67,6 @@ const CurrencyPickerModal = memo(({ visible = false, onClose = () => {}, currenc
     );
   }, [onSelect]);
 
-  // Stable array identity so the FlatList doesn't re-diff on every modal render.
-  const currencyEntries = useMemo(() => Object.entries(currencies), [currencies]);
-
   return (
     <Portal>
       <Modal
@@ -78,7 +75,7 @@ const CurrencyPickerModal = memo(({ visible = false, onClose = () => {}, currenc
         contentContainerStyle={[styles.pickerModalContent, { backgroundColor: colors.card }]}
       >
         <FlatList
-          data={currencyEntries}
+          data={Object.entries(currencies)}
           keyExtractor={([code]) => code}
           renderItem={renderCurrencyItem}
           style={styles.pickerList}
@@ -548,20 +545,17 @@ export default function AccountsScreen({ onBackStateChange }) {
 
   const balanceInputRef = useRef(null);
 
-  // Frozen at mount (portrait Android — the window width does not change), so the
-  // interpolations below keep a stable identity across re-renders.
-  const SCREEN_WIDTH = useMemo(() => Dimensions.get('window').width, []);
+  const SCREEN_WIDTH = Dimensions.get('window').width;
 
-  // Form panel interpolations — memoized on the stable Animated value so a re-render
-  // of AccountsScreen doesn't allocate a fresh AnimatedInterpolation each time.
-  const formPanelTranslateX = useMemo(() => formPanelAnim.interpolate({
+  // Form panel interpolations
+  const formPanelTranslateX = formPanelAnim.interpolate({
     inputRange: [0, 1],
     outputRange: [SCREEN_WIDTH, 0],
-  }), [formPanelAnim, SCREEN_WIDTH]);
-  const formPanelOpacity = useMemo(() => formPanelAnim.interpolate({
+  });
+  const formPanelOpacity = formPanelAnim.interpolate({
     inputRange: [0, 1],
     outputRange: [0, 1],
-  }), [formPanelAnim]);
+  });
 
   const openFormPanel = useCallback((id, values) => {
     setCurrencyPanelVisible(false);

--- a/app/screens/PlannedOperationsScreen.js
+++ b/app/screens/PlannedOperationsScreen.js
@@ -17,6 +17,9 @@ import { useCategories } from '../contexts/CategoriesContext';
 import PlannedOperationModal from '../modals/PlannedOperationModal';
 import currencies from '../../assets/currencies.json';
 
+// Module-level stable reference so the SectionList prop identity never changes.
+const keyExtractor = (item) => item.id;
+
 const TYPE_COLORS = {
   expense: 'expense',
   income: 'income',
@@ -474,7 +477,7 @@ export default function PlannedOperationsScreen() {
       {/* List */}
       <SectionList
         sections={sections}
-        keyExtractor={item => item.id}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={renderEmpty}

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -6,6 +6,14 @@ import { normalizeSearchText } from './searchNormalize';
 
 const DB_NAME = 'penny.db';
 
+// Verbose init/migration narration is dev-only. Each console.* is intercepted by
+// LogService (entry append + scheduled disk flush + Sentry captureLog), so ~30
+// startup log lines add real work on every cold start. Errors/warnings still use
+// console.error/console.warn so they remain visible in production and Sentry.
+// Bound reference avoids the literal `devLog(` so it survives verbose-log edits.
+const rawConsoleLog = console.log.bind(console);
+const devLog = (...args) => { if (__DEV__) rawConsoleLog(...args); };
+
 /**
  * Schema fingerprint for the startup fast path.
  *
@@ -96,9 +104,9 @@ export const getDatabase = async () => {
   // Start initialization
   initPromise = (async () => {
     try {
-      console.log('Opening database:', DB_NAME);
+      devLog('Opening database:', DB_NAME);
       dbInstance = await SQLite.openDatabaseAsync(DB_NAME);
-      console.log('Database opened successfully, instance:', !!dbInstance);
+      devLog('Database opened successfully, instance:', !!dbInstance);
 
       if (!dbInstance) {
         throw new Error('Database instance is null after opening');
@@ -130,10 +138,10 @@ export const getDatabase = async () => {
       }
 
       drizzleInstance = drizzle(dbInstance, { schema });
-      console.log('Drizzle instance created');
+      devLog('Drizzle instance created');
 
       await initializeDatabase(dbInstance, drizzleInstance);
-      console.log('Database initialized successfully');
+      devLog('Database initialized successfully');
     } catch (error) {
       console.error('Failed to open database:', error);
       console.error('Error details:', error.message, error.stack);
@@ -282,11 +290,11 @@ const syncMigrationRecords = async (rawDb, migrationsConfig) => {
     const countMismatch = existing.length !== journalEntries.length;
 
     if (!hasNullHashes && !countMismatch) {
-      console.log('[DB] Migration records are consistent');
+      devLog('[DB] Migration records are consistent');
       return;
     }
 
-    console.log(`[DB] Fixing migration records (${existing.length} records, ${hasNullHashes ? 'has null hashes' : 'count mismatch'})`);
+    devLog(`[DB] Fixing migration records (${existing.length} records, ${hasNullHashes ? 'has null hashes' : 'count mismatch'})`);
 
     // Drop and recreate with proper records using migration SQL as hash
     // (this matches what Drizzle's expo-sqlite migrator stores)
@@ -307,7 +315,7 @@ const syncMigrationRecords = async (rawDb, migrationsConfig) => {
       );
     }
 
-    console.log(`[DB] Migration records rebuilt: ${journalEntries.length} entries`);
+    devLog(`[DB] Migration records rebuilt: ${journalEntries.length} entries`);
   } catch (error) {
     console.warn('[DB] Failed to sync migration records:', error.message);
     // Non-fatal — schema is already complete, this is just housekeeping
@@ -332,7 +340,7 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
   // Determine which migrations have been applied by checking schema markers
   const appliedIndices = await detectAppliedMigrations(rawDb);
   const appliedSet = new Set(appliedIndices);
-  console.log(`[DB] Detected ${appliedIndices.length}/${journalEntries.length} migrations as already applied: ${appliedIndices.join(', ')}`);
+  devLog(`[DB] Detected ${appliedIndices.length}/${journalEntries.length} migrations as already applied: ${appliedIndices.join(', ')}`);
 
   const pendingIndices = [];
   for (let i = 0; i < journalEntries.length; i++) {
@@ -340,12 +348,12 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
   }
 
   if (pendingIndices.length === 0) {
-    console.log('[DB] No pending migrations to apply');
+    devLog('[DB] No pending migrations to apply');
     await syncMigrationRecords(rawDb, migrationsConfig);
     return;
   }
 
-  console.log(`[DB] Applying ${pendingIndices.length} pending migrations: ${pendingIndices.map(i => journalEntries[i].tag).join(', ')}`);
+  devLog(`[DB] Applying ${pendingIndices.length} pending migrations: ${pendingIndices.map(i => journalEntries[i].tag).join(', ')}`);
 
   for (const idx of pendingIndices) {
     const key = migrationKeys[idx];
@@ -356,7 +364,7 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
     // Split on Drizzle's statement breakpoint marker (same logic as Drizzle internals)
     const statements = rawSql.split('--> statement-breakpoint').map(s => s.trim()).filter(Boolean);
 
-    console.log(`[DB] Applying migration ${tag} (${statements.length} statements)`);
+    devLog(`[DB] Applying migration ${tag} (${statements.length} statements)`);
 
     for (const stmt of statements) {
       try {
@@ -370,7 +378,7 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
       }
     }
 
-    console.log(`[DB] Migration ${tag} applied successfully`);
+    devLog(`[DB] Migration ${tag} applied successfully`);
   }
 
   // Rebuild __drizzle_migrations to reflect all migrations as applied
@@ -650,7 +658,7 @@ const initializeDatabase = async (rawDb, db) => {
     // the fast path cannot bypass a corruption this codebase can actually detect.
     const storedVersion = await getStoredSchemaVersion(rawDb);
     if (SCHEMA_VERSION > 0 && storedVersion === SCHEMA_VERSION) {
-      console.log(`[DB] Schema fingerprint matches (user_version=${SCHEMA_VERSION}) — fast startup, skipping inspection`);
+      devLog(`[DB] Schema fingerprint matches (user_version=${SCHEMA_VERSION}) — fast startup, skipping inspection`);
       // Per-connection PRAGMAs are connection-scoped, NOT schema state — they must
       // run on every open regardless of the fast path.
       await rawDb.runAsync('PRAGMA foreign_keys = ON');
@@ -658,14 +666,14 @@ const initializeDatabase = async (rawDb, db) => {
       return;
     }
 
-    console.log('Running Drizzle migrations...');
-    console.log('Available migrations:', migrations.journal.entries.map(e => e.tag).join(', '));
+    devLog('Running Drizzle migrations...');
+    devLog('Available migrations:', migrations.journal.entries.map(e => e.tag).join(', '));
 
     // Check existing tables
     const existingTables = await rawDb.getAllAsync(
       'SELECT name FROM sqlite_master WHERE type="table" ORDER BY name',
     );
-    console.log('Existing tables:', (existingTables || []).map(t => t.name).join(', '));
+    devLog('Existing tables:', (existingTables || []).map(t => t.name).join(', '));
 
     // Check for corrupted migration state
     const isCorrupted = await isDatabaseCorrupted(rawDb);
@@ -690,7 +698,7 @@ const initializeDatabase = async (rawDb, db) => {
         await rawDb.runAsync(`DROP TABLE IF EXISTS "${table.name}"`);
       }
       await rawDb.runAsync('PRAGMA foreign_keys = ON');
-      console.log('[DB] Schema reset complete');
+      devLog('[DB] Schema reset complete');
     }
 
     // Check current migration state before running
@@ -701,9 +709,9 @@ const initializeDatabase = async (rawDb, db) => {
     if (drizzleMigrations && drizzleMigrations.length > 0) {
       const appliedMigrations = await rawDb.getAllAsync('SELECT * FROM __drizzle_migrations ORDER BY created_at ASC');
       const hashList = (appliedMigrations || []).map(m => m.hash || 'null').join(', ');
-      console.log('Previously applied migrations:', hashList || 'none');
+      devLog('Previously applied migrations:', hashList || 'none');
     } else {
-      console.log('No migrations table found - database will be migrated from scratch');
+      devLog('No migrations table found - database will be migrated from scratch');
     }
 
     // Get migrations before applying
@@ -716,7 +724,7 @@ const initializeDatabase = async (rawDb, db) => {
     // already-complete schema is wasteful and can produce confusing logs.
     const schemaAlreadyComplete = await isSchemaComplete(rawDb);
     if (schemaAlreadyComplete) {
-      console.log('[DB] Schema is already at latest version — skipping migrate()');
+      devLog('[DB] Schema is already at latest version — skipping migrate()');
 
       // Fix __drizzle_migrations if it has wrong count or null hashes so future
       // startups are even faster (no need to re-check schema).
@@ -731,7 +739,7 @@ const initializeDatabase = async (rawDb, db) => {
 
       // Log final state
       const finalMigrations = await rawDb.getAllAsync('SELECT * FROM __drizzle_migrations ORDER BY created_at ASC').catch(() => []);
-      console.log(`Total migrations applied: ${(finalMigrations || []).length}/${migrations.journal.entries.length}`);
+      devLog(`Total migrations applied: ${(finalMigrations || []).length}/${migrations.journal.entries.length}`);
 
       // Run post-migration handlers for newly applied migrations
       if (migrations.postMigrationHandlers) {
@@ -744,7 +752,7 @@ const initializeDatabase = async (rawDb, db) => {
             : null;
 
           if (migrationEntry && appliedHashesAfter.has(migrationEntry.hash) && !appliedHashesBefore.has(migrationEntry.hash)) {
-            console.log(`Running post-migration handler for ${key}...`);
+            devLog(`Running post-migration handler for ${key}...`);
             try {
               await handler(rawDb);
             } catch (handlerError) {
@@ -768,7 +776,7 @@ const initializeDatabase = async (rawDb, db) => {
             ).catch(() => null);
 
             if (!completionRow) {
-              console.log(`Retrying incomplete post-migration handler for ${key}...`);
+              devLog(`Retrying incomplete post-migration handler for ${key}...`);
               try {
                 await handler(rawDb);
               } catch (retryError) {
@@ -796,7 +804,7 @@ const initializeDatabase = async (rawDb, db) => {
     // returns early above), so it adds no cost to warm cold starts.
     if (await isSchemaComplete(rawDb)) {
       await setStoredSchemaVersion(rawDb, SCHEMA_VERSION);
-      console.log('Database migrations completed successfully');
+      devLog('Database migrations completed successfully');
     } else {
       console.warn('[DB] Schema incomplete after init — not stamping the fast-path fingerprint; next launch will re-verify and heal');
     }
@@ -910,10 +918,10 @@ export const executeTransaction = async (callback) => {
  */
 export const closeDatabase = async () => {
   if (dbInstance) {
-    console.log('Closing database connection...');
+    devLog('Closing database connection...');
     try {
       await dbInstance.closeAsync();
-      console.log('Database closed successfully');
+      devLog('Database closed successfully');
     } catch (error) {
       console.error('Error closing database:', error);
     } finally {
@@ -968,7 +976,7 @@ export const dropAllTables = async () => {
       if (dbInstance) {
         raw = dbInstance;
       } else {
-        console.log('Opening database for table drop...');
+        devLog('Opening database for table drop...');
         raw = await SQLite.openDatabaseAsync(DB_NAME);
         openedNewConnection = true;
       }
@@ -985,12 +993,12 @@ export const dropAllTables = async () => {
       "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
     );
 
-    console.log('Tables to drop:', tables.map(t => t.name).join(', '));
+    devLog('Tables to drop:', tables.map(t => t.name).join(', '));
 
     // Drop each table (including migrations)
     for (const table of tables) {
       await raw.runAsync(`DROP TABLE IF EXISTS "${table.name}"`);
-      console.log(`Dropped table: ${table.name}`);
+      devLog(`Dropped table: ${table.name}`);
     }
 
     // Re-enable foreign keys
@@ -1004,13 +1012,13 @@ export const dropAllTables = async () => {
     // (fresh-install branch) on the next open, which recreates the schema.
     await raw.runAsync('PRAGMA user_version = 0');
 
-    console.log('All tables dropped successfully');
+    devLog('All tables dropped successfully');
 
     // Close the database connection properly before resetting instances
     // This ensures the native connection is released
     try {
       await raw.closeAsync();
-      console.log('Database connection closed after dropping tables');
+      devLog('Database connection closed after dropping tables');
     } catch (closeError) {
       console.error('Error closing database after dropping tables:', closeError);
     }
@@ -1040,7 +1048,7 @@ export const resetDatabase = async () => {
   try {
     const FileSystem = require('expo-file-system/legacy');
     await FileSystem.deleteAsync(dbPath, { idempotent: true });
-    console.log('Database file deleted');
+    devLog('Database file deleted');
   } catch (error) {
     console.error('Failed to delete database file:', error);
   }

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -1,3 +1,4 @@
+/* global __DEV__ */
 import { drizzle } from 'drizzle-orm/expo-sqlite';
 import * as SQLite from 'expo-sqlite';
 import * as schema from '../db/schema';

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -1,4 +1,3 @@
-/* global __DEV__ */
 import { drizzle } from 'drizzle-orm/expo-sqlite';
 import * as SQLite from 'expo-sqlite';
 import * as schema from '../db/schema';
@@ -6,14 +5,6 @@ import migrations from '../../drizzle/migrations';
 import { normalizeSearchText } from './searchNormalize';
 
 const DB_NAME = 'penny.db';
-
-// Verbose init/migration narration is dev-only. Each console.* is intercepted by
-// LogService (entry append + scheduled disk flush + Sentry captureLog), so ~30
-// startup log lines add real work on every cold start. Errors/warnings still use
-// console.error/console.warn so they remain visible in production and Sentry.
-// Bound reference avoids the literal `devLog(` so it survives verbose-log edits.
-const rawConsoleLog = console.log.bind(console);
-const devLog = (...args) => { if (__DEV__) rawConsoleLog(...args); };
 
 /**
  * Schema fingerprint for the startup fast path.
@@ -105,9 +96,9 @@ export const getDatabase = async () => {
   // Start initialization
   initPromise = (async () => {
     try {
-      devLog('Opening database:', DB_NAME);
+      console.log('Opening database:', DB_NAME);
       dbInstance = await SQLite.openDatabaseAsync(DB_NAME);
-      devLog('Database opened successfully, instance:', !!dbInstance);
+      console.log('Database opened successfully, instance:', !!dbInstance);
 
       if (!dbInstance) {
         throw new Error('Database instance is null after opening');
@@ -139,10 +130,10 @@ export const getDatabase = async () => {
       }
 
       drizzleInstance = drizzle(dbInstance, { schema });
-      devLog('Drizzle instance created');
+      console.log('Drizzle instance created');
 
       await initializeDatabase(dbInstance, drizzleInstance);
-      devLog('Database initialized successfully');
+      console.log('Database initialized successfully');
     } catch (error) {
       console.error('Failed to open database:', error);
       console.error('Error details:', error.message, error.stack);
@@ -291,11 +282,11 @@ const syncMigrationRecords = async (rawDb, migrationsConfig) => {
     const countMismatch = existing.length !== journalEntries.length;
 
     if (!hasNullHashes && !countMismatch) {
-      devLog('[DB] Migration records are consistent');
+      console.log('[DB] Migration records are consistent');
       return;
     }
 
-    devLog(`[DB] Fixing migration records (${existing.length} records, ${hasNullHashes ? 'has null hashes' : 'count mismatch'})`);
+    console.log(`[DB] Fixing migration records (${existing.length} records, ${hasNullHashes ? 'has null hashes' : 'count mismatch'})`);
 
     // Drop and recreate with proper records using migration SQL as hash
     // (this matches what Drizzle's expo-sqlite migrator stores)
@@ -316,7 +307,7 @@ const syncMigrationRecords = async (rawDb, migrationsConfig) => {
       );
     }
 
-    devLog(`[DB] Migration records rebuilt: ${journalEntries.length} entries`);
+    console.log(`[DB] Migration records rebuilt: ${journalEntries.length} entries`);
   } catch (error) {
     console.warn('[DB] Failed to sync migration records:', error.message);
     // Non-fatal — schema is already complete, this is just housekeeping
@@ -341,7 +332,7 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
   // Determine which migrations have been applied by checking schema markers
   const appliedIndices = await detectAppliedMigrations(rawDb);
   const appliedSet = new Set(appliedIndices);
-  devLog(`[DB] Detected ${appliedIndices.length}/${journalEntries.length} migrations as already applied: ${appliedIndices.join(', ')}`);
+  console.log(`[DB] Detected ${appliedIndices.length}/${journalEntries.length} migrations as already applied: ${appliedIndices.join(', ')}`);
 
   const pendingIndices = [];
   for (let i = 0; i < journalEntries.length; i++) {
@@ -349,12 +340,12 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
   }
 
   if (pendingIndices.length === 0) {
-    devLog('[DB] No pending migrations to apply');
+    console.log('[DB] No pending migrations to apply');
     await syncMigrationRecords(rawDb, migrationsConfig);
     return;
   }
 
-  devLog(`[DB] Applying ${pendingIndices.length} pending migrations: ${pendingIndices.map(i => journalEntries[i].tag).join(', ')}`);
+  console.log(`[DB] Applying ${pendingIndices.length} pending migrations: ${pendingIndices.map(i => journalEntries[i].tag).join(', ')}`);
 
   for (const idx of pendingIndices) {
     const key = migrationKeys[idx];
@@ -365,7 +356,7 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
     // Split on Drizzle's statement breakpoint marker (same logic as Drizzle internals)
     const statements = rawSql.split('--> statement-breakpoint').map(s => s.trim()).filter(Boolean);
 
-    devLog(`[DB] Applying migration ${tag} (${statements.length} statements)`);
+    console.log(`[DB] Applying migration ${tag} (${statements.length} statements)`);
 
     for (const stmt of statements) {
       try {
@@ -379,7 +370,7 @@ export const applyPendingMigrations = async (rawDb, migrationsConfig) => {
       }
     }
 
-    devLog(`[DB] Migration ${tag} applied successfully`);
+    console.log(`[DB] Migration ${tag} applied successfully`);
   }
 
   // Rebuild __drizzle_migrations to reflect all migrations as applied
@@ -659,7 +650,7 @@ const initializeDatabase = async (rawDb, db) => {
     // the fast path cannot bypass a corruption this codebase can actually detect.
     const storedVersion = await getStoredSchemaVersion(rawDb);
     if (SCHEMA_VERSION > 0 && storedVersion === SCHEMA_VERSION) {
-      devLog(`[DB] Schema fingerprint matches (user_version=${SCHEMA_VERSION}) — fast startup, skipping inspection`);
+      console.log(`[DB] Schema fingerprint matches (user_version=${SCHEMA_VERSION}) — fast startup, skipping inspection`);
       // Per-connection PRAGMAs are connection-scoped, NOT schema state — they must
       // run on every open regardless of the fast path.
       await rawDb.runAsync('PRAGMA foreign_keys = ON');
@@ -667,14 +658,14 @@ const initializeDatabase = async (rawDb, db) => {
       return;
     }
 
-    devLog('Running Drizzle migrations...');
-    devLog('Available migrations:', migrations.journal.entries.map(e => e.tag).join(', '));
+    console.log('Running Drizzle migrations...');
+    console.log('Available migrations:', migrations.journal.entries.map(e => e.tag).join(', '));
 
     // Check existing tables
     const existingTables = await rawDb.getAllAsync(
       'SELECT name FROM sqlite_master WHERE type="table" ORDER BY name',
     );
-    devLog('Existing tables:', (existingTables || []).map(t => t.name).join(', '));
+    console.log('Existing tables:', (existingTables || []).map(t => t.name).join(', '));
 
     // Check for corrupted migration state
     const isCorrupted = await isDatabaseCorrupted(rawDb);
@@ -699,7 +690,7 @@ const initializeDatabase = async (rawDb, db) => {
         await rawDb.runAsync(`DROP TABLE IF EXISTS "${table.name}"`);
       }
       await rawDb.runAsync('PRAGMA foreign_keys = ON');
-      devLog('[DB] Schema reset complete');
+      console.log('[DB] Schema reset complete');
     }
 
     // Check current migration state before running
@@ -710,9 +701,9 @@ const initializeDatabase = async (rawDb, db) => {
     if (drizzleMigrations && drizzleMigrations.length > 0) {
       const appliedMigrations = await rawDb.getAllAsync('SELECT * FROM __drizzle_migrations ORDER BY created_at ASC');
       const hashList = (appliedMigrations || []).map(m => m.hash || 'null').join(', ');
-      devLog('Previously applied migrations:', hashList || 'none');
+      console.log('Previously applied migrations:', hashList || 'none');
     } else {
-      devLog('No migrations table found - database will be migrated from scratch');
+      console.log('No migrations table found - database will be migrated from scratch');
     }
 
     // Get migrations before applying
@@ -725,7 +716,7 @@ const initializeDatabase = async (rawDb, db) => {
     // already-complete schema is wasteful and can produce confusing logs.
     const schemaAlreadyComplete = await isSchemaComplete(rawDb);
     if (schemaAlreadyComplete) {
-      devLog('[DB] Schema is already at latest version — skipping migrate()');
+      console.log('[DB] Schema is already at latest version — skipping migrate()');
 
       // Fix __drizzle_migrations if it has wrong count or null hashes so future
       // startups are even faster (no need to re-check schema).
@@ -740,7 +731,7 @@ const initializeDatabase = async (rawDb, db) => {
 
       // Log final state
       const finalMigrations = await rawDb.getAllAsync('SELECT * FROM __drizzle_migrations ORDER BY created_at ASC').catch(() => []);
-      devLog(`Total migrations applied: ${(finalMigrations || []).length}/${migrations.journal.entries.length}`);
+      console.log(`Total migrations applied: ${(finalMigrations || []).length}/${migrations.journal.entries.length}`);
 
       // Run post-migration handlers for newly applied migrations
       if (migrations.postMigrationHandlers) {
@@ -753,7 +744,7 @@ const initializeDatabase = async (rawDb, db) => {
             : null;
 
           if (migrationEntry && appliedHashesAfter.has(migrationEntry.hash) && !appliedHashesBefore.has(migrationEntry.hash)) {
-            devLog(`Running post-migration handler for ${key}...`);
+            console.log(`Running post-migration handler for ${key}...`);
             try {
               await handler(rawDb);
             } catch (handlerError) {
@@ -777,7 +768,7 @@ const initializeDatabase = async (rawDb, db) => {
             ).catch(() => null);
 
             if (!completionRow) {
-              devLog(`Retrying incomplete post-migration handler for ${key}...`);
+              console.log(`Retrying incomplete post-migration handler for ${key}...`);
               try {
                 await handler(rawDb);
               } catch (retryError) {
@@ -805,7 +796,7 @@ const initializeDatabase = async (rawDb, db) => {
     // returns early above), so it adds no cost to warm cold starts.
     if (await isSchemaComplete(rawDb)) {
       await setStoredSchemaVersion(rawDb, SCHEMA_VERSION);
-      devLog('Database migrations completed successfully');
+      console.log('Database migrations completed successfully');
     } else {
       console.warn('[DB] Schema incomplete after init — not stamping the fast-path fingerprint; next launch will re-verify and heal');
     }
@@ -919,10 +910,10 @@ export const executeTransaction = async (callback) => {
  */
 export const closeDatabase = async () => {
   if (dbInstance) {
-    devLog('Closing database connection...');
+    console.log('Closing database connection...');
     try {
       await dbInstance.closeAsync();
-      devLog('Database closed successfully');
+      console.log('Database closed successfully');
     } catch (error) {
       console.error('Error closing database:', error);
     } finally {
@@ -977,7 +968,7 @@ export const dropAllTables = async () => {
       if (dbInstance) {
         raw = dbInstance;
       } else {
-        devLog('Opening database for table drop...');
+        console.log('Opening database for table drop...');
         raw = await SQLite.openDatabaseAsync(DB_NAME);
         openedNewConnection = true;
       }
@@ -994,12 +985,12 @@ export const dropAllTables = async () => {
       "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
     );
 
-    devLog('Tables to drop:', tables.map(t => t.name).join(', '));
+    console.log('Tables to drop:', tables.map(t => t.name).join(', '));
 
     // Drop each table (including migrations)
     for (const table of tables) {
       await raw.runAsync(`DROP TABLE IF EXISTS "${table.name}"`);
-      devLog(`Dropped table: ${table.name}`);
+      console.log(`Dropped table: ${table.name}`);
     }
 
     // Re-enable foreign keys
@@ -1013,13 +1004,13 @@ export const dropAllTables = async () => {
     // (fresh-install branch) on the next open, which recreates the schema.
     await raw.runAsync('PRAGMA user_version = 0');
 
-    devLog('All tables dropped successfully');
+    console.log('All tables dropped successfully');
 
     // Close the database connection properly before resetting instances
     // This ensures the native connection is released
     try {
       await raw.closeAsync();
-      devLog('Database connection closed after dropping tables');
+      console.log('Database connection closed after dropping tables');
     } catch (closeError) {
       console.error('Error closing database after dropping tables:', closeError);
     }
@@ -1049,7 +1040,7 @@ export const resetDatabase = async () => {
   try {
     const FileSystem = require('expo-file-system/legacy');
     await FileSystem.deleteAsync(dbPath, { idempotent: true });
-    devLog('Database file deleted');
+    console.log('Database file deleted');
   } catch (error) {
     console.error('Failed to delete database file:', error);
   }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "penny",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.3",
         "@quidone/react-native-wheel-picker": "^1.6.4",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "9.1.0",
@@ -30,6 +31,7 @@
         "expo-sqlite": "~56.0.5",
         "expo-task-manager": "~56.0.20",
         "expo-updates": "~56.0.19",
+        "prop-types": "^15.8.1",
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-chart-kit": "^7.0.1",
@@ -45,7 +47,6 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@eslint/js": "^9.39.2",
-        "@expo/vector-icons": "^15.0.3",
         "@testing-library/react-native": "^14.0.0",
         "babel-preset-expo": "~56.0.15",
         "drizzle-kit": "^1.0.0-beta.8-734e789",
@@ -55,7 +56,6 @@
         "globals": "^17.0.0",
         "jest": "~30.4.2",
         "jest-expo": "~56.0.5",
-        "prop-types": "^15.8.1",
         "react-test-renderer": "19.2.3",
         "test-renderer": "1.2",
       },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
     "@quidone/react-native-wheel-picker": "^1.6.4",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "9.1.0",
@@ -40,6 +41,7 @@
     "expo-sqlite": "~56.0.5",
     "expo-task-manager": "~56.0.20",
     "expo-updates": "~56.0.19",
+    "prop-types": "^15.8.1",
     "react": "19.2.3",
     "react-native": "0.85.3",
     "react-native-chart-kit": "^7.0.1",
@@ -55,7 +57,6 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@eslint/js": "^9.39.2",
-    "@expo/vector-icons": "^15.0.3",
     "@testing-library/react-native": "^14.0.0",
     "babel-preset-expo": "~56.0.15",
     "drizzle-kit": "^1.0.0-beta.8-734e789",
@@ -65,7 +66,6 @@
     "globals": "^17.0.0",
     "jest": "~30.4.2",
     "jest-expo": "~56.0.5",
-    "prop-types": "^15.8.1",
     "react-test-renderer": "19.2.3",
     "test-renderer": "1.2"
   },


### PR DESCRIPTION
## Summary

Clears the low-priority hygiene basket from the `react-native-best-practices` audit (#1354). After a high-effort code review, **6 of the 9 items** land here; 3 are deliberately deferred (see below).

## Items done
- [x] **deps** — `prop-types` and `@expo/vector-icons` moved `devDependencies` → `dependencies` (both used at runtime; they resolved only via transitive hoisting). `bun.lock` updated to match.
- [x] **ModalShell** — keyboard show/hide listeners gated on `visible` (permanently-mounted closed modals no longer run a JS-driven `paddingBottom` animation on every app-wide keyboard event), **and** the offset is seeded from `Keyboard.metrics()` when a modal opens over an already-visible keyboard.
- [x] **DateSeparator / OperationsList** — stable `onDateSeparatorPress` passed down; the date is bound inside `DateSeparator`, so the section-header memo isn't pierced.
- [x] **PlannedOperationsScreen** — `keyExtractor` hoisted to a module-level stable reference.
- [x] **AccountsScreen** — the live currency `FlatList` served from a stable module-level `Object.entries` reference.
- [x] **useLogEntries** — deferred `setTick` timers cleared on unmount.

## Deferred (with reason)
- [ ] **chart-kit → svg/Victory Native** (item 2) — a real chart reimplementation, now tracked as its own Victory Native XL migration (#1387/#1388/#1389).
- [ ] **db.js verbose logging → `__DEV__`** (item 4) — **reverted after review.** The app has an in-app Logs viewer + Sentry breadcrumbs, so gating DB init/migration narration behind `__DEV__` strips it from production field diagnostics; and binding `console.log` at module-eval bypasses `LogService` even in dev. Not worth the observability loss.
- [ ] **AccountsScreen `SCREEN_WIDTH` memo** (item 7) — **reverted after review.** Freezing the width at mount broke the form-panel slide-in offset on Android multi-window/foldable resize, for a negligible allocation saving.

## Review
High-effort code review ran on this branch; the two net-negative items above were reverted and the ModalShell already-open-keyboard edge case was fixed. See the review-response comment. No behavior change intended by the remaining items.

Closes #1354
