### PR TITLE
fix(budgets): four defects found reviewing the v3 executable-templates diff

### DIFF
--- a/__tests__/components/budgets/BudgetPlanLineModal.test.js
+++ b/__tests__/components/budgets/BudgetPlanLineModal.test.js
@@ -278,4 +278,65 @@ describe('BudgetPlanLineModal', () => {
       expect(getByTestId('plan-line-save').props.accessibilityState.disabled).toBe(false);
     });
   });
+
+  // The amount field lost the Calculator that used to police its input, leaving
+  // only the comma->dot normalization. `t` is the identity here, so the rendered
+  // error text IS the translation key.
+  describe('Amount input (regression)', () => {
+    const withTarget = async (getByTestId) => {
+      await waitFor(() => expect(getByTestId('plan-target-picker')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-picker'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-cat1')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-option-cat-cat1'));
+    };
+
+    it('normalizes a locale decimal comma to a dot', async () => {
+      const props = baseProps();
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await withTarget(getByTestId);
+      await fireEvent.changeText(getByTestId('plan-line-amount'), '1,5');
+      await fireEvent.press(getByTestId('plan-line-save'));
+      expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({ amount: '1.5' }));
+    });
+
+    it('normalizes EVERY comma, not just the first', async () => {
+      // A single replace() left "1.234,56" — still unparseable, but it also meant
+      // the field's own handler could no longer be trusted to produce a dot-only
+      // value, so the invalid input reached validation instead of being normalized.
+      const props = baseProps();
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await withTarget(getByTestId);
+      await fireEvent.changeText(getByTestId('plan-line-amount'), '1,234,56');
+      expect(getByTestId('plan-line-amount').props.value).toBe('1.234.56');
+    });
+
+    it('blames an unparseable amount on parsing, not on being non-positive', async () => {
+      const props = baseProps();
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await withTarget(getByTestId);
+      await fireEvent.changeText(getByTestId('plan-line-amount'), '1,234,56');
+      await fireEvent.press(getByTestId('plan-line-save'));
+      expect(props.onSaveLine).not.toHaveBeenCalled();
+      await waitFor(() => expect(getByTestId('plan-line-error')).toBeTruthy());
+      expect(getByTestId('plan-line-error').props.children).toBe('valid_amount_required');
+    });
+
+    it('still reports a well-formed zero as non-positive', async () => {
+      const props = baseProps();
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await withTarget(getByTestId);
+      await fireEvent.changeText(getByTestId('plan-line-amount'), '0');
+      await fireEvent.press(getByTestId('plan-line-save'));
+      expect(props.onSaveLine).not.toHaveBeenCalled();
+      await waitFor(() => expect(getByTestId('plan-line-error')).toBeTruthy());
+      expect(getByTestId('plan-line-error').props.children).toBe('amount_must_be_greater_than_zero');
+    });
+
+    it('labels the field with the plan currency when the line has no currency of its own', async () => {
+      // A template-less one-off line stores currency: null and is priced in the
+      // plan's currency; the label used to go bare in that case.
+      const { getByText } = await render(<BudgetPlanLineModal {...baseProps()} currency="EUR" />);
+      await waitFor(() => expect(getByText('amount · EUR')).toBeTruthy());
+    });
+  });
 });

--- a/__tests__/screens/BudgetScreen.test.js
+++ b/__tests__/screens/BudgetScreen.test.js
@@ -49,15 +49,13 @@ jest.mock('../../app/contexts/CategoriesContext', () => {
   return { useCategories: () => categoriesValue };
 });
 
-jest.mock('../../app/contexts/AccountsDataContext', () => {
-  const accountsValue = {
-    accounts: [
-      { id: 'a1', name: 'Ameria', currency: 'AMD' },
-      { id: 'a2', name: 'Tinkoff', currency: 'RUB' },
-    ],
-  };
-  return { useAccountsData: () => accountsValue };
-});
+// Same stability contract as above, but settable: the currency-reset tests need
+// to delete an account between renders. setAccounts() installs one new stable
+// object; re-renders in between keep handing back that same identity.
+let mockAccountsValue;
+jest.mock('../../app/contexts/AccountsDataContext', () => ({
+  useAccountsData: () => mockAccountsValue,
+}));
 
 jest.mock('../../app/services/OperationsDB', () => ({
   fetchRatesToTarget: jest.fn(async () => new Map([['RUB', '5']])),
@@ -103,12 +101,23 @@ jest.mock('../../app/components/budgets/MonthlyPlanSection', () => {
   });
 });
 
+// The native wheel renders nothing under Jest, so stand in a tappable row per
+// option — that is the only way a test can drive the selection the way a user does.
 jest.mock('@quidone/react-native-wheel-picker', () => {
   const React = require('react');
+  const { View, Pressable } = require('react-native');
   return {
     __esModule: true,
-    default: function MockWheelPicker() {
-      return React.createElement('WheelPicker', null);
+    default: function MockWheelPicker({ data = [], onValueChanged }) {
+      return React.createElement(
+        View,
+        { testID: 'currency-wheel' },
+        data.map((item) => React.createElement(Pressable, {
+          key: item.value,
+          testID: `currency-option-${item.value}`,
+          onPress: () => onValueChanged?.({ item }),
+        })),
+      );
     },
   };
 });
@@ -122,12 +131,22 @@ const setBudgetsData = ({ loading = false, convertAll = true } = {}) => {
   };
 };
 
+const DEFAULT_ACCOUNTS = [
+  { id: 'a1', name: 'Ameria', currency: 'AMD' },
+  { id: 'a2', name: 'Tinkoff', currency: 'RUB' },
+];
+
+const setAccounts = (accounts = DEFAULT_ACCOUNTS) => {
+  mockAccountsValue = { accounts };
+};
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 describe('BudgetScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     capturedSectionProps = null;
     setBudgetsData();
+    setAccounts();
   });
 
   describe('Rendering', () => {
@@ -164,6 +183,64 @@ describe('BudgetScreen', () => {
       await waitFor(() => expect(capturedSectionProps).toBeTruthy());
       expect(capturedSectionProps.expenseCategories.map(c => c.id)).toEqual(['cat1', 'cat2']);
       expect(capturedSectionProps.incomeCategories.map(c => c.id)).toEqual(['cat3']);
+    });
+  });
+
+  describe('Currency selection', () => {
+    it('seeds the selection from the first account', async () => {
+      await render(<BudgetScreen />);
+      await waitFor(() => expect(capturedSectionProps?.currency).toBe('AMD'));
+    });
+
+    it('hands the picked currency down to the list', async () => {
+      const { getByTestId } = await render(<BudgetScreen />);
+      await waitFor(() => expect(getByTestId('currency-option-RUB')).toBeTruthy());
+      fireEvent.press(getByTestId('currency-option-RUB'));
+      await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
+    });
+
+    // Regression: the init effect only re-seeded when accounts went empty, so a
+    // selection whose last account was deleted survived — and since the wheel is
+    // only rendered while currencyItems.length > 1, deleting down to one currency
+    // took away the only control that could have corrected it. The stale value kept
+    // flowing into MonthlyPlanSection as the currency of any plan it creates.
+    it('re-seeds when the selected currency loses its last account', async () => {
+      const { getByTestId, queryByTestId, rerender } = await render(<BudgetScreen />);
+      await waitFor(() => expect(getByTestId('currency-option-RUB')).toBeTruthy());
+      fireEvent.press(getByTestId('currency-option-RUB'));
+      await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
+
+      setAccounts([{ id: 'a1', name: 'Ameria', currency: 'AMD' }]);
+      await rerender(<BudgetScreen />);
+
+      await waitFor(() => expect(capturedSectionProps.currency).toBe('AMD'));
+      // And the wheel really is gone, which is what made this unrecoverable.
+      expect(queryByTestId('currency-option-RUB')).toBeNull();
+    });
+
+    it('clears the selection when the last account of any kind is deleted', async () => {
+      const { rerender } = await render(<BudgetScreen />);
+      await waitFor(() => expect(capturedSectionProps?.currency).toBe('AMD'));
+
+      setAccounts([]);
+      await rerender(<BudgetScreen />);
+
+      await waitFor(() => expect(capturedSectionProps.currency).toBe(''));
+    });
+
+    it('leaves a still-valid selection alone when an unrelated account is deleted', async () => {
+      const { getByTestId, rerender } = await render(<BudgetScreen />);
+      await waitFor(() => expect(getByTestId('currency-option-RUB')).toBeTruthy());
+      fireEvent.press(getByTestId('currency-option-RUB'));
+      await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
+
+      setAccounts([
+        { id: 'a2', name: 'Tinkoff', currency: 'RUB' },
+        { id: 'a3', name: 'Other', currency: 'USD' },
+      ]);
+      await rerender(<BudgetScreen />);
+
+      await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
     });
   });
 

--- a/__tests__/services/BudgetPlansDB.test.js
+++ b/__tests__/services/BudgetPlansDB.test.js
@@ -662,6 +662,66 @@ describe('BudgetPlansDB', () => {
           .rejects.toThrow('UNIQUE constraint failed: budget_plans.month');
       });
     });
+
+    // Regression: phase 3 stopped deleting a one-off line on execution (the line
+    // has to survive so the plan keeps measuring what it allocated). That removed
+    // the only thing keeping an executed one-off out of copyPlan, which clones with
+    // last_executed_month = NULL — i.e. re-adds finished business as PENDING,
+    // inflating the new month's allocation and offering a swipe that duplicates the
+    // operation. Executed lines are now filtered out of the copy source.
+    describe('executed lines are not carried into the new month', () => {
+      const executedFridge = {
+        id: 'l-fridge', plan_id: 'src', label: 'Buy fridge', amount: '50000', comment: null,
+        category_id: 'c9', to_account_id: null, sort_order: 1, account_id: 'a1',
+        last_executed_month: '2026-06',
+      };
+      const pendingRent = {
+        id: 'l-rent', plan_id: 'src', label: 'Rent', amount: '65000', comment: null,
+        category_id: 'c1', to_account_id: null, sort_order: 0, account_id: null,
+        last_executed_month: null,
+      };
+
+      const arrangeCopy = (lines) => {
+        queryFirst
+          .mockResolvedValueOnce({ id: 'src', month: '2026-06', currency: 'USD', expected_income: '445000' })
+          .mockResolvedValueOnce(null);
+        queryAll.mockResolvedValue(lines);
+      };
+
+      it('skips a line executed in the source month while still copying the pending ones', async () => {
+        arrangeCopy([pendingRent, executedFridge]);
+
+        await BudgetPlansDB.copyPlan('2026-06', '2026-07');
+
+        const lineInserts = mockRunAsync.mock.calls
+          .filter(([sql]) => sql.includes('INSERT INTO budget_plan_lines'));
+        expect(lineInserts).toHaveLength(1);
+        expect(lineInserts[0][1]).toContain('Rent');
+        expect(lineInserts[0][1]).not.toContain('Buy fridge');
+      });
+
+      it('skips a line stamped with a month other than the source month (executed while browsing back)', async () => {
+        // executeLine stamps currentMonthKey(), not the plan's month, so a June
+        // line can carry a July stamp. Any stamp at all means "already done".
+        arrangeCopy([{ ...executedFridge, last_executed_month: '2026-07' }]);
+
+        await BudgetPlansDB.copyPlan('2026-06', '2026-07');
+
+        expect(mockRunAsync.mock.calls.filter(([sql]) => sql.includes('INSERT INTO budget_plan_lines')))
+          .toHaveLength(0);
+      });
+
+      it('copies a line whose execution was undone (stamp cleared back to NULL)', async () => {
+        arrangeCopy([{ ...executedFridge, last_executed_month: null }]);
+
+        await BudgetPlansDB.copyPlan('2026-06', '2026-07');
+
+        const lineInserts = mockRunAsync.mock.calls
+          .filter(([sql]) => sql.includes('INSERT INTO budget_plan_lines'));
+        expect(lineInserts).toHaveLength(1);
+        expect(lineInserts[0][1]).toContain('Buy fridge');
+      });
+    });
   });
 
   describe('error propagation', () => {
@@ -856,6 +916,26 @@ describe('BudgetPlansDB', () => {
       expect(createOperationInTx).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ description: 'Rent Category: rigged' }),
+      );
+    });
+
+    // Regression: the claim above was only half true — sanitizeLabel handled the
+    // "|" but did nothing about the system prefixes, so a real category named
+    // "Category: Groceries" (the shape a MoneyOK import produces) passed straight
+    // through and the created operation became invisible AND undeletable.
+    it('strips a leading system prefix from a real entity name', async () => {
+      await BudgetPlansDB.executeLine(template({ label: null, comment: null }), 'Category: Groceries');
+      expect(createOperationInTx).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ description: 'Groceries' }),
+      );
+    });
+
+    it('stores no description when the name is nothing but a system prefix', async () => {
+      await BudgetPlansDB.executeLine(template({ label: 'Account:' }));
+      expect(createOperationInTx).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ description: null }),
       );
     });
 

--- a/__tests__/utils/labelUtils.test.js
+++ b/__tests__/utils/labelUtils.test.js
@@ -5,6 +5,7 @@ import {
   MAX_LABEL_LENGTH,
   normalizeLabel,
   sanitizeLabel,
+  sanitizeNewLabel,
   parseLabels,
   serializeLabels,
   hasLabel,
@@ -42,6 +43,58 @@ describe('labelUtils', () => {
 
     it('returns empty string for whitespace-only input', () => {
       expect(sanitizeLabel('   ')).toBe('');
+    });
+  });
+
+  // Regression: executeLine (Budgets v3 phase 3) writes a plan line's name straight
+  // into operations.description. sanitizeLabel alone only guards the delimiter, so a
+  // real category named "Category: Groceries" (MoneyOK imports produce exactly this
+  // shape) became a *system* label: hidden from the operation list by
+  // visibleListLabels and non-deletable per isProtectedOperation.
+  describe('sanitizeNewLabel', () => {
+    it('keeps doing everything sanitizeLabel does', () => {
+      expect(sanitizeNewLabel('  work   trip ')).toBe('work trip');
+      expect(sanitizeNewLabel('a|b')).toBe('a b');
+      expect(sanitizeNewLabel(null)).toBe('');
+      expect(sanitizeNewLabel('x'.repeat(MAX_LABEL_LENGTH + 20))).toHaveLength(MAX_LABEL_LENGTH);
+    });
+
+    it('strips a leading system prefix so the result is never a hidden label', () => {
+      expect(sanitizeNewLabel('Category: Groceries')).toBe('Groceries');
+      expect(sanitizeNewLabel('Account: Cash')).toBe('Cash');
+      expect(sanitizeNewLabel('Category group: Expenses')).toBe('Expenses');
+    });
+
+    it('matches the prefix case-insensitively, like isSystemLabel does', () => {
+      expect(sanitizeNewLabel('cATEGORY: Groceries')).toBe('Groceries');
+    });
+
+    it('keeps stripping until nothing system-looking is left', () => {
+      expect(sanitizeNewLabel('Category: Account: Cash')).toBe('Cash');
+      expect(isSystemLabel(sanitizeNewLabel('Category: '.repeat(6) + 'Groceries'))).toBe(false);
+    });
+
+    it('rejects the [MoneyOK] marker, which prefix stripping cannot catch', () => {
+      // An exact match, not a prefix — but it makes the operation protected all the same.
+      expect(sanitizeNewLabel('[MoneyOK]')).toBe('');
+      expect(sanitizeNewLabel('[moneyok]')).toBe('');
+    });
+
+    it('returns empty when a name is nothing but a prefix', () => {
+      expect(sanitizeNewLabel('Category:')).toBe('');
+    });
+
+    it('leaves an ordinary name that merely contains a prefix word alone', () => {
+      expect(sanitizeNewLabel('Groceries Category: none')).toBe('Groceries Category: none');
+    });
+
+    it('its output never reads back as protected or hidden', () => {
+      for (const raw of ['Category: Groceries', 'Amount: 500', 'Date: today', '[MoneyOK]', 'Rent']) {
+        const clean = sanitizeNewLabel(raw);
+        if (!clean) continue;
+        expect(isProtectedOperation(clean)).toBe(false);
+        expect(visibleListLabels([clean])).toEqual([clean]);
+      }
     });
   });
 

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -98,6 +98,11 @@ export default function BudgetPlanLineModal({
   // template-less recurring line.
   const executionCurrency = accountId != null ? accountsById.get(accountId)?.currency : null;
   const effectiveCurrency = executionCurrency || (isRecurring ? lineCurrency : null);
+  // What the amount is actually denominated in. A template-less one-off line stores
+  // currency: null and is priced in the plan's currency, so the field is labelled
+  // with that rather than left bare. (May still be '' if the plan has no currency
+  // yet — no accounts exist.)
+  const displayCurrency = effectiveCurrency || currency;
 
   // Currency options for a recurring line: every currency in use across the
   // user's accounts, the plan's own currency (always offered, even if no
@@ -239,13 +244,19 @@ export default function BudgetPlanLineModal({
   // Normalize a locale decimal comma to a dot — Android decimal-pad keyboards
   // emit "," in many locales and the currency parsing downstream reads a comma
   // string as garbage (parseFloat('1,5') === 1, Decimal treats it as 0). Same
-  // treatment every other amount field in the app gives its input.
+  // treatment every other amount field in the app gives its input, except the
+  // replace is global: leaving a second comma in place would smuggle a value past
+  // this handler that only Currency.isValid can then reject.
   const handleAmountChange = useCallback((text) => {
-    setAmount(text.replace(',', '.'));
+    setAmount(text.replace(/,/g, '.'));
     setError(null);
   }, []);
 
-  const amountIsValid = Currency.isValid(amount) && Currency.compare(amount, '0') > 0;
+  // Kept apart so the error can say which of the two things is wrong: "1,234,56"
+  // normalizes to an unparseable "1.234.56", which is not the same complaint as a
+  // well-formed zero.
+  const amountIsParseable = Currency.isValid(amount);
+  const amountIsPositive = amountIsParseable && Currency.compare(amount, '0') > 0;
 
   const handleSave = useCallback(() => {
     // The host is already mid-save (e.g. the previous tap's ensurePlan()/save is
@@ -262,7 +273,11 @@ export default function BudgetPlanLineModal({
       setError(t('destination_account_required'));
       return;
     }
-    if (!amountIsValid) {
+    if (!amountIsParseable) {
+      setError(t('valid_amount_required'));
+      return;
+    }
+    if (!amountIsPositive) {
       setError(t('amount_must_be_greater_than_zero'));
       return;
     }
@@ -283,7 +298,7 @@ export default function BudgetPlanLineModal({
       // one-off line inherits the plan's (null).
       currency: effectiveCurrency,
     });
-  }, [saving, kind, amount, amountIsValid, label, comment, categoryId, toAccountId, accountId,
+  }, [saving, kind, amount, amountIsParseable, amountIsPositive, label, comment, categoryId, toAccountId, accountId,
     isRecurring, effectiveCurrency, onSaveLine, t]);
 
   const handleDelete = useCallback(() => {
@@ -557,7 +572,7 @@ export default function BudgetPlanLineModal({
                       bought nothing the number pad doesn't already give. */}
                   <View style={styles.field}>
                     <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                      {t('amount')}{effectiveCurrency ? ` · ${effectiveCurrency}` : ''}
+                      {t('amount')}{displayCurrency ? ` · ${displayCurrency}` : ''}
                     </Text>
                     <FormInput
                       value={amount}

--- a/app/screens/BudgetScreen.js
+++ b/app/screens/BudgetScreen.js
@@ -76,14 +76,20 @@ const BudgetScreen = () => {
   [currencies],
   );
 
-  // Initialize default currency from first account
+  // Seed the currency from the first account, and re-seed whenever the selected
+  // one stops existing (its last account was deleted). The membership check is not
+  // cosmetic: the picker is only rendered while currencyItems.length > 1, so a
+  // stale selection could otherwise survive with no UI left to change it, and it
+  // is still handed to MonthlyPlanSection as the currency of any plan it creates.
   useEffect(() => {
-    if (accounts.length > 0 && !selectedCurrency) {
-      setSelectedCurrency(accounts[0].currency);
-    } else if (accounts.length === 0 && selectedCurrency) {
-      setSelectedCurrency('');
+    if (accounts.length === 0) {
+      if (selectedCurrency) setSelectedCurrency('');
+      return;
     }
-  }, [accounts, selectedCurrency]);
+    if (!selectedCurrency || !currencies.includes(selectedCurrency)) {
+      setSelectedCurrency(accounts[0].currency);
+    }
+  }, [accounts, currencies, selectedCurrency]);
 
   const expenseCategories = useMemo(() =>
     categories.filter(cat => cat.categoryType === 'expense'),

--- a/app/services/BudgetPlansDB.js
+++ b/app/services/BudgetPlansDB.js
@@ -14,7 +14,7 @@ import * as Currency from './currency';
 import * as CategoriesDB from './CategoriesDB';
 import { calculateSpendingForBudget, deriveSpendingStatus } from './BudgetsDB';
 import { formatDate as formatLocalDate } from './BalanceHistoryDB';
-import { sanitizeLabel } from '../utils/labelUtils';
+import { sanitizeNewLabel } from '../utils/labelUtils';
 import {
   fetchRatesToTarget,
   convertWithRateMap,
@@ -838,9 +838,10 @@ export const getPlanTotals = async (planId) => {
 };
 
 /**
- * Clone a plan (and all its lines) from one month into a new month. Used by the
- * editor's "start from last month". Fails if the source month has no plan or the
- * target month already has one.
+ * Clone a plan and its still-pending lines from one month into a new month. Used
+ * by the editor's "start from last month". Lines already executed in the source
+ * month are left behind. Fails if the source month has no plan or the target month
+ * already has one.
  * @param {string} fromMonth - YYYY-MM to copy from
  * @param {string} toMonth - YYYY-MM to copy into
  * @returns {Promise<Object>} The newly created plan (camelCase).
@@ -861,7 +862,13 @@ export const copyPlan = async (fromMonth, toMonth) => {
       throw new Error('A plan for this month already exists');
     }
 
-    const sourceLines = await getPlanLines(source.id);
+    // Already-executed lines are NOT carried over. getPlanLines only returns the
+    // month's own one-off lines (recurring ones hang off plan_id IS NULL), and a
+    // one-off that already fired is finished business — cloning it would re-add it
+    // as pending (see the last_executed_month note below), inflating the new
+    // month's allocation and offering a swipe that duplicates the operation.
+    const sourceLines = (await getPlanLines(source.id))
+      .filter((line) => !isSet(line.lastExecutedMonth));
     const now = new Date().toISOString();
     const newPlanId = uuid.v4();
 
@@ -874,9 +881,10 @@ export const copyPlan = async (fromMonth, toMonth) => {
 
         for (let i = 0; i < sourceLines.length; i++) {
           const line = sourceLines[i];
-          // `last_executed_month` is deliberately NOT copied: a template cloned
-          // into a new month starts pending, exactly like a recurring one does
-          // when the month rolls over.
+          // `last_executed_month` is written NULL: every line that reaches here is
+          // pending already (see the filter above), and a clone starts the new
+          // month pending too, exactly like a recurring line does when the month
+          // rolls over.
           await db.runAsync(
             'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, ?, ?)',
             [
@@ -1360,9 +1368,10 @@ export const executeLine = async (line, fallbackName = null) => {
     // `operations.description` is not free text — it is the delimited label list
     // owned by labelUtils. An unsanitized name containing "|" would silently
     // become two labels, and one starting with a system prefix ("Category:", …)
-    // would hide the operation from the list AND mark it non-deletable.
+    // would hide the operation from the list AND mark it non-deletable;
+    // sanitizeNewLabel handles both (plain sanitizeLabel only handles the former).
     const rawDescription = line.label || line.comment || fallbackName || null;
-    const description = rawDescription ? sanitizeLabel(rawDescription) || null : null;
+    const description = rawDescription ? sanitizeNewLabel(rawDescription) || null : null;
     const operationData = {
       type: line.kind || 'expense',
       amount: line.amount,

--- a/app/utils/labelUtils.js
+++ b/app/utils/labelUtils.js
@@ -221,6 +221,34 @@ export const isHiddenLabel = (label) => {
 };
 
 /**
+ * Sanitize a label that is about to become a NEWLY created operation's description,
+ * additionally guaranteeing it is not a hidden label. Plain {@link sanitizeLabel}
+ * only guards the delimiter and the length cap; it says nothing about the system
+ * prefixes, so a real entity name that merely looks like imported metadata — a
+ * MoneyOK-imported category literally called "Category: Groceries" — would be
+ * written through verbatim and then read back as metadata: hidden from the
+ * operation list by {@link visibleListLabels} and non-deletable per
+ * {@link isProtectedOperation}. Leading system prefixes are therefore stripped.
+ *
+ * The loop terminates because every prefix is at least 5 characters long, so each
+ * pass strictly shortens the value.
+ * @param {*} label
+ * @returns {string} '' when nothing usable (or nothing safe) is left.
+ */
+export const sanitizeNewLabel = (label) => {
+  let clean = sanitizeLabel(label);
+  while (clean) {
+    const lower = clean.toLowerCase();
+    const prefix = SYSTEM_LABEL_PREFIXES.find((p) => lower.startsWith(p.toLowerCase()));
+    if (!prefix) break;
+    clean = clean.slice(prefix.length).trim();
+  }
+  // Prefix stripping cannot catch the [MoneyOK] marker (an exact match, not a
+  // prefix), and a name equal to it would likewise mark the operation protected.
+  return isHiddenLabel(clean) ? '' : clean;
+};
+
+/**
  * Whether an operation's description marks it as a protected import — it carries
  * either a system label (Account:/Category:/Category group:) or the [MoneyOK]
  * marker. Protected operations are non-deletable.


### PR DESCRIPTION
Four defects found while reviewing the Budgets v3 executable-templates diff, plus regression coverage for each.

## 1. `copyPlan` cloned already-executed one-off lines into the new month

Phase 3 stopped deleting a one-off line on execution — the line has to survive so the plan keeps measuring what it allocated. That also removed the only thing that had kept a fired line out of `copyPlan`, which clones with `last_executed_month = NULL`, i.e. re-adds finished business as **pending**.

> July plan has a one-off "Buy fridge, 50 000", executed on the 15th. On 1 Aug the user taps *Copy from last month*. August gets a pending "Buy fridge 50 000" line: allocation inflated by 50 000, remainder possibly into the red, and one swipe creates a duplicate 50 000 operation.

Executed lines are now filtered out of the copy source. The check is for *any* stamp rather than one equal to the source month: `executeLine` stamps `currentMonthKey()`, not the plan's month, so a June line can legitimately carry a July stamp. An undone execution (stamp cleared back to `NULL`) still copies.

## 2. `executeLine`'s sanitization did not do what its comment claimed

The comment promised protection against a name "starting with a system prefix (`Category:`, …)". `sanitizeLabel` is `normalizeLabel(...).slice(0, 60)` — it guards the `|` delimiter and the length cap, and nothing else.

> A MoneyOK-imported category literally named `Category: Groceries` is the fallback name for an executable line. The created operation's description makes `isSystemLabel()` true → `visibleListLabels()` hides it from the operations list and `isProtectedOperation()` makes it non-deletable.

Chose the real guard over correcting the comment. New `sanitizeNewLabel` in `labelUtils` = `sanitizeLabel` + leading system-prefix stripping (terminates: every prefix is at least 5 chars, so each pass strictly shortens the value) + rejection of the exact `[MoneyOK]` marker, which prefix matching cannot catch.

## 3. Stale `selectedCurrency` in `BudgetScreen`

The init effect only re-seeded when `accounts.length === 0`.

> Accounts in USD + EUR, user picks EUR, then deletes the EUR account. The wheel is only rendered while `currencyItems.length > 1`, so it disappears — but `selectedCurrency` stays `EUR`, with no UI left to change it, and keeps flowing into `MonthlyPlanSection` as the currency of any plan `ensurePlan`/`addPlan` creates.

The effect now also re-seeds when the selection is not among the accounts' currencies. Written so the guard is false after a successful seed — no repeated `setState`.

## 4. Amount field in `BudgetPlanLineModal`

`text.replace(',', '.')` replaced only the first comma, and there is no other input filtering now that the Calculator is gone. `1,234,56` was correctly blocked but reported as `amount_must_be_greater_than_zero`, which is not what is wrong. The replace is now global and the validation is split into parseable / positive, so the error names the actual problem. Also restores the currency hint on the field label: a template-less one-off line stores `currency: null` and is priced in the plan's currency, so it is labelled with that instead of going bare.

## Tests

+23 tests, one group per fix: `copyPlan`'s filter (incl. foreign-month stamp and undone execution), `sanitizeNewLabel`, `executeLine`'s description, the currency re-seed, and the amount field. The `WheelPicker` mock in `BudgetScreen.test.js` was upgraded to tappable rows and the accounts mock made settable — the "account deleted" scenario is not reachable otherwise; referential stability of the context value is preserved.

The highest-stakes fix was mutation-checked: with the `copyPlan` filter removed, two of the new tests go red.

```
Test Suites: 162 passed, 162 total
Tests:       4719 passed, 4719 total
```

`npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

## Not addressed

`sanitizeNewLabel` still truncates at `MAX_LABEL_LENGTH` (60), so a longer category name is silently clipped in the stored description. That cap is shared by every newly created label; carving out an exception for this path alone would mean two different length policies. Worth a separate discussion rather than a drive-by change here.
