### PR TITLE
feat(ci): attach x86_64 APK to GitHub releases

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       profile:
-        description: 'Primary build profile (preview = arm64 only; emulator = arm64 + x86_64). A separate x86_64-only APK always builds in parallel.'
+        description: 'Primary build profile (preview = arm64 only; emulator = arm64 + x86_64). A separate x86_64-only APK always builds in parallel and is attached to the release alongside it.'
         required: true
         default: 'preview'
         type: choice
@@ -23,26 +23,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    # arm64 (the dispatch-selected profile, default preview) is the primary build
-    # and the only one attached to the GitHub Release. x86_64 builds in parallel
-    # but is published as a workflow artifact only — staged rollout: older installs
-    # still pick the first .apk on a release, so we keep x86_64 off the release
-    # until the arch-aware auto-updater (extractApkAsset, prefers non-x86) has
-    # propagated.
-    #
-    # NEXT RELEASE (once the arch-aware updater has propagated): flip x86_64 onto
-    # the release by dropping the "&& matrix.arch == 'arm64'" guard on the release
-    # upload step, and rename the primary asset by setting the arm64 entry's
-    # apk_suffix to '_arm64'. Result: "<tag>_arm64.apk" + "<tag>_x86_64.apk".
-    # No app-side change needed then — extractApkAsset already prefers "_arm64",
-    # falling back to the unsuffixed arm64 APK.
+    # Both ABIs are attached to the GitHub Release, each suffixed by arch
+    # ("<tag>_arm64.apk" + "<tag>_x86_64.apk"). extractApkAsset (AppUpdateService.js)
+    # already prefers "_arm64", falling back to any non-x86 .apk, so older installs
+    # keep picking the right asset without an app-side change.
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: arm64
             profile: ${{ github.event.inputs.profile || 'preview' }}
-            apk_suffix: ''
+            apk_suffix: '_arm64'
           - arch: x86_64
             profile: x86
             apk_suffix: '_x86_64'
@@ -151,10 +142,8 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-      # Only the arm64 build is attached to the release. See the strategy comment:
-      # the x86_64 APK stays an artifact until the arch-aware updater propagates.
       - name: 📤 Upload APK and checksum to Release
-        if: github.ref_type == 'tag' && matrix.arch == 'arm64'
+        if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v3
         with:
           files: |


### PR DESCRIPTION
## Summary
- Attach the x86_64 APK to GitHub releases alongside arm64, instead of publishing it as a workflow-artifact-only build.
- Rename the primary build's release asset to `<tag>_arm64.apk` (was unsuffixed) so both ABIs are explicitly named.

## Why
This completes the staged rollout noted in the original workflow comment: the arch-aware auto-updater (`extractApkAsset` in `app/services/AppUpdateService.js`) already prefers an `_arm64`-suffixed asset, falling back to any non-x86 `.apk`. Since that updater logic has already propagated to installs, it's safe to flip x86_64 onto the release now.

## Test plan
- [x] Validated the workflow YAML parses correctly
- [ ] CI: `Build Android APK (EAS)` workflow triggers on a `penny-v*` tag and produces both `<tag>_arm64.apk` and `<tag>_x86_64.apk` as release assets
- [ ] Verify an existing (pre-change) install still picks the correct `_arm64` asset via the in-app updater
