### PR TITLE
fix(graphs): align donut icon markers with Victory Native slice geometry

### DIFF
--- a/__tests__/components/graphs/DonutChart.test.js
+++ b/__tests__/components/graphs/DonutChart.test.js
@@ -77,22 +77,37 @@ describe('computeIconMarkers', () => {
     expect(computeIconMarkers(data)[0].showIcon).toBe(false);
   });
 
-  it('single full-circle slice midAngle=π maps to the bottom of the ring', async () => {
+  // Victory Native starts the first slice at 3 o'clock and sweeps clockwise, so
+  // the overlay must too: angle 0 → right, π/2 → bottom, π → left.
+  it('single full-circle slice midAngle=π maps to the left of the ring', async () => {
     const markers = computeIconMarkers([{ amount: 1, color: '#f00', icon: 'food' }]);
     // midAngle = (0 + 0.5) * 2π = π
-    expect(markers[0].x).toBeCloseTo(CENTER, 1); // sin(π) ≈ 0
-    expect(markers[0].y).toBeCloseTo(CENTER + ICON_RADIUS, 1); // −cos(π) = 1
+    expect(markers[0].x).toBeCloseTo(CENTER - ICON_RADIUS, 1); // cos(π) = −1
+    expect(markers[0].y).toBeCloseTo(CENTER, 1); // sin(π) ≈ 0
   });
 
-  it('a half-and-half split places markers on opposite sides (top vs bottom)', async () => {
+  it('a half-and-half split places markers on opposite sides (bottom vs top)', async () => {
     const markers = computeIconMarkers([
-      { amount: 1, color: '#f00', icon: 'food' }, // midAngle = π/2 → right
-      { amount: 1, color: '#0f0', icon: 'car' }, //  midAngle = 3π/2 → left
+      { amount: 1, color: '#f00', icon: 'food' }, // midAngle = π/2 → bottom
+      { amount: 1, color: '#0f0', icon: 'car' }, //  midAngle = 3π/2 → top
     ]);
-    expect(markers[0].x).toBeCloseTo(CENTER + ICON_RADIUS, 1); // sin(π/2) = 1
-    expect(markers[0].y).toBeCloseTo(CENTER, 1); // −cos(π/2) ≈ 0
-    expect(markers[1].x).toBeCloseTo(CENTER - ICON_RADIUS, 1); // sin(3π/2) = −1
-    expect(markers[1].y).toBeCloseTo(CENTER, 1); // −cos(3π/2) ≈ 0
+    expect(markers[0].x).toBeCloseTo(CENTER, 1); // cos(π/2) ≈ 0
+    expect(markers[0].y).toBeCloseTo(CENTER + ICON_RADIUS, 1); // sin(π/2) = 1
+    expect(markers[1].x).toBeCloseTo(CENTER, 1); // cos(3π/2) ≈ 0
+    expect(markers[1].y).toBeCloseTo(CENTER - ICON_RADIUS, 1); // sin(3π/2) = −1
+  });
+
+  it('regression: a marker lands inside its own slice (quarter turn off before)', async () => {
+    // Four equal slices sweeping clockwise from 3 o'clock: right-bottom,
+    // bottom-left, left-top, top-right quadrant midpoints at 45°/135°/225°/315°.
+    const quarter = (ICON_RADIUS * Math.SQRT2) / 2;
+    const markers = computeIconMarkers(
+      ['a', 'b', 'c', 'd'].map((icon) => ({ amount: 25, color: '#f00', icon })),
+    );
+    expect(markers[0].x).toBeCloseTo(CENTER + quarter, 1);
+    expect(markers[0].y).toBeCloseTo(CENTER + quarter, 1);
+    expect(markers[2].x).toBeCloseTo(CENTER - quarter, 1);
+    expect(markers[2].y).toBeCloseTo(CENTER - quarter, 1);
   });
 
   it('preserves color and icon from input', async () => {

--- a/app/components/graphs/DonutChart.js
+++ b/app/components/graphs/DonutChart.js
@@ -28,9 +28,13 @@ export const mapPieData = (data) =>
     color: item.color,
   }));
 
-// Victory Native draws pie slices starting at 12 o'clock and sweeping clockwise
-// (d3-shape convention). We mirror that here to lay MaterialCommunityIcons
-// glyphs over each slice, since VN has no vector-icon slice label.
+// Victory Native draws pie slices in Skia's angular convention: 0° points at
+// 3 o'clock (the +x axis) and angles grow clockwise, since screen y grows
+// downwards. The slice geometry VN hands to the render function below uses that
+// same convention (see computeSliceGradient, which feeds startAngle/endAngle
+// straight into cos/sin), so the icon overlay has to share it — laying the
+// markers out from 12 o'clock instead rotates every glyph a quarter turn off
+// its slice. We mirror the sweep here because VN has no vector-icon slice label.
 export const computeIconMarkers = (data) => {
   const total = data.reduce((sum, item) => sum + item.amount, 0);
   if (total === 0) return [];
@@ -43,8 +47,8 @@ export const computeIconMarkers = (data) => {
       color: item.color,
       icon: item.icon,
       showIcon: fraction >= ICON_THRESHOLD && !!item.icon,
-      x: CENTER + ICON_RADIUS * Math.sin(midAngle),
-      y: CENTER - ICON_RADIUS * Math.cos(midAngle),
+      x: CENTER + ICON_RADIUS * Math.cos(midAngle),
+      y: CENTER + ICON_RADIUS * Math.sin(midAngle),
     };
     cumulative += fraction;
     return marker;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -520,7 +520,9 @@ jest.mock(
     // eslint-disable-next-line react/prop-types
     const BarGroup = ({ children }) =>
       React.createElement(View, { testID: 'vn-bar-group' }, children);
-    BarGroup.Bar = () => React.createElement(View, { testID: 'vn-bar-group-bar' });
+    const BarGroupBar = () => React.createElement(View, { testID: 'vn-bar-group-bar' });
+    BarGroupBar.displayName = 'BarGroup.Bar';
+    BarGroup.Bar = BarGroupBar;
     // Gesture state stubs: components read `.value` off Reanimated shared values,
     // so every axis slot has to be an object with a `value` field.
     const shared = (v) => ({ value: v });


### PR DESCRIPTION
## Problem

Category icons on the expense/income donut chart sit a quarter turn away from the slices they belong to — e.g. the food glyph rendered over the neighbouring "Monthly" slice.

## Cause

Victory Native XL draws pie slices in Skia's angular convention: 0° points at 3 o'clock (+x axis) and angles grow clockwise (screen y grows downwards). `computeIconMarkers` laid the overlay out from 12 o'clock instead:

```js
x: CENTER + ICON_RADIUS * Math.sin(midAngle),
y: CENTER - ICON_RADIUS * Math.cos(midAngle),
```

That is a fixed 90° offset from where VN actually paints the slice. `computeSliceGradient` in the same file already used the correct convention — it feeds `slice.startAngle` / `slice.endAngle` straight into `cos`/`sin` — so the two halves of the component disagreed.

## Fix

Use the same convention for the markers:

```js
x: CENTER + ICON_RADIUS * Math.cos(midAngle),
y: CENTER + ICON_RADIUS * Math.sin(midAngle),
```

Only the absolutely-positioned icon overlay changes; slices, gradients and insets are untouched, so the donut itself renders exactly as before.

## Tests

Two existing geometry assertions encoded the same wrong convention and passed by mirroring the bug — they are corrected to the VN convention (0 → right, π/2 → bottom, π → left), and a four-quadrant regression test pins each marker inside its own slice.

- `npx jest` — 162 suites / 4733 tests passing
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean
