### PR TITLE
feat(budgets): monthly income-allocation plan data layer (Budgets v2 2/5)

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,6 +14,7 @@ import { CategoriesProvider } from './app/contexts/CategoriesContext';
 import { OperationsDataProvider } from './app/contexts/OperationsDataContext';
 import { OperationsActionsProvider } from './app/contexts/OperationsActionsContext';
 import { BudgetsProvider } from './app/contexts/BudgetsContext';
+import { BudgetPlansProvider } from './app/contexts/BudgetPlansContext';
 import { PlannedOperationsProvider } from './app/contexts/PlannedOperationsContext';
 import { LocalizationProvider } from './app/contexts/LocalizationContext';
 import { DialogProvider } from './app/contexts/DialogContext';
@@ -83,9 +84,11 @@ function App() {
                                   <OperationsDataProvider>
                                     <OperationsActionsProvider>
                                       <BudgetsProvider>
-                                        <PlannedOperationsProvider>
-                                          <AppContent />
-                                        </PlannedOperationsProvider>
+                                        <BudgetPlansProvider>
+                                          <PlannedOperationsProvider>
+                                            <AppContent />
+                                          </PlannedOperationsProvider>
+                                        </BudgetPlansProvider>
                                       </BudgetsProvider>
                                     </OperationsActionsProvider>
                                   </OperationsDataProvider>

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -52,6 +52,10 @@ jest.mock('../app/contexts/BudgetsContext', () => ({
   BudgetsProvider: ({ children }) => children,
 }));
 
+jest.mock('../app/contexts/BudgetPlansContext', () => ({
+  BudgetPlansProvider: ({ children }) => children,
+}));
+
 jest.mock('../app/contexts/PlannedOperationsContext', () => ({
   PlannedOperationsProvider: ({ children }) => children,
 }));

--- a/__tests__/contexts/BudgetPlansContext.test.js
+++ b/__tests__/contexts/BudgetPlansContext.test.js
@@ -1,0 +1,273 @@
+/**
+ * Tests for BudgetPlansContext (Budgets v2) — state management for monthly
+ * income-allocation plans. Mirrors the BudgetsContext test patterns.
+ */
+
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { BudgetPlansProvider, useBudgetPlans } from '../../app/contexts/BudgetPlansContext';
+import * as BudgetPlansDB from '../../app/services/BudgetPlansDB';
+import { appEvents, EVENTS } from '../../app/services/eventEmitter';
+
+jest.mock('../../app/services/BudgetPlansDB');
+jest.mock('../../app/services/eventEmitter', () => ({
+  appEvents: { on: jest.fn(), emit: jest.fn() },
+  EVENTS: { RELOAD_ALL: 'RELOAD_ALL', DATABASE_RESET: 'DATABASE_RESET' },
+}));
+
+const mockShowDialog = jest.fn();
+jest.mock('../../app/contexts/DialogContext', () => ({
+  DialogProvider: ({ children }) => children,
+  useDialog: () => ({ showDialog: mockShowDialog, hideDialog: jest.fn() }),
+}));
+
+let mockUuidCounter = 0;
+jest.mock('react-native-uuid', () => ({
+  v4: jest.fn(() => `plan-uuid-${++mockUuidCounter}`),
+}));
+
+const wrapper = ({ children }) => <BudgetPlansProvider>{children}</BudgetPlansProvider>;
+
+describe('BudgetPlansContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockShowDialog.mockClear();
+    mockUuidCounter = 0;
+
+    appEvents.on.mockReturnValue(jest.fn());
+    BudgetPlansDB.getAllPlans.mockResolvedValue([]);
+    BudgetPlansDB.validatePlan.mockReturnValue(null);
+    BudgetPlansDB.createPlan.mockImplementation(async (plan) => ({ ...plan }));
+    BudgetPlansDB.updatePlan.mockResolvedValue(undefined);
+    BudgetPlansDB.deletePlan.mockResolvedValue(undefined);
+    BudgetPlansDB.copyPlan.mockResolvedValue({ id: 'copied', month: '2026-08', currency: 'USD', expectedIncome: '100' });
+  });
+
+  describe('Initialization', () => {
+    it('loads plans on mount', async () => {
+      const plans = [{ id: 'p1', month: '2026-07', currency: 'USD', expectedIncome: '445000' }];
+      BudgetPlansDB.getAllPlans.mockResolvedValue(plans);
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.plans).toEqual(plans);
+      expect(result.current.saveError).toBeNull();
+      expect(BudgetPlansDB.getAllPlans).toHaveBeenCalled();
+    });
+
+    it('handles a load error gracefully', async () => {
+      BudgetPlansDB.getAllPlans.mockRejectedValue(new Error('load failed'));
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.plans).toEqual([]);
+      expect(result.current.saveError).toBe('load failed');
+    });
+
+    it('throws when used outside a provider', async () => {
+      const originalError = console.error;
+      console.error = jest.fn();
+      await expect(renderHook(() => useBudgetPlans()))
+        .rejects.toThrow('useBudgetPlans must be used within a BudgetPlansProvider');
+      console.error = originalError;
+    });
+  });
+
+  describe('addPlan', () => {
+    it('creates a plan and prepends it to state', async () => {
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      let created;
+      await act(async () => {
+        created = await result.current.addPlan({ month: '2026-07', currency: 'USD', expectedIncome: '445000' });
+      });
+
+      expect(created.id).toBe('plan-uuid-1');
+      expect(BudgetPlansDB.createPlan).toHaveBeenCalledWith(
+        expect.objectContaining({ month: '2026-07', id: 'plan-uuid-1' }),
+      );
+      expect(result.current.plans).toHaveLength(1);
+    });
+
+    it('rejects an invalid plan and surfaces a dialog', async () => {
+      BudgetPlansDB.validatePlan.mockReturnValue('A valid month (YYYY-MM) is required');
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await expect(act(async () => {
+        await result.current.addPlan({ currency: 'USD' });
+      })).rejects.toThrow('A valid month (YYYY-MM) is required');
+
+      expect(BudgetPlansDB.createPlan).not.toHaveBeenCalled();
+      expect(mockShowDialog).toHaveBeenCalledWith('Error', 'A valid month (YYYY-MM) is required', [{ text: 'OK' }]);
+      expect(result.current.plans).toHaveLength(0);
+    });
+
+    it('surfaces a DB failure', async () => {
+      BudgetPlansDB.createPlan.mockRejectedValue(new Error('duplicate month'));
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await expect(act(async () => {
+        await result.current.addPlan({ month: '2026-07', currency: 'USD' });
+      })).rejects.toThrow('duplicate month');
+      expect(mockShowDialog).toHaveBeenCalledWith('Error', 'duplicate month', [{ text: 'OK' }]);
+    });
+  });
+
+  describe('updatePlan / deletePlan', () => {
+    beforeEach(() => {
+      BudgetPlansDB.getAllPlans.mockResolvedValue([
+        { id: 'p1', month: '2026-07', currency: 'USD', expectedIncome: '445000' },
+      ]);
+    });
+
+    it('updates an existing plan', async () => {
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.updatePlan('p1', { expectedIncome: '500000' });
+      });
+
+      expect(BudgetPlansDB.updatePlan).toHaveBeenCalledWith('p1', { expectedIncome: '500000' });
+      expect(result.current.plans[0].expectedIncome).toBe('500000');
+    });
+
+    it('rejects updating a non-existent plan', async () => {
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await expect(act(async () => {
+        await result.current.updatePlan('nope', { currency: 'EUR' });
+      })).rejects.toThrow('Budget plan not found');
+      expect(BudgetPlansDB.updatePlan).not.toHaveBeenCalled();
+    });
+
+    it('deletes a plan', async () => {
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.deletePlan('p1');
+      });
+
+      expect(BudgetPlansDB.deletePlan).toHaveBeenCalledWith('p1');
+      expect(result.current.plans).toHaveLength(0);
+    });
+
+    it('surfaces a delete failure', async () => {
+      BudgetPlansDB.deletePlan.mockRejectedValue(new Error('boom'));
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await expect(act(async () => {
+        await result.current.deletePlan('p1');
+      })).rejects.toThrow('boom');
+      expect(mockShowDialog).toHaveBeenCalledWith('Error', 'Failed to delete plan. Please try again.', [{ text: 'OK' }]);
+    });
+  });
+
+  describe('copyPlan', () => {
+    it('clones a plan and prepends it', async () => {
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      let created;
+      await act(async () => {
+        created = await result.current.copyPlan('2026-07', '2026-08');
+      });
+
+      expect(BudgetPlansDB.copyPlan).toHaveBeenCalledWith('2026-07', '2026-08');
+      expect(created.id).toBe('copied');
+      expect(result.current.plans[0].id).toBe('copied');
+    });
+  });
+
+  describe('line delegation', () => {
+    it('delegates line operations to the DB layer', async () => {
+      BudgetPlansDB.addLine.mockResolvedValue({ id: 'l1' });
+      BudgetPlansDB.getPlanTotals.mockResolvedValue({ expectedIncome: '100', allocated: '40', remainder: '60' });
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.addLine('p1', { amount: '40', categoryId: 'c1' });
+        await result.current.updateLine('l1', { amount: '50' });
+        await result.current.deleteLine('l1');
+        await result.current.reorderLines('p1', ['l1']);
+        await result.current.getPlanTotals('p1');
+        await result.current.getPlanLines('p1');
+        await result.current.getBrokenLines('p1');
+        await result.current.getPlanByMonth('2026-07');
+      });
+
+      expect(BudgetPlansDB.addLine).toHaveBeenCalledWith('p1', { amount: '40', categoryId: 'c1' });
+      expect(BudgetPlansDB.updateLine).toHaveBeenCalledWith('l1', { amount: '50' });
+      expect(BudgetPlansDB.deleteLine).toHaveBeenCalledWith('l1');
+      expect(BudgetPlansDB.reorderLines).toHaveBeenCalledWith('p1', ['l1']);
+      expect(BudgetPlansDB.getPlanTotals).toHaveBeenCalledWith('p1');
+      expect(BudgetPlansDB.getPlanLines).toHaveBeenCalledWith('p1');
+      expect(BudgetPlansDB.getBrokenLines).toHaveBeenCalledWith('p1');
+      expect(BudgetPlansDB.getPlanByMonth).toHaveBeenCalledWith('2026-07');
+    });
+  });
+
+  describe('Event handling', () => {
+    it('reloads on RELOAD_ALL', async () => {
+      let reloadCb;
+      appEvents.on.mockImplementation((event, cb) => {
+        if (event === EVENTS.RELOAD_ALL) reloadCb = cb;
+        return jest.fn();
+      });
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const next = [{ id: 'p9', month: '2026-09', currency: 'USD', expectedIncome: '0' }];
+      BudgetPlansDB.getAllPlans.mockResolvedValue(next);
+
+      await act(async () => { reloadCb(); });
+      await waitFor(() => expect(result.current.plans).toEqual(next));
+    });
+
+    it('clears plans on DATABASE_RESET', async () => {
+      let resetCb;
+      appEvents.on.mockImplementation((event, cb) => {
+        if (event === EVENTS.DATABASE_RESET) resetCb = cb;
+        return jest.fn();
+      });
+      BudgetPlansDB.getAllPlans.mockResolvedValue([{ id: 'p1', month: '2026-07', currency: 'USD', expectedIncome: '0' }]);
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.plans).toHaveLength(1));
+
+      await act(async () => { resetCb(); });
+      expect(result.current.plans).toEqual([]);
+    });
+
+    it('unsubscribes from events on unmount', async () => {
+      const reloadUnsub = jest.fn();
+      const resetUnsub = jest.fn();
+      appEvents.on.mockImplementation((event) => {
+        if (event === EVENTS.RELOAD_ALL) return reloadUnsub;
+        if (event === EVENTS.DATABASE_RESET) return resetUnsub;
+        return jest.fn();
+      });
+
+      const { unmount, result } = await renderHook(() => useBudgetPlans(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await unmount();
+      expect(reloadUnsub).toHaveBeenCalled();
+      expect(resetUnsub).toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/db/schema.test.js
+++ b/__tests__/db/schema.test.js
@@ -700,4 +700,100 @@ describe('Database Schema', () => {
       expect(schema.accountsBalanceHistory.date.notNull).toBe(true);
     });
   });
+
+  describe('budgetPlans Table (Budgets v2)', () => {
+    it('has correct table name', async () => {
+      expect(schema.budgetPlans[Symbol.for('drizzle:Name')]).toBe('budget_plans');
+    });
+
+    it('defines all required columns', async () => {
+      const columns = schema.budgetPlans;
+      expect(columns.id).toBeDefined();
+      expect(columns.month).toBeDefined();
+      expect(columns.currency).toBeDefined();
+      expect(columns.expectedIncome).toBeDefined();
+      expect(columns.createdAt).toBeDefined();
+      expect(columns.updatedAt).toBeDefined();
+    });
+
+    it('has a text primary key', async () => {
+      expect(schema.budgetPlans.id.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlans.id.primary).toBe(true);
+    });
+
+    it('stores month, currency, and expectedIncome as text (string decimals)', async () => {
+      expect(schema.budgetPlans.month.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlans.currency.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlans.expectedIncome.columnType).toBe('SQLiteText');
+    });
+
+    it('has notNull constraints on required fields', async () => {
+      expect(schema.budgetPlans.month.notNull).toBe(true);
+      expect(schema.budgetPlans.currency.notNull).toBe(true);
+      expect(schema.budgetPlans.expectedIncome.notNull).toBe(true);
+      expect(schema.budgetPlans.createdAt.notNull).toBe(true);
+      expect(schema.budgetPlans.updatedAt.notNull).toBe(true);
+    });
+
+    it('defaults expectedIncome to "0"', async () => {
+      expect(schema.budgetPlans.expectedIncome.default).toBe('0');
+    });
+  });
+
+  describe('budgetPlanLines Table (Budgets v2)', () => {
+    it('has correct table name', async () => {
+      expect(schema.budgetPlanLines[Symbol.for('drizzle:Name')]).toBe('budget_plan_lines');
+    });
+
+    it('defines all required columns', async () => {
+      const columns = schema.budgetPlanLines;
+      expect(columns.id).toBeDefined();
+      expect(columns.planId).toBeDefined();
+      expect(columns.label).toBeDefined();
+      expect(columns.amount).toBeDefined();
+      expect(columns.comment).toBeDefined();
+      expect(columns.categoryId).toBeDefined();
+      expect(columns.toAccountId).toBeDefined();
+      expect(columns.sortOrder).toBeDefined();
+      expect(columns.createdAt).toBeDefined();
+      expect(columns.updatedAt).toBeDefined();
+    });
+
+    it('has a text primary key and a required plan reference', async () => {
+      expect(schema.budgetPlanLines.id.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlanLines.id.primary).toBe(true);
+      expect(schema.budgetPlanLines.planId.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlanLines.planId.notNull).toBe(true);
+    });
+
+    it('has nullable target columns (exactly-one enforced in the service)', async () => {
+      expect(schema.budgetPlanLines.categoryId.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlanLines.categoryId.notNull).toBeFalsy();
+      // to_account_id is an integer FK to accounts.id
+      expect(schema.budgetPlanLines.toAccountId.columnType).toBe('SQLiteInteger');
+      expect(schema.budgetPlanLines.toAccountId.notNull).toBeFalsy();
+    });
+
+    it('has optional label and comment', async () => {
+      expect(schema.budgetPlanLines.label.notNull).toBeFalsy();
+      expect(schema.budgetPlanLines.comment.notNull).toBeFalsy();
+    });
+
+    it('defaults sortOrder to 0 and requires amount', async () => {
+      expect(schema.budgetPlanLines.sortOrder.default).toBe(0);
+      expect(schema.budgetPlanLines.sortOrder.notNull).toBe(true);
+      expect(schema.budgetPlanLines.amount.notNull).toBe(true);
+      expect(schema.budgetPlanLines.amount.columnType).toBe('SQLiteText');
+    });
+
+    it('planId references budget_plans.id', async () => {
+      const planId = schema.budgetPlanLines.planId;
+      const refs = planId.references;
+      if (typeof refs === 'function') {
+        expect(refs()).toBeDefined();
+      } else if (planId.config?.references) {
+        expect(planId.config.references()).toBeDefined();
+      }
+    });
+  });
 });

--- a/__tests__/services/BudgetPlansDB.test.js
+++ b/__tests__/services/BudgetPlansDB.test.js
@@ -1,0 +1,396 @@
+/**
+ * Tests for BudgetPlansDB — Budgets v2 (monthly income-allocation plans).
+ * Covers validation (incl. the exactly-one-target invariant), CRUD for plans and
+ * lines, totals (incl. negative remainder), copyPlan, reorder, and the broken-line
+ * state produced by ON DELETE SET NULL.
+ */
+
+import * as BudgetPlansDB from '../../app/services/BudgetPlansDB';
+import { executeQuery, queryAll, queryFirst, executeTransaction } from '../../app/services/db';
+
+jest.mock('../../app/services/db');
+
+// Predictable UUIDs.
+let mockUuidCounter = 0;
+jest.mock('react-native-uuid', () => ({
+  v4: jest.fn(() => `uuid-${++mockUuidCounter}`),
+}));
+
+let mockRunAsync;
+
+describe('BudgetPlansDB', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUuidCounter = 0;
+
+    executeQuery.mockResolvedValue(undefined);
+    queryAll.mockResolvedValue([]);
+    queryFirst.mockResolvedValue(null);
+
+    mockRunAsync = jest.fn().mockResolvedValue(undefined);
+    executeTransaction.mockImplementation(async (cb) => cb({ runAsync: mockRunAsync }));
+  });
+
+  describe('validatePlan', () => {
+    it('accepts a valid plan', () => {
+      expect(BudgetPlansDB.validatePlan({
+        month: '2026-07', currency: 'USD', expectedIncome: '445000',
+      })).toBeNull();
+    });
+
+    it('accepts a plan without expectedIncome (defaults later)', () => {
+      expect(BudgetPlansDB.validatePlan({ month: '2026-07', currency: 'USD' })).toBeNull();
+    });
+
+    it('rejects a missing/invalid month', () => {
+      expect(BudgetPlansDB.validatePlan({ currency: 'USD' })).toBe('A valid month (YYYY-MM) is required');
+      expect(BudgetPlansDB.validatePlan({ month: '2026-7', currency: 'USD' })).toBe('A valid month (YYYY-MM) is required');
+      expect(BudgetPlansDB.validatePlan({ month: '2026-13', currency: 'USD' })).toBe('A valid month (YYYY-MM) is required');
+    });
+
+    it('rejects a missing currency', () => {
+      expect(BudgetPlansDB.validatePlan({ month: '2026-07' })).toBe('Currency is required');
+    });
+
+    it('rejects a negative expectedIncome', () => {
+      expect(BudgetPlansDB.validatePlan({ month: '2026-07', currency: 'USD', expectedIncome: '-1' }))
+        .toBe('Expected income must be a non-negative number');
+    });
+  });
+
+  describe('validatePlanLine (exactly-one-target invariant)', () => {
+    it('accepts a category-linked line', () => {
+      expect(BudgetPlansDB.validatePlanLine({ amount: '100', categoryId: 'cat1' })).toBeNull();
+    });
+
+    it('accepts an account-linked line', () => {
+      expect(BudgetPlansDB.validatePlanLine({ amount: '100', toAccountId: 5 })).toBeNull();
+    });
+
+    it('rejects a line linked to both a category and an account', () => {
+      expect(BudgetPlansDB.validatePlanLine({ amount: '100', categoryId: 'cat1', toAccountId: 5 }))
+        .toBe('A line must link to either a category or an account, not both');
+    });
+
+    it('rejects a line linked to neither target', () => {
+      expect(BudgetPlansDB.validatePlanLine({ amount: '100' }))
+        .toBe('A line must link to a category or an account');
+    });
+
+    it('rejects a zero, negative, or missing amount', () => {
+      expect(BudgetPlansDB.validatePlanLine({ amount: '0', categoryId: 'c' })).toBe('Amount must be greater than zero');
+      expect(BudgetPlansDB.validatePlanLine({ amount: '-5', categoryId: 'c' })).toBe('Amount must be greater than zero');
+      expect(BudgetPlansDB.validatePlanLine({ categoryId: 'c' })).toBe('Amount must be greater than zero');
+    });
+  });
+
+  describe('mapLineFields', () => {
+    it('returns null for null input', () => {
+      expect(BudgetPlansDB.mapLineFields(null)).toBeNull();
+    });
+
+    it('maps snake_case to camelCase and flags broken lines', () => {
+      const broken = BudgetPlansDB.mapLineFields({
+        id: 'l1', plan_id: 'p1', label: null, amount: '100', comment: null,
+        category_id: null, to_account_id: null, sort_order: 2,
+        created_at: 't', updated_at: 't',
+      });
+      expect(broken.isBroken).toBe(true);
+      expect(broken.sortOrder).toBe(2);
+
+      const linked = BudgetPlansDB.mapLineFields({
+        id: 'l2', plan_id: 'p1', amount: '100', category_id: 'cat1', to_account_id: null, sort_order: 0,
+      });
+      expect(linked.isBroken).toBe(false);
+      expect(linked.categoryId).toBe('cat1');
+    });
+  });
+
+  describe('createPlan', () => {
+    it('inserts a plan and returns the mapped object', async () => {
+      const result = await BudgetPlansDB.createPlan({
+        id: 'plan1', month: '2026-07', currency: 'USD', expectedIncome: '445000',
+      });
+
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO budget_plans'),
+        expect.arrayContaining(['plan1', '2026-07', 'USD', '445000']),
+      );
+      expect(result).toMatchObject({ id: 'plan1', month: '2026-07', currency: 'USD', expectedIncome: '445000' });
+    });
+
+    it('defaults expected_income to "0" when omitted', async () => {
+      await BudgetPlansDB.createPlan({ id: 'plan1', month: '2026-07', currency: 'USD' });
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['0']),
+      );
+    });
+
+    it('generates an id when none is provided', async () => {
+      const result = await BudgetPlansDB.createPlan({ month: '2026-07', currency: 'USD' });
+      expect(result.id).toBe('uuid-1');
+    });
+
+    it('throws on invalid data before touching the DB', async () => {
+      await expect(BudgetPlansDB.createPlan({ currency: 'USD' }))
+        .rejects.toThrow('A valid month (YYYY-MM) is required');
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('throws when a plan already exists for the month', async () => {
+      queryFirst.mockResolvedValue({ id: 'existing', month: '2026-07', currency: 'USD', expected_income: '0' });
+      await expect(BudgetPlansDB.createPlan({ month: '2026-07', currency: 'USD' }))
+        .rejects.toThrow('A plan for this month already exists');
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('read queries', () => {
+    it('getPlanByMonth maps the row', async () => {
+      queryFirst.mockResolvedValue({ id: 'p1', month: '2026-07', currency: 'USD', expected_income: '10' });
+      const plan = await BudgetPlansDB.getPlanByMonth('2026-07');
+      expect(queryFirst).toHaveBeenCalledWith('SELECT * FROM budget_plans WHERE month = ?', ['2026-07']);
+      expect(plan.expectedIncome).toBe('10');
+    });
+
+    it('getPlanById returns null when not found', async () => {
+      queryFirst.mockResolvedValue(null);
+      expect(await BudgetPlansDB.getPlanById('nope')).toBeNull();
+    });
+
+    it('getAllPlans maps all rows newest-month-first', async () => {
+      queryAll.mockResolvedValue([
+        { id: 'p2', month: '2026-08', currency: 'USD', expected_income: '0' },
+        { id: 'p1', month: '2026-07', currency: 'USD', expected_income: '0' },
+      ]);
+      const plans = await BudgetPlansDB.getAllPlans();
+      expect(queryAll).toHaveBeenCalledWith('SELECT * FROM budget_plans ORDER BY month DESC');
+      expect(plans).toHaveLength(2);
+      expect(plans[0].month).toBe('2026-08');
+    });
+
+    it('getAllPlans handles an empty result', async () => {
+      queryAll.mockResolvedValue([]);
+      expect(await BudgetPlansDB.getAllPlans()).toEqual([]);
+    });
+  });
+
+  describe('updatePlan', () => {
+    it('builds a dynamic UPDATE for provided fields', async () => {
+      await BudgetPlansDB.updatePlan('p1', { currency: 'EUR', expectedIncome: '500' });
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE budget_plans SET'),
+        expect.arrayContaining(['EUR', '500', 'p1']),
+      );
+    });
+
+    it('does nothing when no fields are provided', async () => {
+      await BudgetPlansDB.updatePlan('p1', {});
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid month', async () => {
+      await expect(BudgetPlansDB.updatePlan('p1', { month: 'bad' }))
+        .rejects.toThrow('A valid month (YYYY-MM) is required');
+    });
+
+    it('rejects a negative expectedIncome', async () => {
+      await expect(BudgetPlansDB.updatePlan('p1', { expectedIncome: '-5' }))
+        .rejects.toThrow('Expected income must be a non-negative number');
+    });
+  });
+
+  describe('deletePlan', () => {
+    it('deletes the plan (lines cascade at the DB level)', async () => {
+      await BudgetPlansDB.deletePlan('p1');
+      expect(executeQuery).toHaveBeenCalledWith('DELETE FROM budget_plans WHERE id = ?', ['p1']);
+    });
+  });
+
+  describe('lines', () => {
+    it('getPlanLines maps ordered rows', async () => {
+      queryAll.mockResolvedValue([
+        { id: 'l1', plan_id: 'p1', amount: '100', category_id: 'c1', to_account_id: null, sort_order: 0 },
+      ]);
+      const lines = await BudgetPlansDB.getPlanLines('p1');
+      expect(queryAll).toHaveBeenCalledWith(
+        expect.stringContaining('WHERE plan_id = ? ORDER BY sort_order ASC'),
+        ['p1'],
+      );
+      expect(lines[0].categoryId).toBe('c1');
+    });
+
+    it('getBrokenLines queries lines with both targets null', async () => {
+      queryAll.mockResolvedValue([
+        { id: 'l1', plan_id: 'p1', amount: '100', category_id: null, to_account_id: null, sort_order: 0 },
+      ]);
+      const broken = await BudgetPlansDB.getBrokenLines('p1');
+      expect(queryAll).toHaveBeenCalledWith(
+        expect.stringContaining('category_id IS NULL AND to_account_id IS NULL'),
+        ['p1'],
+      );
+      expect(broken[0].isBroken).toBe(true);
+    });
+
+    it('addLine inserts a valid line and returns it', async () => {
+      const line = await BudgetPlansDB.addLine('p1', { amount: '73000', categoryId: 'c1', label: 'Rent' });
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO budget_plan_lines'),
+        expect.arrayContaining(['p1', 'Rent', '73000', 'c1']),
+      );
+      expect(line).toMatchObject({ planId: 'p1', amount: '73000', categoryId: 'c1', toAccountId: null, sortOrder: 0 });
+      expect(line.id).toBe('uuid-1');
+    });
+
+    it('addLine rejects an invalid (dual-target) line', async () => {
+      await expect(BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1', toAccountId: 2 }))
+        .rejects.toThrow('not both');
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('updateLine builds a dynamic UPDATE', async () => {
+      await BudgetPlansDB.updateLine('l1', { amount: '200', comment: 'x' });
+      expect(executeQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE budget_plan_lines SET'),
+        expect.arrayContaining(['200', 'x', 'l1']),
+      );
+    });
+
+    it('updateLine rejects setting both targets at once', async () => {
+      await expect(BudgetPlansDB.updateLine('l1', { categoryId: 'c1', toAccountId: 2 }))
+        .rejects.toThrow('not both');
+    });
+
+    it('updateLine clears the account link when a category is (re)assigned', async () => {
+      await BudgetPlansDB.updateLine('l1', { categoryId: 'c9' });
+      const [sql, params] = executeQuery.mock.calls[0];
+      expect(sql).toContain('category_id = ?');
+      expect(sql).toContain('to_account_id = ?');
+      // c9 written for category, null written for the (implicitly cleared) account.
+      expect(params).toEqual(expect.arrayContaining(['c9', null, 'l1']));
+    });
+
+    it('updateLine clears the category link when an account is (re)assigned', async () => {
+      await BudgetPlansDB.updateLine('l1', { toAccountId: 7 });
+      const [sql, params] = executeQuery.mock.calls[0];
+      expect(sql).toContain('to_account_id = ?');
+      expect(sql).toContain('category_id = ?');
+      expect(params).toEqual(expect.arrayContaining([7, null, 'l1']));
+    });
+
+    it('updateLine rejects a non-positive amount', async () => {
+      await expect(BudgetPlansDB.updateLine('l1', { amount: '0' }))
+        .rejects.toThrow('Amount must be greater than zero');
+    });
+
+    it('updateLine does nothing when no fields are provided', async () => {
+      await BudgetPlansDB.updateLine('l1', {});
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('deleteLine deletes by id', async () => {
+      await BudgetPlansDB.deleteLine('l1');
+      expect(executeQuery).toHaveBeenCalledWith('DELETE FROM budget_plan_lines WHERE id = ?', ['l1']);
+    });
+
+    it('reorderLines updates sort_order in a transaction', async () => {
+      await BudgetPlansDB.reorderLines('p1', ['l3', 'l1', 'l2']);
+      expect(executeTransaction).toHaveBeenCalled();
+      expect(mockRunAsync).toHaveBeenCalledTimes(3);
+      expect(mockRunAsync).toHaveBeenNthCalledWith(1, expect.any(String), [0, expect.any(String), 'l3', 'p1']);
+      expect(mockRunAsync).toHaveBeenNthCalledWith(2, expect.any(String), [1, expect.any(String), 'l1', 'p1']);
+    });
+
+    it('reorderLines rejects duplicate ids', async () => {
+      await expect(BudgetPlansDB.reorderLines('p1', ['l1', 'l1']))
+        .rejects.toThrow('Duplicate line ID');
+    });
+
+    it('reorderLines rejects a missing id', async () => {
+      await expect(BudgetPlansDB.reorderLines('p1', ['l1', null]))
+        .rejects.toThrow('missing id');
+    });
+  });
+
+  describe('getPlanTotals', () => {
+    it('computes expectedIncome, allocated, and a positive remainder', async () => {
+      queryFirst.mockResolvedValue({ id: 'p1', month: '2026-07', currency: 'USD', expected_income: '445000' });
+      queryAll.mockResolvedValue([
+        { id: 'l1', plan_id: 'p1', amount: '430000', category_id: 'c1', to_account_id: null, sort_order: 0 },
+      ]);
+
+      const totals = await BudgetPlansDB.getPlanTotals('p1');
+      expect(totals).toEqual({ expectedIncome: '445000.00', allocated: '430000.00', remainder: '15000.00' });
+    });
+
+    it('returns a negative remainder when over-allocated', async () => {
+      queryFirst.mockResolvedValue({ id: 'p1', month: '2026-07', currency: 'USD', expected_income: '100' });
+      queryAll.mockResolvedValue([
+        { id: 'l1', plan_id: 'p1', amount: '60', category_id: 'c1', to_account_id: null, sort_order: 0 },
+        { id: 'l2', plan_id: 'p1', amount: '90', category_id: null, to_account_id: 3, sort_order: 1 },
+      ]);
+
+      const totals = await BudgetPlansDB.getPlanTotals('p1');
+      expect(totals.allocated).toBe('150.00');
+      expect(totals.remainder).toBe('-50.00');
+    });
+
+    it('throws when the plan does not exist', async () => {
+      queryFirst.mockResolvedValue(null);
+      await expect(BudgetPlansDB.getPlanTotals('nope')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('copyPlan', () => {
+    it('clones a plan and its lines into a new month', async () => {
+      queryFirst
+        .mockResolvedValueOnce({ id: 'src', month: '2026-06', currency: 'USD', expected_income: '445000' }) // fromMonth
+        .mockResolvedValueOnce(null); // toMonth free
+      queryAll.mockResolvedValue([
+        { id: 'l1', plan_id: 'src', label: 'Rent', amount: '65000', comment: null, category_id: 'c1', to_account_id: null, sort_order: 0 },
+        { id: 'l2', plan_id: 'src', label: 'Savings', amount: '50000', comment: null, category_id: null, to_account_id: 4, sort_order: 1 },
+      ]);
+
+      const created = await BudgetPlansDB.copyPlan('2026-06', '2026-07');
+
+      expect(created).toMatchObject({ month: '2026-07', currency: 'USD', expectedIncome: '445000' });
+      // 1 plan insert + 2 line inserts.
+      expect(mockRunAsync).toHaveBeenCalledTimes(3);
+      expect(mockRunAsync).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('INSERT INTO budget_plans'),
+        expect.arrayContaining(['2026-07', 'USD', '445000']),
+      );
+    });
+
+    it('throws when the source month has no plan', async () => {
+      queryFirst.mockResolvedValue(null);
+      await expect(BudgetPlansDB.copyPlan('2026-06', '2026-07')).rejects.toThrow('No budget plan found');
+    });
+
+    it('throws when the target month already has a plan', async () => {
+      queryFirst
+        .mockResolvedValueOnce({ id: 'src', month: '2026-06', currency: 'USD', expected_income: '0' })
+        .mockResolvedValueOnce({ id: 'dst', month: '2026-07', currency: 'USD', expected_income: '0' });
+      await expect(BudgetPlansDB.copyPlan('2026-06', '2026-07')).rejects.toThrow('already exists');
+    });
+
+    it('rejects an invalid target month', async () => {
+      await expect(BudgetPlansDB.copyPlan('2026-06', 'bad')).rejects.toThrow('A valid month (YYYY-MM) is required');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates DB errors from getAllPlans', async () => {
+      queryAll.mockRejectedValue(new Error('DB down'));
+      await expect(BudgetPlansDB.getAllPlans()).rejects.toThrow('DB down');
+    });
+
+    it('propagates DB errors from createPlan insert', async () => {
+      executeQuery.mockRejectedValue(new Error('insert failed'));
+      await expect(BudgetPlansDB.createPlan({ month: '2026-07', currency: 'USD' }))
+        .rejects.toThrow('insert failed');
+    });
+  });
+});

--- a/__tests__/services/db.fastpath.test.js
+++ b/__tests__/services/db.fastpath.test.js
@@ -44,7 +44,7 @@ const SCHEMA_VERSION = 3; // must equal the journal entry count above
 import { getDatabase, closeDatabase, dropAllTables } from '../../app/services/db';
 import * as SQLite from 'expo-sqlite';
 
-// The nine tables isSchemaComplete() expects, plus per-table columns that satisfy
+// The tables isSchemaComplete() expects, plus per-table columns that satisfy
 // every column check in it. Used to simulate a genuinely complete post-migration
 // schema so the fast-path fingerprint is stamped (the stamp is now gated on
 // isSchemaComplete — a half-applied migration must NOT be stamped).
@@ -52,6 +52,7 @@ const COMPLETE_TABLES = [
   'accounts', 'categories', 'operations', 'budgets', 'app_metadata',
   'accounts_balance_history', 'planned_operations',
   'notification_merchant_rules', 'pending_notifications',
+  'budget_plans', 'budget_plan_lines',
 ];
 const mockSchemaComplete = (db, storedUserVersion) => {
   db.getFirstAsync.mockImplementation((q) => {

--- a/app/contexts/BudgetPlansActionsContext.js
+++ b/app/contexts/BudgetPlansActionsContext.js
@@ -1,0 +1,151 @@
+import React, { createContext, useContext, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import uuid from 'react-native-uuid';
+import * as BudgetPlansDB from '../services/BudgetPlansDB';
+import { useDialog } from './DialogContext';
+import { useBudgetPlansData } from './BudgetPlansDataContext';
+
+const BudgetPlansActionsContext = createContext();
+
+/**
+ * Stable action functions for budget plans (Budgets v2). Plan-level mutations keep
+ * the plans list in the data context in sync; line-level mutations delegate to the
+ * DB (lines are not held in context state).
+ */
+export const BudgetPlansActionsProvider = ({ children }) => {
+  const { showDialog } = useDialog();
+  const { plans, reloadPlans, _setPlans, _setSaveError } = useBudgetPlansData();
+
+  const reportError = useCallback((error, fallbackMessage) => {
+    _setSaveError(error.message);
+    showDialog('Error', fallbackMessage || error.message, [{ text: 'OK' }]);
+  }, [showDialog, _setSaveError]);
+
+  /**
+   * Create a plan for a month.
+   */
+  const addPlan = useCallback(async (plan) => {
+    try {
+      const validationError = BudgetPlansDB.validatePlan(plan);
+      if (validationError) {
+        throw new Error(validationError);
+      }
+      const newPlan = { ...plan, id: plan.id || uuid.v4() };
+      const created = await BudgetPlansDB.createPlan(newPlan);
+      _setPlans(prev => [created, ...prev]);
+      _setSaveError(null);
+      return created;
+    } catch (error) {
+      console.error('Failed to create budget plan:', error);
+      reportError(error);
+      throw error;
+    }
+  }, [_setPlans, _setSaveError, reportError]);
+
+  /**
+   * Update a plan.
+   */
+  const updatePlan = useCallback(async (id, updates) => {
+    try {
+      const existing = plans.find(p => p.id === id);
+      if (!existing) {
+        throw new Error('Budget plan not found');
+      }
+      await BudgetPlansDB.updatePlan(id, updates);
+      // Keep the list in month-DESC order (matches getAllPlans) in case the month
+      // itself changed, so consumers don't see a transiently mis-sorted list.
+      _setPlans(prev => prev
+        .map(p => (p.id === id ? { ...p, ...updates } : p))
+        .sort((a, b) => b.month.localeCompare(a.month)));
+      _setSaveError(null);
+    } catch (error) {
+      console.error('Failed to update budget plan:', error);
+      reportError(error);
+      throw error;
+    }
+  }, [plans, _setPlans, _setSaveError, reportError]);
+
+  /**
+   * Delete a plan (and its lines, via cascade).
+   */
+  const deletePlan = useCallback(async (id) => {
+    try {
+      await BudgetPlansDB.deletePlan(id);
+      _setPlans(prev => prev.filter(p => p.id !== id));
+      _setSaveError(null);
+    } catch (error) {
+      console.error('Failed to delete budget plan:', error);
+      reportError(error, 'Failed to delete plan. Please try again.');
+      throw error;
+    }
+  }, [_setPlans, _setSaveError, reportError]);
+
+  /**
+   * Clone a plan from one month into another.
+   */
+  const copyPlan = useCallback(async (fromMonth, toMonth) => {
+    try {
+      const created = await BudgetPlansDB.copyPlan(fromMonth, toMonth);
+      _setPlans(prev => [created, ...prev]);
+      _setSaveError(null);
+      return created;
+    } catch (error) {
+      console.error('Failed to copy budget plan:', error);
+      reportError(error);
+      throw error;
+    }
+  }, [_setPlans, _setSaveError, reportError]);
+
+  // Line-level operations delegate straight to the DB (lines are fetched on demand
+  // by consumers via getPlanLines, not held in context state).
+  const addLine = useCallback((planId, line) => BudgetPlansDB.addLine(planId, line), []);
+  const updateLine = useCallback((id, updates) => BudgetPlansDB.updateLine(id, updates), []);
+  const deleteLine = useCallback((id) => BudgetPlansDB.deleteLine(id), []);
+  const reorderLines = useCallback((planId, orderedIds) => BudgetPlansDB.reorderLines(planId, orderedIds), []);
+  const getPlanLines = useCallback((planId) => BudgetPlansDB.getPlanLines(planId), []);
+  const getBrokenLines = useCallback((planId) => BudgetPlansDB.getBrokenLines(planId), []);
+  const getPlanTotals = useCallback((planId) => BudgetPlansDB.getPlanTotals(planId), []);
+  const getPlanByMonth = useCallback((month) => BudgetPlansDB.getPlanByMonth(month), []);
+
+  const value = useMemo(() => ({
+    addPlan,
+    updatePlan,
+    deletePlan,
+    copyPlan,
+    addLine,
+    updateLine,
+    deleteLine,
+    reorderLines,
+    getPlanLines,
+    getBrokenLines,
+    getPlanTotals,
+    getPlanByMonth,
+    reloadPlans,
+  }), [
+    addPlan,
+    updatePlan,
+    deletePlan,
+    copyPlan,
+    addLine,
+    updateLine,
+    deleteLine,
+    reorderLines,
+    getPlanLines,
+    getBrokenLines,
+    getPlanTotals,
+    getPlanByMonth,
+    reloadPlans,
+  ]);
+
+  return (
+    <BudgetPlansActionsContext.Provider value={value}>
+      {children}
+    </BudgetPlansActionsContext.Provider>
+  );
+};
+
+BudgetPlansActionsProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export const useBudgetPlansActions = () => useContext(BudgetPlansActionsContext);

--- a/app/contexts/BudgetPlansContext.js
+++ b/app/contexts/BudgetPlansContext.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { BudgetPlansDataProvider, useBudgetPlansData } from './BudgetPlansDataContext';
+import { BudgetPlansActionsProvider, useBudgetPlansActions } from './BudgetPlansActionsContext';
+
+/**
+ * Budgets v2 (monthly income-allocation plans). Follows the Data/Actions split
+ * pattern used by budgets:
+ * - BudgetPlansDataContext (the plans list + load state)
+ * - BudgetPlansActionsContext (stable action functions)
+ *
+ * New code should import useBudgetPlansData / useBudgetPlansActions directly; this
+ * merged hook + combined provider are the convenience wrappers.
+ */
+
+/**
+ * Merged hook combining plans data and actions.
+ */
+export const useBudgetPlans = () => {
+  const data = useBudgetPlansData();
+  const actions = useBudgetPlansActions();
+
+  if (!data || !actions) {
+    throw new Error('useBudgetPlans must be used within a BudgetPlansProvider');
+  }
+
+  return {
+    ...data,
+    ...actions,
+  };
+};
+
+/**
+ * Combined provider that wraps both split contexts.
+ */
+export const BudgetPlansProvider = ({ children }) => {
+  return (
+    <BudgetPlansDataProvider>
+      <BudgetPlansActionsProvider>
+        {children}
+      </BudgetPlansActionsProvider>
+    </BudgetPlansDataProvider>
+  );
+};
+
+BudgetPlansProvider.propTypes = {
+  children: PropTypes.node,
+};

--- a/app/contexts/BudgetPlansDataContext.js
+++ b/app/contexts/BudgetPlansDataContext.js
@@ -1,0 +1,80 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import * as BudgetPlansDB from '../services/BudgetPlansDB';
+import { appEvents, EVENTS } from '../services/eventEmitter';
+
+const BudgetPlansDataContext = createContext();
+
+/**
+ * Holds the list of budget plans (Budgets v2). Lines and derived totals are loaded
+ * on demand through the actions context — this context only tracks the plans
+ * themselves so the tree doesn't re-render on per-line edits.
+ */
+export const BudgetPlansDataProvider = ({ children }) => {
+  const [plans, setPlans] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saveError, setSaveError] = useState(null);
+
+  /**
+   * Load all plans from the database.
+   */
+  const reloadPlans = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await BudgetPlansDB.getAllPlans();
+      setPlans(data);
+      setSaveError(null);
+    } catch (error) {
+      console.error('Failed to load budget plans:', error);
+      setSaveError(error.message);
+      setPlans([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    reloadPlans();
+  }, [reloadPlans]);
+
+  // Reload on the global RELOAD_ALL signal (e.g. after a restore).
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.RELOAD_ALL, () => {
+      console.debug('Reloading all budget plans...');
+      reloadPlans();
+    });
+    return unsubscribe;
+  }, [reloadPlans]);
+
+  // Clear state on a database reset — the tables are gone until the user finishes
+  // re-onboarding, and reloading now would race the reset.
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.DATABASE_RESET, () => {
+      console.log('BudgetPlansDataContext: Database reset detected, clearing plans');
+      setPlans([]);
+    });
+    return unsubscribe;
+  }, []);
+
+  const value = useMemo(() => ({
+    plans,
+    loading,
+    saveError,
+    reloadPlans,
+    // Internal setters for the actions context.
+    _setPlans: setPlans,
+    _setSaveError: setSaveError,
+  }), [plans, loading, saveError, reloadPlans]);
+
+  return (
+    <BudgetPlansDataContext.Provider value={value}>
+      {children}
+    </BudgetPlansDataContext.Provider>
+  );
+};
+
+BudgetPlansDataProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export const useBudgetPlansData = () => useContext(BudgetPlansDataContext);

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -237,3 +237,58 @@ export const accountsBalanceHistory = sqliteTable('accounts_balance_history', {
   dateIdx: index('idx_balance_history_date').on(table.date),
   uniqueAccountDate: unique().on(table.accountId, table.date),
 }));
+
+/**
+ * Budget Plans table (Budgets v2 — envelope-style monthly income allocation)
+ *
+ * One plan per calendar month. `expected_income` is the total income the user
+ * expects that month; it is split into budget_plan_lines. The un-allocated
+ * remainder (expected_income − Σ lines) is always COMPUTED, never stored.
+ *
+ * Amounts follow the codebase convention: string decimals (see budgets.amount),
+ * with all arithmetic going through app/services/currency.js.
+ */
+export const budgetPlans = sqliteTable('budget_plans', {
+  id: text('id').primaryKey(),
+  // YYYY-MM. Unique — a month has at most one plan.
+  month: text('month').notNull(),
+  // Display/base currency of the plan.
+  currency: text('currency').notNull(),
+  // Total expected income for the month (string decimal). Defaults to '0'.
+  expectedIncome: text('expected_income').notNull().default('0'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => ({
+  monthIdx: unique('idx_budget_plans_month').on(table.month),
+}));
+
+/**
+ * Budget Plan Lines table
+ *
+ * Each line allocates part of the plan's expected income to a tracking target.
+ * Every line is linked to EXACTLY ONE of:
+ *   - an expense `category_id` → tracked against category spending, or
+ *   - a destination `to_account_id` → tracked against transfers INTO that account.
+ * The "exactly one" invariant is enforced in the service (BudgetPlansDB), not by
+ * SQL, so a line whose FK is nulled by a category/account deletion (ON DELETE SET
+ * NULL) becomes "broken" (both targets null) instead of crashing — the UI (later
+ * parts) prompts the user to re-link it.
+ *
+ * `to_account_id` is an integer FK to match accounts.id (integer autoincrement),
+ * consistent with operations.to_account_id / planned_operations.to_account_id.
+ */
+export const budgetPlanLines = sqliteTable('budget_plan_lines', {
+  id: text('id').primaryKey(),
+  planId: text('plan_id').notNull().references(() => budgetPlans.id, { onDelete: 'cascade' }),
+  // Optional display name; falls back to the linked category/account name.
+  label: text('label'),
+  amount: text('amount').notNull(),
+  comment: text('comment'),
+  categoryId: text('category_id').references(() => categories.id, { onDelete: 'set null' }),
+  toAccountId: integer('to_account_id').references(() => accounts.id, { onDelete: 'set null' }),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+}, (table) => ({
+  planIdx: index('idx_budget_plan_lines_plan').on(table.planId),
+}));

--- a/app/services/BudgetPlansDB.js
+++ b/app/services/BudgetPlansDB.js
@@ -1,0 +1,550 @@
+/**
+ * BudgetPlansDB — data access for Budgets v2 (envelope-style monthly income
+ * allocation). One plan per month with an expected income, split into lines that
+ * each link to EXACTLY ONE tracking target (an expense category or a destination
+ * account). See app/db/schema.js (budget_plans, budget_plan_lines).
+ *
+ * Mirrors the style of BudgetsDB.js: snake_case → camelCase mapping, validation
+ * in the service, and precise decimal math via app/services/currency.js (no floats).
+ */
+
+import uuid from 'react-native-uuid';
+import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
+import * as Currency from './currency';
+
+// YYYY-MM with a real 01–12 month.
+const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+/**
+ * Map a budget_plans row (snake_case) to the camelCase shape the app uses.
+ * @param {Object|null} row
+ * @returns {Object|null}
+ */
+export const mapPlanFields = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    month: row.month,
+    currency: row.currency,
+    expectedIncome: row.expected_income,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
+
+/**
+ * Map a budget_plan_lines row to camelCase. Adds a computed `isBroken` flag: a
+ * line is broken when neither target is set (its category/account FK was nulled by
+ * an ON DELETE SET NULL). The UI (later parts) prompts to re-link such lines.
+ * @param {Object|null} row
+ * @returns {Object|null}
+ */
+export const mapLineFields = (row) => {
+  if (!row) return null;
+  const categoryId = row.category_id ?? null;
+  const toAccountId = row.to_account_id ?? null;
+  return {
+    id: row.id,
+    planId: row.plan_id,
+    label: row.label ?? null,
+    amount: row.amount,
+    comment: row.comment ?? null,
+    categoryId,
+    toAccountId,
+    sortOrder: row.sort_order ?? 0,
+    isBroken: categoryId === null && toAccountId === null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
+
+// True when a target reference is meaningfully set (not null/undefined/'').
+const isSet = (value) => value !== null && value !== undefined && value !== '';
+
+/**
+ * Validate a plan.
+ * @param {Object} plan
+ * @returns {string|null} Error message or null if valid.
+ */
+export const validatePlan = (plan) => {
+  if (!plan || !plan.month || !MONTH_REGEX.test(plan.month)) {
+    return 'A valid month (YYYY-MM) is required';
+  }
+  if (!plan.currency) {
+    return 'Currency is required';
+  }
+  // expectedIncome is optional (defaults to '0'); when present it must be a
+  // valid, non-negative number.
+  if (isSet(plan.expectedIncome)) {
+    if (!Currency.isValid(plan.expectedIncome) || Currency.isNegative(plan.expectedIncome)) {
+      return 'Expected income must be a non-negative number';
+    }
+  }
+  return null;
+};
+
+/**
+ * Validate a plan line, including the "exactly one target" invariant.
+ * @param {Object} line
+ * @returns {string|null} Error message or null if valid.
+ */
+export const validatePlanLine = (line) => {
+  if (!line || !Currency.isValid(line.amount) || Currency.compare(line.amount, '0') <= 0) {
+    return 'Amount must be greater than zero';
+  }
+  const hasCategory = isSet(line.categoryId);
+  const hasAccount = isSet(line.toAccountId);
+  if (hasCategory && hasAccount) {
+    return 'A line must link to either a category or an account, not both';
+  }
+  if (!hasCategory && !hasAccount) {
+    return 'A line must link to a category or an account';
+  }
+  return null;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Plans                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Create a plan. Requires a unique month.
+ * @param {Object} plan - { id, month, currency, expectedIncome? }
+ * @returns {Promise<Object>} The created plan (camelCase).
+ */
+export const createPlan = async (plan) => {
+  try {
+    const validationError = validatePlan(plan);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
+    const existing = await getPlanByMonth(plan.month);
+    if (existing) {
+      throw new Error('A plan for this month already exists');
+    }
+
+    const now = new Date().toISOString();
+    const row = {
+      id: plan.id || uuid.v4(),
+      month: plan.month,
+      currency: plan.currency,
+      expected_income: isSet(plan.expectedIncome) ? String(plan.expectedIncome) : '0',
+      created_at: now,
+      updated_at: now,
+    };
+
+    await executeQuery(
+      'INSERT INTO budget_plans (id, month, currency, expected_income, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [row.id, row.month, row.currency, row.expected_income, row.created_at, row.updated_at],
+    );
+
+    return mapPlanFields(row);
+  } catch (error) {
+    console.error('Failed to create budget plan:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get a plan by month (YYYY-MM).
+ * @param {string} month
+ * @returns {Promise<Object|null>}
+ */
+export const getPlanByMonth = async (month) => {
+  try {
+    const row = await queryFirst('SELECT * FROM budget_plans WHERE month = ?', [month]);
+    return mapPlanFields(row);
+  } catch (error) {
+    console.error('Failed to get budget plan by month:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get a plan by ID.
+ * @param {string} id
+ * @returns {Promise<Object|null>}
+ */
+export const getPlanById = async (id) => {
+  try {
+    const row = await queryFirst('SELECT * FROM budget_plans WHERE id = ?', [id]);
+    return mapPlanFields(row);
+  } catch (error) {
+    console.error('Failed to get budget plan by id:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get all plans, newest month first.
+ * @returns {Promise<Array>}
+ */
+export const getAllPlans = async () => {
+  try {
+    const rows = await queryAll('SELECT * FROM budget_plans ORDER BY month DESC');
+    return (rows || []).map(mapPlanFields);
+  } catch (error) {
+    console.error('Failed to get budget plans:', error);
+    throw error;
+  }
+};
+
+/**
+ * Update a plan.
+ * @param {string} id
+ * @param {Object} updates - Partial { month, currency, expectedIncome }
+ * @returns {Promise<void>}
+ */
+export const updatePlan = async (id, updates) => {
+  try {
+    const fields = [];
+    const values = [];
+
+    if (updates.month !== undefined) {
+      if (!MONTH_REGEX.test(updates.month)) {
+        throw new Error('A valid month (YYYY-MM) is required');
+      }
+      fields.push('month = ?');
+      values.push(updates.month);
+    }
+    if (updates.currency !== undefined) {
+      fields.push('currency = ?');
+      values.push(updates.currency);
+    }
+    if (updates.expectedIncome !== undefined) {
+      if (!Currency.isValid(updates.expectedIncome) || Currency.isNegative(updates.expectedIncome)) {
+        throw new Error('Expected income must be a non-negative number');
+      }
+      fields.push('expected_income = ?');
+      values.push(String(updates.expectedIncome));
+    }
+
+    if (fields.length === 0) {
+      return; // Nothing to update
+    }
+
+    fields.push('updated_at = ?');
+    values.push(new Date().toISOString());
+    values.push(id);
+
+    await executeQuery(`UPDATE budget_plans SET ${fields.join(', ')} WHERE id = ?`, values);
+  } catch (error) {
+    console.error('Failed to update budget plan:', error);
+    throw error;
+  }
+};
+
+/**
+ * Delete a plan. Its lines are removed by ON DELETE CASCADE.
+ * @param {string} id
+ * @returns {Promise<void>}
+ */
+export const deletePlan = async (id) => {
+  try {
+    await executeQuery('DELETE FROM budget_plans WHERE id = ?', [id]);
+  } catch (error) {
+    console.error('Failed to delete budget plan:', error);
+    throw error;
+  }
+};
+
+/* -------------------------------------------------------------------------- */
+/* Lines                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Get the lines of a plan, ordered by sort order.
+ * @param {string} planId
+ * @returns {Promise<Array>}
+ */
+export const getPlanLines = async (planId) => {
+  try {
+    const rows = await queryAll(
+      'SELECT * FROM budget_plan_lines WHERE plan_id = ? ORDER BY sort_order ASC, created_at ASC',
+      [planId],
+    );
+    return (rows || []).map(mapLineFields);
+  } catch (error) {
+    console.error('Failed to get budget plan lines:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get the "broken" lines of a plan — those whose category/account link was nulled
+ * by a deletion and now track nothing. Exposed so the UI can prompt to re-link.
+ * @param {string} planId
+ * @returns {Promise<Array>}
+ */
+export const getBrokenLines = async (planId) => {
+  try {
+    const rows = await queryAll(
+      'SELECT * FROM budget_plan_lines WHERE plan_id = ? AND category_id IS NULL AND to_account_id IS NULL ORDER BY sort_order ASC',
+      [planId],
+    );
+    return (rows || []).map(mapLineFields);
+  } catch (error) {
+    console.error('Failed to get broken budget plan lines:', error);
+    throw error;
+  }
+};
+
+/**
+ * Add a line to a plan.
+ * @param {string} planId
+ * @param {Object} line - { label?, amount, comment?, categoryId?, toAccountId?, sortOrder? }
+ * @returns {Promise<Object>} The created line (camelCase).
+ */
+export const addLine = async (planId, line) => {
+  try {
+    const validationError = validatePlanLine(line);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+
+    const now = new Date().toISOString();
+    const row = {
+      id: line.id || uuid.v4(),
+      plan_id: planId,
+      label: line.label ?? null,
+      amount: String(line.amount),
+      comment: line.comment ?? null,
+      category_id: isSet(line.categoryId) ? line.categoryId : null,
+      to_account_id: isSet(line.toAccountId) ? line.toAccountId : null,
+      sort_order: Number.isInteger(line.sortOrder) ? line.sortOrder : 0,
+      created_at: now,
+      updated_at: now,
+    };
+
+    await executeQuery(
+      'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        row.id, row.plan_id, row.label, row.amount, row.comment,
+        row.category_id, row.to_account_id, row.sort_order, row.created_at, row.updated_at,
+      ],
+    );
+
+    return mapLineFields(row);
+  } catch (error) {
+    console.error('Failed to add budget plan line:', error);
+    throw error;
+  }
+};
+
+/**
+ * Update a line. Partial updates. The "exactly one target" invariant is preserved
+ * even for partial updates: (re)assigning one target to a real value implicitly
+ * clears the other, so a line can never end up linked to both — a partial update
+ * cannot silently pair a new account onto a line that still holds a category.
+ * @param {string} id
+ * @param {Object} updates - Partial { label, amount, comment, categoryId, toAccountId, sortOrder }
+ * @returns {Promise<void>}
+ */
+export const updateLine = async (id, updates) => {
+  try {
+    // Reject setting both targets in a single update outright.
+    if (isSet(updates.categoryId) && isSet(updates.toAccountId)) {
+      throw new Error('A line must link to either a category or an account, not both');
+    }
+    if (updates.amount !== undefined
+      && (!Currency.isValid(updates.amount) || Currency.compare(updates.amount, '0') <= 0)) {
+      throw new Error('Amount must be greater than zero');
+    }
+
+    // Derive the target writes. Assigning one real target clears the opposite one,
+    // even when the caller didn't mention it — that's what keeps a partial update
+    // from leaving both set (the row may already hold the other target).
+    let categoryId = updates.categoryId;
+    let toAccountId = updates.toAccountId;
+    if (isSet(updates.categoryId)) {
+      toAccountId = null;
+    } else if (isSet(updates.toAccountId)) {
+      categoryId = null;
+    }
+
+    const fields = [];
+    const values = [];
+
+    if (updates.label !== undefined) {
+      fields.push('label = ?');
+      values.push(updates.label ?? null);
+    }
+    if (updates.amount !== undefined) {
+      fields.push('amount = ?');
+      values.push(String(updates.amount));
+    }
+    if (updates.comment !== undefined) {
+      fields.push('comment = ?');
+      values.push(updates.comment ?? null);
+    }
+    if (categoryId !== undefined) {
+      fields.push('category_id = ?');
+      values.push(isSet(categoryId) ? categoryId : null);
+    }
+    if (toAccountId !== undefined) {
+      fields.push('to_account_id = ?');
+      values.push(isSet(toAccountId) ? toAccountId : null);
+    }
+    if (updates.sortOrder !== undefined) {
+      fields.push('sort_order = ?');
+      values.push(Number.isInteger(updates.sortOrder) ? updates.sortOrder : 0);
+    }
+
+    if (fields.length === 0) {
+      return; // Nothing to update
+    }
+
+    fields.push('updated_at = ?');
+    values.push(new Date().toISOString());
+    values.push(id);
+
+    await executeQuery(`UPDATE budget_plan_lines SET ${fields.join(', ')} WHERE id = ?`, values);
+  } catch (error) {
+    console.error('Failed to update budget plan line:', error);
+    throw error;
+  }
+};
+
+/**
+ * Delete a line.
+ * @param {string} id
+ * @returns {Promise<void>}
+ */
+export const deleteLine = async (id) => {
+  try {
+    await executeQuery('DELETE FROM budget_plan_lines WHERE id = ?', [id]);
+  } catch (error) {
+    console.error('Failed to delete budget plan line:', error);
+    throw error;
+  }
+};
+
+/**
+ * Persist a new line order for a plan. `orderedIds` is the full list of line IDs
+ * in the desired order; each line's sort_order is set to its index.
+ * @param {string} planId
+ * @param {Array<string>} orderedIds
+ * @returns {Promise<void>}
+ */
+export const reorderLines = async (planId, orderedIds) => {
+  try {
+    const seen = new Set();
+    for (const id of orderedIds) {
+      if (!id) {
+        throw new Error('Invalid line data: missing id');
+      }
+      if (seen.has(id)) {
+        throw new Error(`Duplicate line ID in reorder: ${id}`);
+      }
+      seen.add(id);
+    }
+
+    const now = new Date().toISOString();
+    await executeTransaction(async (db) => {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await db.runAsync(
+          'UPDATE budget_plan_lines SET sort_order = ?, updated_at = ? WHERE id = ? AND plan_id = ?',
+          [i, now, orderedIds[i], planId],
+        );
+      }
+    });
+  } catch (error) {
+    console.error('Failed to reorder budget plan lines:', error);
+    throw error;
+  }
+};
+
+/* -------------------------------------------------------------------------- */
+/* Derived                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Compute a plan's totals. The remainder is COMPUTED, never stored, and may be
+ * negative when the plan is over-allocated.
+ * @param {string} planId
+ * @returns {Promise<{ expectedIncome: string, allocated: string, remainder: string }>}
+ */
+export const getPlanTotals = async (planId) => {
+  try {
+    const plan = await getPlanById(planId);
+    if (!plan) {
+      throw new Error(`Budget plan ${planId} not found`);
+    }
+    const currency = plan.currency;
+    const lines = await getPlanLines(planId);
+
+    let allocated = Currency.add('0', '0', currency);
+    for (const line of lines) {
+      allocated = Currency.add(allocated, line.amount, currency);
+    }
+
+    const expectedIncome = Currency.add(plan.expectedIncome, '0', currency);
+    const remainder = Currency.subtract(expectedIncome, allocated, currency);
+
+    return { expectedIncome, allocated, remainder };
+  } catch (error) {
+    console.error('Failed to compute budget plan totals:', error);
+    throw error;
+  }
+};
+
+/**
+ * Clone a plan (and all its lines) from one month into a new month. Used by the
+ * editor's "start from last month". Fails if the source month has no plan or the
+ * target month already has one.
+ * @param {string} fromMonth - YYYY-MM to copy from
+ * @param {string} toMonth - YYYY-MM to copy into
+ * @returns {Promise<Object>} The newly created plan (camelCase).
+ */
+export const copyPlan = async (fromMonth, toMonth) => {
+  try {
+    if (!MONTH_REGEX.test(toMonth)) {
+      throw new Error('A valid month (YYYY-MM) is required');
+    }
+
+    const source = await getPlanByMonth(fromMonth);
+    if (!source) {
+      throw new Error(`No budget plan found for ${fromMonth}`);
+    }
+
+    const existing = await getPlanByMonth(toMonth);
+    if (existing) {
+      throw new Error('A plan for this month already exists');
+    }
+
+    const sourceLines = await getPlanLines(source.id);
+    const now = new Date().toISOString();
+    const newPlanId = uuid.v4();
+
+    await executeTransaction(async (db) => {
+      await db.runAsync(
+        'INSERT INTO budget_plans (id, month, currency, expected_income, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+        [newPlanId, toMonth, source.currency, source.expectedIncome, now, now],
+      );
+
+      for (let i = 0; i < sourceLines.length; i++) {
+        const line = sourceLines[i];
+        await db.runAsync(
+          'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          [
+            uuid.v4(), newPlanId, line.label, line.amount, line.comment,
+            line.categoryId, line.toAccountId, line.sortOrder ?? i, now, now,
+          ],
+        );
+      }
+    });
+
+    return mapPlanFields({
+      id: newPlanId,
+      month: toMonth,
+      currency: source.currency,
+      expected_income: source.expectedIncome,
+      created_at: now,
+      updated_at: now,
+    });
+  } catch (error) {
+    console.error('Failed to copy budget plan:', error);
+    throw error;
+  }
+};

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -170,6 +170,7 @@ const isSchemaComplete = async (rawDb) => {
       'accounts', 'categories', 'operations', 'budgets',
       'app_metadata', 'accounts_balance_history', 'planned_operations',
       'notification_merchant_rules', 'pending_notifications',
+      'budget_plans', 'budget_plan_lines',
     ];
     const existingTables = await rawDb.getAllAsync(
       "SELECT name FROM sqlite_master WHERE type='table'",
@@ -258,6 +259,12 @@ const isSchemaComplete = async (rawDb) => {
     // gain the columns.
     const pendingCols = await rawDb.getAllAsync('PRAGMA table_info(pending_notifications)');
     if (!pendingCols.some(c => c.name === 'latitude') || !pendingCols.some(c => c.name === 'longitude')) return false;
+
+    // Migration 0018: adds the budget_plans and budget_plan_lines tables. Both are
+    // covered by the expectedTables check above — a fresh install through 0017 has
+    // neither, so its schema reads "incomplete" here and migrate() runs to create
+    // them (rather than the fast path skipping migrate() and crashing with
+    // `no such table` on the first BudgetPlansDB query).
 
     return true;
   } catch (error) {
@@ -555,6 +562,13 @@ const detectAppliedMigrations = async (rawDb) => {
     if (pnCols.some(c => c.name === 'latitude') && pnCols.some(c => c.name === 'longitude')) {
       applied.push(17);
     }
+  }
+
+  // Migration 0018: Creates budget_plans and budget_plan_lines tables. Require
+  // BOTH — a half-applied 0018 (plans created, lines not) must re-run so the
+  // missing table is created.
+  if ((await tableExists('budget_plans')) && (await tableExists('budget_plan_lines'))) {
+    applied.push(18);
   }
 
   return applied.sort((a, b) => a - b);

--- a/drizzle/0018_budget_plans.js
+++ b/drizzle/0018_budget_plans.js
@@ -1,0 +1,39 @@
+/**
+ * Migration 0018: Add budget_plans and budget_plan_lines tables
+ *
+ * Budgets v2 (envelope-style monthly income allocation). One plan per month with
+ * an expected income, split into lines each linked to exactly one tracking target
+ * (an expense category or a destination account). See app/db/schema.js.
+ *
+ * Append-only: never edit or revert an existing migration. This migration is also
+ * registered in app/services/db.js (isSchemaComplete + detectAppliedMigrations),
+ * otherwise existing installs would skip migrate() and crash with `no such table`.
+ */
+
+const sql = `CREATE TABLE IF NOT EXISTS \`budget_plans\` (
+	\`id\` text PRIMARY KEY NOT NULL,
+	\`month\` text NOT NULL,
+	\`currency\` text NOT NULL,
+	\`expected_income\` text NOT NULL DEFAULT '0',
+	\`created_at\` text NOT NULL,
+	\`updated_at\` text NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS \`idx_budget_plans_month\` ON \`budget_plans\` (\`month\`);--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS \`budget_plan_lines\` (
+	\`id\` text PRIMARY KEY NOT NULL,
+	\`plan_id\` text NOT NULL,
+	\`label\` text,
+	\`amount\` text NOT NULL,
+	\`comment\` text,
+	\`category_id\` text,
+	\`to_account_id\` integer,
+	\`sort_order\` integer NOT NULL DEFAULT 0,
+	\`created_at\` text NOT NULL,
+	\`updated_at\` text NOT NULL,
+	FOREIGN KEY (\`plan_id\`) REFERENCES \`budget_plans\`(\`id\`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (\`category_id\`) REFERENCES \`categories\`(\`id\`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (\`to_account_id\`) REFERENCES \`accounts\`(\`id\`) ON UPDATE no action ON DELETE set null
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS \`idx_budget_plan_lines_plan\` ON \`budget_plan_lines\` (\`plan_id\`)`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1767200000000,
       "tag": "0017_add_pending_notification_location",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1767300000000,
+      "tag": "0018_budget_plans",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -19,6 +19,7 @@ import m0014 from './0014_account_rounding_mode.js';
 import m0015 from './0015_account_show_in_main_menu.js';
 import m0016 from './0016_merchant_rule_last_matched.js';
 import m0017 from './0017_add_pending_notification_location.js';
+import m0018 from './0018_budget_plans.js';
 
 export default {
   journal,
@@ -41,6 +42,7 @@ export default {
     m0015,
     m0016,
     m0017,
+    m0018,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,


### PR DESCRIPTION
## What

Part 2 of the Budgets v2 roadmap (#1395). **Data layer only, no UI** — the foundation for envelope-style monthly income-allocation plans.

Closes #1395.

## Changes

**Schema (`app/db/schema.js`)** — two new tables:
- `budget_plans`: one plan per month (`month` unique index), `currency`, `expected_income` (string decimal, default `'0'`).
- `budget_plan_lines`: allocation lines, each linked to **exactly one** target — an expense `category_id` (`ON DELETE SET NULL`) or a destination `to_account_id` (`ON DELETE SET NULL`). `to_account_id` is an **integer** FK to match `accounts.id` (consistent with `operations`/`planned_operations`), not the `text` the issue sketched. When a target FK is nulled by a deletion, the line becomes "broken" (both targets null) rather than crashing.

**Migration (`drizzle/0018_budget_plans.js`)** — append-only, creates both tables + indexes. Registered in `app/services/db.js` `isSchemaComplete()` (expected-tables list) and `detectAppliedMigrations()` (index 18, requires *both* tables) so existing installs run `migrate()` instead of hitting `no such table`. Journal + `migrations.js` updated.

**Service (`app/services/BudgetPlansDB.js`)** — mirrors `BudgetsDB` style:
- `validatePlan`, `validatePlanLine` (enforces the exactly-one-target invariant in the service, not only SQL).
- Plan CRUD: `createPlan`, `getPlanByMonth`, `getPlanById`, `getAllPlans`, `updatePlan`, `deletePlan`.
- Line ops: `getPlanLines`, `getBrokenLines`, `addLine`, `updateLine` (re-assigning one target auto-clears the other so a partial update can't leave both set), `deleteLine`, `reorderLines`.
- `getPlanTotals` → `{ expectedIncome, allocated, remainder }`, remainder computed (never stored) and may be negative when over-allocated.
- `copyPlan(fromMonth, toMonth)` for "start from last month".
- All currency arithmetic through `app/services/currency.js` — no floats.

**Context** — `BudgetPlansDataContext` + `BudgetPlansActionsContext` + merged `BudgetPlansContext` (Data/Actions split like budgets), subscribing to `RELOAD_ALL` / `DATABASE_RESET`. Provider mounted in `App.js` next to `BudgetsProvider`.

## Tests

- `__tests__/services/BudgetPlansDB.test.js` — validation (incl. both-targets-rejected / neither-target), CRUD, totals (incl. negative remainder), copyPlan, reorder, broken-line state, target auto-clear on update.
- `__tests__/contexts/BudgetPlansContext.test.js` — init, plan CRUD, copyPlan, line delegation, `RELOAD_ALL` / `DATABASE_RESET`, unsubscribe.
- Extended `__tests__/db/schema.test.js` for both new tables; updated `db.fastpath` and `App.test` mocks for the new tables/provider.

`npm test -- --coverage` green: **4654 passed / 4654**, threshold met (new files 89–100%). ESLint clean (0 warnings).

## Non-goals

No UI (#1396), no actuals/spending tracking (#1397), no backup/export integration (#1398).
