### PR TITLE
build(ci): parallel x86_64 APK build with staged ABI-aware auto-update

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       profile:
-        description: 'EAS profile (preview = arm64 only; emulator = arm64 + x86_64 for AVDs)'
+        description: 'Primary build profile (preview = arm64 only; emulator = arm64 + x86_64). A separate x86_64-only APK always builds in parallel.'
         required: true
         default: 'preview'
         type: choice
@@ -19,10 +19,24 @@ on:
 
 jobs:
   build:
-    name: Build Android APK
+    name: Build Android APK (${{ matrix.arch }})
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # arm64 (the dispatch-selected profile, default preview) is the primary build;
+    # x86_64 builds in parallel. Both are attached to the GitHub Release, the
+    # x86_64 one suffixed "_x86_64". The app's auto-updater (extractApkAsset)
+    # prefers the non-x86 asset so arm64 devices still get the arm64 APK.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            profile: ${{ github.event.inputs.profile || 'preview' }}
+            apk_suffix: ''
+          - arch: x86_64
+            profile: x86
+            apk_suffix: '_x86_64'
 
     steps:
       - name: 🏗 Setup repo
@@ -75,12 +89,15 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          BUILD_PROFILE: ${{ github.event.inputs.profile || 'preview' }}
+          BUILD_PROFILE: ${{ matrix.profile }}
         run: |
           eas build --platform android --local --profile "$BUILD_PROFILE" --non-interactive
 
       - name: 📦 Find and rename APK
         id: find_apk
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          APK_SUFFIX: ${{ matrix.apk_suffix }}
         run: |
           # EAS build outputs APK in current directory or android/app/build/outputs/apk
           APK_PATH=$(find . -name "*.apk" -type f 2>/dev/null | grep -v "node_modules" | grep -v unaligned | head -1)
@@ -94,9 +111,10 @@ jobs:
           # Use git ref for filename. Sanitize "/" (present in branch names such
           # as those used for workflow_dispatch runs) so cp does not try to write
           # into a non-existent directory. Tag names like "penny-v*" are unaffected.
-          TAG_NAME="${{ github.ref_name }}"
-          SAFE_NAME="${TAG_NAME//\//-}"
-          NEW_NAME="${SAFE_NAME}.apk"
+          # APK_SUFFIX distinguishes parallel ABI builds (e.g. "_x86_64"); it is
+          # empty for the primary arm64 build so its release asset name is unchanged.
+          SAFE_NAME="${REF_NAME//\//-}"
+          NEW_NAME="${SAFE_NAME}${APK_SUFFIX}.apk"
           cp "$APK_PATH" "$NEW_NAME"
           echo "apk_path=$NEW_NAME" >> $GITHUB_OUTPUT
           echo "Renamed to: $NEW_NAME"
@@ -117,7 +135,7 @@ jobs:
       - name: 📦 Upload APK as workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: penny-apk
+          name: penny-apk-${{ matrix.arch }}
           path: |
             ${{ steps.find_apk.outputs.apk_path }}
             ${{ steps.checksum.outputs.checksum_path }}
@@ -135,10 +153,16 @@ jobs:
 
       - name: Post build summary
         if: github.ref_type == 'tag'
+        env:
+          BUILD_PROFILE: ${{ matrix.profile }}
+          BUILD_ARCH: ${{ matrix.arch }}
+          REF_NAME: ${{ github.ref_name }}
+          APK_PATH: ${{ steps.find_apk.outputs.apk_path }}
+          CHECKSUM_PATH: ${{ steps.checksum.outputs.checksum_path }}
         run: |
           echo "## 🚀 Android Build Completed (EAS)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Profile:** preview" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**APK:** ${{ steps.find_apk.outputs.apk_path }}" >> $GITHUB_STEP_SUMMARY
-          echo "**SHA-256:** $(cat ${{ steps.checksum.outputs.checksum_path }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Profile:** $BUILD_PROFILE ($BUILD_ARCH)" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** $REF_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "**APK:** $APK_PATH" >> $GITHUB_STEP_SUMMARY
+          echo "**SHA-256:** $(cat "$CHECKSUM_PATH")" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -23,10 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # arm64 (the dispatch-selected profile, default preview) is the primary build;
-    # x86_64 builds in parallel. Both are attached to the GitHub Release, the
-    # x86_64 one suffixed "_x86_64". The app's auto-updater (extractApkAsset)
-    # prefers the non-x86 asset so arm64 devices still get the arm64 APK.
+    # arm64 (the dispatch-selected profile, default preview) is the primary build
+    # and the only one attached to the GitHub Release. x86_64 builds in parallel
+    # but is published as a workflow artifact only — staged rollout: older installs
+    # still pick the first .apk on a release, so we keep x86_64 off the release
+    # until the arch-aware auto-updater (extractApkAsset, prefers non-x86) has
+    # propagated. A later release can start attaching the "_x86_64" APK safely.
     strategy:
       fail-fast: false
       matrix:
@@ -142,8 +144,10 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      # Only the arm64 build is attached to the release. See the strategy comment:
+      # the x86_64 APK stays an artifact until the arch-aware updater propagates.
       - name: 📤 Upload APK and checksum to Release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && matrix.arch == 'arm64'
         uses: softprops/action-gh-release@v3
         with:
           files: |

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -28,7 +28,14 @@ jobs:
     # but is published as a workflow artifact only — staged rollout: older installs
     # still pick the first .apk on a release, so we keep x86_64 off the release
     # until the arch-aware auto-updater (extractApkAsset, prefers non-x86) has
-    # propagated. A later release can start attaching the "_x86_64" APK safely.
+    # propagated.
+    #
+    # NEXT RELEASE (once the arch-aware updater has propagated): flip x86_64 onto
+    # the release by dropping the "&& matrix.arch == 'arm64'" guard on the release
+    # upload step, and rename the primary asset by setting the arm64 entry's
+    # apk_suffix to '_arm64'. Result: "<tag>_arm64.apk" + "<tag>_x86_64.apk".
+    # No app-side change needed then — extractApkAsset already prefers "_arm64",
+    # falling back to the unsuffixed arm64 APK.
     strategy:
       fail-fast: false
       matrix:

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -163,6 +163,25 @@ describe('AppUpdateService', () => {
     it('returns null when no apk assets exist', async () => {
       expect(extractApkAsset([{ name: 'archive.zip', browser_download_url: 'https://example.com/archive.zip' }])).toBeNull();
     });
+
+    it('prefers the non-x86 apk when a release carries both ABIs', async () => {
+      // Asset order is not guaranteed by the GitHub API, so the x86_64 build may
+      // come first. Real devices are arm64 and must not be handed an x86_64 APK.
+      const asset = extractApkAsset([
+        { name: 'penny-v1.0.0_x86_64.apk', browser_download_url: 'https://example.com/penny-x86_64.apk' },
+        { name: 'penny-v1.0.0.apk', browser_download_url: 'https://example.com/penny.apk' },
+      ]);
+
+      expect(asset.browser_download_url).toBe('https://example.com/penny.apk');
+    });
+
+    it('falls back to an x86_64 apk when it is the only option', async () => {
+      const asset = extractApkAsset([
+        { name: 'penny-v1.0.0_x86_64.apk', browser_download_url: 'https://example.com/penny-x86_64.apk' },
+      ]);
+
+      expect(asset.browser_download_url).toBe('https://example.com/penny-x86_64.apk');
+    });
   });
 
   describe('checkAlreadyDownloaded', () => {

--- a/__tests__/services/AppUpdateService.test.js
+++ b/__tests__/services/AppUpdateService.test.js
@@ -175,6 +175,15 @@ describe('AppUpdateService', () => {
       expect(asset.browser_download_url).toBe('https://example.com/penny.apk');
     });
 
+    it('prefers the _arm64-suffixed apk over other ABIs (future rename)', async () => {
+      const asset = extractApkAsset([
+        { name: 'penny-v1.0.0_x86_64.apk', browser_download_url: 'https://example.com/penny-x86_64.apk' },
+        { name: 'penny-v1.0.0_arm64.apk', browser_download_url: 'https://example.com/penny-arm64.apk' },
+      ]);
+
+      expect(asset.browser_download_url).toBe('https://example.com/penny-arm64.apk');
+    });
+
     it('falls back to an x86_64 apk when it is the only option', async () => {
       const asset = extractApkAsset([
         { name: 'penny-v1.0.0_x86_64.apk', browser_download_url: 'https://example.com/penny-x86_64.apk' },

--- a/app.config.js
+++ b/app.config.js
@@ -1,14 +1,18 @@
 // Architecture filtering to speed up build time:
 //  - preview:  arm64-v8a only (real devices; ~75% faster than all-ABI)
 //  - emulator: arm64-v8a + x86_64 (installable on x86_64 AVDs for UI testing)
+//  - x86:      x86_64 only (parallel CI build for x86_64 AVDs / Chromebooks)
 //  - other:    all architectures
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview';
 const IS_EMULATOR = process.env.APP_VARIANT === 'emulator';
+const IS_X86 = process.env.APP_VARIANT === 'x86';
 const ANDROID_ARCHITECTURES = IS_PREVIEW
   ? ['arm64-v8a']
   : IS_EMULATOR
     ? ['arm64-v8a', 'x86_64']
-    : undefined; // undefined = all architectures
+    : IS_X86
+      ? ['x86_64']
+      : undefined; // undefined = all architectures
 
 module.exports = {
   expo: {

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -70,12 +70,21 @@ export const extractApkAsset = (assets = []) => {
   });
 
   // A release may carry more than one ABI (e.g. an arm64 build plus a parallel
-  // "*_x86_64.apk"). Real devices are arm64, so prefer the non-x86 asset and
-  // only fall back to an x86_64 APK when it is the sole option (asset order in
-  // the GitHub API is not guaranteed, so we must not just take the first .apk).
+  // "*_x86_64.apk"). Real devices are arm64, so resolve in priority order; asset
+  // order in the GitHub API is not guaranteed, so we must not just take the first
+  // .apk. This already anticipates the planned "<tag>_arm64.apk" rename: it is
+  // preferred now, with the current unsuffixed arm64 APK as the fallback, so the
+  // rename ships without a matching app-side change.
   const isX86 = (name) => /x86/i.test(name);
+  const isArm64 = (name) => /arm64/i.test(name);
   return (
-    apkAssets.find((asset) => !isX86(asset.name)) || apkAssets[0] || null
+    // 1. Explicit arm64 asset (future "<tag>_arm64.apk").
+    apkAssets.find((asset) => isArm64(asset.name)) ||
+    // 2. Current unsuffixed arm64 APK — any non-x86 .apk.
+    apkAssets.find((asset) => !isX86(asset.name)) ||
+    // 3. Last resort: an x86_64-only release.
+    apkAssets[0] ||
+    null
   );
 };
 

--- a/app/services/AppUpdateService.js
+++ b/app/services/AppUpdateService.js
@@ -62,12 +62,21 @@ export const extractApkAsset = (assets = []) => {
     return null;
   }
 
-  return assets.find((asset) => {
+  const apkAssets = assets.filter((asset) => {
     if (!asset || typeof asset.name !== 'string') {
       return false;
     }
     return asset.name.toLowerCase().endsWith('.apk') && !!asset.browser_download_url;
-  }) || null;
+  });
+
+  // A release may carry more than one ABI (e.g. an arm64 build plus a parallel
+  // "*_x86_64.apk"). Real devices are arm64, so prefer the non-x86 asset and
+  // only fall back to an x86_64 APK when it is the sole option (asset order in
+  // the GitHub API is not guaranteed, so we must not just take the first .apk).
+  const isX86 = (name) => /x86/i.test(name);
+  return (
+    apkAssets.find((asset) => !isX86(asset.name)) || apkAssets[0] || null
+  );
 };
 
 // Finds a SHA-256 checksum asset matching the APK filename.

--- a/eas.json
+++ b/eas.json
@@ -33,6 +33,18 @@
       },
       "channel": "preview"
     },
+    "x86": {
+      "distribution": "internal",
+      "node": "22.12.0",
+      "android": {
+        "buildType": "apk",
+        "gradleCommand": ":app:preBuild :app:assembleRelease"
+      },
+      "env": {
+        "APP_VARIANT": "x86"
+      },
+      "channel": "preview"
+    },
     "production": {
       "autoIncrement": true,
       "node": "22.12.0",

--- a/plugins/withR8Config.js
+++ b/plugins/withR8Config.js
@@ -30,12 +30,16 @@ const withR8Config = (config) => {
     // reliable method than expo-build-properties buildArchs (known issues).
     //  - preview:  arm64-v8a only (real devices)
     //  - emulator: arm64-v8a + x86_64 (installable on x86_64 AVDs for UI testing)
+    //  - x86:      x86_64 only (parallel CI build for x86_64 AVDs / Chromebooks)
     if (process.env.APP_VARIANT === 'preview') {
       properties['reactNativeArchitectures'] = 'arm64-v8a';
       console.log('🏗️  Building for arm64-v8a only (preview build)');
     } else if (process.env.APP_VARIANT === 'emulator') {
       properties['reactNativeArchitectures'] = 'arm64-v8a,x86_64';
       console.log('🏗️  Building for arm64-v8a + x86_64 (emulator build)');
+    } else if (process.env.APP_VARIANT === 'x86') {
+      properties['reactNativeArchitectures'] = 'x86_64';
+      console.log('🏗️  Building for x86_64 only (x86 build)');
     }
 
     // Update or add each property


### PR DESCRIPTION
## Summary

Adds a parallel x86_64 APK build to the release CI/CD pipeline (matrix strategy) and makes the in-app auto-updater ABI-aware, with a staged rollout so existing installs are never handed the wrong-ABI APK.

## What changed

**CI (`build-release-apk.yml`)**
- Build job converted to a `strategy.matrix`: the primary `arm64` build (dispatch-selected profile, default `preview`) and a new `x86_64` build run in parallel on every tag push and manual dispatch. `fail-fast: false` so one ABI failing doesn't kill the other.
- Per-arch artifact names (`penny-apk-<arch>`) and an `apk_suffix` so filenames don't collide.
- Untrusted `github.ref_name` moved into `env:` for the `run:` steps (workflow-injection hygiene).

**New `x86` build profile** — `eas.json` profile + `APP_VARIANT=x86` handled in `app.config.js` and `plugins/withR8Config.js` to restrict native ABIs to `x86_64` only.

**Staged rollout (this release)**
- Only the **arm64** APK is attached to the GitHub Release, keeping its current unsuffixed name for backward compatibility. The **x86_64** APK is published as a **workflow artifact only** — older installs resolve releases by "first `.apk`", so x86_64 stays off the release until the ABI-aware updater has propagated.

**Auto-updater (`AppUpdateService.js`)**
- `extractApkAsset` now resolves by priority instead of taking the first `.apk`: (1) an explicit `_arm64` asset, (2) any non-x86 `.apk` (today's unsuffixed arm64 build), (3) x86_64 as last resort. This is forward-compatible with the planned `_arm64` rename — no future app-side change needed.
- New test cases for the multi-ABI priority order.

## Next release (documented in the workflow)
Once the ABI-aware updater has propagated: drop the `&& matrix.arch == 'arm64'` guard on the release-upload step and set the arm64 entry's `apk_suffix` to `_arm64`. Result: `<tag>_arm64.apk` + `<tag>_x86_64.apk`, no app change required.

## Testing
- `npx jest` — full suite green (4720 tests); `AppUpdateService` suite covers the new priority logic.
- `eslint --max-warnings 0` clean on touched files; workflow YAML validated.
