### PR TITLE
feat(graphs): migrate all charts to Victory Native XL (drop chart-kit)

### DIFF
--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import BalanceHistoryCard from '../../app/components/graphs/BalanceHistoryCard';
+import BalanceHistoryCard, { computeBalanceChart, formatYAxisLabel } from '../../app/components/graphs/BalanceHistoryCard';
 
 // Mock DisplaySettingsContext
 jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
@@ -14,10 +14,10 @@ jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
   })),
 }));
 
-// Mock LineChart from the modern v2 charts subpath
-jest.mock('react-native-chart-kit/v2', () => ({
-  LineChart: 'LineChart',
-}));
+// victory-native (CartesianChart → testID "cartesian-chart", Line → testID
+// "vn-line") and @shopify/react-native-skia are virtually mocked in jest.setup.js.
+// The mock does not forward chart/line props, so chart data & series are asserted
+// via the pure computeBalanceChart export, and rendering via the testIDs above.
 
 // Mock SimplePicker
 jest.mock('../../app/components/SimplePicker', () => 'SimplePicker');
@@ -245,7 +245,7 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.type === 'LineChart')[0]).toBeFalsy();
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeFalsy();
     });
   });
 
@@ -346,7 +346,7 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.type === 'LineChart')[0]).toBeFalsy();
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeFalsy();
     });
   });
 
@@ -394,7 +394,7 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.type === 'LineChart')[0]).toBeTruthy();
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
     });
 
     it('configures chart with correct data including plain avg line', async () => {
@@ -423,10 +423,18 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      expect(lineChart.props.data.map(d => d.day)).toEqual(['1', '5', '10', '15', '20', '25', '28']);
-      // Should have 4 series: actual + plain avg + prevMonth + zero baseline (no forecast when not current month)
-      expect(lineChart.props.series).toHaveLength(4);
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(4);
+      const { data, series } = computeBalanceChart({
+        balanceHistoryData: mockBalanceHistoryData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
+      expect(data.map(d => d.day)).toEqual([1, 5, 10, 15, 20, 25, 28]);
+      // 4 series: actual + plain avg + prevMonth + zero baseline (no forecast when not current month)
+      expect(series).toHaveLength(4);
     });
 
     it('includes actual dataset with correct styling', async () => {
@@ -453,9 +461,17 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualSeries = lineChart.props.series.find(s => s.yKey === 'actual');
-      expect(lineChart.props.data.map(d => d.actual)).toEqual(mockBalanceHistoryData.actualForChart);
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data, series } = computeBalanceChart({
+        balanceHistoryData: mockBalanceHistoryData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
+      const actualSeries = series.find(s => s.yKey === 'actual');
+      expect(data.map(d => d.actual)).toEqual(mockBalanceHistoryData.actualForChart);
       expect(actualSeries.strokeWidth).toBe(3);
     });
 
@@ -485,9 +501,17 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const plainAvgSeries = lineChart.props.series.find(s => s.yKey === 'plainAvg');
-      expect(plainAvgSeries.dot).toBe(false);
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { series } = computeBalanceChart({
+        balanceHistoryData: mockBalanceHistoryData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
+      const plainAvgSeries = series.find(s => s.yKey === 'plainAvg');
+      expect(plainAvgSeries.dashed).toBe(false);
       expect(plainAvgSeries.strokeWidth).toBe(2);
       // Plain avg should be gray color
       expect(plainAvgSeries.color).toBe('rgba(128, 128, 128, 0.4)');
@@ -533,10 +557,18 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(5);
+      const { series } = computeBalanceChart({
+        balanceHistoryData: mockBalanceHistoryData,
+        spendingPrediction: mockSpendingPrediction,
+        isCurrentMonth: true,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
       // 5 series: actual + forecast (split) + plain avg + prevMonth + zero baseline
-      expect(lineChart.props.series).toHaveLength(5);
-      expect(lineChart.props.series.find(s => s.yKey === 'forecast')).toBeTruthy();
+      expect(series).toHaveLength(5);
+      expect(series.find(s => s.yKey === 'forecast')).toBeTruthy();
 
       global.Date.mockRestore();
     });
@@ -567,12 +599,20 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(4);
+      const { series } = computeBalanceChart({
+        balanceHistoryData: mockBalanceHistoryData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
       // 4 series: actual + plain avg + prevMonth + zero baseline (no forecast)
-      expect(lineChart.props.series).toHaveLength(4);
-      const prevMonthSeries = lineChart.props.series.find(s => s.yKey === 'prevMonth');
+      expect(series).toHaveLength(4);
+      const prevMonthSeries = series.find(s => s.yKey === 'prevMonth');
       expect(prevMonthSeries).toBeTruthy();
-      expect(prevMonthSeries.dot).toBe(false);
+      expect(prevMonthSeries.dashed).toBe(false);
     });
 
     it('excludes prevMonth dataset when not available', async () => {
@@ -604,10 +644,18 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
+      const { series } = computeBalanceChart({
+        balanceHistoryData: dataWithoutPrevMonth,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
       // 3 series: actual + plain avg + zero baseline (no prevMonth)
-      expect(lineChart.props.series).toHaveLength(3);
-      expect(lineChart.props.series.find(s => s.yKey === 'prevMonth')).toBeFalsy();
+      expect(series).toHaveLength(3);
+      expect(series.find(s => s.yKey === 'prevMonth')).toBeFalsy();
     });
 
     it('excludes prevMonth dataset when all values are undefined', async () => {
@@ -639,9 +687,17 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
+      const { series } = computeBalanceChart({
+        balanceHistoryData: dataWithUndefinedPrevMonth,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
       // 3 series: actual + plain avg + zero baseline (no prevMonth since all undefined)
-      expect(lineChart.props.series).toHaveLength(3);
+      expect(series).toHaveLength(3);
     });
   });
 
@@ -1031,10 +1087,9 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      expect(lineChart).toBeTruthy();
-      // Verify formatYLabel function formats large numbers correctly
-      const formattedValue = lineChart.props.formatYLabel('1500000');
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      // Verify the Y-axis label formatter turns large numbers into compact units
+      const formattedValue = formatYAxisLabel('1500000', false);
       expect(formattedValue).toBe('2M'); // Should format as millions
     });
   });
@@ -1219,9 +1274,17 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
-      expect(actualDataset.data).toEqual([1000, 1200]); // undefined should be filtered
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data } = computeBalanceChart({
+        balanceHistoryData: dataWithUndefined,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
+      const actualData = data.map(d => d.actual).filter(v => v !== null);
+      expect(actualData).toEqual([1000, 1200]); // undefined should be filtered
     });
 
     it('handles zero max value in scale calculation', async () => {
@@ -1256,8 +1319,7 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      expect(lineChart).toBeTruthy();
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
       // Should handle zero values without crashing
     });
 
@@ -1518,9 +1580,17 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
-      expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data } = computeBalanceChart({
+        balanceHistoryData: fullMonthData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2025,
+        selectedMonth: 11,
+        primaryColor: mockColors.primary,
+      });
+      const actualData = data.map(d => d.actual).filter(v => v !== null);
+      expect(actualData).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
 
     it('shows all actual data for a past month regardless of current date (day 15)', async () => {
@@ -1552,9 +1622,17 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
-      expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data } = computeBalanceChart({
+        balanceHistoryData: fullMonthData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2025,
+        selectedMonth: 5,
+        primaryColor: mockColors.primary,
+      });
+      const actualData = data.map(d => d.actual).filter(v => v !== null);
+      expect(actualData).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
 
     it('shows all actual data for a past month regardless of current date (day 28)', async () => {
@@ -1586,9 +1664,17 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
-      expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data } = computeBalanceChart({
+        balanceHistoryData: fullMonthData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2025,
+        selectedMonth: 10,
+        primaryColor: mockColors.primary,
+      });
+      const actualData = data.map(d => d.actual).filter(v => v !== null);
+      expect(actualData).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
 
     it('shows only data up to current day for the current month (day 10)', async () => {
@@ -1620,10 +1706,18 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data } = computeBalanceChart({
+        balanceHistoryData: fullMonthData,
+        spendingPrediction: null,
+        isCurrentMonth: true,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
+      const actualData = data.map(d => d.actual).filter(v => v !== null);
       // Labels are [1, 5, 10, 15, 20, 25, 31] — days 1, 5, 10 are <= 10
-      expect(actualDataset.data).toEqual([500, 600, 700]);
+      expect(actualData).toEqual([500, 600, 700]);
     });
 
     it('shows only first data point for current month when date is early (day 3)', async () => {
@@ -1655,10 +1749,18 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data } = computeBalanceChart({
+        balanceHistoryData: fullMonthData,
+        spendingPrediction: null,
+        isCurrentMonth: true,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
+      const actualData = data.map(d => d.actual).filter(v => v !== null);
       // Labels are [1, 5, 10, ...] — only day 1 is <= 3
-      expect(actualDataset.data).toEqual([500]);
+      expect(actualData).toEqual([500]);
     });
 
     it('shows all data points for current month at end of month (day 31)', async () => {
@@ -1690,10 +1792,18 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      const actualDataset = { data: lineChart.props.data.map(d => d.actual).filter(v => v !== null) };
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data } = computeBalanceChart({
+        balanceHistoryData: fullMonthData,
+        spendingPrediction: null,
+        isCurrentMonth: true,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
+      const actualData = data.map(d => d.actual).filter(v => v !== null);
       // All labels [1, 5, 10, 15, 20, 25, 31] are <= 31
-      expect(actualDataset.data).toEqual([500, 600, 700, 800, 750, 900, 1000]);
+      expect(actualData).toEqual([500, 600, 700, 800, 750, 900, 1000]);
     });
 
     it('includes forecast data after current day for current month', async () => {
@@ -1735,13 +1845,21 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      const { data, series } = computeBalanceChart({
+        balanceHistoryData: fullMonthData,
+        spendingPrediction: mockSpendingPrediction,
+        isCurrentMonth: true,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+      });
       // Forecast now lives in its own dashed series (days after today), not appended to actual
-      const forecastValues = lineChart.props.data.map(d => d.forecast).filter(v => v !== null);
+      const forecastValues = data.map(d => d.forecast).filter(v => v !== null);
       expect(forecastValues.length).toBeGreaterThan(0);
-      expect(lineChart.props.series.find(s => s.yKey === 'forecast')).toBeTruthy();
+      expect(series.find(s => s.yKey === 'forecast')).toBeTruthy();
       // Actual series stops at today: days 1, 5, 10, 15 (<= 16)
-      const actualValues = lineChart.props.data.map(d => d.actual).filter(v => v !== null);
+      const actualValues = data.map(d => d.actual).filter(v => v !== null);
       expect(actualValues).toEqual([500, 600, 700, 800]);
     });
   });
@@ -1836,7 +1954,7 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.type === 'LineChart')[0]).toBeTruthy();
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
 
       global.Date.mockRestore();
     });
@@ -1870,10 +1988,10 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      const lineChart = container.queryAll(n => n.type === 'LineChart')[0];
-      expect(lineChart.props.formatYLabel('1000')).toBe('');
-      expect(lineChart.props.formatYLabel('1000000')).toBe('');
-      expect(lineChart.props.formatYLabel('0')).toBe('');
+      expect(container.queryAll(n => n.props.testID === 'cartesian-chart')[0]).toBeTruthy();
+      expect(formatYAxisLabel('1000', true)).toBe('');
+      expect(formatYAxisLabel('1000000', true)).toBe('');
+      expect(formatYAxisLabel('0', true)).toBe('');
 
       global.Date.mockRestore();
     });

--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -95,13 +95,13 @@ describe('CategorySpendingCard', () => {
       expect(getByText('Food')).toBeTruthy();
     });
 
-    it('renders bar chart SVG with 12 months of bars', async () => {
-      const { container } = await render(
+    it('renders the Victory Native bar chart with bars', async () => {
+      const { getByTestId, getAllByTestId } = await render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      const svg = container.queryAll(n => n.type === 'Svg')[0];
-      expect(svg).toBeTruthy();
+      expect(getByTestId('cartesian-chart')).toBeTruthy();
+      expect(getAllByTestId('vn-bar').length).toBeGreaterThan(0);
     });
 
     it('shows loading indicator when loading', async () => {
@@ -128,12 +128,12 @@ describe('CategorySpendingCard', () => {
         loadData: jest.fn(),
       });
 
-      const { getByText, container } = await render(
+      const { getByText, queryByTestId } = await render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
       expect(getByText('no_spending_data')).toBeTruthy();
-      expect(container.queryAll(n => n.type === 'Svg')[0]).toBeFalsy();
+      expect(queryByTestId('cartesian-chart')).toBeFalsy();
     });
 
     it('renders null when no parent expense categories', async () => {
@@ -365,11 +365,11 @@ describe('CategorySpendingCard', () => {
     });
 
     it('still renders the bar chart', async () => {
-      const { container } = await render(
+      const { getByTestId } = await render(
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(container.queryAll(n => n.type === 'Svg')[0]).toBeTruthy();
+      expect(getByTestId('cartesian-chart')).toBeTruthy();
     });
   });
 

--- a/__tests__/components/graphs/DonutChart.test.js
+++ b/__tests__/components/graphs/DonutChart.test.js
@@ -1,60 +1,66 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import DonutChart, {
-  computeSegments,
-  CIRCUMFERENCE,
+  mapPieData,
+  computeIconMarkers,
   CENTER,
-  RADIUS,
+  ICON_RADIUS,
   ICON_THRESHOLD,
 } from '../../../app/components/graphs/DonutChart';
 
-describe('computeSegments', () => {
+describe('mapPieData', () => {
+  it('maps amount/color onto Victory Native value/color keys', async () => {
+    const data = [
+      { amount: 450, color: '#f00', icon: 'food' },
+      { amount: 300, color: '#0f0', icon: 'car' },
+    ];
+    expect(mapPieData(data)).toEqual([
+      { label: 'food-0', value: 450, color: '#f00' },
+      { label: 'car-1', value: 300, color: '#0f0' },
+    ]);
+  });
+
+  it('produces a unique label even when icons repeat or are missing', async () => {
+    const data = [
+      { amount: 10, color: '#f00', icon: 'dots-horizontal' },
+      { amount: 10, color: '#0f0', icon: 'dots-horizontal' },
+      { amount: 10, color: '#00f', icon: null },
+    ];
+    const labels = mapPieData(data).map((d) => d.label);
+    expect(new Set(labels).size).toBe(3);
+    expect(labels).toEqual(['dots-horizontal-0', 'dots-horizontal-1', 'slice-2']);
+  });
+
+  it('returns an empty array for empty data', async () => {
+    expect(mapPieData([])).toEqual([]);
+  });
+});
+
+describe('computeIconMarkers', () => {
   it('returns empty array for empty data', async () => {
-    expect(computeSegments([])).toEqual([]);
+    expect(computeIconMarkers([])).toEqual([]);
   });
 
   it('returns empty array when all amounts are zero', async () => {
-    expect(computeSegments([{ amount: 0, color: '#f00', icon: 'food' }])).toEqual([]);
+    expect(computeIconMarkers([{ amount: 0, color: '#f00', icon: 'food' }])).toEqual([]);
   });
 
-  it('arc lengths sum to CIRCUMFERENCE', async () => {
+  it('returns one marker per slice', async () => {
     const data = [
       { amount: 450, color: '#f00', icon: 'food' },
       { amount: 300, color: '#0f0', icon: 'car' },
       { amount: 250, color: '#00f', icon: 'shopping' },
     ];
-    const segs = computeSegments(data);
-    const total = segs.reduce((s, seg) => s + seg.arcLength, 0);
-    expect(total).toBeCloseTo(CIRCUMFERENCE, 5);
-  });
-
-  it('first segment has dashOffset of 0', async () => {
-    const data = [
-      { amount: 500, color: '#f00', icon: 'food' },
-      { amount: 500, color: '#0f0', icon: 'car' },
-    ];
-    expect(computeSegments(data)[0].dashOffset).toBe(0);
-  });
-
-  it('each subsequent segment dashOffset equals negative sum of prior arcLengths', async () => {
-    const data = [
-      { amount: 400, color: '#f00', icon: 'food' },
-      { amount: 300, color: '#0f0', icon: 'car' },
-      { amount: 300, color: '#00f', icon: 'shopping' },
-    ];
-    const segs = computeSegments(data);
-    expect(segs[1].dashOffset).toBeCloseTo(-segs[0].arcLength, 5);
-    expect(segs[2].dashOffset).toBeCloseTo(-(segs[0].arcLength + segs[1].arcLength), 5);
+    expect(computeIconMarkers(data)).toHaveLength(3);
   });
 
   it('shows icon for segment exactly at ICON_THRESHOLD', async () => {
     const pct = ICON_THRESHOLD; // 10%
     const data = [
       { amount: 1 - pct, color: '#f00', icon: 'food' },
-      { amount: pct,     color: '#0f0', icon: 'car' },
+      { amount: pct, color: '#0f0', icon: 'car' },
     ];
-    const segs = computeSegments(data);
-    expect(segs[1].showIcon).toBe(true);
+    expect(computeIconMarkers(data)[1].showIcon).toBe(true);
   });
 
   it('hides icon for segment just below ICON_THRESHOLD', async () => {
@@ -62,43 +68,55 @@ describe('computeSegments', () => {
       { amount: 0.91, color: '#f00', icon: 'food' },
       { amount: 0.09, color: '#0f0', icon: 'car' }, // 9%
     ];
-    expect(computeSegments(data)[1].showIcon).toBe(false);
+    expect(computeIconMarkers(data)[1].showIcon).toBe(false);
   });
 
   it('hides icon when item.icon is falsy', async () => {
     const data = [{ amount: 1000, color: '#f00', icon: null }];
-    expect(computeSegments(data)[0].showIcon).toBe(false);
+    expect(computeIconMarkers(data)[0].showIcon).toBe(false);
   });
 
-  it('single segment spans full circumference', async () => {
-    const segs = computeSegments([{ amount: 100, color: '#f00', icon: 'food' }]);
-    expect(segs[0].arcLength).toBeCloseTo(CIRCUMFERENCE, 5);
-    expect(segs[0].dashOffset).toBe(0);
+  it('single full-circle slice midAngle=π maps to the bottom of the ring', async () => {
+    const markers = computeIconMarkers([{ amount: 1, color: '#f00', icon: 'food' }]);
+    // midAngle = (0 + 0.5) * 2π = π
+    expect(markers[0].x).toBeCloseTo(CENTER, 1); // sin(π) ≈ 0
+    expect(markers[0].y).toBeCloseTo(CENTER + ICON_RADIUS, 1); // −cos(π) = 1
   });
 
-  it('icon position math: full-circle segment midAngle=π maps to bottom (x≈CENTER, y≈CENTER+RADIUS)', async () => {
-    const segs = computeSegments([{ amount: 1, color: '#f00', icon: 'food' }]);
-    // midAngle = (0 + CIRCUMFERENCE/2) / RADIUS = π
-    expect(segs[0].iconX).toBeCloseTo(CENTER, 1);         // sin(π) ≈ 0
-    expect(segs[0].iconY).toBeCloseTo(CENTER + RADIUS, 1); // −cos(π) = 1
+  it('a half-and-half split places markers on opposite sides (top vs bottom)', async () => {
+    const markers = computeIconMarkers([
+      { amount: 1, color: '#f00', icon: 'food' }, // midAngle = π/2 → right
+      { amount: 1, color: '#0f0', icon: 'car' }, //  midAngle = 3π/2 → left
+    ]);
+    expect(markers[0].x).toBeCloseTo(CENTER + ICON_RADIUS, 1); // sin(π/2) = 1
+    expect(markers[0].y).toBeCloseTo(CENTER, 1); // −cos(π/2) ≈ 0
+    expect(markers[1].x).toBeCloseTo(CENTER - ICON_RADIUS, 1); // sin(3π/2) = −1
+    expect(markers[1].y).toBeCloseTo(CENTER, 1); // −cos(3π/2) ≈ 0
   });
 
   it('preserves color and icon from input', async () => {
-    const segs = computeSegments([{ amount: 100, color: '#abc123', icon: 'pizza' }]);
-    expect(segs[0].color).toBe('#abc123');
-    expect(segs[0].icon).toBe('pizza');
+    const markers = computeIconMarkers([{ amount: 100, color: '#abc123', icon: 'pizza' }]);
+    expect(markers[0].color).toBe('#abc123');
+    expect(markers[0].icon).toBe('pizza');
   });
 });
 
 describe('DonutChart', () => {
   const mockData = [
-    { amount: 560, color: '#7c83fd', icon: 'food' },   // 60.9% — above threshold
-    { amount: 280, color: '#fd7c7c', icon: 'car' },    // 30.4% — above threshold
-    { amount: 80,  color: '#7ce8fd', icon: 'heart' },  //  8.7% — below threshold
+    { amount: 560, color: '#7c83fd', icon: 'food' }, // 60.9% — above threshold
+    { amount: 280, color: '#fd7c7c', icon: 'car' }, // 30.4% — above threshold
+    { amount: 80, color: '#7ce8fd', icon: 'heart' }, //  8.7% — below threshold
   ];
 
   it('renders without crashing', async () => {
     await render(<DonutChart data={mockData} />);
+  });
+
+  it('renders the Victory Native polar/pie donut primitives', async () => {
+    const { getByTestId } = await render(<DonutChart data={mockData} />);
+    expect(getByTestId('donut-chart')).toBeTruthy();
+    expect(getByTestId('polar-chart')).toBeTruthy();
+    expect(getByTestId('vn-pie')).toBeTruthy();
   });
 
   it('renders icons for segments at or above threshold', async () => {
@@ -112,8 +130,10 @@ describe('DonutChart', () => {
     expect(queryByTestId('icon-heart')).toBeNull();
   });
 
-  it('renders no icons when data is empty', async () => {
-    const { queryAllByTestId } = await render(<DonutChart data={[]} />);
+  it('still renders the donut (and no icons) when data is empty', async () => {
+    const { getByTestId, queryAllByTestId } = await render(<DonutChart data={[]} />);
+    expect(getByTestId('donut-chart')).toBeTruthy();
+    expect(getByTestId('polar-chart')).toBeTruthy();
     expect(queryAllByTestId(/^icon-/).length).toBe(0);
   });
 

--- a/__tests__/hooks/useBalanceHistory.test.js
+++ b/__tests__/hooks/useBalanceHistory.test.js
@@ -601,7 +601,7 @@ describe('useBalanceHistory', () => {
 
     it('should not produce undefined/null at end of prevMonth when current month has more days than previous month', async () => {
       // May has 31 days, April has 30 — day 31 previously returned undefined which
-      // react-native-chart-kit rendered as 0, making the purple line drop to zero.
+      // the chart rendered as 0, making the purple line drop to zero.
       const mayYear = 2026;
       const mayMonthIndex = 4; // May (0-based)
 

--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -7,14 +7,9 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 
-// Mock all dependencies
-jest.mock('react-native-chart-kit', () => ({
-  PieChart: () => 'PieChart',
-}));
-
-jest.mock('react-native-chart-kit/v2', () => ({
-  LineChart: () => 'LineChart',
-}));
+// Mock all dependencies.
+// Charts are Victory Native XL now — victory-native and @shopify/react-native-skia
+// are virtually mocked globally in jest.setup.js, so no per-file chart mock is needed.
 
 jest.mock('../../app/contexts/ThemeColorsContext', () => ({
   useThemeColors: jest.fn(() => ({

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -1,20 +1,13 @@
 import React, { useState, useMemo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
-import { LineChart } from 'react-native-chart-kit/v2';
+import { CartesianChart, Line } from 'victory-native';
+import { matchFont, DashPathEffect } from '@shopify/react-native-skia';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import SimplePicker from '../SimplePicker';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 import BalanceHistoryCalendarView from './BalanceHistoryCalendarView';
-
-const screenWidth = Dimensions.get('window').width;
-
-const formatCurrency = (amount, currency) => {
-  const currencyInfo = currencies[currency];
-  const decimals = currencyInfo?.decimal_digits ?? 2;
-  return `${parseFloat(amount).toFixed(decimals)} ${currency}`;
-};
 
 // Helper to format numbers compactly (e.g., 10K, 1.5M)
 const formatCompact = (value, currency) => {
@@ -84,14 +77,252 @@ const formatBalanceCompact = (amount, currency) => {
   return `${symbol}${formatted}`;
 };
 
-// Helper to convert hex color to rgba
-const hexToRgba = (hex, alpha) => {
-  // Remove # if present
-  const cleanHex = hex.replace('#', '');
-  const r = parseInt(cleanHex.substring(0, 2), 16);
-  const g = parseInt(cleanHex.substring(2, 4), 16);
-  const b = parseInt(cleanHex.substring(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+// Compact Y-axis tick formatter. Exported so it can be unit-tested directly
+// (Victory Native XL consumes it via axisOptions.formatYLabel, whose output is
+// rendered on the Skia canvas and therefore not inspectable from the test tree).
+export const formatYAxisLabel = (value, hideBalances) => {
+  if (hideBalances) return '';
+  const numValue = parseFloat(value);
+  if (numValue === 0) return '';
+  const absValue = Math.abs(numValue);
+  const isNegative = numValue < 0;
+
+  if (absValue >= 1000000) {
+    const result = `${(absValue / 1000000).toFixed(0)}M`;
+    return isNegative ? `-${result}` : result;
+  } else if (absValue >= 1000) {
+    const result = `${(absValue / 1000).toFixed(0)}K`;
+    return isNegative ? `-${result}` : result;
+  }
+  return numValue.toFixed(0);
+};
+
+// X-axis tick formatter: only label the milestone days (1/5/10/15/20/25 + last).
+const formatXAxisLabel = (value, lastDay) => {
+  const day = parseInt(value, 10);
+  if (day === 1 || day === 5 || day === 10 || day === 15 ||
+    day === 20 || day === 25 || day === lastDay) {
+    return String(day);
+  }
+  return '';
+};
+
+// Pure builder for the balance-history chart. Returns the derived legend data
+// (`computed`), the Victory Native XL record array (`data`, xKey = day, one
+// numeric field per series) and the per-series descriptors (`series`). Kept as a
+// standalone export so the date-sensitive actual/forecast split and series
+// composition can be unit-tested without rendering the Skia canvas.
+export const computeBalanceChart = ({
+  balanceHistoryData,
+  spendingPrediction,
+  isCurrentMonth,
+  selectedYear,
+  selectedMonth,
+  primaryColor,
+}) => {
+  if (!balanceHistoryData.actual || balanceHistoryData.actual.length === 0) {
+    return { computed: null, data: [], series: [] };
+  }
+
+  const currentDay = new Date().getDate();
+
+  const calculateForecastData = () => {
+    if (!spendingPrediction || !isCurrentMonth) return [];
+    const actualPoints = (balanceHistoryData.actual || []).filter(p => p.x <= currentDay);
+    if (actualPoints.length === 0) return [];
+    const lastActualPoint = actualPoints[actualPoints.length - 1];
+    const predictions = [];
+    for (let day = currentDay; day <= spendingPrediction.daysInMonth; day++) {
+      const daysFromNow = day - currentDay;
+      const predictedBalance = lastActualPoint.y - (spendingPrediction.dailyAverage * daysFromNow);
+      predictions.push({ x: day, y: predictedBalance });
+    }
+    return predictions;
+  };
+
+  const forecastData = calculateForecastData();
+  const hasForecast = forecastData.length > 0;
+
+  const combinedActualForecast = balanceHistoryData.labels.map((day, index) => {
+    if (!isCurrentMonth || day <= currentDay) {
+      return balanceHistoryData.actualForChart[index];
+    } else if (hasForecast) {
+      const point = forecastData.find(p => p.x === day);
+      return point ? point.y : undefined;
+    }
+    return undefined;
+  });
+
+  const actualValues = balanceHistoryData.actualForChart.filter(v => v !== undefined);
+  const maxBalance = actualValues.length > 0 ? Math.max(...actualValues) : 0;
+  const daysInMonth = balanceHistoryData.labels[balanceHistoryData.labels.length - 1];
+
+  // Burndown ("plain avg") line starts from the month's spendable ceiling
+  // (day-1 balance + post-day-1 inflows − outgoing transfers), computed in the
+  // hook. Fall back to the peak-actual max when it's unavailable so older data /
+  // accounts younger than the month keep the previous behaviour.
+  const rawPlainAvgMax = balanceHistoryData.plainAvgMax;
+  const plainAvgMax = (rawPlainAvgMax != null && Number.isFinite(rawPlainAvgMax))
+    ? rawPlainAvgMax
+    : maxBalance;
+
+  const plainAvgData = balanceHistoryData.labels.map(day =>
+    plainAvgMax * (1 - (day - 1) / (daysInMonth - 1)),
+  );
+
+  const forecastValues = combinedActualForecast.filter(v => v !== undefined);
+  const prevMonthValues = (balanceHistoryData.prevMonth || []).filter(v => v !== undefined);
+  const allValues = [...actualValues, ...forecastValues, ...prevMonthValues, ...plainAvgData];
+  const maxValue = allValues.length > 0 ? Math.max(...allValues) : 0;
+  const minValue = allValues.length > 0 ? Math.min(...allValues) : 0;
+  const hasNegativeValues = minValue < 0;
+
+  const { max: niceMax, interval: niceInterval } = calculateNiceScale(maxValue);
+  const lastDay = balanceHistoryData.labels[balanceHistoryData.labels.length - 1];
+
+  // Legend table values
+  const now = new Date();
+  const isCurrentMonthLocal = selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
+  const displayDay = isCurrentMonthLocal
+    ? now.getDate()
+    : (balanceHistoryData.labels && balanceHistoryData.labels.length > 0
+      ? balanceHistoryData.labels[balanceHistoryData.labels.length - 1]
+      : null);
+
+  const findActualAtDay = (day) => {
+    if (!day) return undefined;
+    const point = (balanceHistoryData.actual || []).find(p => p.x === day);
+    if (point) return point.y;
+    const prior = (balanceHistoryData.actual || []).filter(p => p.x <= day);
+    if (prior.length > 0) return prior[prior.length - 1].y;
+    return undefined;
+  };
+
+  const actualCurrent = findActualAtDay(displayDay);
+  const actualEnd = findActualAtDay(daysInMonth);
+
+  let actualDailyAvg = null;
+  if (spendingPrediction && isCurrentMonth) {
+    actualDailyAvg = -spendingPrediction.dailyAverage;
+  } else if (actualValues.length >= 1) {
+    const actualDataPoints = balanceHistoryData.actual || [];
+    if (actualDataPoints.length >= 2) {
+      const firstPoint = actualDataPoints[0];
+      const lastPoint = actualDataPoints[actualDataPoints.length - 1];
+      const daySpan = lastPoint.x - firstPoint.x;
+      actualDailyAvg = daySpan > 0 ? (lastPoint.y - firstPoint.y) / daySpan : 0;
+    } else {
+      actualDailyAvg = 0;
+    }
+  }
+
+  const plainAvgDaily = daysInMonth > 1 ? -plainAvgMax / (daysInMonth - 1) : 0;
+  const plainAvgCurrent = displayDay ? plainAvgMax * (1 - (displayDay - 1) / (daysInMonth - 1)) : null;
+
+  let forecastEnd = null;
+  let forecastDailyAvg = null;
+  const hasForecastData = spendingPrediction && isCurrentMonth;
+  if (hasForecastData && actualCurrent !== undefined) {
+    const daysRemaining = spendingPrediction.daysInMonth - now.getDate();
+    forecastEnd = actualCurrent - (spendingPrediction.dailyAverage * daysRemaining);
+    forecastDailyAvg = -spendingPrediction.dailyAverage;
+  }
+
+  const hasPrevMonthData = balanceHistoryData.prevMonth && balanceHistoryData.prevMonth.some(v => v !== undefined);
+  let prevMonthMax = null;
+  let prevMonthCurrent = null;
+  let prevMonthEnd = null;
+  let prevMonthDailyAvg = null;
+  if (hasPrevMonthData) {
+    const prevMonthAllValues = balanceHistoryData.prevMonth || [];
+    const prevMonthActualValues = prevMonthAllValues.filter(v => v !== undefined);
+    prevMonthMax = prevMonthActualValues.length > 0 ? Math.max(...prevMonthActualValues) : null;
+
+    const prevMonthAtDay = (day) => {
+      if (!day) return null;
+      const idx = Math.min(day - 1, prevMonthAllValues.length - 1);
+      for (let i = idx; i >= 0; i--) {
+        if (prevMonthAllValues[i] !== undefined) return prevMonthAllValues[i];
+      }
+      return null;
+    };
+
+    const prevMonthDaysCount = balanceHistoryData.prevMonthDaysCount || new Date(selectedYear, selectedMonth, 0).getDate();
+    prevMonthCurrent = prevMonthAtDay(displayDay);
+    prevMonthEnd = prevMonthAtDay(prevMonthDaysCount);
+
+    const prevTotalExpenses = balanceHistoryData.prevMonthTotalExpenses;
+    if (prevTotalExpenses != null && prevMonthDaysCount > 0) {
+      prevMonthDailyAvg = -parseFloat(prevTotalExpenses) / prevMonthDaysCount;
+    }
+  }
+
+  const computed = {
+    currentDay,
+    hasForecast,
+    forecastData,
+    combinedActualForecast,
+    actualValues,
+    maxBalance,
+    plainAvgMax,
+    daysInMonth,
+    plainAvgData,
+    hasNegativeValues,
+    niceMax,
+    niceInterval,
+    lastDay,
+    displayDay,
+    actualCurrent,
+    actualEnd,
+    actualDailyAvg,
+    plainAvgDaily,
+    plainAvgCurrent,
+    hasForecastData,
+    forecastEnd,
+    forecastDailyAvg,
+    hasPrevMonthData,
+    prevMonthMax,
+    prevMonthCurrent,
+    prevMonthEnd,
+    prevMonthDailyAvg,
+  };
+
+  // Victory Native XL consumes an array of records (xKey = day + one numeric
+  // field per series) instead of the legacy parallel { labels, datasets } shape.
+  // The actual line is split into a solid "actual" series (up to today) and a
+  // dashed "forecast" series (today onward), which makes the "today" boundary
+  // self-evident — replacing the old hand-drawn vertical decorator line.
+  const prevMonth = balanceHistoryData.prevMonth || [];
+  const showForecast = isCurrentMonth && hasForecast;
+  const data = balanceHistoryData.labels.map((day, i) => {
+    const raw = combinedActualForecast[i];
+    const value = raw === undefined ? null : raw;
+    const isForecastDay = showForecast && day > currentDay;
+    const isBoundaryDay = showForecast && day === currentDay;
+    return {
+      day,
+      actual: isForecastDay ? null : value,
+      // include the boundary day in the forecast series too so the segments touch
+      forecast: (isForecastDay || isBoundaryDay) ? value : null,
+      plainAvg: plainAvgData[i] ?? null,
+      prevMonth: prevMonth[i] ?? null,
+      zero: 0,
+    };
+  });
+
+  const series = [
+    { yKey: 'actual', color: primaryColor, strokeWidth: 3, curveType: 'monotoneX', dashed: false },
+  ];
+  if (showForecast) {
+    series.push({ yKey: 'forecast', color: primaryColor, strokeWidth: 2, curveType: 'monotoneX', dashed: true });
+  }
+  series.push({ yKey: 'plainAvg', color: 'rgba(128, 128, 128, 0.4)', strokeWidth: 2, curveType: 'linear', dashed: false });
+  if (hasPrevMonthData) {
+    series.push({ yKey: 'prevMonth', color: 'rgba(156, 39, 176, 0.5)', strokeWidth: 2, curveType: 'monotoneX', dashed: false });
+  }
+  series.push({ yKey: 'zero', color: 'rgba(128, 128, 128, 0.5)', strokeWidth: 1, curveType: 'linear', dashed: false });
+
+  return { computed, data, series };
 };
 
 const BalanceHistoryCard = ({
@@ -131,231 +362,39 @@ const BalanceHistoryCard = ({
     ? new Date(selectedYear, selectedMonth + 1, 0).getDate()
     : null;
 
-  const chartComputed = useMemo(() => {
-    if (!balanceHistoryData.actual || balanceHistoryData.actual.length === 0) {
+  const { computed: chartComputed, data: chartData, series: chartSeries } = useMemo(
+    () => computeBalanceChart({
+      balanceHistoryData,
+      spendingPrediction,
+      isCurrentMonth,
+      selectedYear,
+      selectedMonth,
+      primaryColor: colors.primary,
+    }),
+    [balanceHistoryData, spendingPrediction, isCurrentMonth, selectedYear, selectedMonth, colors.primary],
+  );
+
+  // yKeys drive Victory's shared y-domain (the always-present "zero" key keeps the
+  // baseline in range). Only the keys with a rendered <Line> are listed.
+  const chartYKeys = useMemo(() => chartSeries.map(s => s.yKey), [chartSeries]);
+
+  // Fixed [0, niceMax] domain unless the data dips negative (then let Victory
+  // auto-scale to include the negative portion), mirroring the old yDomain logic.
+  const yDomain = useMemo(() => {
+    if (!chartComputed) return undefined;
+    if (chartComputed.hasNegativeValues || !chartComputed.niceMax) return undefined;
+    return { y: [0, chartComputed.niceMax] };
+  }, [chartComputed]);
+
+  // System-font axis labels (the project ships no .ttf). Guarded because matchFont
+  // returns a stub under Jest and a real SkFont on device.
+  const axisFont = useMemo(() => {
+    try {
+      return matchFont({ fontFamily: 'sans-serif', fontSize: 11 }) || null;
+    } catch (e) {
       return null;
     }
-
-    const currentDay = new Date().getDate();
-
-    const calculateForecastData = () => {
-      if (!spendingPrediction || !isCurrentMonth) return [];
-      const actualPoints = (balanceHistoryData.actual || []).filter(p => p.x <= currentDay);
-      if (actualPoints.length === 0) return [];
-      const lastActualPoint = actualPoints[actualPoints.length - 1];
-      const predictions = [];
-      for (let day = currentDay; day <= spendingPrediction.daysInMonth; day++) {
-        const daysFromNow = day - currentDay;
-        const predictedBalance = lastActualPoint.y - (spendingPrediction.dailyAverage * daysFromNow);
-        predictions.push({ x: day, y: predictedBalance });
-      }
-      return predictions;
-    };
-
-    const forecastData = calculateForecastData();
-    const hasForecast = forecastData.length > 0;
-
-    const combinedActualForecast = balanceHistoryData.labels.map((day, index) => {
-      if (!isCurrentMonth || day <= currentDay) {
-        return balanceHistoryData.actualForChart[index];
-      } else if (hasForecast) {
-        const point = forecastData.find(p => p.x === day);
-        return point ? point.y : undefined;
-      }
-      return undefined;
-    });
-
-    const actualValues = balanceHistoryData.actualForChart.filter(v => v !== undefined);
-    const maxBalance = actualValues.length > 0 ? Math.max(...actualValues) : 0;
-    const daysInMonth = balanceHistoryData.labels[balanceHistoryData.labels.length - 1];
-
-    // Burndown ("plain avg") line starts from the month's spendable ceiling
-    // (day-1 balance + post-day-1 inflows − outgoing transfers), computed in the
-    // hook. Fall back to the peak-actual max when it's unavailable so older data /
-    // accounts younger than the month keep the previous behaviour.
-    const rawPlainAvgMax = balanceHistoryData.plainAvgMax;
-    const plainAvgMax = (rawPlainAvgMax != null && Number.isFinite(rawPlainAvgMax))
-      ? rawPlainAvgMax
-      : maxBalance;
-
-    const plainAvgData = balanceHistoryData.labels.map(day =>
-      plainAvgMax * (1 - (day - 1) / (daysInMonth - 1)),
-    );
-
-    const forecastValues = combinedActualForecast.filter(v => v !== undefined);
-    const prevMonthValues = (balanceHistoryData.prevMonth || []).filter(v => v !== undefined);
-    const allValues = [...actualValues, ...forecastValues, ...prevMonthValues, ...plainAvgData];
-    const maxValue = allValues.length > 0 ? Math.max(...allValues) : 0;
-    const minValue = allValues.length > 0 ? Math.min(...allValues) : 0;
-    const hasNegativeValues = minValue < 0;
-
-    const { max: niceMax, interval: niceInterval } = calculateNiceScale(maxValue);
-    const lastDay = balanceHistoryData.labels[balanceHistoryData.labels.length - 1];
-
-    // Legend table values
-    const now = new Date();
-    const isCurrentMonthLocal = selectedYear === now.getFullYear() && selectedMonth === now.getMonth();
-    const displayDay = isCurrentMonthLocal
-      ? now.getDate()
-      : (balanceHistoryData.labels && balanceHistoryData.labels.length > 0
-        ? balanceHistoryData.labels[balanceHistoryData.labels.length - 1]
-        : null);
-
-    const findActualAtDay = (day) => {
-      if (!day) return undefined;
-      const point = (balanceHistoryData.actual || []).find(p => p.x === day);
-      if (point) return point.y;
-      const prior = (balanceHistoryData.actual || []).filter(p => p.x <= day);
-      if (prior.length > 0) return prior[prior.length - 1].y;
-      return undefined;
-    };
-
-    const actualCurrent = findActualAtDay(displayDay);
-    const actualEnd = findActualAtDay(daysInMonth);
-
-    let actualDailyAvg = null;
-    if (spendingPrediction && isCurrentMonth) {
-      actualDailyAvg = -spendingPrediction.dailyAverage;
-    } else if (actualValues.length >= 1) {
-      const actualDataPoints = balanceHistoryData.actual || [];
-      if (actualDataPoints.length >= 2) {
-        const firstPoint = actualDataPoints[0];
-        const lastPoint = actualDataPoints[actualDataPoints.length - 1];
-        const daySpan = lastPoint.x - firstPoint.x;
-        actualDailyAvg = daySpan > 0 ? (lastPoint.y - firstPoint.y) / daySpan : 0;
-      } else {
-        actualDailyAvg = 0;
-      }
-    }
-
-    const plainAvgDaily = daysInMonth > 1 ? -plainAvgMax / (daysInMonth - 1) : 0;
-    const plainAvgCurrent = displayDay ? plainAvgMax * (1 - (displayDay - 1) / (daysInMonth - 1)) : null;
-
-    let forecastEnd = null;
-    let forecastDailyAvg = null;
-    const hasForecastData = spendingPrediction && isCurrentMonth;
-    if (hasForecastData && actualCurrent !== undefined) {
-      const daysRemaining = spendingPrediction.daysInMonth - now.getDate();
-      forecastEnd = actualCurrent - (spendingPrediction.dailyAverage * daysRemaining);
-      forecastDailyAvg = -spendingPrediction.dailyAverage;
-    }
-
-    const hasPrevMonthData = balanceHistoryData.prevMonth && balanceHistoryData.prevMonth.some(v => v !== undefined);
-    let prevMonthMax = null;
-    let prevMonthCurrent = null;
-    let prevMonthEnd = null;
-    let prevMonthDailyAvg = null;
-    if (hasPrevMonthData) {
-      const prevMonthAllValues = balanceHistoryData.prevMonth || [];
-      const prevMonthActualValues = prevMonthAllValues.filter(v => v !== undefined);
-      prevMonthMax = prevMonthActualValues.length > 0 ? Math.max(...prevMonthActualValues) : null;
-
-      const prevMonthAtDay = (day) => {
-        if (!day) return null;
-        const idx = Math.min(day - 1, prevMonthAllValues.length - 1);
-        for (let i = idx; i >= 0; i--) {
-          if (prevMonthAllValues[i] !== undefined) return prevMonthAllValues[i];
-        }
-        return null;
-      };
-
-      const prevMonthDaysCount = balanceHistoryData.prevMonthDaysCount || new Date(selectedYear, selectedMonth, 0).getDate();
-      prevMonthCurrent = prevMonthAtDay(displayDay);
-      prevMonthEnd = prevMonthAtDay(prevMonthDaysCount);
-
-      const prevTotalExpenses = balanceHistoryData.prevMonthTotalExpenses;
-      if (prevTotalExpenses != null && prevMonthDaysCount > 0) {
-        prevMonthDailyAvg = -parseFloat(prevTotalExpenses) / prevMonthDaysCount;
-      }
-    }
-
-    return {
-      currentDay,
-      hasForecast,
-      forecastData,
-      combinedActualForecast,
-      actualValues,
-      maxBalance,
-      plainAvgMax,
-      daysInMonth,
-      plainAvgData,
-      hasNegativeValues,
-      niceMax,
-      niceInterval,
-      lastDay,
-      displayDay,
-      actualCurrent,
-      actualEnd,
-      actualDailyAvg,
-      plainAvgDaily,
-      plainAvgCurrent,
-      hasForecastData,
-      forecastEnd,
-      forecastDailyAvg,
-      hasPrevMonthData,
-      prevMonthMax,
-      prevMonthCurrent,
-      prevMonthEnd,
-      prevMonthDailyAvg,
-    };
-  }, [balanceHistoryData, spendingPrediction, isCurrentMonth, selectedYear, selectedMonth, selectedAccount]);
-
-  // v2 LineChart consumes an array of records (xKey + per-series yKeys) instead of
-  // the legacy parallel { labels, datasets } shape. The actual line is split into a
-  // solid "actual" series (up to today) and a dashed "forecast" series (today onward),
-  // which makes the "today" boundary self-evident — replacing the old hand-drawn
-  // vertical decorator line and its hardcoded chart geometry.
-  const chartData = useMemo(() => {
-    if (!chartComputed) return [];
-    const { combinedActualForecast, plainAvgData, currentDay, hasForecast } = chartComputed;
-    const prevMonth = balanceHistoryData.prevMonth || [];
-    const showForecast = isCurrentMonth && hasForecast;
-    return balanceHistoryData.labels.map((day, i) => {
-      const raw = combinedActualForecast[i];
-      const value = raw === undefined ? null : raw;
-      const isForecastDay = showForecast && day > currentDay;
-      const isBoundaryDay = showForecast && day === currentDay;
-      return {
-        day: String(day),
-        actual: isForecastDay ? null : value,
-        // include the boundary day in the forecast series too so the segments touch
-        forecast: (isForecastDay || isBoundaryDay) ? value : null,
-        plainAvg: plainAvgData[i] ?? null,
-        prevMonth: prevMonth[i] ?? null,
-        zero: 0,
-      };
-    });
-  }, [chartComputed, balanceHistoryData, isCurrentMonth]);
-
-  const chartSeries = useMemo(() => {
-    if (!chartComputed) return [];
-    const series = [
-      { yKey: 'actual', label: 'actual', color: colors.primary, strokeWidth: 3, dot: { radius: 2 } },
-    ];
-    if (isCurrentMonth && chartComputed.hasForecast) {
-      series.push({ yKey: 'forecast', label: 'forecast', color: colors.primary, strokeWidth: 3, strokeDasharray: [5, 5], dot: false });
-    }
-    series.push({ yKey: 'plainAvg', label: 'plainAvg', color: 'rgba(128, 128, 128, 0.4)', strokeWidth: 2, dot: false });
-    if (chartComputed.hasPrevMonthData) {
-      series.push({ yKey: 'prevMonth', label: 'prevMonth', color: 'rgba(156, 39, 176, 0.5)', strokeWidth: 2, dot: false });
-    }
-    series.push({ yKey: 'zero', label: 'zero', color: 'rgba(128, 128, 128, 0.5)', strokeWidth: 1, dot: false });
-    return series;
-  }, [chartComputed, colors.primary, isCurrentMonth]);
-
-  const chartTheme = useMemo(() => ({
-    background: colors.altRow,
-    plotBackground: colors.altRow,
-    grid: colors.border,
-    axis: colors.mutedText,
-    text: colors.mutedText,
-    tooltip: {
-      background: colors.surface,
-      border: colors.border,
-      text: colors.text,
-      mutedText: colors.mutedText,
-    },
-  }), [colors.altRow, colors.border, colors.mutedText, colors.surface, colors.text]);
+  }, []);
 
   return (
     <View style={[styles.balanceHistoryCard, { backgroundColor: colors.surface, borderColor: colors.border }]}>
@@ -434,51 +473,49 @@ const BalanceHistoryCard = ({
             </View>
           ) : (
             <View onLayout={(e) => setContentHeight(e.nativeEvent.layout.height)}>
-              <View
-                style={styles.balanceHistoryChartContainer}
-              >
+              <View style={styles.balanceHistoryChartContainer}>
                 {chartComputed && (
-                  <LineChart
-                    data={chartData}
-                    xKey="day"
-                    series={chartSeries}
-                    width={screenWidth - 33}
-                    height={220}
-                    theme={chartTheme}
-                    curve="monotone"
-                    connectNulls
-                    yDomain={chartComputed.hasNegativeValues || !chartComputed.niceMax ? 'auto' : [0, chartComputed.niceMax]}
-                    formatYLabel={hideBalances ? () => '' : (value) => {
-                      const numValue = parseFloat(value);
-                      if (numValue === 0) return '';
-                      const absValue = Math.abs(numValue);
-                      const isNegative = numValue < 0;
-
-                      if (absValue >= 1000000) {
-                        const result = `${(absValue / 1000000).toFixed(0)}M`;
-                        return isNegative ? `-${result}` : result;
-                      } else if (absValue >= 1000) {
-                        const result = `${(absValue / 1000).toFixed(0)}K`;
-                        return isNegative ? `-${result}` : result;
-                      }
-                      return numValue.toFixed(0);
-                    }}
-                    formatXLabel={(value) => {
-                      const day = parseInt(value);
-                      if (day === 1 || day === 5 || day === 10 || day === 15 ||
-                      day === 20 || day === 25 || day === chartComputed.lastDay) {
-                        return value;
-                      }
-                      return '';
-                    }}
-                    showHorizontalGridLines
-                    showVerticalGridLines={false}
-                    legend={false}
-                    crosshair
-                    tooltip={!hideBalances}
+                  <View
+                    style={[styles.balanceHistoryChart, { backgroundColor: colors.altRow }]}
+                    accessibilityRole="image"
                     accessibilityLabel={t('balance_history') || 'Balance history chart'}
-                    style={styles.lineChartStyle}
-                  />
+                  >
+                    <CartesianChart
+                      data={chartData}
+                      xKey="day"
+                      yKeys={chartYKeys}
+                      domain={yDomain}
+                      domainPadding={{ top: 16, bottom: 16 }}
+                      axisOptions={{
+                        font: axisFont,
+                        lineColor: colors.border,
+                        labelColor: colors.mutedText,
+                        formatYLabel: (value) => formatYAxisLabel(value, hideBalances),
+                        formatXLabel: (value) => formatXAxisLabel(value, chartComputed.lastDay),
+                      }}
+                    >
+                      {({ points }) => (
+                        <>
+                          {chartSeries.map((s) => (
+                            <Line
+                              key={s.yKey}
+                              points={points[s.yKey]}
+                              color={s.color}
+                              strokeWidth={s.strokeWidth}
+                              curveType={s.curveType}
+                              connectMissingData
+                            >
+                              {/* DashPathEffect is a Skia paint child; guarded so the
+                                  system stays robust if the effect is unavailable. */}
+                              {s.dashed && DashPathEffect ? (
+                                <DashPathEffect intervals={[6, 6]} />
+                              ) : null}
+                            </Line>
+                          ))}
+                        </>
+                      )}
+                    </CartesianChart>
+                  </View>
                 )}
               </View>
 
@@ -625,6 +662,9 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     padding: 16,
   },
+  balanceHistoryChart: {
+    height: 220,
+  },
   balanceHistoryChartContainer: {
     marginHorizontal: -16,
   },
@@ -708,9 +748,6 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 12,
     textAlign: 'right',
-  },
-  lineChartStyle: {
-    borderRadius: 8,
   },
 });
 

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Dimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import PropTypes from 'prop-types';
-import Svg, { Line, Rect, Text as SvgText, Path } from 'react-native-svg';
+import { CartesianChart, Bar } from 'victory-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
 import useCategoryMonthlySpending from '../../hooks/useCategoryMonthlySpending';
@@ -22,6 +22,8 @@ const BAR_HEIGHT = 90;
 const LABEL_HEIGHT = 18;
 const TOP_PADDING = 8;
 const Y_AXIS_WIDTH = 32;
+const CHART_HEIGHT = TOP_PADDING + BAR_HEIGHT;
+const CORNER = 4;
 const VS_COLOR = '#FF7043';
 
 const formatYTick = (value) => {
@@ -32,312 +34,237 @@ const formatYTick = (value) => {
 
 const formatPctTick = (value) => value + '%';
 
-const BarChart = ({ data, vsData, monthAbbreviations, colors, width, selectedIndex, onBarPress }) => {
-  const hasVs = vsData != null && vsData.length === data.length;
-  const max = Math.max(
-    ...data.map(d => d.total),
-    ...(hasVs ? vsData.map(d => d.total) : []),
-    1,
-  );
+// "Nice" y-axis step so ticks land on round numbers.
+const niceStepFor = (max) => {
+  const raw = max / 5;
+  const mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const normalized = raw / mag;
+  let nice;
+  if (normalized < 1.5) nice = 1;
+  else if (normalized < 3.5) nice = 2;
+  else if (normalized < 7.5) nice = 5;
+  else nice = 10;
+  return nice * mag;
+};
+
+/**
+ * Category-spending bar chart backed by Victory Native XL.
+ *
+ * Three layouts, all driven by the same <CartesianChart>/<Bar> primitives:
+ *  - single:  one series, selected bar highlighted in `primary`, rest dimmed `mutedText`
+ *  - grouped: primary (wide) + vs (narrow) bars overlaid per month for comparison
+ *  - stacked: `vs` full-height behind + `primary` bottom portion in front → 100%-normalized stack
+ *
+ * Axis labels, month ticks, the selection reference line and bar-press hit areas are
+ * rendered as React Native views (not Skia) so they stay themeable, queryable and font-free.
+ */
+const SpendingBarChart = ({
+  data,
+  vsData,
+  stacked,
+  monthAbbreviations,
+  colors,
+  width,
+  selectedIndex,
+  onBarPress,
+}) => {
   const count = data.length;
+  const hasVs = vsData != null && vsData.length === count;
+  const isStacked = stacked && hasVs;
   const chartW = width - Y_AXIS_WIDTH;
-  const slotW = chartW / count;
-  const totalHeight = TOP_PADDING + BAR_HEIGHT + LABEL_HEIGHT;
 
-  const niceStep = (() => {
-    const raw = max / 5;
-    const mag = Math.pow(10, Math.floor(Math.log10(raw)));
-    const normalized = raw / mag;
-    let nice;
-    if (normalized < 1.5) nice = 1;
-    else if (normalized < 3.5) nice = 2;
-    else if (normalized < 7.5) nice = 5;
-    else nice = 10;
-    return nice * mag;
-  })();
+  const { axisMax, yTicks } = useMemo(() => {
+    if (isStacked) {
+      return {
+        axisMax: 100,
+        yTicks: [0, 25, 50, 75, 100].map((v) => ({
+          value: v,
+          label: formatPctTick(v),
+          y: TOP_PADDING + BAR_HEIGHT - (v / 100) * BAR_HEIGHT,
+        })),
+      };
+    }
+    const max = Math.max(
+      ...data.map((d) => d.total),
+      ...(hasVs ? vsData.map((d) => d.total) : []),
+      1,
+    );
+    const step = niceStepFor(max);
+    const aMax = Math.ceil(max / step) * step;
+    const tickCount = Math.round(aMax / step);
+    return {
+      axisMax: aMax,
+      yTicks: Array.from({ length: tickCount + 1 }, (_, i) => ({
+        value: step * i,
+        label: formatYTick(step * i),
+        y: TOP_PADDING + BAR_HEIGHT - ((step * i) / aMax) * BAR_HEIGHT,
+      })),
+    };
+  }, [isStacked, data, vsData, hasVs]);
 
-  const axisMax = Math.ceil(max / niceStep) * niceStep;
-  const tickCount = Math.round(axisMax / niceStep);
-
-  const yTicks = Array.from({ length: tickCount + 1 }, (_, i) => ({
-    value: niceStep * i,
-    y: TOP_PADDING + BAR_HEIGHT - (niceStep * i / axisMax) * BAR_HEIGHT,
-  }));
-
-  // Single bar dimensions (original layout)
-  const singleBarW = slotW * 0.55;
-  const singleGap = slotW * 0.45;
-
-  // Dual bar dimensions
-  const dualGapBetween = Math.max(slotW * 0.04, 1);
-  const dualOuterPad = slotW * 0.07;
-  const dualBarW = (slotW - 2 * dualOuterPad - dualGapBetween) / 2;
-
-  return (
-    <Svg width={width} height={totalHeight} style={styles.barChartSvg}>
-      {/* Y axis ticks */}
-      {yTicks.map(({ value, y }) => (
-        <SvgText
-          key={value}
-          x={Y_AXIS_WIDTH - 4}
-          y={y + 3.5}
-          fontSize={8}
-          fontFamily="Inter"
-          fill={colors.mutedText}
-          textAnchor="end"
-          opacity={0.7}
-        >
-          {formatYTick(value)}
-        </SvgText>
-      ))}
-
-      {/* Selected bar dotted reference line (primary category) */}
-      {selectedIndex !== null && selectedIndex !== undefined && data[selectedIndex] && (() => {
-        const selH = Math.max((data[selectedIndex].total / axisMax) * BAR_HEIGHT, data[selectedIndex].total > 0 ? 2 : 0);
-        const lineY = TOP_PADDING + BAR_HEIGHT - selH;
-        return (
-          <Line
-            x1={Y_AXIS_WIDTH}
-            y1={lineY}
-            x2={width}
-            y2={lineY}
-            stroke={colors.primary}
-            strokeWidth={2}
-            strokeDasharray="5,3"
-            opacity={0.9}
-          />
-        );
-      })()}
-
-      {/* Bars */}
-      {data.map((d, i) => {
-        const isSelected = i === selectedIndex;
-        const label = monthAbbreviations[d.month];
-
-        if (hasVs) {
-          const vsD = vsData[i];
-          const h1 = Math.max((d.total / axisMax) * BAR_HEIGHT, d.total > 0 ? 2 : 0);
-          const h2 = Math.max((vsD.total / axisMax) * BAR_HEIGHT, vsD.total > 0 ? 2 : 0);
-          const bar1X = Y_AXIS_WIDTH + i * slotW + dualOuterPad;
-          const bar2X = bar1X + dualBarW + dualGapBetween;
-          const y1 = TOP_PADDING + BAR_HEIGHT - h1;
-          const y2 = TOP_PADDING + BAR_HEIGHT - h2;
-
-          return (
-            <React.Fragment key={i}>
-              {/* Full-slot transparent hit area */}
-              <Rect
-                x={Y_AXIS_WIDTH + i * slotW}
-                y={TOP_PADDING}
-                width={slotW}
-                height={BAR_HEIGHT}
-                fill="transparent"
-                onPress={() => onBarPress(i)}
-              />
-              {/* Primary bar */}
-              <Rect
-                x={bar1X}
-                y={y1}
-                width={dualBarW}
-                height={h1}
-                rx={2}
-                fill={colors.primary}
-                fillOpacity={isSelected ? 1 : 0.3}
-                onPress={() => onBarPress(i)}
-              />
-              {/* VS bar */}
-              <Rect
-                x={bar2X}
-                y={y2}
-                width={dualBarW}
-                height={h2}
-                rx={2}
-                fill={VS_COLOR}
-                fillOpacity={isSelected ? 1 : 0.3}
-                onPress={() => onBarPress(i)}
-              />
-              {/* Month label centered in slot */}
-              <SvgText
-                x={Y_AXIS_WIDTH + i * slotW + slotW / 2}
-                y={TOP_PADDING + BAR_HEIGHT + 13}
-                fontSize={9.5}
-                fontFamily="Inter"
-                fill={colors.mutedText}
-                textAnchor="middle"
-              >
-                {label}
-              </SvgText>
-            </React.Fragment>
-          );
-        }
-
-        // Single bar (original layout)
-        const h = Math.max((d.total / axisMax) * BAR_HEIGHT, d.total > 0 ? 2 : 0);
-        const x = Y_AXIS_WIDTH + i * slotW + singleGap / 2;
-        const y = TOP_PADDING + BAR_HEIGHT - h;
-        return (
-          <React.Fragment key={i}>
-            <Rect
-              x={x}
-              y={TOP_PADDING}
-              width={singleBarW}
-              height={BAR_HEIGHT}
-              fill="transparent"
-              onPress={() => onBarPress(i)}
-            />
-            <Rect
-              x={x}
-              y={y}
-              width={singleBarW}
-              height={h}
-              rx={3}
-              fill={isSelected ? colors.primary : colors.mutedText}
-              fillOpacity={isSelected ? 1 : 0.3}
-              onPress={() => onBarPress(i)}
-            />
-            <SvgText
-              x={x + singleBarW / 2}
-              y={TOP_PADDING + BAR_HEIGHT + 13}
-              fontSize={9.5}
-              fontFamily="Inter"
-              fill={colors.mutedText}
-              textAnchor="middle"
-            >
-              {label}
-            </SvgText>
-          </React.Fragment>
-        );
-      })}
-    </Svg>
-  );
-};
-
-// Build an SVG path for a rect with rounded top corners only
-const roundedTopPath = (x, y, w, h, r) => {
-  const cr = Math.min(r, w / 2, Math.max(h, 0));
-  return `M ${x + cr},${y} L ${x + w - cr},${y} Q ${x + w},${y} ${x + w},${y + cr} L ${x + w},${y + h} L ${x},${y + h} L ${x},${y + cr} Q ${x},${y} ${x + cr},${y} Z`;
-};
-
-// Build an SVG path for a rect with rounded bottom corners only
-const roundedBottomPath = (x, y, w, h, r) => {
-  const cr = Math.min(r, w / 2, Math.max(h, 0));
-  return `M ${x},${y} L ${x + w},${y} L ${x + w},${y + h - cr} Q ${x + w},${y + h} ${x + w - cr},${y + h} L ${x + cr},${y + h} Q ${x},${y + h} ${x},${y + h - cr} Z`;
-};
-
-const StackedBarChart = ({ data, vsData, monthAbbreviations, colors, width, selectedIndex, onBarPress }) => {
-  const count = data.length;
-  const chartW = width - Y_AXIS_WIDTH;
-  const slotW = chartW / count;
-  const totalHeight = TOP_PADDING + BAR_HEIGHT + LABEL_HEIGHT;
-  const barW = slotW * 0.6;
-  const barPad = (slotW - barW) / 2;
-  const RADIUS = 3;
-
-  const yTicks = [0, 25, 50, 75, 100].map(pct => ({
-    value: pct,
-    y: TOP_PADDING + BAR_HEIGHT - (pct / 100) * BAR_HEIGHT,
-  }));
-
-  return (
-    <Svg width={width} height={totalHeight} style={styles.barChartSvg}>
-      {yTicks.map(({ value, y }) => (
-        <SvgText
-          key={value}
-          x={Y_AXIS_WIDTH - 4}
-          y={y + 3.5}
-          fontSize={8}
-          fontFamily="Inter"
-          fill={colors.mutedText}
-          textAnchor="end"
-          opacity={0.7}
-        >
-          {formatPctTick(value)}
-        </SvgText>
-      ))}
-
-      {data.map((d, i) => {
+  // Per-month field bundle consumed by Victory Native. Every series we draw must be a
+  // field here AND listed in yKeys, otherwise VN never computes points for it.
+  const chartData = useMemo(() => {
+    return data.map((d, i) => {
+      const isSel = i === selectedIndex;
+      if (isStacked) {
         const vsD = vsData[i];
         const totalAmt = d.total + vsD.total;
-        const isSelected = i === selectedIndex;
-        const label = monthAbbreviations[d.month];
-        const barX = Y_AXIS_WIDTH + i * slotW + barPad;
-        const opacity = isSelected ? 1 : 0.3;
+        const primaryPct = totalAmt > 0 ? (d.total / totalAmt) * 100 : 0;
+        // `back` (vs) is full height and sits behind; `front` (primary) covers the
+        // bottom portion, so the exposed top slice reads as the vs share.
+        const back = totalAmt > 0 ? 100 : 0;
+        const front = totalAmt > 0 ? primaryPct : 0;
+        return {
+          x: i,
+          track: totalAmt > 0 ? 0 : 100,
+          back,
+          front,
+          backSel: isSel ? back : 0,
+          frontSel: isSel ? front : 0,
+        };
+      }
+      if (hasVs) {
+        const vsD = vsData[i];
+        return {
+          x: i,
+          primary: d.total,
+          primarySel: isSel ? d.total : 0,
+          vs: vsD.total,
+          vsSel: isSel ? vsD.total : 0,
+        };
+      }
+      return {
+        x: i,
+        amount: d.total,
+        amountSel: isSel ? d.total : 0,
+      };
+    });
+  }, [data, vsData, hasVs, isStacked, selectedIndex]);
 
-        let vsH = 0;
-        let primaryH = 0;
-        if (totalAmt > 0) {
-          vsH = (vsD.total / totalAmt) * BAR_HEIGHT;
-          primaryH = BAR_HEIGHT - vsH;
-        }
+  const yKeys = useMemo(() => {
+    if (isStacked) return ['track', 'back', 'front', 'backSel', 'frontSel'];
+    if (hasVs) return ['primary', 'primarySel', 'vs', 'vsSel'];
+    return ['amount', 'amountSel'];
+  }, [isStacked, hasVs]);
 
+  const domain = useMemo(() => ({ y: [0, axisMax] }), [axisMax]);
+
+  // Dotted reference line at the selected bar's top (single/grouped only, matching the
+  // original which omitted it in stacked mode).
+  const selLineTop = useMemo(() => {
+    if (isStacked) return null;
+    if (selectedIndex == null || !data[selectedIndex]) return null;
+    const sel = data[selectedIndex];
+    const h = Math.max((sel.total / axisMax) * BAR_HEIGHT, sel.total > 0 ? 2 : 0);
+    return TOP_PADDING + BAR_HEIGHT - h;
+  }, [isStacked, selectedIndex, data, axisMax]);
+
+  const renderBars = useCallback(
+    ({ points, chartBounds }) => {
+      const slot = (chartBounds.right - chartBounds.left) / Math.max(count, 1);
+      const wideW = slot * 0.5;
+      const narrowW = slot * 0.28;
+
+      if (isStacked) {
+        const barW = slot * 0.6;
         return (
-          <React.Fragment key={i}>
-            <Rect
-              x={Y_AXIS_WIDTH + i * slotW}
-              y={TOP_PADDING}
-              width={slotW}
-              height={BAR_HEIGHT}
-              fill="transparent"
-              onPress={() => onBarPress(i)}
-            />
-            {totalAmt === 0 ? (
-              <Rect
-                x={barX}
-                y={TOP_PADDING}
-                width={barW}
-                height={BAR_HEIGHT}
-                rx={RADIUS}
-                fill={colors.mutedText}
-                fillOpacity={0.12}
-              />
-            ) : vsH === 0 ? (
-              <Rect
-                x={barX}
-                y={TOP_PADDING}
-                width={barW}
-                height={BAR_HEIGHT}
-                rx={RADIUS}
-                fill={colors.primary}
-                fillOpacity={opacity}
-              />
-            ) : primaryH === 0 ? (
-              <Rect
-                x={barX}
-                y={TOP_PADDING}
-                width={barW}
-                height={BAR_HEIGHT}
-                rx={RADIUS}
-                fill={VS_COLOR}
-                fillOpacity={opacity}
-              />
-            ) : (
-              <>
-                <Path
-                  d={roundedTopPath(barX, TOP_PADDING, barW, vsH, RADIUS)}
-                  fill={VS_COLOR}
-                  fillOpacity={opacity}
-                />
-                <Path
-                  d={roundedBottomPath(barX, TOP_PADDING + vsH, barW, primaryH, RADIUS)}
-                  fill={colors.primary}
-                  fillOpacity={opacity}
-                />
-              </>
-            )}
-            <SvgText
-              x={Y_AXIS_WIDTH + i * slotW + slotW / 2}
-              y={TOP_PADDING + BAR_HEIGHT + 13}
-              fontSize={9.5}
-              fontFamily="Inter"
-              fill={colors.mutedText}
-              textAnchor="middle"
-            >
-              {label}
-            </SvgText>
-          </React.Fragment>
+          <>
+            <Bar points={points.track} chartBounds={chartBounds} color={colors.mutedText} opacity={0.12} barWidth={barW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+            <Bar points={points.back} chartBounds={chartBounds} color={VS_COLOR} opacity={0.3} barWidth={barW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+            <Bar points={points.front} chartBounds={chartBounds} color={colors.primary} opacity={0.3} barWidth={barW} roundedCorners={{ bottomLeft: CORNER, bottomRight: CORNER }} />
+            <Bar points={points.backSel} chartBounds={chartBounds} color={VS_COLOR} opacity={1} barWidth={barW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+            <Bar points={points.frontSel} chartBounds={chartBounds} color={colors.primary} opacity={1} barWidth={barW} roundedCorners={{ bottomLeft: CORNER, bottomRight: CORNER }} />
+          </>
         );
-      })}
-    </Svg>
+      }
+
+      if (hasVs) {
+        return (
+          <>
+            <Bar points={points.primary} chartBounds={chartBounds} color={colors.primary} opacity={0.3} barWidth={wideW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+            <Bar points={points.primarySel} chartBounds={chartBounds} color={colors.primary} opacity={1} barWidth={wideW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+            <Bar points={points.vs} chartBounds={chartBounds} color={VS_COLOR} opacity={0.3} barWidth={narrowW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+            <Bar points={points.vsSel} chartBounds={chartBounds} color={VS_COLOR} opacity={1} barWidth={narrowW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+          </>
+        );
+      }
+
+      return (
+        <>
+          <Bar points={points.amount} chartBounds={chartBounds} color={colors.mutedText} opacity={0.3} barWidth={wideW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+          <Bar points={points.amountSel} chartBounds={chartBounds} color={colors.primary} opacity={1} barWidth={wideW} roundedCorners={{ topLeft: CORNER, topRight: CORNER }} />
+        </>
+      );
+    },
+    [isStacked, hasVs, colors.primary, colors.mutedText, count],
+  );
+
+  return (
+    <View style={[styles.chartWrap, { width }]}>
+      <View style={styles.chartRow}>
+        {/* Y axis labels */}
+        <View style={styles.yAxis}>
+          {yTicks.map((tick) => (
+            <Text
+              key={tick.value}
+              style={[styles.yTick, { top: tick.y - 5, color: colors.mutedText }]}
+              numberOfLines={1}
+            >
+              {tick.label}
+            </Text>
+          ))}
+        </View>
+
+        {/* Bars */}
+        <View style={[styles.barsArea, { width: chartW }]}>
+          <CartesianChart
+            data={chartData}
+            xKey="x"
+            yKeys={yKeys}
+            domain={domain}
+            domainPadding={{ left: 6, right: 6, top: TOP_PADDING }}
+          >
+            {renderBars}
+          </CartesianChart>
+
+          {/* Selection reference line */}
+          {selLineTop != null && (
+            <View
+              pointerEvents="none"
+              style={[styles.selLine, { top: selLineTop, borderColor: colors.primary }]}
+            />
+          )}
+
+          {/* Transparent hit areas for bar selection */}
+          <View style={styles.touchRow} pointerEvents="box-none">
+            {data.map((d, i) => (
+              <TouchableOpacity
+                key={i}
+                style={styles.touchSlot}
+                activeOpacity={0.6}
+                onPress={() => onBarPress(i)}
+                accessibilityRole="button"
+                accessibilityLabel={`${monthAbbreviations[d.month]} ${formatYTick(d.total)}`}
+              />
+            ))}
+          </View>
+        </View>
+      </View>
+
+      {/* Month labels */}
+      <View style={styles.monthRow}>
+        {data.map((d, i) => (
+          <Text
+            key={i}
+            style={[styles.monthLabel, { color: colors.mutedText }]}
+            numberOfLines={1}
+          >
+            {monthAbbreviations[d.month]}
+          </Text>
+        ))}
+      </View>
+    </View>
   );
 };
 
@@ -652,20 +579,11 @@ const CategorySpendingCard = ({
             {t('no_spending_data')}
           </Text>
         </View>
-      ) : showStackedBar && hasVsData ? (
-        <StackedBarChart
-          data={monthlyData}
-          vsData={vsMonthlyData}
-          monthAbbreviations={monthAbbreviations}
-          colors={colors}
-          width={screenWidth - 64}
-          selectedIndex={effectiveBarIndex}
-          onBarPress={setSelectedBarIndex}
-        />
       ) : (
-        <BarChart
+        <SpendingBarChart
           data={monthlyData}
           vsData={hasVsData ? vsMonthlyData : null}
+          stacked={showStackedBar && hasVsData}
           monthAbbreviations={monthAbbreviations}
           colors={colors}
           width={screenWidth - 64}
@@ -677,23 +595,14 @@ const CategorySpendingCard = ({
   );
 };
 
-BarChart.propTypes = {
+SpendingBarChart.propTypes = {
   colors: PropTypes.object.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape({ total: PropTypes.number, month: PropTypes.number })).isRequired,
   monthAbbreviations: PropTypes.arrayOf(PropTypes.string).isRequired,
   onBarPress: PropTypes.func.isRequired,
   selectedIndex: PropTypes.number,
+  stacked: PropTypes.bool,
   vsData: PropTypes.arrayOf(PropTypes.shape({ total: PropTypes.number, month: PropTypes.number })),
-  width: PropTypes.number.isRequired,
-};
-
-StackedBarChart.propTypes = {
-  colors: PropTypes.object.isRequired,
-  data: PropTypes.arrayOf(PropTypes.shape({ total: PropTypes.number, month: PropTypes.number })).isRequired,
-  monthAbbreviations: PropTypes.arrayOf(PropTypes.string).isRequired,
-  onBarPress: PropTypes.func.isRequired,
-  selectedIndex: PropTypes.number,
-  vsData: PropTypes.arrayOf(PropTypes.shape({ total: PropTypes.number, month: PropTypes.number })).isRequired,
   width: PropTypes.number.isRequired,
 };
 
@@ -708,8 +617,9 @@ CategorySpendingCard.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  barChartSvg: {
-    marginTop: 12,
+  barsArea: {
+    height: CHART_HEIGHT,
+    position: 'relative',
   },
   card: {
     borderRadius: 16,
@@ -736,6 +646,13 @@ const styles = StyleSheet.create({
   categoryText: {
     fontSize: 16,
     fontWeight: '500',
+  },
+  chartRow: {
+    flexDirection: 'row',
+    height: CHART_HEIGHT,
+  },
+  chartWrap: {
+    marginTop: 12,
   },
   childRow: {
     borderBottomWidth: 1,
@@ -799,6 +716,17 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
   },
+  monthLabel: {
+    flex: 1,
+    fontSize: 9.5,
+    textAlign: 'center',
+  },
+  monthRow: {
+    flexDirection: 'row',
+    height: LABEL_HEIGHT,
+    marginLeft: Y_AXIS_WIDTH,
+    paddingTop: 2,
+  },
   parentRow: {
     alignItems: 'center',
     borderBottomWidth: 1,
@@ -808,6 +736,13 @@ const styles = StyleSheet.create({
     fontSize: 11,
     fontWeight: '500',
     letterSpacing: 0.5,
+  },
+  selLine: {
+    borderStyle: 'dashed',
+    borderTopWidth: 2,
+    left: 0,
+    position: 'absolute',
+    right: 0,
   },
   stackedToggleBtn: {
     alignSelf: 'flex-end',
@@ -819,6 +754,17 @@ const styles = StyleSheet.create({
   thisMonthLabel: {
     fontSize: 11,
     marginTop: 2,
+  },
+  touchRow: {
+    bottom: 0,
+    flexDirection: 'row',
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  touchSlot: {
+    flex: 1,
   },
   vsCategoryName: {
     flexShrink: 1,
@@ -839,6 +785,18 @@ const styles = StyleSheet.create({
   vsText: {
     fontSize: 12,
     fontWeight: '500',
+  },
+  yAxis: {
+    height: CHART_HEIGHT,
+    position: 'relative',
+    width: Y_AXIS_WIDTH,
+  },
+  yTick: {
+    fontSize: 8,
+    opacity: 0.7,
+    position: 'absolute',
+    right: 4,
+    textAlign: 'right',
   },
 });
 

--- a/app/components/graphs/DonutChart.js
+++ b/app/components/graphs/DonutChart.js
@@ -1,77 +1,80 @@
 import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Svg, { Circle } from 'react-native-svg';
+import { Pie, PolarChart } from 'victory-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 
-export const SVG_SIZE = 140;
-export const RADIUS = 48;
-export const STROKE_WIDTH = 26;
-export const CENTER = SVG_SIZE / 2;
-export const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
-export const ICON_THRESHOLD = 0.10;
+// Victory Native fills its container, so the container size doubles as the
+// donut diameter and as the coordinate space for the icon overlay below.
+export const CHART_SIZE = 140;
+export const CENTER = CHART_SIZE / 2;
+// Donut hole as a fraction of the outer radius. Mirrors the old hand-rolled
+// ring (inner edge 35 / outer edge 61 ≈ 0.57) closely enough to read the same.
+export const INNER_RADIUS_RATIO = 0.6;
+export const INNER_RADIUS = `${INNER_RADIUS_RATIO * 100}%`;
+// Icons sit on the middle of the donut band.
+export const ICON_RADIUS = CENTER * ((1 + INNER_RADIUS_RATIO) / 2);
+export const ICON_THRESHOLD = 0.1;
 export const ICON_SIZE = 14;
 
-export const computeSegments = (data) => {
+// Map the shared slice shape ({ amount, color, icon }) onto the keys Victory
+// Native's Pie expects. `label` only needs to be unique per slice — the legend
+// renders category names itself — so we derive it from the icon + index.
+export const mapPieData = (data) =>
+  data.map((item, index) => ({
+    label: `${item.icon ?? 'slice'}-${index}`,
+    value: item.amount,
+    color: item.color,
+  }));
+
+// Victory Native draws pie slices starting at 12 o'clock and sweeping clockwise
+// (d3-shape convention). We mirror that here to lay MaterialCommunityIcons
+// glyphs over each slice, since VN has no vector-icon slice label.
+export const computeIconMarkers = (data) => {
   const total = data.reduce((sum, item) => sum + item.amount, 0);
   if (total === 0) return [];
 
   let cumulative = 0;
   return data.map((item) => {
     const fraction = item.amount / total;
-    const arcLength = fraction * CIRCUMFERENCE;
-    const midAngle = (cumulative + arcLength / 2) / RADIUS;
-    const seg = {
+    const midAngle = (cumulative + fraction / 2) * 2 * Math.PI;
+    const marker = {
       color: item.color,
       icon: item.icon,
-      arcLength,
-      dashOffset: cumulative === 0 ? 0 : -cumulative,
       showIcon: fraction >= ICON_THRESHOLD && !!item.icon,
-      iconX: CENTER + RADIUS * Math.sin(midAngle),
-      iconY: CENTER - RADIUS * Math.cos(midAngle),
+      x: CENTER + ICON_RADIUS * Math.sin(midAngle),
+      y: CENTER - ICON_RADIUS * Math.cos(midAngle),
     };
-    cumulative += arcLength;
-    return seg;
+    cumulative += fraction;
+    return marker;
   });
 };
 
 const DonutChart = ({ data }) => {
-  const segments = useMemo(() => computeSegments(data), [data]);
+  const pieData = useMemo(() => mapPieData(data), [data]);
+  const markers = useMemo(() => computeIconMarkers(data), [data]);
 
   return (
-    <View testID="donut-chart" style={styles.container}>
-      <Svg width={SVG_SIZE} height={SVG_SIZE}>
-        {segments.map((seg, i) => (
-          <Circle
-            key={i}
-            cx={CENTER}
-            cy={CENTER}
-            r={RADIUS}
-            fill="none"
-            stroke={seg.color}
-            strokeWidth={STROKE_WIDTH}
-            strokeDasharray={`${seg.arcLength} ${CIRCUMFERENCE - seg.arcLength}`}
-            strokeDashoffset={seg.dashOffset}
-            rotation={-90}
-            origin={`${CENTER}, ${CENTER}`}
-          />
-        ))}
-      </Svg>
-      {segments
-        .filter((seg) => seg.showIcon)
-        .map((seg, i) => (
+    <View testID="donut-chart" style={styles.container} accessibilityRole="image">
+      <PolarChart data={pieData} labelKey="label" valueKey="value" colorKey="color">
+        <Pie.Chart innerRadius={INNER_RADIUS} />
+      </PolarChart>
+      {markers
+        .filter((marker) => marker.showIcon)
+        .map((marker, i) => (
           <View
             key={i}
-            testID={`icon-${seg.icon}`}
+            testID={`icon-${marker.icon}`}
+            pointerEvents="none"
             style={[
               styles.iconWrapper,
               {
-                left: seg.iconX - ICON_SIZE / 2,
-                top: seg.iconY - ICON_SIZE / 2,
+                left: marker.x - ICON_SIZE / 2,
+                top: marker.y - ICON_SIZE / 2,
               },
             ]}
           >
-            <Icon name={seg.icon} size={ICON_SIZE} color="#fff" />
+            <Icon name={marker.icon} size={ICON_SIZE} color="#fff" />
           </View>
         ))}
     </View>
@@ -90,8 +93,8 @@ DonutChart.propTypes = {
 
 const styles = StyleSheet.create({
   container: {
-    height: SVG_SIZE,
-    width: SVG_SIZE,
+    height: CHART_SIZE,
+    width: CHART_SIZE,
   },
   iconWrapper: {
     position: 'absolute',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -483,15 +483,83 @@ jest.mock('@react-native-community/datetimepicker', () => {
   };
 });
 
-// Mock react-native-chart-kit (legacy root + modern v2 subpath)
-jest.mock('react-native-chart-kit', () => ({
-  LineChart: () => 'LineChart',
-  PieChart: () => 'PieChart',
-}));
+// Mock victory-native (Victory Native XL) — it is Skia/Reanimated-powered and
+// has no jsdom-friendly runtime, so we stub the chart primitives. `virtual: true`
+// because the native package is not resolvable in the Jest environment.
+jest.mock(
+  'victory-native',
+  () => {
+    const React = require('react');
+    const { View } = require('react-native');
+    // Render functions read points[yKey]; a proxy keeps any key access safe.
+    const pointsProxy = new Proxy({}, { get: () => [] });
+    const chartBounds = { left: 0, right: 300, top: 0, bottom: 200 };
+    // eslint-disable-next-line react/prop-types
+    const CartesianChart = ({ children }) =>
+      React.createElement(
+        View,
+        { testID: 'cartesian-chart' },
+        typeof children === 'function'
+          ? children({ points: pointsProxy, chartBounds })
+          : children,
+      );
+    // eslint-disable-next-line react/prop-types
+    const PolarChart = ({ children }) =>
+      React.createElement(
+        View,
+        { testID: 'polar-chart' },
+        typeof children === 'function' ? null : children,
+      );
+    const Line = () => React.createElement(View, { testID: 'vn-line' });
+    const Bar = () => React.createElement(View, { testID: 'vn-bar' });
+    const Area = () => React.createElement(View, { testID: 'vn-area' });
+    const Pie = {
+      // eslint-disable-next-line react/prop-types
+      Chart: ({ children }) =>
+        React.createElement(
+          View,
+          { testID: 'vn-pie' },
+          typeof children === 'function' ? null : children,
+        ),
+      Slice: () => null,
+      SliceAngularInset: () => null,
+      Label: () => null,
+    };
+    return {
+      __esModule: true,
+      CartesianChart,
+      PolarChart,
+      Line,
+      Bar,
+      Area,
+      Pie,
+      useChartPressState: () => ({ state: {}, isActive: false }),
+      useLinePath: () => ({ path: '' }),
+      useAreaPath: () => ({ path: '' }),
+    };
+  },
+  { virtual: true },
+);
 
-jest.mock('react-native-chart-kit/v2', () => ({
-  LineChart: () => 'LineChart',
-}));
+// Mock @shopify/react-native-skia — native Skia bindings are unavailable under
+// Jest. `virtual: true` because the package is not installed in this environment.
+jest.mock(
+  '@shopify/react-native-skia',
+  () => ({
+    __esModule: true,
+    useFont: () => null,
+    matchFont: () => ({ getSize: () => 12, getTextWidth: () => 0 }),
+    Skia: { Font: () => null },
+    Circle: 'SkCircle',
+    Path: 'SkPath',
+    Group: 'SkGroup',
+    Text: 'SkText',
+    Canvas: 'SkCanvas',
+    LinearGradient: 'SkLinearGradient',
+    vec: (x, y) => ({ x, y }),
+  }),
+  { virtual: true },
+);
 
 // Mock react-native-svg
 jest.mock('react-native-svg', () => ({

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@react-native-community/datetimepicker": "9.1.0",
     "@react-native-google-signin/google-signin": "^16.1.2",
     "@sentry/react-native": "~8.19.0",
+    "@shopify/react-native-skia": "2.10.0",
     "decimal.js": "^10.6.0",
     "drizzle-orm": "^1.0.0-beta.6-7aaf14b",
     "expo": "~56.0.12",
@@ -44,7 +45,6 @@
     "prop-types": "^15.8.1",
     "react": "19.2.3",
     "react-native": "0.85.3",
-    "react-native-chart-kit": "^7.0.1",
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "~2.31.1",
     "react-native-paper": "^5.14.5",
@@ -52,7 +52,8 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-svg": "15.15.4",
     "react-native-uuid": "^2.0.3",
-    "react-native-worklets": "0.8.3"
+    "react-native-worklets": "0.8.3",
+    "victory-native": "^41.26.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
Resolves #1387
Resolves #1388
Resolves #1389

## Summary

Migrates **all three graph surfaces** off `react-native-chart-kit` and the hand-rolled `react-native-svg` renderers onto [Victory Native XL](https://github.com/formidablelabs/victory-native-xl) (Skia / Reanimated / D3 powered). One PR covering the three tracked issues:

- **balance-history line chart** → `CartesianChart + Line` — closes #1387 (also removes the last `react-native-chart-kit` consumer, so the dep is dropped)
- **expense / income donut charts** → `PolarChart + Pie` — closes #1388 (shared `DonutChart` renderer, covers both)
- **category-spending bar chart** → `CartesianChart + Bar` — closes #1389

## Dependencies

- **+** `victory-native@^41.26.0`, **+** `@shopify/react-native-skia@2.10.0` (new native module — autolinked, New-Architecture compatible)
- **−** `react-native-chart-kit` (zero remaining imports in `app/`)
- `bun.lock` is regenerated by CI's non-frozen `bun install` (bun was unavailable in the authoring env); run `bun install` locally to materialize the committed lock if desired.

## Approach

- Each card's **public props are unchanged (drop-in)** — `GraphsScreen`, `ChartModal`, `ExpensePieChart`/`IncomePieChart` need no edits.
- Axis labels use `matchFont` (system font) since the project ships no `.ttf`; guarded for the Jest stub.
- Victory Native + Skia are **virtually mocked** in `jest.setup.js`; component tests were rewritten against the new structure.
- Donut icons and bar y-ticks/month-labels/selection are rendered as themeable RN views layered over the Skia canvas (VN has no vector-icon slice label / the tick column stays queryable & font-free).

## Tests

Full suite green: **158 suites, 4555 tests, 0 failed**. ESLint clean.

## Review notes — verify on device (Skia renders nothing under Jest)

The following are geometry/visual assumptions that only a real Skia render can confirm (called out by `/code-review`, being checked on an `emulator`-profile build):

- Donut icon-to-slice alignment (assumes VN Pie starts at 12 o'clock, clockwise).
- Category-spending y-tick column alignment with VN's domain/`domainPadding`, and edge-tap → correct-bar mapping.
- Dashed forecast line, stacked/vs overlay readability, per-slice colors in light + dark.

## Notes

- Removed two helpers (`formatCurrency`, `hexToRgba`) in `BalanceHistoryCard` orphaned by the chart-kit removal.
- The vs comparison bar layout uses a nested overlay rather than true side-by-side (`BarGroup`/`StackedBar` weren't wired into the mock); same colors + dim/highlight semantics.
