### PR TITLE
feat(budgets): backup/restore + Sheets export for monthly plans (Budgets v2 3/5)

### DIFF
--- a/__tests__/contexts/ImportProgressContext.test.js
+++ b/__tests__/contexts/ImportProgressContext.test.js
@@ -86,14 +86,14 @@ describe('ImportProgressContext', () => {
         result.current.startImport();
       });
 
-      expect(result.current.steps).toHaveLength(13);
+      expect(result.current.steps).toHaveLength(14);
       expect(result.current.steps[0]).toEqual({
         id: 'format',
         label: 'Detecting format',
         status: 'pending',
         data: null,
       });
-      expect(result.current.steps[12]).toEqual({
+      expect(result.current.steps[13]).toEqual({
         id: 'complete',
         label: 'Database restored successfully',
         status: 'pending',
@@ -130,6 +130,7 @@ describe('ImportProgressContext', () => {
         'operations',
         'balance_history',
         'budgets',
+        'budget_plans',
         'metadata',
         'upgrades',
         'complete',
@@ -215,7 +216,7 @@ describe('ImportProgressContext', () => {
       });
 
       // Steps should remain unchanged
-      expect(result.current.steps).toHaveLength(13);
+      expect(result.current.steps).toHaveLength(14);
     });
   });
 
@@ -501,7 +502,7 @@ describe('ImportProgressContext', () => {
       });
 
       expect(result.current.isImporting).toBe(true);
-      expect(result.current.steps).toHaveLength(13);
+      expect(result.current.steps).toHaveLength(14);
       expect(result.current.currentStep).toBe('format');
     });
 
@@ -527,7 +528,7 @@ describe('ImportProgressContext', () => {
       });
 
       expect(result.current.isImporting).toBe(true);
-      expect(result.current.steps).toHaveLength(13);
+      expect(result.current.steps).toHaveLength(14);
       expect(result.current.currentStep).toBe('format');
     });
   });

--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -171,7 +171,9 @@ describe('BackupRestore', () => {
         },
       });
       expect(backup.timestamp).toBeDefined();
-      expect(mockDb.queryAll).toHaveBeenCalledTimes(8);
+      // accounts, categories, operations, budgets, app_metadata, balance_history,
+      // planned_operations, notification_merchant_rules, budget_plans, budget_plan_lines
+      expect(mockDb.queryAll).toHaveBeenCalledTimes(10);
     });
 
     it('includes empty arrays when tables are empty', async () => {
@@ -534,7 +536,7 @@ describe('BackupRestore', () => {
       expect(deleteCalls.length).toBeGreaterThan(0);
     });
 
-    it('deletes in correct order (budgets, operations, categories, accounts)', async () => {
+    it('deletes in correct order (budgets, budget plans, operations, categories, accounts)', async () => {
       const mockDbInstance = {
         runAsync: jest.fn().mockImplementation(() => Promise.resolve({ lastInsertRowId: Math.floor(Math.random() * 1000) })),
         getAllAsync: jest.fn().mockResolvedValue([]),
@@ -559,10 +561,12 @@ describe('BackupRestore', () => {
       expect(deleteCalls[0]).toContain('notification_merchant_rules');
       expect(deleteCalls[1]).toContain('planned_operations');
       expect(deleteCalls[2]).toContain('budgets');
-      expect(deleteCalls[3]).toContain('accounts_balance_history');
-      expect(deleteCalls[4]).toContain('operations');
-      expect(deleteCalls[5]).toContain('categories');
-      expect(deleteCalls[6]).toContain('accounts');
+      expect(deleteCalls[3]).toContain('budget_plan_lines');
+      expect(deleteCalls[4]).toContain('budget_plans');
+      expect(deleteCalls[5]).toContain('accounts_balance_history');
+      expect(deleteCalls[6]).toContain('operations');
+      expect(deleteCalls[7]).toContain('categories');
+      expect(deleteCalls[8]).toContain('accounts');
     });
 
     it('preserves db_version metadata', async () => {
@@ -1560,6 +1564,256 @@ op-2,income,20,acc-1,cat-1`;
 
       // Should still succeed despite snapshot failure
       await expect(BackupRestore.restoreBackup(backup)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Budget plans round-trip (Budgets v2, issue #1398)', () => {
+    // A UUID account so the restore exercises account-ID remapping on the
+    // transfer line's to_account_id.
+    const planAccount = { id: 'acc-uuid', name: 'Savings', balance: '0', currency: 'USD' };
+    const planCategory = {
+      id: 'cat-1', name: 'Food', type: 'folder', category_type: 'expense',
+      is_shadow: 0, created_at: 'x', updated_at: 'y',
+    };
+    const mockPlan = {
+      id: 'plan-1', month: '2026-07', currency: 'USD', expected_income: '3000.00',
+      created_at: '2026-07-01T00:00:00.000Z', updated_at: '2026-07-01T00:00:00.000Z',
+    };
+    // Non-ASCII comment must survive the round-trip.
+    const NON_ASCII_COMMENT = 'Отложить на 日本 — €100';
+    const categoryLine = {
+      id: 'line-cat', plan_id: 'plan-1', label: 'Groceries', amount: '400.00',
+      comment: NON_ASCII_COMMENT, category_id: 'cat-1', to_account_id: null,
+      sort_order: 0, created_at: 'x', updated_at: 'y',
+    };
+    const transferLine = {
+      id: 'line-xfer', plan_id: 'plan-1', label: 'To savings', amount: '500.00',
+      comment: null, category_id: null, to_account_id: 'acc-uuid',
+      sort_order: 1, created_at: 'x', updated_at: 'y',
+    };
+
+    // The UUID account is auto-assigned a new integer ID on insert; pin it to a
+    // known value so the transfer line's remapped to_account_id is deterministic.
+    const REMAPPED_ACCOUNT_ID = 42;
+    const makeDbInstance = () => {
+      let insertCount = 0;
+      return {
+        runAsync: jest.fn().mockImplementation((query) => {
+          if (typeof query === 'string' && query.includes('INSERT INTO accounts')) {
+            return Promise.resolve({ lastInsertRowId: REMAPPED_ACCOUNT_ID });
+          }
+          return Promise.resolve({ lastInsertRowId: ++insertCount });
+        }),
+        getAllAsync: jest.fn().mockResolvedValue([
+          { id: 'shadow-adjustment-expense' },
+          { id: 'shadow-adjustment-income' },
+        ]),
+      };
+    };
+
+    const findInsert = (dbInstance, table) =>
+      dbInstance.runAsync.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes(`INSERT INTO ${table}`),
+      );
+
+    const backupWithPlan = () => ({
+      version: 1,
+      timestamp: '2026-07-01T00:00:00.000Z',
+      platform: 'native',
+      data: {
+        accounts: [planAccount],
+        categories: [planCategory],
+        operations: [],
+        app_metadata: mockMetadata,
+        budget_plans: [mockPlan],
+        budget_plan_lines: [categoryLine, transferLine],
+      },
+    });
+
+    it('includes budget_plans and budget_plan_lines in a created backup', async () => {
+      mockDb.queryAll.mockImplementation((query) => {
+        if (query.includes('budget_plan_lines')) return Promise.resolve([categoryLine, transferLine]);
+        if (query.includes('budget_plans')) return Promise.resolve([mockPlan]);
+        return Promise.resolve([]);
+      });
+
+      const backup = await BackupRestore.createBackup();
+
+      expect(backup.data.budget_plans).toEqual([mockPlan]);
+      expect(backup.data.budget_plan_lines).toEqual([categoryLine, transferLine]);
+    });
+
+    it('restores a plan with a category line and a transfer line (account FK remapped)', async () => {
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      await BackupRestore.restoreBackup(backupWithPlan());
+
+      const planInserts = findInsert(dbInstance, 'budget_plans');
+      expect(planInserts).toHaveLength(1);
+      expect(planInserts[0][1]).toEqual([
+        'plan-1', '2026-07', 'USD', '3000.00',
+        '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z',
+      ]);
+
+      const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
+      expect(lineInserts).toHaveLength(2);
+
+      // Category line: keeps category_id as-is, to_account_id null, comment intact.
+      const catCall = lineInserts.find(c => c[1][0] === 'line-cat');
+      expect(catCall[1]).toEqual([
+        'line-cat', 'plan-1', 'Groceries', '400.00', NON_ASCII_COMMENT,
+        'cat-1', null, 0, 'x', 'y',
+      ]);
+
+      // Transfer line: category_id null, to_account_id remapped 'acc-uuid' -> 42.
+      const xferCall = lineInserts.find(c => c[1][0] === 'line-xfer');
+      expect(xferCall[1]).toEqual([
+        'line-xfer', 'plan-1', 'To savings', '500.00', null,
+        null, REMAPPED_ACCOUNT_ID, 1, 'x', 'y',
+      ]);
+    });
+
+    it('skips a plan line whose parent plan was not restored', async () => {
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      const backup = backupWithPlan();
+      backup.data.budget_plan_lines = [
+        categoryLine,
+        { ...transferLine, id: 'line-orphan', plan_id: 'plan-does-not-exist', to_account_id: null, category_id: 'cat-1' },
+      ];
+
+      await BackupRestore.restoreBackup(backup);
+
+      const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
+      expect(lineInserts).toHaveLength(1);
+      expect(lineInserts[0][1][0]).toBe('line-cat');
+    });
+
+    it('skips lines of a plan that was itself skipped for missing fields (no FK abort)', async () => {
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      const backup = backupWithPlan();
+      // Plan has an id but no currency → skipped on insert. Its line must not be
+      // inserted (else plan_id FK fails and the whole restore aborts).
+      backup.data.budget_plans = [{ ...mockPlan, currency: undefined }];
+      backup.data.budget_plan_lines = [categoryLine];
+
+      await expect(BackupRestore.restoreBackup(backup)).resolves.toBeUndefined();
+      expect(findInsert(dbInstance, 'budget_plans')).toHaveLength(0);
+      expect(findInsert(dbInstance, 'budget_plan_lines')).toHaveLength(0);
+    });
+
+    it('skips a plan line with an empty amount', async () => {
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      const backup = backupWithPlan();
+      backup.data.budget_plan_lines = [{ ...categoryLine, amount: '' }];
+
+      await BackupRestore.restoreBackup(backup);
+      expect(findInsert(dbInstance, 'budget_plan_lines')).toHaveLength(0);
+    });
+
+    it('aborts cleanly when a transfer line references an account absent from the backup', async () => {
+      const backup = backupWithPlan();
+      backup.data.budget_plan_lines = [
+        { ...transferLine, to_account_id: 'ghost-account' },
+      ];
+
+      await expect(BackupRestore.restoreBackup(backup)).rejects.toThrow(
+        /account IDs not found in the backup.*Restore aborted/,
+      );
+      expect(mockDb.executeTransaction).not.toHaveBeenCalled();
+    });
+
+    it('imports an old backup without plan tables cleanly (zero plans, no error)', async () => {
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      const oldBackup = {
+        version: 1,
+        timestamp: '2024-01-01T00:00:00.000Z',
+        platform: 'native',
+        data: {
+          accounts: [planAccount],
+          categories: [planCategory],
+          operations: [],
+          app_metadata: mockMetadata,
+          // No budget_plans / budget_plan_lines keys at all.
+        },
+      };
+
+      await expect(BackupRestore.restoreBackup(oldBackup)).resolves.toBeUndefined();
+      expect(findInsert(dbInstance, 'budget_plans')).toHaveLength(0);
+      expect(findInsert(dbInstance, 'budget_plan_lines')).toHaveLength(0);
+    });
+
+    it('exports budget plan sections (with non-ASCII comment) to CSV', async () => {
+      mockDb.queryAll.mockImplementation((query) => {
+        if (query.includes('budget_plan_lines')) return Promise.resolve([categoryLine, transferLine]);
+        if (query.includes('budget_plans')) return Promise.resolve([mockPlan]);
+        if (query.includes('accounts')) return Promise.resolve([planAccount]);
+        if (query.includes('categories')) return Promise.resolve([planCategory]);
+        return Promise.resolve([]);
+      });
+
+      await BackupRestore.exportBackup('csv');
+
+      const written = mockFileSystem.writeAsStringAsync.mock.calls[0][1];
+      expect(written).toContain('[BUDGET_PLANS]');
+      expect(written).toContain('[BUDGET_PLAN_LINES]');
+      expect(written).toContain('plan-1');
+      expect(written).toContain('2026-07');
+      expect(written).toContain(NON_ASCII_COMMENT);
+    });
+
+    it('round-trips budget plans through CSV import', async () => {
+      const csvContent = `# Money Tracker Backup - 2026-07-01T00:00:00.000Z
+# Version: 1
+
+[ACCOUNTS]
+id,name,balance,currency
+acc-uuid,Savings,0,USD
+
+[CATEGORIES]
+id,name,type,category_type
+cat-1,Food,folder,expense
+
+[OPERATIONS]
+id,type,amount,account_id,category_id
+
+[BUDGET_PLANS]
+id,month,currency,expected_income
+plan-1,2026-07,USD,3000.00
+
+[BUDGET_PLAN_LINES]
+id,plan_id,label,amount,comment,category_id,to_account_id,sort_order
+line-cat,plan-1,Groceries,400.00,"${NON_ASCII_COMMENT}",cat-1,,0`;
+
+      mockDocumentPicker.getDocumentAsync.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file:///mock/backup.csv', name: 'backup.csv' }],
+      });
+      mockFileSystem.readAsStringAsync.mockResolvedValue(csvContent);
+
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      const backup = await BackupRestore.importBackup();
+
+      expect(backup.data.budget_plans).toHaveLength(1);
+      expect(backup.data.budget_plans[0]).toMatchObject({ id: 'plan-1', month: '2026-07', currency: 'USD' });
+      expect(backup.data.budget_plan_lines).toHaveLength(1);
+      expect(backup.data.budget_plan_lines[0]).toMatchObject({
+        id: 'line-cat', plan_id: 'plan-1', category_id: 'cat-1', comment: NON_ASCII_COMMENT,
+      });
+
+      const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
+      expect(lineInserts).toHaveLength(1);
+      expect(lineInserts[0][1]).toEqual(expect.arrayContaining(['line-cat', 'plan-1', NON_ASCII_COMMENT]));
     });
   });
 });

--- a/__tests__/services/GoogleSheetsService.test.js
+++ b/__tests__/services/GoogleSheetsService.test.js
@@ -141,11 +141,12 @@ describe('GoogleSheetsService', () => {
       },
     };
 
-    it('returns 6 sheets with correct titles', async () => {
+    it('returns 8 sheets with correct titles', async () => {
       const sheets = buildSheetsData(mockBackup);
       const titles = sheets.map(s => s.range.split('!')[0]);
       expect(titles).toEqual([
         'Accounts', 'Operations', 'Categories', 'Budgets', 'Planned Operations', 'Balance History',
+        'Budget Plans', 'Budget Plan Lines',
       ]);
     });
 
@@ -609,6 +610,139 @@ describe('GoogleSheetsService', () => {
     it('maps balance_history account_id by ID column', async () => {
       const backup = await importFromSheets('token');
       expect(backup.data.balance_history[0].account_id).toBe('1');
+    });
+  });
+
+  describe('Budget plans (Budgets v2, issue #1398)', () => {
+    const { getPreference } = require('../../app/services/PreferencesDB');
+    const NON_ASCII_COMMENT = 'Отложить на 日本 — €100';
+
+    const mockBackup = {
+      data: {
+        accounts: [{ id: 1, name: 'Savings', balance: '0', currency: 'USD' }],
+        categories: [{ id: 'cat-1', name: 'Food', type: 'entry', category_type: 'expense', icon: 'food' }],
+        operations: [],
+        budgets: [],
+        planned_operations: [],
+        balance_history: [],
+        budget_plans: [
+          { id: 'plan-1', month: '2026-07', currency: 'USD', expected_income: '3000.00' },
+        ],
+        budget_plan_lines: [
+          { id: 'line-cat', plan_id: 'plan-1', label: 'Groceries', amount: '400', comment: NON_ASCII_COMMENT, category_id: 'cat-1', to_account_id: null, sort_order: 0 },
+          { id: 'line-xfer', plan_id: 'plan-1', label: 'To savings', amount: '500', comment: null, category_id: null, to_account_id: 1, sort_order: 1 },
+        ],
+      },
+    };
+
+    it('builds a Budget Plans sheet with header and rows', () => {
+      const sheets = buildSheetsData(mockBackup);
+      const plans = sheets.find(s => s.range === 'Budget Plans!A1');
+      expect(plans.values[0]).toEqual(['id', 'month', 'currency', 'expected_income']);
+      expect(plans.values[1]).toEqual(['plan-1', '2026-07', 'USD', '3000.00']);
+    });
+
+    it('builds a Budget Plan Lines sheet resolving category/account names, preserving IDs and comment', () => {
+      const sheets = buildSheetsData(mockBackup);
+      const lines = sheets.find(s => s.range === 'Budget Plan Lines!A1');
+      const header = lines.values[0];
+      expect(header).toEqual(['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order']);
+
+      const catRow = lines.values.find(r => r[0] === 'line-cat');
+      expect(catRow[header.indexOf('category')]).toBe('Food');
+      expect(catRow[header.indexOf('category_id')]).toBe('cat-1');
+      expect(catRow[header.indexOf('comment')]).toBe(NON_ASCII_COMMENT);
+      expect(catRow[header.indexOf('account')]).toBe('');
+
+      const xferRow = lines.values.find(r => r[0] === 'line-xfer');
+      expect(xferRow[header.indexOf('account')]).toBe('Savings');
+      expect(xferRow[header.indexOf('to_account_id')]).toBe(1);
+      expect(xferRow[header.indexOf('category')]).toBe('');
+    });
+
+    it('tolerates a backup that lacks budget plan data (empty sheets)', () => {
+      const legacy = { data: { ...mockBackup.data, budget_plans: undefined, budget_plan_lines: undefined } };
+      const sheets = buildSheetsData(legacy);
+      const plans = sheets.find(s => s.range === 'Budget Plans!A1');
+      const lines = sheets.find(s => s.range === 'Budget Plan Lines!A1');
+      expect(plans.values).toHaveLength(1); // header only
+      expect(lines.values).toHaveLength(1); // header only
+    });
+
+    it('creates spreadsheet with Budget Plans and Budget Plan Lines tabs', async () => {
+      const { setPreference } = require('../../app/services/PreferencesDB');
+      getPreference.mockResolvedValue(null);
+      setPreference.mockResolvedValue(undefined);
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ spreadsheetId: 'sid' }) }); // create
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ sheets: [] }) });
+
+      await exportToSheets('token', mockBackup);
+
+      const createBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const titles = createBody.sheets.map(s => s.properties.title);
+      expect(titles).toContain('Budget Plans');
+      expect(titles).toContain('Budget Plan Lines');
+    });
+
+    it('imports budget plans and lines from sheets, resolving FKs', async () => {
+      getPreference.mockResolvedValue('sheet-id-123');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          valueRanges: [
+            { range: 'Accounts!A1:D2', values: [['id', 'name', 'balance', 'currency'], ['1', 'Savings', '0', 'USD']] },
+            { range: 'Operations!A1:A1', values: [['id', 'date', 'type', 'amount', 'currency', 'category', 'account', 'to_account', 'description']] },
+            { range: 'Categories!A1:B2', values: [['id', 'name', 'type', 'category_type', 'icon', 'parent_id', 'color', 'is_shadow'], ['cat-1', 'Food', 'entry', 'expense', 'food', '', '', '0']] },
+            { range: 'Budgets!A1:A1', values: [['id']] },
+            { range: 'Planned Operations!A1:A1', values: [['id']] },
+            { range: 'Balance History!A1:A1', values: [['account', 'date', 'balance', 'account_id']] },
+            { range: 'Budget Plans!A1:D2', values: [['id', 'month', 'currency', 'expected_income'], ['plan-1', '2026-07', 'USD', '3000.00']] },
+            {
+              range: 'Budget Plan Lines!A1:J3',
+              values: [
+                ['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order'],
+                ['line-cat', 'plan-1', 'Groceries', '400', NON_ASCII_COMMENT, 'Food', '', 'cat-1', '', '0'],
+                ['line-xfer', 'plan-1', 'To savings', '500', '', '', 'Savings', '', '1', '1'],
+              ],
+            },
+          ],
+        }),
+      });
+
+      const backup = await importFromSheets('token');
+
+      expect(backup.data.budget_plans).toHaveLength(1);
+      expect(backup.data.budget_plans[0]).toMatchObject({ id: 'plan-1', month: '2026-07', currency: 'USD', expected_income: '3000.00' });
+
+      expect(backup.data.budget_plan_lines).toHaveLength(2);
+      const cat = backup.data.budget_plan_lines.find(l => l.id === 'line-cat');
+      expect(cat.category_id).toBe('cat-1');
+      expect(cat.to_account_id).toBeNull();
+      expect(cat.comment).toBe(NON_ASCII_COMMENT);
+      expect(cat.sort_order).toBe(0);
+
+      const xfer = backup.data.budget_plan_lines.find(l => l.id === 'line-xfer');
+      expect(xfer.to_account_id).toBe('1'); // resolved by ID column
+      expect(xfer.category_id).toBeNull();
+      expect(xfer.sort_order).toBe(1);
+    });
+
+    it('returns empty plan arrays when the sheets are missing (old spreadsheet)', async () => {
+      getPreference.mockResolvedValue('sheet-id-123');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          valueRanges: [
+            { range: 'Accounts!A1:D2', values: [['id', 'name', 'balance', 'currency'], ['1', 'Savings', '0', 'USD']] },
+            { range: 'Categories!A1:A1', values: [['id', 'name', 'type', 'category_type', 'icon', 'parent_id', 'color', 'is_shadow']] },
+            // No Budget Plans / Budget Plan Lines tabs.
+          ],
+        }),
+      });
+
+      const backup = await importFromSheets('token');
+      expect(backup.data.budget_plans).toEqual([]);
+      expect(backup.data.budget_plan_lines).toEqual([]);
     });
   });
 });

--- a/app/contexts/ImportProgressContext.js
+++ b/app/contexts/ImportProgressContext.js
@@ -35,6 +35,7 @@ export const ImportProgressProvider = ({ children }) => {
       { id: 'operations', label: 'Restoring operations', status: 'pending', data: null },
       { id: 'balance_history', label: 'Restoring balance history', status: 'pending', data: null },
       { id: 'budgets', label: 'Restoring budgets', status: 'pending', data: null },
+      { id: 'budget_plans', label: 'Restoring budget plans', status: 'pending', data: null },
       { id: 'metadata', label: 'Restoring metadata', status: 'pending', data: null },
       { id: 'upgrades', label: 'Performing post-restore upgrades', status: 'pending', data: null },
       { id: 'complete', label: 'Database restored successfully', status: 'pending', data: null },

--- a/app/modals/ImportProgressModal.js
+++ b/app/modals/ImportProgressModal.js
@@ -57,6 +57,8 @@ export default function ImportProgressModal() {
         return `Restoring ${step.data} operations...`;
       case 'budgets':
         return `Restoring ${step.data} budgets...`;
+      case 'budget_plans':
+        return `Restoring ${step.data} budget plans...`;
       case 'metadata':
         return `Restoring ${step.data} metadata entries...`;
       default:
@@ -77,6 +79,8 @@ export default function ImportProgressModal() {
         return `Restored ${step.data} operations`;
       case 'budgets':
         return `Restored ${step.data} budgets`;
+      case 'budget_plans':
+        return `Restored ${step.data} budget plans`;
       case 'metadata':
         return `Restored ${step.data} metadata entries`;
       case 'complete': {

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -29,7 +29,7 @@ export const createBackup = async () => {
     console.log('Creating database backup...');
 
     // Fetch all data from all tables
-    const [accounts, categories, operations, budgets, appMetadata, balanceHistory, plannedOperations, merchantRules] = await Promise.all([
+    const [accounts, categories, operations, budgets, appMetadata, balanceHistory, plannedOperations, merchantRules, budgetPlans, budgetPlanLines] = await Promise.all([
       queryAll('SELECT * FROM accounts ORDER BY created_at ASC'),
       queryAll('SELECT * FROM categories ORDER BY created_at ASC'),
       queryAll('SELECT * FROM operations ORDER BY created_at ASC'),
@@ -39,6 +39,10 @@ export const createBackup = async () => {
       queryAll('SELECT * FROM planned_operations ORDER BY created_at ASC').catch(() => []),
       // Newer table — guard so backups of pre-0010 databases don't fail.
       queryAll('SELECT * FROM notification_merchant_rules ORDER BY created_at ASC').catch(() => []),
+      // Budgets v2 (migration 0018). Guarded so backups of pre-0018 databases
+      // don't fail. Plans before lines so the FK order is preserved on restore.
+      queryAll('SELECT * FROM budget_plans ORDER BY created_at ASC').catch(() => []),
+      queryAll('SELECT * FROM budget_plan_lines ORDER BY sort_order ASC, created_at ASC').catch(() => []),
     ]);
 
     // Create backup object
@@ -57,6 +61,9 @@ export const createBackup = async () => {
         // Learned merchant -> category rules (the pending_notifications queue is
         // transient state and intentionally not backed up).
         notification_merchant_rules: merchantRules || [],
+        // Budgets v2 monthly plans and their allocation lines.
+        budget_plans: budgetPlans || [],
+        budget_plan_lines: budgetPlanLines || [],
       },
     };
 
@@ -67,6 +74,8 @@ export const createBackup = async () => {
       budgets: backup.data.budgets.length,
       balance_history: backup.data.balance_history.length,
       planned_operations: backup.data.planned_operations.length,
+      budget_plans: backup.data.budget_plans.length,
+      budget_plan_lines: backup.data.budget_plan_lines.length,
     });
 
     return backup;
@@ -87,6 +96,8 @@ const TABLE_FIELDS = {
   balance_history:    ['id', 'account_id', 'date', 'balance', 'created_at'],
   planned_operations: ['id', 'name', 'type', 'amount', 'account_id', 'category_id', 'to_account_id', 'description', 'is_recurring', 'last_executed_month', 'display_order', 'created_at', 'updated_at'],
   notification_merchant_rules: ['id', 'merchant', 'package_name', 'category_id', 'label_override', 'created_at', 'updated_at'],
+  budget_plans: ['id', 'month', 'currency', 'expected_income', 'created_at', 'updated_at'],
+  budget_plan_lines: ['id', 'plan_id', 'label', 'amount', 'comment', 'category_id', 'to_account_id', 'sort_order', 'created_at', 'updated_at'],
 };
 
 /**
@@ -143,6 +154,8 @@ export const exportBackupCSV = async () => {
       'app_metadata.csv': convertToCSV(backup.data.app_metadata, TABLE_FIELDS.app_metadata),
       'balance_history.csv': convertToCSV(backup.data.balance_history, TABLE_FIELDS.balance_history),
       'planned_operations.csv': convertToCSV(backup.data.planned_operations, TABLE_FIELDS.planned_operations),
+      'budget_plans.csv': convertToCSV(backup.data.budget_plans, TABLE_FIELDS.budget_plans),
+      'budget_plan_lines.csv': convertToCSV(backup.data.budget_plan_lines, TABLE_FIELDS.budget_plan_lines),
       'backup_info.csv': `version,timestamp,platform\n${backup.version},${backup.timestamp},${backup.platform}`,
     };
 
@@ -157,7 +170,9 @@ export const exportBackupCSV = async () => {
     combinedCSV += `[BUDGETS]\n${csvFiles['budgets.csv']}\n\n`;
     combinedCSV += `[APP_METADATA]\n${csvFiles['app_metadata.csv']}\n\n`;
     combinedCSV += `[BALANCE_HISTORY]\n${csvFiles['balance_history.csv']}\n\n`;
-    combinedCSV += `[PLANNED_OPERATIONS]\n${csvFiles['planned_operations.csv']}\n`;
+    combinedCSV += `[PLANNED_OPERATIONS]\n${csvFiles['planned_operations.csv']}\n\n`;
+    combinedCSV += `[BUDGET_PLANS]\n${csvFiles['budget_plans.csv']}\n\n`;
+    combinedCSV += `[BUDGET_PLAN_LINES]\n${csvFiles['budget_plan_lines.csv']}\n`;
 
     const filename = `money_tracker_backup_${timestamp}.csv`;
     const fileUri = `${FileSystem.documentDirectory}${filename}`;
@@ -419,6 +434,15 @@ export const restoreBackup = async (backup, cancelToken) => {
         unmappedAccountIds.push(planned.to_account_id);
       }
     }
+    // Budget plan lines may target an account (transfer allocation). Validate that
+    // reference too, so a dangling to_account_id aborts cleanly instead of dying
+    // on a raw FK error mid-transaction. A category-linked or broken line has a
+    // null to_account_id and is skipped here.
+    for (const line of backup.data.budget_plan_lines || []) {
+      if (line.to_account_id != null && !accountIdsInBackup.has(line.to_account_id)) {
+        unmappedAccountIds.push(line.to_account_id);
+      }
+    }
 
     if (unmappedAccountIds.length > 0) {
       const uniqueIds = [...new Set(unmappedAccountIds.map(String))];
@@ -473,6 +497,11 @@ export const restoreBackup = async (backup, cancelToken) => {
       await db.runAsync('DELETE FROM notification_merchant_rules').catch(() => {});
       await db.runAsync('DELETE FROM planned_operations').catch(() => {});
       await db.runAsync('DELETE FROM budgets');
+      // Budgets v2: lines reference plans (cascade), categories and accounts (set
+      // null), so clear lines before plans, and both before categories/accounts.
+      // Guarded so a restore into a pre-0018 database doesn't fail.
+      await db.runAsync('DELETE FROM budget_plan_lines').catch(() => {});
+      await db.runAsync('DELETE FROM budget_plans').catch(() => {});
       await db.runAsync('DELETE FROM accounts_balance_history');
       await db.runAsync('DELETE FROM operations');
       await db.runAsync('DELETE FROM categories');
@@ -777,6 +806,89 @@ export const restoreBackup = async (backup, cancelToken) => {
         });
       }
 
+      // Restore budget plans (Budgets v2) and their allocation lines. Plans are
+      // inserted before lines to satisfy the plan_id FK. Line category_id keeps
+      // its string ID as-is (categories are not remapped); to_account_id is
+      // remapped through accountIdMapping like operations/planned operations.
+      // A single 'budget_plans' progress step covers both tables.
+      {
+        const plans = backup.data.budget_plans || [];
+        const lines = backup.data.budget_plan_lines || [];
+        appEvents.emit(IMPORT_PROGRESS_EVENT, {
+          stepId: 'budget_plans',
+          status: 'in_progress',
+          data: plans.length,
+        });
+
+        // Track the plans actually inserted (not merely present in the backup):
+        // a plan skipped for missing fields must NOT let its lines through, or
+        // their plan_id FK would fail and abort the whole restore.
+        const restoredPlanIds = new Set();
+        let restoredPlans = 0;
+        for (const plan of plans) {
+          if (!plan.id || !plan.month || !plan.currency) {
+            console.warn('Skipping budget plan with missing required fields:', plan);
+            continue;
+          }
+          await db.runAsync(
+            'INSERT INTO budget_plans (id, month, currency, expected_income, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+            [
+              plan.id,
+              plan.month,
+              plan.currency,
+              plan.expected_income ?? '0',
+              plan.created_at || new Date().toISOString(),
+              plan.updated_at || new Date().toISOString(),
+            ],
+          );
+          restoredPlanIds.add(plan.id);
+          restoredPlans++;
+        }
+
+        // Only insert lines whose parent plan was actually restored, so an
+        // orphaned line (dangling plan_id) is skipped rather than aborting the
+        // whole import on an FK violation.
+        let restoredLines = 0;
+        for (const line of lines) {
+          // amount is a NOT NULL text column; treat null/empty as invalid and
+          // skip (mirrors how budgets skip rows with missing required fields).
+          if (!line.id || !line.plan_id || line.amount == null || line.amount === '') {
+            console.warn('Skipping budget plan line with missing required fields:', line);
+            continue;
+          }
+          if (!restoredPlanIds.has(line.plan_id)) {
+            console.warn('Skipping budget plan line with unknown plan_id:', line.plan_id);
+            continue;
+          }
+          let mappedToAccountId = null;
+          if (line.to_account_id != null) {
+            mappedToAccountId = accountIdMapping.get(String(line.to_account_id)) ?? line.to_account_id;
+          }
+          await db.runAsync(
+            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+              line.id,
+              line.plan_id,
+              line.label ?? null,
+              line.amount,
+              line.comment ?? null,
+              line.category_id ?? null,
+              mappedToAccountId,
+              Number.isInteger(line.sort_order) ? line.sort_order : Number(line.sort_order) || 0,
+              line.created_at || new Date().toISOString(),
+              line.updated_at || new Date().toISOString(),
+            ],
+          );
+          restoredLines++;
+        }
+        console.log(`Restored ${restoredPlans} budget plans and ${restoredLines} plan lines`);
+        appEvents.emit(IMPORT_PROGRESS_EVENT, {
+          stepId: 'budget_plans',
+          status: 'completed',
+          data: plans.length,
+        });
+      }
+
       // Restore app metadata (except db_version)
       if (backup.data.app_metadata) {
         appEvents.emit(IMPORT_PROGRESS_EVENT, {
@@ -1076,9 +1188,13 @@ const importBackupCSV = async (fileUri, cancelToken) => {
     app_metadata: [],
     balance_history: [],
     planned_operations: [],
+    budget_plans: [],
+    budget_plan_lines: [],
   };
 
-  // Split by section markers
+  // Split by section markers. [BUDGET_PLANS] and [BUDGET_PLAN_LINES] don't
+  // collide: the marker + newline (`[BUDGET_PLANS]\n`) is not a substring of
+  // `[BUDGET_PLAN_LINES]`.
   const accountsMatch = fileContent.match(/\[ACCOUNTS\]\n([\s\S]*?)(?=\n\[|$)/);
   const categoriesMatch = fileContent.match(/\[CATEGORIES\]\n([\s\S]*?)(?=\n\[|$)/);
   const operationsMatch = fileContent.match(/\[OPERATIONS\]\n([\s\S]*?)(?=\n\[|$)/);
@@ -1086,6 +1202,8 @@ const importBackupCSV = async (fileUri, cancelToken) => {
   const metadataMatch = fileContent.match(/\[APP_METADATA\]\n([\s\S]*?)(?=\n\[|$)/);
   const balanceHistoryMatch = fileContent.match(/\[BALANCE_HISTORY\]\n([\s\S]*?)(?=\n\[|$)/);
   const plannedOpsMatch = fileContent.match(/\[PLANNED_OPERATIONS\]\n([\s\S]*?)(?=\n\[|$)/);
+  const budgetPlansMatch = fileContent.match(/\[BUDGET_PLANS\]\n([\s\S]*?)(?=\n\[|$)/);
+  const budgetPlanLinesMatch = fileContent.match(/\[BUDGET_PLAN_LINES\]\n([\s\S]*?)(?=\n\[|$)/);
 
   if (accountsMatch) sections.accounts = parseCSV(accountsMatch[1]);
   if (categoriesMatch) sections.categories = parseCSV(categoriesMatch[1]);
@@ -1094,6 +1212,8 @@ const importBackupCSV = async (fileUri, cancelToken) => {
   if (metadataMatch) sections.app_metadata = parseCSV(metadataMatch[1]);
   if (balanceHistoryMatch) sections.balance_history = parseCSV(balanceHistoryMatch[1]);
   if (plannedOpsMatch) sections.planned_operations = parseCSV(plannedOpsMatch[1]);
+  if (budgetPlansMatch) sections.budget_plans = parseCSV(budgetPlansMatch[1]);
+  if (budgetPlanLinesMatch) sections.budget_plan_lines = parseCSV(budgetPlanLinesMatch[1]);
 
   // Extract version from header
   const versionMatch = fileContent.match(/# Version: (\d+)/);
@@ -1208,6 +1328,16 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
       console.warn('No notification_merchant_rules table in imported database (older format)');
     }
 
+    // Budgets v2 tables may not exist in pre-0018 backups.
+    let budgetPlans = [];
+    let budgetPlanLines = [];
+    try {
+      budgetPlans = await tempDb.getAllAsync('SELECT * FROM budget_plans ORDER BY created_at ASC');
+      budgetPlanLines = await tempDb.getAllAsync('SELECT * FROM budget_plan_lines ORDER BY sort_order ASC, created_at ASC');
+    } catch (e) {
+      console.warn('No budget_plans/budget_plan_lines tables in imported database (older format)');
+    }
+
     // Create backup object
     const backup = {
       version: BACKUP_VERSION,
@@ -1222,6 +1352,8 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
         balance_history: balanceHistory || [],
         planned_operations: plannedOperations || [],
         notification_merchant_rules: merchantRules || [],
+        budget_plans: budgetPlans || [],
+        budget_plan_lines: budgetPlanLines || [],
       },
     };
 

--- a/app/services/GoogleSheetsService.js
+++ b/app/services/GoogleSheetsService.js
@@ -66,12 +66,15 @@ export const signOut = async () => {
 };
 
 /**
- * Build the 6-sheet data structure from a backup object.
+ * Build the 8-sheet data structure from a backup object.
  * @param {Object} backup - Backup object from createBackup()
  * @returns {Array<{range: string, values: Array<Array>}>}
  */
 export const buildSheetsData = (backup) => {
-  const { accounts, categories, operations, budgets, planned_operations, balance_history } = backup.data;
+  const {
+    accounts, categories, operations, budgets, planned_operations, balance_history,
+    budget_plans, budget_plan_lines,
+  } = backup.data;
 
   const accountNames = new Map(accounts.map(a => [a.id, a.name]));
   const categoryNames = new Map(categories.map(c => [c.id, c.name]));
@@ -158,6 +161,29 @@ export const buildSheetsData = (backup) => {
         ]),
       ],
     },
+    {
+      range: 'Budget Plans!A1',
+      values: [
+        ['id', 'month', 'currency', 'expected_income'],
+        ...(budget_plans || []).map(p => [
+          p.id, p.month, p.currency, p.expected_income ?? '0',
+        ]),
+      ],
+    },
+    {
+      range: 'Budget Plan Lines!A1',
+      values: [
+        ['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order'],
+        ...(budget_plan_lines || []).map(l => [
+          l.id, l.plan_id, l.label || '', l.amount, l.comment || '',
+          categoryNames.get(l.category_id) || '',
+          l.to_account_id ? (accountNames.get(l.to_account_id) || '') : '',
+          l.category_id || '',
+          l.to_account_id || '',
+          l.sort_order ?? 0,
+        ]),
+      ],
+    },
   ];
 };
 
@@ -200,7 +226,7 @@ export const importFromSheets = async (accessToken, onProgress) => {
     throw new Error('no_spreadsheet_configured');
   }
 
-  const sheetNames = ['Accounts', 'Operations', 'Categories', 'Budgets', 'Planned Operations', 'Balance History'];
+  const sheetNames = ['Accounts', 'Operations', 'Categories', 'Budgets', 'Planned Operations', 'Balance History', 'Budget Plans', 'Budget Plan Lines'];
   const rangesParam = sheetNames.map(n => `ranges=${encodeURIComponent(n)}`).join('&');
   const response = await fetch(
     `${SHEETS_API}/${spreadsheetId}/values:batchGet?${rangesParam}`,
@@ -235,6 +261,8 @@ export const importFromSheets = async (accessToken, onProgress) => {
   const budgetRows = findSheet('Budgets');
   const plannedRows = findSheet('Planned Operations');
   const historyRows = findSheet('Balance History');
+  const budgetPlanRows = findSheet('Budget Plans');
+  const budgetPlanLineRows = findSheet('Budget Plan Lines');
 
   // Build lookup maps: id->id (direct) and name->id (fallback)
   const accountIdMap = new Map();
@@ -349,6 +377,29 @@ export const importFromSheets = async (accessToken, onProgress) => {
     created_at: now,
   }));
 
+  const budget_plans = budgetPlanRows.map(p => ({
+    id: p.id,
+    month: p.month,
+    currency: p.currency,
+    expected_income: p.expected_income || '0',
+    created_at: now,
+    updated_at: now,
+  }));
+
+  const budget_plan_lines = budgetPlanLineRows.map(l => ({
+    id: l.id,
+    plan_id: l.plan_id,
+    label: l.label || null,
+    amount: l.amount,
+    comment: l.comment || null,
+    // Exactly one target: resolve category or account, whichever the row carries.
+    category_id: (l.category || l.category_id) ? resolveCategoryId(l, 'category_id', 'category') : null,
+    to_account_id: (l.account || l.to_account_id) ? resolveAccountId(l, 'to_account_id', 'account') : null,
+    sort_order: (l.sort_order !== '' && l.sort_order != null) ? Number(l.sort_order) : 0,
+    created_at: now,
+    updated_at: now,
+  }));
+
   // Preserve current app preferences (language, theme, etc.) so they survive the restore.
   // Do NOT catch DB errors here — a locked or corrupted DB must abort the import loudly
   // rather than silently overwriting all user preferences with an empty set (#747).
@@ -368,6 +419,8 @@ export const importFromSheets = async (accessToken, onProgress) => {
       app_metadata,
       balance_history,
       planned_operations,
+      budget_plans,
+      budget_plan_lines,
     },
   };
 };
@@ -388,6 +441,8 @@ const createSpreadsheet = async (accessToken) => {
         { properties: { title: 'Budgets' } },
         { properties: { title: 'Planned Operations' } },
         { properties: { title: 'Balance History' } },
+        { properties: { title: 'Budget Plans' } },
+        { properties: { title: 'Budget Plan Lines' } },
       ],
     }),
   });


### PR DESCRIPTION
## Summary

Part 3 of the Budgets v2 roadmap. Brings the new `budget_plans` / `budget_plan_lines` tables (added in #1401) into every backup/restore path so plans created through the upcoming editor UI (#1396) are backup-safe. Closes #1398.

Deliberately ordered **before** the plan-editor UI: backups must cover the new tables before users can create plans, otherwise a restore performed in the gap would silently drop them.

## What changed

- **`BackupRestore.js`**
  - JSON: `createBackup` now reads `budget_plans` + `budget_plan_lines` (guarded for pre-0018 DBs); `restoreBackup` inserts plans before lines (satisfying the `plan_id` FK), keeps `category_id` as-is (categories aren't remapped), and remaps `to_account_id` through `accountIdMapping` exactly like operations / planned operations.
  - Clear order: `budget_plan_lines` then `budget_plans`, both before `categories`/`accounts`.
  - Transfer-line `to_account_id` joins the pre-restore unmapped-account validation, so a dangling reference aborts cleanly instead of dying on a raw FK error mid-transaction.
  - Robustness: a line whose parent plan was **not actually inserted** (skipped for missing fields, or unknown `plan_id`) is skipped rather than aborting the whole import on an FK violation; lines with an empty `amount` are skipped.
  - CSV export/import: `[BUDGET_PLANS]` and `[BUDGET_PLAN_LINES]` sections + `TABLE_FIELDS` entries.
  - SQLite import: extract both tables (guarded for older files).
- **`ImportProgressContext` / `ImportProgressModal`**: a `budget_plans` restore step mirroring the existing `budgets` step (labels follow the modal's existing hardcoded-string convention — the progress modal doesn't use i18n).
- **`GoogleSheetsService.js`**: `Budget Plans` and `Budget Plan Lines` sheets added to `buildSheetsData`, `createSpreadsheet`, `importFromSheets`, and the fetched ranges. Line rows carry both human-readable name and raw FK id columns (id-first, name fallback on import), mirroring operations.
- **Reset paths**: already covered by #1395 (dynamic `dropAllTables` + `isSchemaComplete`), confirmed — no change needed.
- Daily/weekly auto-backups are covered automatically since they reuse `createBackup()`.

## Tests

Extended `BackupRestore.test.js` and `GoogleSheetsService.test.js`:
- Round-trip with a category-linked line, a transfer-target line (`to_account_id` remapped), and a **non-ASCII** comment, across JSON, CSV and Sheets structures (mocked network).
- Old-format backup (no plan tables) imports cleanly with zero plans and no error.
- Edge cases: orphaned line skipped, skipped-plan's lines skipped (no FK abort), empty-amount line skipped, dangling account reference aborts.
- Updated the delete-order / query-count / step-count assertions in the existing suites.

`npm test -- --silent`: **162 suites, 4671 tests, all green.** Lint clean.

## Known limitation (pre-existing, not addressed here)

The Google Sheets export/import requests a fixed set of tab names. For a spreadsheet **created before this release**, the two new tabs don't exist yet, so `values:batchClear` / `batchGet` over those ranges can return a 400 until the tabs are provisioned. This is a pre-existing property of the sheet-addition pattern (the sheet set already grew this way in #574) and is out of scope for this "mirror budgets" change. Worth a follow-up to add tab-provisioning (ensure-missing-tabs before clear/write, and filter ranges to existing tabs on import).
