### PR TITLE
feat(budgets): let a plan line track several categories

### DIFF
--- a/__tests__/components/budgets/BudgetPlanLineModal.test.js
+++ b/__tests__/components/budgets/BudgetPlanLineModal.test.js
@@ -74,12 +74,79 @@ describe('BudgetPlanLineModal', () => {
     await fireEvent.press(getByTestId('plan-target-picker'));
     await waitFor(() => expect(getByTestId('plan-target-option-cat-cat1')).toBeTruthy());
     await fireEvent.press(getByTestId('plan-target-option-cat-cat1'));
+    // The picker stays open for further categories now, so close it explicitly.
+    await fireEvent.press(getByTestId('plan-target-done'));
     await fireEvent.changeText(getByTestId('plan-line-amount'), '150');
     await fireEvent.press(getByTestId('plan-line-save'));
     expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
       amount: '150',
-      categoryId: 'cat1',
+      categoryIds: ['cat1'],
       toAccountId: null,
+    }));
+  });
+
+  // Migration 0021: one line, several categories.
+  it('saves every category picked, and drops one that is tapped again', async () => {
+    const props = {
+      ...baseProps(),
+      expenseCategories: [
+        { id: 'cat1', name: 'Groceries', categoryType: 'expense' },
+        { id: 'cat2', name: 'Cafes', categoryType: 'expense' },
+        { id: 'cat3', name: 'Taxi', categoryType: 'expense' },
+      ],
+    };
+    const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+    await fireEvent.press(getByTestId('plan-target-picker'));
+    await waitFor(() => expect(getByTestId('plan-target-option-cat-cat1')).toBeTruthy());
+    await fireEvent.press(getByTestId('plan-target-option-cat-cat1'));
+    await fireEvent.press(getByTestId('plan-target-option-cat-cat2'));
+    await fireEvent.press(getByTestId('plan-target-option-cat-cat3'));
+    // Tapping a selected category removes it — the picker toggles, not replaces.
+    await fireEvent.press(getByTestId('plan-target-option-cat-cat2'));
+    await fireEvent.press(getByTestId('plan-target-done'));
+    await fireEvent.changeText(getByTestId('plan-line-amount'), '150');
+    await fireEvent.press(getByTestId('plan-line-save'));
+    expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
+      categoryIds: ['cat1', 'cat3'],
+    }));
+  });
+
+  it('defaults includeChildren on and lets it be switched off', async () => {
+    const props = baseProps();
+    const { getByTestId, queryByTestId } = await render(<BudgetPlanLineModal {...props} />);
+    // The roll-up toggle only exists once the line tracks a category.
+    expect(queryByTestId('plan-line-include-children-toggle')).toBeNull();
+    await fireEvent.press(getByTestId('plan-target-picker'));
+    await waitFor(() => expect(getByTestId('plan-target-option-cat-cat1')).toBeTruthy());
+    await fireEvent.press(getByTestId('plan-target-option-cat-cat1'));
+    await fireEvent.press(getByTestId('plan-target-done'));
+    await fireEvent.changeText(getByTestId('plan-line-amount'), '150');
+    await waitFor(() => expect(getByTestId('plan-line-include-children-toggle')).toBeTruthy());
+    await fireEvent.press(getByTestId('plan-line-include-children-toggle'));
+    await fireEvent.press(getByTestId('plan-line-save'));
+    expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
+      includeChildren: false,
+    }));
+  });
+
+  it('seeds the picker from an edited line\'s stored category set', async () => {
+    const props = {
+      ...baseProps(),
+      expenseCategories: [
+        { id: 'cat1', name: 'Groceries', categoryType: 'expense' },
+        { id: 'cat2', name: 'Cafes', categoryType: 'expense' },
+      ],
+      line: {
+        id: 'l1', amount: '150', kind: 'expense',
+        categoryId: 'cat1', categoryIds: ['cat1', 'cat2'], includeChildren: false,
+      },
+    };
+    const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+    await waitFor(() => expect(getByTestId('plan-line-save')).toBeTruthy());
+    await fireEvent.press(getByTestId('plan-line-save'));
+    expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
+      categoryIds: ['cat1', 'cat2'],
+      includeChildren: false,
     }));
   });
 
@@ -98,7 +165,7 @@ describe('BudgetPlanLineModal', () => {
     expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
       amount: '400',
       kind: 'transfer',
-      categoryId: null,
+      categoryIds: [],
       toAccountId: 1,
     }));
   });
@@ -111,7 +178,7 @@ describe('BudgetPlanLineModal', () => {
       await fireEvent.changeText(getByTestId('plan-line-amount'), '2500');
       await fireEvent.press(getByTestId('plan-line-save'));
       expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
-        kind: 'income', amount: '2500', categoryId: null, toAccountId: null,
+        kind: 'income', amount: '2500', categoryIds: [], toAccountId: null,
       }));
     });
 
@@ -219,7 +286,7 @@ describe('BudgetPlanLineModal', () => {
       await fireEvent.changeText(getByTestId('plan-line-amount'), '65000');
       await fireEvent.press(getByTestId('plan-line-save'));
       expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
-        amount: '65000', categoryId: 'cat1', isRecurring: true, currency: 'USD',
+        amount: '65000', categoryIds: ['cat1'], isRecurring: true, currency: 'USD',
       }));
     });
 

--- a/__tests__/db/schema.coverage.test.js
+++ b/__tests__/db/schema.coverage.test.js
@@ -12,6 +12,11 @@ const mockUnique = jest.fn(() => ({
   on: jest.fn((...columns) => ({ type: 'unique', columns })),
 }));
 
+// Composite primary key (budget_plan_line_categories, migration 0021). Unlike
+// index()/unique() this one takes its columns up front and returns the
+// constraint directly — there is no .on() to chain.
+const mockPrimaryKey = jest.fn(({ columns }) => ({ type: 'primaryKey', columns }));
+
 jest.mock('drizzle-orm/sqlite-core', () => {
   // Helper to create column with chained methods
   const createColumnMethods = () => {
@@ -74,6 +79,7 @@ jest.mock('drizzle-orm/sqlite-core', () => {
     }),
     index: mockIndex,
     unique: mockUnique,
+    primaryKey: mockPrimaryKey,
   };
 });
 

--- a/__tests__/db/schema.test.js
+++ b/__tests__/db/schema.test.js
@@ -807,5 +807,25 @@ describe('Database Schema', () => {
         expect(planId.config.references()).toBeDefined();
       }
     });
+
+    // Migration 0021: descendants roll up unless this is switched off.
+    it('defaults includeChildren to 1', async () => {
+      expect(schema.budgetPlanLines.includeChildren.columnType).toBe('SQLiteInteger');
+      expect(schema.budgetPlanLines.includeChildren.notNull).toBe(true);
+      expect(schema.budgetPlanLines.includeChildren.default).toBe(1);
+    });
+  });
+
+  describe('budgetPlanLineCategories Table (migration 0021)', () => {
+    it('has correct table name', async () => {
+      expect(schema.budgetPlanLineCategories[Symbol.for('drizzle:Name')]).toBe('budget_plan_line_categories');
+    });
+
+    it('defines both link columns as required text/FK pair', async () => {
+      expect(schema.budgetPlanLineCategories.lineId.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlanLineCategories.lineId.notNull).toBe(true);
+      expect(schema.budgetPlanLineCategories.categoryId.columnType).toBe('SQLiteText');
+      expect(schema.budgetPlanLineCategories.categoryId.notNull).toBe(true);
+    });
   });
 });

--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -172,8 +172,9 @@ describe('BackupRestore', () => {
       });
       expect(backup.timestamp).toBeDefined();
       // accounts, categories, operations, budgets, app_metadata, balance_history,
-      // planned_operations, notification_merchant_rules, budget_plans, budget_plan_lines
-      expect(mockDb.queryAll).toHaveBeenCalledTimes(10);
+      // planned_operations, notification_merchant_rules, budget_plans,
+      // budget_plan_lines, budget_plan_line_categories
+      expect(mockDb.queryAll).toHaveBeenCalledTimes(11);
     });
 
     it('includes empty arrays when tables are empty', async () => {
@@ -561,12 +562,14 @@ describe('BackupRestore', () => {
       expect(deleteCalls[0]).toContain('notification_merchant_rules');
       expect(deleteCalls[1]).toContain('planned_operations');
       expect(deleteCalls[2]).toContain('budgets');
-      expect(deleteCalls[3]).toContain('budget_plan_lines');
-      expect(deleteCalls[4]).toContain('budget_plans');
-      expect(deleteCalls[5]).toContain('accounts_balance_history');
-      expect(deleteCalls[6]).toContain('operations');
-      expect(deleteCalls[7]).toContain('categories');
-      expect(deleteCalls[8]).toContain('accounts');
+      // The 0021 junction is cleared before the lines it hangs off.
+      expect(deleteCalls[3]).toContain('budget_plan_line_categories');
+      expect(deleteCalls[4]).toContain('budget_plan_lines');
+      expect(deleteCalls[5]).toContain('budget_plans');
+      expect(deleteCalls[6]).toContain('accounts_balance_history');
+      expect(deleteCalls[7]).toContain('operations');
+      expect(deleteCalls[8]).toContain('categories');
+      expect(deleteCalls[9]).toContain('accounts');
     });
 
     it('preserves db_version metadata', async () => {
@@ -1616,6 +1619,13 @@ op-2,income,20,acc-1,cat-1`;
         (c) => typeof c[0] === 'string' && c[0].includes(`INSERT INTO ${table}`),
       );
 
+    // The 0021 junction is written with INSERT OR IGNORE, which findInsert's
+    // `INSERT INTO <table>` match doesn't cover.
+    const findLinkInserts = (dbInstance) =>
+      dbInstance.runAsync.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('INTO budget_plan_line_categories'),
+      );
+
     const backupWithPlan = () => ({
       version: 1,
       timestamp: '2026-07-01T00:00:00.000Z',
@@ -1661,18 +1671,78 @@ op-2,income,20,acc-1,cat-1`;
 
       // Category line: keeps category_id as-is, to_account_id null, comment
       // intact; one-off (is_recurring 0, currency null).
+      // include_children restores as 1 (roll descendants up) for a backup that
+      // predates the flag — the behaviour those lines had when written.
       const catCall = lineInserts.find(c => c[1][0] === 'line-cat');
       expect(catCall[1]).toEqual([
         'line-cat', 'plan-1', 'Groceries', '400.00', NON_ASCII_COMMENT,
-        'cat-1', null, 0, 0, null, null, null, null, 'x', 'y',
+        'cat-1', null, 0, 0, null, null, null, null, 1, 'x', 'y',
       ]);
 
       // Transfer line: category_id null, to_account_id remapped 'acc-uuid' -> 42.
       const xferCall = lineInserts.find(c => c[1][0] === 'line-xfer');
       expect(xferCall[1]).toEqual([
         'line-xfer', 'plan-1', 'To savings', '500.00', null,
-        null, REMAPPED_ACCOUNT_ID, 1, 0, null, null, null, null, 'x', 'y',
+        null, REMAPPED_ACCOUNT_ID, 1, 0, null, null, null, null, 1, 'x', 'y',
       ]);
+
+      // A pre-0021 backup carries no junction, so the category line's link is
+      // rebuilt from its category_id — otherwise it would restore as broken.
+      const linkInserts = findLinkInserts(dbInstance);
+      expect(linkInserts.map(c => c[1])).toEqual([['line-cat', 'cat-1']]);
+    });
+
+    // Regression: a CSV backup yields '' for a column the file doesn't carry,
+    // and Number('') is 0 — so a naive numeric check would silently switch the
+    // descendant roll-up OFF for every line restored from a CSV.
+    it('treats a blank include_children as on, not off', async () => {
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      const backup = backupWithPlan();
+      backup.data.budget_plan_lines = [{ ...categoryLine, include_children: '' }];
+
+      await BackupRestore.restoreBackup(backup);
+
+      const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
+      expect(lineInserts[0][1][13]).toBe(1);
+    });
+
+    // Migration 0021: a line tracking several categories round-trips through the
+    // junction, not through the single category_id column.
+    it('restores every category link of a multi-category line', async () => {
+      const dbInstance = makeDbInstance();
+      mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+      const backup = backupWithPlan();
+      backup.data.categories = [
+        { id: 'cat-1', name: 'Groceries', type: 'entry', category_type: 'expense' },
+        { id: 'cat-2', name: 'Cafes', type: 'entry', category_type: 'expense' },
+      ];
+      backup.data.budget_plan_lines = [{
+        ...categoryLine, category_id: 'cat-1', include_children: 0,
+      }];
+      backup.data.budget_plan_line_categories = [
+        { line_id: 'line-cat', category_id: 'cat-1' },
+        { line_id: 'line-cat', category_id: 'cat-2' },
+        // A link to a category the backup doesn't contain is dropped rather than
+        // failing the NOT NULL FK and aborting the whole restore.
+        { line_id: 'line-cat', category_id: 'cat-gone' },
+        // Same for a link to a line that was never inserted.
+        { line_id: 'line-gone', category_id: 'cat-2' },
+      ];
+
+      await BackupRestore.restoreBackup(backup);
+
+      const linkInserts = findLinkInserts(dbInstance);
+      expect(linkInserts.map(c => c[1])).toEqual([
+        ['line-cat', 'cat-1'],
+        ['line-cat', 'cat-2'],
+      ]);
+      // ...and the stored flag survives the round trip.
+      const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
+      expect(lineInserts[0][1]).toContain(0);
+      expect(lineInserts[0][1][13]).toBe(0);
     });
 
     it('restores a recurring (global template) line with no plan_id and its own currency', async () => {
@@ -1694,7 +1764,7 @@ op-2,income,20,acc-1,cat-1`;
       expect(lineInserts).toHaveLength(1);
       expect(lineInserts[0][1]).toEqual([
         'line-rec', null, 'Rent', '65000', null,
-        'cat-1', null, 0, 1, 'USD', null, null, null, 'x', 'y',
+        'cat-1', null, 0, 1, 'USD', null, null, null, 1, 'x', 'y',
       ]);
     });
 

--- a/__tests__/services/BudgetPlansDB.status.test.js
+++ b/__tests__/services/BudgetPlansDB.status.test.js
@@ -9,7 +9,7 @@
 
 import * as BudgetPlansDB from '../../app/services/BudgetPlansDB';
 import * as CategoriesDB from '../../app/services/CategoriesDB';
-import { calculateSpendingForBudget } from '../../app/services/BudgetsDB';
+import { calculateSpendingForCategories } from '../../app/services/BudgetsDB';
 import { queryAll, queryFirst } from '../../app/services/db';
 import {
   fetchRatesToTarget,
@@ -24,7 +24,7 @@ jest.mock('../../app/services/CategoriesDB');
 // spending engine — its own behavior is covered by BudgetsDB.convertAll.test.js.
 jest.mock('../../app/services/BudgetsDB', () => ({
   ...jest.requireActual('../../app/services/BudgetsDB'),
-  calculateSpendingForBudget: jest.fn(),
+  calculateSpendingForCategories: jest.fn(),
 }));
 jest.mock('../../app/services/OperationsDB', () => ({
   fetchRatesToTarget: jest.fn(),
@@ -73,7 +73,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
     queryAll.mockResolvedValue([]);
     queryFirst.mockResolvedValue(null);
     CategoriesDB.getAllDescendants.mockResolvedValue([]);
-    calculateSpendingForBudget.mockResolvedValue('0');
+    calculateSpendingForCategories.mockResolvedValue('0');
     getTransferTotals.mockResolvedValue({ incoming: '0', outgoing: '0' });
     getUnconvertibleCurrencies.mockResolvedValue([]);
     stubRates({});
@@ -104,22 +104,55 @@ describe('BudgetPlansDB plan-vs-actual', () => {
 
   describe('calculateLineActual — category lines', () => {
     it('delegates to the shared spending engine including descendants', async () => {
-      calculateSpendingForBudget.mockResolvedValue('123.45');
+      calculateSpendingForCategories.mockResolvedValue('123.45');
 
       const result = await BudgetPlansDB.calculateLineActual(categoryLine(), '2026-07', 'USD', true);
 
       expect(result).toEqual({ broken: false, actual: '123.45' });
-      expect(calculateSpendingForBudget).toHaveBeenCalledWith(
-        'cat1', 'USD', '2026-07-01', '2026-07-31', true, true,
+      expect(calculateSpendingForCategories).toHaveBeenCalledWith(
+        ['cat1'], 'USD', '2026-07-01', '2026-07-31', true, true,
       );
     });
 
     it('passes convertAll=false through so only plan-currency operations count', async () => {
       await BudgetPlansDB.calculateLineActual(categoryLine(), '2026-07', 'USD', false);
 
-      expect(calculateSpendingForBudget).toHaveBeenCalledWith(
-        'cat1', 'USD', '2026-07-01', '2026-07-31', true, false,
+      expect(calculateSpendingForCategories).toHaveBeenCalledWith(
+        ['cat1'], 'USD', '2026-07-01', '2026-07-31', true, false,
       );
+    });
+
+    // Migration 0021.
+    it('sums every category a multi-category line tracks', async () => {
+      calculateSpendingForCategories.mockResolvedValue('700');
+
+      const result = await BudgetPlansDB.calculateLineActual(
+        categoryLine({ categoryId: 'cat1', categoryIds: ['cat1', 'cat2'] }), '2026-07', 'USD', false,
+      );
+
+      expect(result).toEqual({ broken: false, actual: '700' });
+      expect(calculateSpendingForCategories).toHaveBeenCalledWith(
+        ['cat1', 'cat2'], 'USD', '2026-07-01', '2026-07-31', true, false,
+      );
+    });
+
+    it('passes includeChildren=false through so only the picked categories count', async () => {
+      await BudgetPlansDB.calculateLineActual(
+        categoryLine({ categoryIds: ['cat1'], includeChildren: false }), '2026-07', 'USD', false,
+      );
+
+      expect(calculateSpendingForCategories).toHaveBeenCalledWith(
+        ['cat1'], 'USD', '2026-07-01', '2026-07-31', false, false,
+      );
+    });
+
+    it('reports a line whose category set is empty as broken', async () => {
+      const result = await BudgetPlansDB.calculateLineActual(
+        categoryLine({ categoryId: null, categoryIds: [] }), '2026-07', 'USD', false,
+      );
+
+      expect(result).toEqual({ broken: true, actual: '0' });
+      expect(calculateSpendingForCategories).not.toHaveBeenCalled();
     });
   });
 
@@ -175,7 +208,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
       const result = await BudgetPlansDB.calculateLineActual(broken, '2026-07', 'USD', true);
 
       expect(result).toEqual({ broken: true, actual: '0' });
-      expect(calculateSpendingForBudget).not.toHaveBeenCalled();
+      expect(calculateSpendingForCategories).not.toHaveBeenCalled();
       expect(getTransferTotals).not.toHaveBeenCalled();
     });
   });
@@ -289,7 +322,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
       const spendingByCategory = {
         'cat-safe': '50', 'cat-warn': '70', 'cat-danger': '95', 'cat-over': '150',
       };
-      calculateSpendingForBudget.mockImplementation(async (categoryId) => spendingByCategory[categoryId]);
+      calculateSpendingForCategories.mockImplementation(async (categoryIds) => spendingByCategory[categoryIds[0]]);
 
       const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
 
@@ -319,7 +352,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
         ],
         incomeTotal: 0,
       });
-      calculateSpendingForBudget.mockResolvedValue('30');
+      calculateSpendingForCategories.mockResolvedValue('30');
 
       const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
 
@@ -340,7 +373,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
         expenseCurrencies: ['XYZ', 'USD'],
         accountCurrency: 'AMD',
       });
-      calculateSpendingForBudget.mockResolvedValue('0');
+      calculateSpendingForCategories.mockResolvedValue('0');
       getTransferTotals.mockResolvedValue({ incoming: '10', outgoing: '0' });
       stubRates({ AMD: '0.0025' });
       getUnconvertibleCurrencies.mockResolvedValue(['XYZ']);
@@ -375,13 +408,13 @@ describe('BudgetPlansDB plan-vs-actual', () => {
 
     it('defaults the display currency to the plan currency', async () => {
       setupDb({ lines: [lineRow('l1', '100', 'cat1', null, 0)] });
-      calculateSpendingForBudget.mockResolvedValue('10');
+      calculateSpendingForCategories.mockResolvedValue('10');
 
       const status = await BudgetPlansDB.calculatePlanStatus('p1');
 
       expect(status.currency).toBe('USD');
-      expect(calculateSpendingForBudget).toHaveBeenCalledWith(
-        'cat1', 'USD', '2026-07-01', '2026-07-31', true, false,
+      expect(calculateSpendingForCategories).toHaveBeenCalledWith(
+        ['cat1'], 'USD', '2026-07-01', '2026-07-31', true, false,
       );
     });
 
@@ -398,7 +431,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
           recurringLines: [recurringLineRow('l-rec', '50', 'USD', 'cat2', null, 0)],
           incomeTotal: 0,
         });
-        calculateSpendingForBudget.mockResolvedValue('10');
+        calculateSpendingForCategories.mockResolvedValue('10');
 
         const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
 
@@ -411,7 +444,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
           lines: [],
           recurringLines: [recurringLineRow('l-rec', '100', 'AMD', 'cat2', null, 0)],
         });
-        calculateSpendingForBudget.mockResolvedValue('0');
+        calculateSpendingForCategories.mockResolvedValue('0');
         stubRates({ AMD: '0.0025' });
 
         const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
@@ -434,7 +467,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
             recurringLineRow('l-rec-3', '25', 'AMD', 'cat4', null, 2), // duplicate currency
           ],
         });
-        calculateSpendingForBudget.mockResolvedValue('0');
+        calculateSpendingForCategories.mockResolvedValue('0');
         stubRates({ AMD: '0.0025', EUR: '1.1' });
 
         await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
@@ -462,7 +495,7 @@ describe('BudgetPlansDB plan-vs-actual', () => {
 
       it('a one-off line (no currency of its own) is never converted, matching pre-recurring behavior', async () => {
         setupDb({ lines: [lineRow('l1', '100', 'cat1', null, 0)] });
-        calculateSpendingForBudget.mockResolvedValue('10');
+        calculateSpendingForCategories.mockResolvedValue('10');
 
         await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
 

--- a/__tests__/services/BudgetPlansDB.test.js
+++ b/__tests__/services/BudgetPlansDB.test.js
@@ -132,6 +132,49 @@ describe('BudgetPlansDB', () => {
       expect(linked.isBroken).toBe(false);
       expect(linked.categoryId).toBe('cat1');
     });
+
+    // Migration 0021: the junction column travels with every line SELECT.
+    describe('category set (migration 0021)', () => {
+      it('splits the GROUP_CONCAT column into categoryIds', () => {
+        const line = BudgetPlansDB.mapLineFields({
+          id: 'l1', amount: '100', category_id: 'cat1', category_ids: 'cat1,cat2', to_account_id: null,
+        });
+        expect(line.categoryIds).toEqual(['cat1', 'cat2']);
+        expect(line.categoryId).toBe('cat1');
+        expect(line.isBroken).toBe(false);
+      });
+
+      it('falls back to the single category_id when the row has no junction column', () => {
+        const line = BudgetPlansDB.mapLineFields({ id: 'l1', amount: '100', category_id: 'cat1' });
+        expect(line.categoryIds).toEqual(['cat1']);
+      });
+
+      it('re-heads the set when the stored primary category is gone', () => {
+        // ON DELETE SET NULL nulls category_id, but the line still tracks cat2 —
+        // reporting it as broken would silently stop counting real spending.
+        const line = BudgetPlansDB.mapLineFields({
+          id: 'l1', amount: '100', category_id: null, category_ids: 'cat2', to_account_id: null,
+        });
+        expect(line.categoryId).toBe('cat2');
+        expect(line.categoryIds).toEqual(['cat2']);
+        expect(line.isBroken).toBe(false);
+      });
+
+      it('is broken only when the junction is empty and no account is linked', () => {
+        const line = BudgetPlansDB.mapLineFields({
+          id: 'l1', amount: '100', category_id: 'stale-cat', category_ids: null, to_account_id: null,
+        });
+        expect(line.categoryIds).toEqual([]);
+        expect(line.categoryId).toBeNull();
+        expect(line.isBroken).toBe(true);
+      });
+
+      it('reads includeChildren from the column, defaulting to on', () => {
+        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1' }).includeChildren).toBe(true);
+        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1', include_children: 1 }).includeChildren).toBe(true);
+        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1', include_children: 0 }).includeChildren).toBe(false);
+      });
+    });
   });
 
   describe('createPlan', () => {
@@ -281,38 +324,80 @@ describe('BudgetPlansDB', () => {
       ]);
       const lines = await BudgetPlansDB.getPlanLines('p1');
       expect(queryAll).toHaveBeenCalledWith(
-        expect.stringContaining('WHERE plan_id = ? ORDER BY sort_order ASC'),
+        expect.stringContaining('WHERE l.plan_id = ? ORDER BY l.sort_order ASC'),
         ['p1'],
       );
       expect(lines[0].categoryId).toBe('c1');
     });
 
-    it('getBrokenLines queries lines with both targets null', async () => {
+    it('getBrokenLines asks for lines with no linked category and no account', async () => {
       queryAll.mockResolvedValue([
-        { id: 'l1', plan_id: 'p1', amount: '100', category_id: null, to_account_id: null, sort_order: 0 },
+        { id: 'l1', plan_id: 'p1', amount: '100', category_id: null, category_ids: null, to_account_id: null, sort_order: 0 },
       ]);
       const broken = await BudgetPlansDB.getBrokenLines('p1');
-      expect(queryAll).toHaveBeenCalledWith(
-        expect.stringContaining('category_id IS NULL AND to_account_id IS NULL'),
-        ['p1'],
-      );
+      const [sql, params] = queryAll.mock.calls[0];
+      // "No category" is the absence of a junction row, not a null category_id:
+      // a line whose primary category was deleted may still track others.
+      expect(sql).toContain('NOT EXISTS');
+      expect(sql).toContain('budget_plan_line_categories');
+      expect(sql).toContain('l.to_account_id IS NULL');
+      expect(params).toEqual(['p1']);
       expect(broken[0].isBroken).toBe(true);
     });
 
     it('addLine inserts a valid line and returns it', async () => {
       const line = await BudgetPlansDB.addLine('p1', { amount: '73000', categoryId: 'c1', label: 'Rent' });
-      expect(executeQuery).toHaveBeenCalledWith(
+      // Row + category links go in one transaction (migration 0021).
+      expect(mockRunAsync).toHaveBeenNthCalledWith(
+        1,
         expect.stringContaining('INSERT INTO budget_plan_lines'),
         expect.arrayContaining(['p1', 'Rent', '73000', 'c1']),
       );
-      expect(line).toMatchObject({ planId: 'p1', amount: '73000', categoryId: 'c1', toAccountId: null, sortOrder: 0 });
+      expect(mockRunAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT OR IGNORE INTO budget_plan_line_categories'),
+        ['uuid-1', 'c1'],
+      );
+      expect(line).toMatchObject({
+        planId: 'p1', amount: '73000', categoryId: 'c1', categoryIds: ['c1'], toAccountId: null, sortOrder: 0,
+      });
       expect(line.id).toBe('uuid-1');
     });
 
     it('addLine rejects an invalid (dual-target) line', async () => {
       await expect(BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1', toAccountId: 2 }))
         .rejects.toThrow('not both');
-      expect(executeQuery).not.toHaveBeenCalled();
+      expect(mockRunAsync).not.toHaveBeenCalled();
+    });
+
+    // Migration 0021: the whole point — one line, several categories.
+    it('addLine links every category of a multi-category line', async () => {
+      const line = await BudgetPlansDB.addLine('p1', { amount: '500', categoryIds: ['groceries', 'cafes'] });
+      const links = mockRunAsync.mock.calls
+        .filter(([sql]) => sql.includes('budget_plan_line_categories'))
+        .filter(([sql]) => sql.startsWith('INSERT'));
+      expect(links.map(([, params]) => params)).toEqual([
+        ['uuid-1', 'groceries'],
+        ['uuid-1', 'cafes'],
+      ]);
+      // The row's own category_id keeps the primary (first) one.
+      const [, insertParams] = mockRunAsync.mock.calls[0];
+      expect(insertParams).toEqual(expect.arrayContaining(['groceries']));
+      expect(line).toMatchObject({ categoryId: 'groceries', categoryIds: ['groceries', 'cafes'] });
+    });
+
+    it('addLine de-duplicates repeated category IDs', async () => {
+      const line = await BudgetPlansDB.addLine('p1', { amount: '500', categoryIds: ['c1', 'c1', 'c2'] });
+      expect(line.categoryIds).toEqual(['c1', 'c2']);
+    });
+
+    it('addLine defaults includeChildren on and stores the flag', async () => {
+      const rolled = await BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1' });
+      expect(rolled.includeChildren).toBe(true);
+      const flat = await BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1', includeChildren: false });
+      expect(flat.includeChildren).toBe(false);
+      const rowInserts = mockRunAsync.mock.calls.filter(([sql]) => sql.includes('INSERT INTO budget_plan_lines'));
+      expect(rowInserts[1][0]).toContain('include_children');
+      expect(rowInserts[1][1]).toEqual(expect.arrayContaining([0]));
     });
 
     // Bug 10 (adversarial review): addLine/addRecurringLine share one insertPlanLine
@@ -321,7 +406,8 @@ describe('BudgetPlansDB', () => {
     describe('addRecurringLine (shares insertPlanLine with addLine)', () => {
       it('inserts a recurring line with plan_id NULL and is_recurring=1', async () => {
         const line = await BudgetPlansDB.addRecurringLine({ amount: '65000', categoryId: 'cat1', currency: 'EUR', label: 'Rent' });
-        expect(executeQuery).toHaveBeenCalledWith(
+        expect(mockRunAsync).toHaveBeenNthCalledWith(
+          1,
           expect.stringContaining('INSERT INTO budget_plan_lines'),
           expect.arrayContaining([null, 'Rent', '65000', 'cat1', 1, 'EUR']),
         );
@@ -331,13 +417,13 @@ describe('BudgetPlansDB', () => {
       it('requires a currency', async () => {
         await expect(BudgetPlansDB.addRecurringLine({ amount: '100', categoryId: 'c1' }))
           .rejects.toThrow('Currency is required for a recurring allocation');
-        expect(executeQuery).not.toHaveBeenCalled();
+        expect(mockRunAsync).not.toHaveBeenCalled();
       });
 
       it('still enforces the exactly-one-target invariant', async () => {
         await expect(BudgetPlansDB.addRecurringLine({ amount: '100', categoryId: 'c1', toAccountId: 2, currency: 'USD' }))
           .rejects.toThrow('not both');
-        expect(executeQuery).not.toHaveBeenCalled();
+        expect(mockRunAsync).not.toHaveBeenCalled();
       });
     });
 
@@ -346,7 +432,7 @@ describe('BudgetPlansDB', () => {
     // stores what it is given...
     it('addLine keeps a one-off line currency when one is given', async () => {
       const line = await BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1', currency: 'EUR' });
-      const [, params] = executeQuery.mock.calls[0];
+      const [, params] = mockRunAsync.mock.calls[0];
       expect(params).toContain('EUR');
       expect(line).toMatchObject({ isRecurring: false, currency: 'EUR' });
     });
@@ -372,19 +458,66 @@ describe('BudgetPlansDB', () => {
 
     it('updateLine clears the account link when a category is (re)assigned', async () => {
       await BudgetPlansDB.updateLine('l1', { categoryId: 'c9' });
-      const [sql, params] = executeQuery.mock.calls[0];
+      // A category change rewrites the junction, so the UPDATE runs inside the
+      // same transaction as the link rewrite rather than as a bare executeQuery.
+      const [sql, params] = mockRunAsync.mock.calls[0];
       expect(sql).toContain('category_id = ?');
       expect(sql).toContain('to_account_id = ?');
       // c9 written for category, null written for the (implicitly cleared) account.
       expect(params).toEqual(expect.arrayContaining(['c9', null, 'l1']));
+      expect(mockRunAsync).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM budget_plan_line_categories'),
+        ['l1'],
+      );
+      expect(mockRunAsync).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT OR IGNORE INTO budget_plan_line_categories'),
+        ['l1', 'c9'],
+      );
+    });
+
+    it('updateLine replaces the whole category set when given categoryIds', async () => {
+      await BudgetPlansDB.updateLine('l1', { categoryIds: ['a', 'b'] });
+      const links = mockRunAsync.mock.calls.filter(([sql]) => sql.includes('budget_plan_line_categories'));
+      expect(links[0][0]).toContain('DELETE');
+      expect(links.slice(1).map(([, p]) => p)).toEqual([['l1', 'a'], ['l1', 'b']]);
+      // The primary column follows the head of the set.
+      expect(mockRunAsync.mock.calls[0][1]).toEqual(expect.arrayContaining(['a']));
+    });
+
+    it('updateLine unlinks every category when given an empty set', async () => {
+      await BudgetPlansDB.updateLine('l1', { categoryIds: [] });
+      const [sql, params] = mockRunAsync.mock.calls[0];
+      expect(sql).toContain('category_id = ?');
+      expect(params).toEqual(expect.arrayContaining([null, 'l1']));
+      const inserts = mockRunAsync.mock.calls
+        .filter(([s]) => s.includes('INSERT OR IGNORE INTO budget_plan_line_categories'));
+      expect(inserts).toHaveLength(0);
+    });
+
+    it('updateLine leaves the links alone when categories are not mentioned', async () => {
+      await BudgetPlansDB.updateLine('l1', { amount: '200' });
+      expect(executeQuery).toHaveBeenCalled();
+      expect(mockRunAsync).not.toHaveBeenCalled();
+    });
+
+    it('updateLine persists includeChildren', async () => {
+      await BudgetPlansDB.updateLine('l1', { includeChildren: false });
+      const [sql, params] = executeQuery.mock.calls[0];
+      expect(sql).toContain('include_children = ?');
+      expect(params).toEqual(expect.arrayContaining([0, 'l1']));
     });
 
     it('updateLine clears the category link when an account is (re)assigned', async () => {
       await BudgetPlansDB.updateLine('l1', { toAccountId: 7 });
-      const [sql, params] = executeQuery.mock.calls[0];
+      const [sql, params] = mockRunAsync.mock.calls[0];
       expect(sql).toContain('to_account_id = ?');
       expect(sql).toContain('category_id = ?');
       expect(params).toEqual(expect.arrayContaining([7, null, 'l1']));
+      // ...and drops the whole category set, not just the primary column.
+      expect(mockRunAsync).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM budget_plan_line_categories'),
+        ['l1'],
+      );
     });
 
     it('updateLine rejects a non-positive amount', async () => {
@@ -588,20 +721,24 @@ describe('BudgetPlansDB', () => {
         .mockResolvedValueOnce({ id: 'src', month: '2026-06', currency: 'USD', expected_income: '445000' }) // fromMonth
         .mockResolvedValueOnce(null); // toMonth free
       queryAll.mockResolvedValue([
-        { id: 'l1', plan_id: 'src', label: 'Rent', amount: '65000', comment: null, category_id: 'c1', to_account_id: null, sort_order: 0 },
-        { id: 'l2', plan_id: 'src', label: 'Savings', amount: '50000', comment: null, category_id: null, to_account_id: 4, sort_order: 1 },
+        { id: 'l1', plan_id: 'src', label: 'Rent', amount: '65000', comment: null, category_id: 'c1', category_ids: 'c1,c2', to_account_id: null, sort_order: 0 },
+        { id: 'l2', plan_id: 'src', label: 'Savings', amount: '50000', comment: null, category_id: null, category_ids: null, to_account_id: 4, sort_order: 1 },
       ]);
 
       const created = await BudgetPlansDB.copyPlan('2026-06', '2026-07');
 
       expect(created).toMatchObject({ month: '2026-07', currency: 'USD', expectedIncome: '445000' });
-      // 1 plan insert + 2 line inserts.
-      expect(mockRunAsync).toHaveBeenCalledTimes(3);
       expect(mockRunAsync).toHaveBeenNthCalledWith(
         1,
         expect.stringContaining('INSERT INTO budget_plans'),
         expect.arrayContaining(['2026-07', 'USD', '445000']),
       );
+      // A clone tracks the same SET of categories, not just the primary one the
+      // row's column carries.
+      const linkInserts = mockRunAsync.mock.calls
+        .filter(([sql]) => sql.startsWith('INSERT OR IGNORE INTO budget_plan_line_categories'))
+        .map(([, params]) => params[1]);
+      expect(linkInserts).toEqual(['c1', 'c2']);
     });
 
     it('throws when the source month has no plan', async () => {

--- a/__tests__/services/BudgetsDB.convertAll.test.js
+++ b/__tests__/services/BudgetsDB.convertAll.test.js
@@ -189,4 +189,80 @@ describe('BudgetsDB convert-all spending', () => {
       expect(parseFloat(statuses.get('b1').spent)).toBe(2500);
     });
   });
+
+  // Migration 0021: a plan line can track several categories at once.
+  describe('calculateSpendingForCategories (multi-category)', () => {
+    it('sums over every tracked category and their descendants', async () => {
+      CategoriesDB.getAllDescendants.mockImplementation(async (id) => (
+        id === 'groceries' ? [{ id: 'groceries-child' }] : []
+      ));
+      queryFirst.mockResolvedValue({ total: 900 });
+
+      const total = await BudgetsDB.calculateSpendingForCategories(
+        ['groceries', 'cafes'], 'AMD', '2026-07-01', '2026-07-31', true, false,
+      );
+
+      expect(parseFloat(total)).toBe(900);
+      const [sql, params] = queryFirst.mock.calls[0];
+      expect(sql).toContain('o.category_id IN (?,?,?)');
+      expect(params.slice(0, 3)).toEqual(['groceries', 'cafes', 'groceries-child']);
+    });
+
+    it('counts a category once even when it is also a descendant of another', async () => {
+      // Tracking a parent AND its own child: with the roll-up on, the child
+      // would otherwise be listed twice.
+      CategoriesDB.getAllDescendants.mockImplementation(async (id) => (
+        id === 'food' ? [{ id: 'cafes' }] : []
+      ));
+      queryFirst.mockResolvedValue({ total: 100 });
+
+      await BudgetsDB.calculateSpendingForCategories(
+        ['food', 'cafes'], 'AMD', '2026-07-01', '2026-07-31', true, false,
+      );
+
+      const [sql, params] = queryFirst.mock.calls[0];
+      expect(sql).toContain('o.category_id IN (?,?)');
+      expect(params.slice(0, 2)).toEqual(['food', 'cafes']);
+    });
+
+    it('leaves descendants out when the roll-up is switched off', async () => {
+      CategoriesDB.getAllDescendants.mockResolvedValue([{ id: 'child' }]);
+      queryFirst.mockResolvedValue({ total: 50 });
+
+      await BudgetsDB.calculateSpendingForCategories(
+        ['food'], 'AMD', '2026-07-01', '2026-07-31', false, false,
+      );
+
+      expect(CategoriesDB.getAllDescendants).not.toHaveBeenCalled();
+      const [, params] = queryFirst.mock.calls[0];
+      expect(params.slice(0, 1)).toEqual(['food']);
+    });
+
+    it('returns 0 without querying when nothing is tracked', async () => {
+      // An empty IN () is a SQL syntax error, so the empty set must short-circuit
+      // — this is the state of a line whose every category was deleted.
+      expect(await BudgetsDB.calculateSpendingForCategories(
+        [], 'AMD', '2026-07-01', '2026-07-31', true, false,
+      )).toBe('0');
+      expect(await BudgetsDB.calculateSpendingForCategories(
+        [null, undefined, ''], 'AMD', '2026-07-01', '2026-07-31', true, true,
+      )).toBe('0');
+      expect(queryFirst).not.toHaveBeenCalled();
+      expect(queryAll).not.toHaveBeenCalled();
+    });
+
+    it('converts across currencies for a multi-category set too', async () => {
+      stubRates({ RUB: '5' });
+      queryAll.mockResolvedValue([
+        { currency: 'AMD', total: 1000 },
+        { currency: 'RUB', total: 200 },
+      ]);
+
+      const total = await BudgetsDB.calculateSpendingForCategories(
+        ['a', 'b'], 'AMD', '2026-07-01', '2026-07-31', false, true,
+      );
+
+      expect(parseFloat(total)).toBe(2000);
+    });
+  });
 });

--- a/__tests__/services/GoogleSheetsService.test.js
+++ b/__tests__/services/GoogleSheetsService.test.js
@@ -636,7 +636,7 @@ describe('GoogleSheetsService', () => {
       const sheets = buildSheetsData(mockBackup);
       const lines = sheets.find(s => s.range === 'Budget Plan Lines!A1');
       const header = lines.values[0];
-      expect(header).toEqual(['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month']);
+      expect(header).toEqual(['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month', 'categories', 'category_ids', 'include_children']);
 
       const catRow = lines.values.find(r => r[0] === 'line-cat');
       expect(catRow[header.indexOf('category')]).toBe('Food');
@@ -656,6 +656,43 @@ describe('GoogleSheetsService', () => {
       expect(recRow[header.indexOf('plan_id')]).toBe('');
       expect(recRow[header.indexOf('is_recurring')]).toBe(1);
       expect(recRow[header.indexOf('currency')]).toBe('USD');
+
+      // No junction in this backup (pre-0021 shape), so the set falls back to
+      // the line's own category and the roll-up flag reads as on.
+      expect(catRow[header.indexOf('category_ids')]).toBe('cat-1');
+      expect(catRow[header.indexOf('categories')]).toBe('Food');
+      expect(catRow[header.indexOf('include_children')]).toBe(1);
+      expect(xferRow[header.indexOf('category_ids')]).toBe('');
+    });
+
+    // Migration 0021: the sheet carries the whole set, semicolon-joined.
+    it('writes every category of a multi-category line into the sheet', () => {
+      const backup = {
+        ...mockBackup,
+        data: {
+          ...mockBackup.data,
+          categories: [
+            { id: 'cat-1', name: 'Food', type: 'entry', category_type: 'expense' },
+            { id: 'cat-2', name: 'Cafes', type: 'entry', category_type: 'expense' },
+          ],
+          budget_plan_line_categories: [
+            { line_id: 'line-cat', category_id: 'cat-1' },
+            { line_id: 'line-cat', category_id: 'cat-2' },
+          ],
+          budget_plan_lines: [
+            { ...mockBackup.data.budget_plan_lines[0], include_children: 0 },
+          ],
+        },
+      };
+      const sheets = buildSheetsData(backup);
+      const lines = sheets.find(s => s.range === 'Budget Plan Lines!A1');
+      const header = lines.values[0];
+      const row = lines.values.find(r => r[0] === 'line-cat');
+      expect(row[header.indexOf('category_ids')]).toBe('cat-1;cat-2');
+      expect(row[header.indexOf('categories')]).toBe('Food;Cafes');
+      expect(row[header.indexOf('include_children')]).toBe(0);
+      // The single-category columns still name the primary one.
+      expect(row[header.indexOf('category_id')]).toBe('cat-1');
     });
 
     it('tolerates a backup that lacks budget plan data (empty sheets)', () => {
@@ -733,6 +770,62 @@ describe('GoogleSheetsService', () => {
       expect(rec.plan_id).toBeNull();
       expect(rec.is_recurring).toBe(1);
       expect(rec.currency).toBe('USD');
+
+      // A sheet with no category_ids column (this one) still yields one link per
+      // category-tracking line, rebuilt from the single category it names.
+      expect(backup.data.budget_plan_line_categories).toEqual([
+        { line_id: 'line-cat', category_id: 'cat-1' },
+        { line_id: 'line-rec', category_id: 'cat-1' },
+      ]);
+      // ...and include_children defaults to on for such a sheet.
+      expect(cat.include_children).toBe(1);
+    });
+
+    // Migration 0021.
+    it('reads a multi-category line from category_ids, or from the names column', async () => {
+      getPreference.mockResolvedValue('sheet-id-123');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          valueRanges: [
+            { range: 'Accounts!A1:D2', values: [['id', 'name', 'balance', 'currency'], ['1', 'Savings', '0', 'USD']] },
+            {
+              range: 'Categories!A1:B3',
+              values: [
+                ['id', 'name', 'type', 'category_type', 'icon', 'parent_id', 'color', 'is_shadow'],
+                ['cat-1', 'Food', 'entry', 'expense', 'food', '', '', '0'],
+                ['cat-2', 'Cafes', 'entry', 'expense', 'cup', '', '', '0'],
+              ],
+            },
+            { range: 'Budget Plans!A1:D2', values: [['id', 'month', 'currency', 'expected_income'], ['plan-1', '2026-07', 'USD', '3000.00']] },
+            {
+              range: 'Budget Plan Lines!A1:S3',
+              values: [
+                ['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month', 'categories', 'category_ids', 'include_children'],
+                ['line-ids', 'plan-1', 'Eating', '400', '', 'Food', '', 'cat-1', '', '0', '0', '', '', '', '', '', '', 'cat-1;cat-2', '0'],
+                // Hand-edited row: names typed into `categories`, no IDs.
+                ['line-names', 'plan-1', 'Eating too', '300', '', '', '', '', '', '1', '0', '', '', '', '', '', 'Food;Cafes', '', ''],
+              ],
+            },
+          ],
+        }),
+      });
+
+      const backup = await importFromSheets('token');
+
+      expect(backup.data.budget_plan_line_categories).toEqual([
+        { line_id: 'line-ids', category_id: 'cat-1' },
+        { line_id: 'line-ids', category_id: 'cat-2' },
+        { line_id: 'line-names', category_id: 'cat-1' },
+        { line_id: 'line-names', category_id: 'cat-2' },
+      ]);
+
+      const byIds = backup.data.budget_plan_lines.find(l => l.id === 'line-ids');
+      expect(byIds.include_children).toBe(0);
+      // The primary column follows the head of the set, so the two can't disagree.
+      const byNames = backup.data.budget_plan_lines.find(l => l.id === 'line-names');
+      expect(byNames.category_id).toBe('cat-1');
+      expect(byNames.include_children).toBe(1);
     });
 
     it('returns empty plan arrays when the sheets are missing (old spreadsheet)', async () => {

--- a/__tests__/services/db.fastpath.test.js
+++ b/__tests__/services/db.fastpath.test.js
@@ -52,7 +52,7 @@ const COMPLETE_TABLES = [
   'accounts', 'categories', 'operations', 'budgets', 'app_metadata',
   'accounts_balance_history', 'planned_operations',
   'notification_merchant_rules', 'pending_notifications',
-  'budget_plans', 'budget_plan_lines',
+  'budget_plans', 'budget_plan_lines', 'budget_plan_line_categories',
 ];
 const mockSchemaComplete = (db, storedUserVersion) => {
   db.getFirstAsync.mockImplementation((q) => {
@@ -95,6 +95,7 @@ const mockSchemaComplete = (db, storedUserVersion) => {
         { name: 'is_recurring', type: 'INTEGER' }, { name: 'currency', type: 'TEXT' },
         { name: 'kind', type: 'TEXT' }, { name: 'account_id', type: 'INTEGER' },
         { name: 'last_executed_month', type: 'TEXT' },
+        { name: 'include_children', type: 'INTEGER' },
       ]);
     }
     return Promise.resolve([]);

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -33,12 +33,15 @@ const KINDS = ['income', 'expense', 'transfer'];
  * SAME modal — never a nested Modal.
  *
  * `kind` decides what the line means and what an execution would create:
- *   - expense  → tracks spending of ONE expense category (required),
+ *   - expense  → tracks spending across ONE OR MORE expense categories (at least
+ *     one required); the picker toggles them, and `includeChildren` says whether
+ *     their descendants roll up too (migration 0021),
  *   - transfer → tracks incoming transfers into ONE destination account (required),
- *   - income   → declares part of the month's expected income; a category is
+ *   - income   → declares part of the month's expected income; categories are
  *     optional context (income is compared against the month's real income as a
  *     whole, see BudgetPlansDB.calculateLineActual).
- * That "exactly one target" invariant is enforced here and again in BudgetPlansDB.
+ * A line links to categories OR an account, never both — enforced here and again
+ * in BudgetPlansDB.
  *
  * Picking an EXECUTION ACCOUNT turns the line into a one-tap payable (the former
  * planned operation): the account is what the created operation touches, so the
@@ -73,10 +76,14 @@ export default function BudgetPlanLineModal({
   const [amount, setAmount] = useState('');
   const [label, setLabel] = useState('');
   const [comment, setComment] = useState('');
-  // Exactly one of these is set for expense/transfer (the "exactly one target"
-  // invariant); an income line may have neither.
-  const [categoryId, setCategoryId] = useState(null);
+  // A line tracks EITHER categories OR a destination account (the "exactly one
+  // kind of target" invariant); an income line may have neither. Since migration
+  // 0021 the category side is a SET — several categories can share one budget.
+  const [categoryIds, setCategoryIds] = useState([]);
   const [toAccountId, setToAccountId] = useState(null);
+  // Whether descendants of the picked categories count too. On by default, which
+  // is what every line did before the flag existed.
+  const [includeChildren, setIncludeChildren] = useState(true);
   // Execution account — set means "this line is executable".
   const [accountId, setAccountId] = useState(null);
   const [isRecurring, setIsRecurring] = useState(false);
@@ -131,7 +138,9 @@ export default function BudgetPlanLineModal({
       setAmount(line.amount != null ? String(line.amount) : '');
       setLabel(line.label || '');
       setComment(line.comment || '');
-      setCategoryId(line.categoryId ?? null);
+      // Older callers (and stored lines read before 0021) only carry categoryId.
+      setCategoryIds(line.categoryIds ?? (line.categoryId != null ? [line.categoryId] : []));
+      setIncludeChildren(line.includeChildren !== false);
       setToAccountId(line.toAccountId ?? null);
       setAccountId(line.accountId ?? null);
       setIsRecurring(!!line.isRecurring);
@@ -141,7 +150,8 @@ export default function BudgetPlanLineModal({
       setAmount('');
       setLabel('');
       setComment('');
-      setCategoryId(null);
+      setCategoryIds([]);
+      setIncludeChildren(true);
       setToAccountId(null);
       setAccountId(null);
       setIsRecurring(false);
@@ -207,11 +217,16 @@ export default function BudgetPlanLineModal({
     setKind(next);
     setError(null);
     if (next === 'transfer') {
-      setCategoryId(null);
+      setCategoryIds([]);
     } else {
       setToAccountId(null);
-      if (next === 'income') setCategoryId(prev => (incomeCategories.some(c => c.id === prev) ? prev : null));
-      else setCategoryId(prev => (expenseCategories.some(c => c.id === prev) ? prev : null));
+      // Keep whichever of the picked categories still belong to the new kind's
+      // list — switching expense↔income shares no categories, so this usually
+      // empties the set, but it never silently keeps an income category on an
+      // expense line.
+      const allowed = next === 'income' ? incomeCategories : expenseCategories;
+      const allowedIds = new Set(allowed.map(c => c.id));
+      setCategoryIds(prev => prev.filter(id => allowedIds.has(id)));
     }
   }, [incomeCategories, expenseCategories]);
 
@@ -219,17 +234,21 @@ export default function BudgetPlanLineModal({
   // other: a line tracking a destination account IS a transfer, and one tracking
   // a category is not (income keeps its kind — an income line may carry an income
   // category for context).
-  const handleSelectCategory = useCallback((cat) => {
-    setCategoryId(cat.id);
+  // Categories toggle rather than replace, and the panel STAYS OPEN — picking a
+  // set of them is the point, and closing on the first tap would make adding a
+  // second category a four-tap round trip. "Done" (or back) closes it.
+  const handleToggleCategory = useCallback((cat) => {
     setToAccountId(null);
     setKind(prev => (prev === 'transfer' ? 'expense' : prev));
     setError(null);
-    closeSubPanel();
-  }, [closeSubPanel]);
+    setCategoryIds(prev => (
+      prev.includes(cat.id) ? prev.filter(id => id !== cat.id) : [...prev, cat.id]
+    ));
+  }, []);
 
   const handleSelectTransferTarget = useCallback((acc) => {
     setToAccountId(acc.id);
-    setCategoryId(null);
+    setCategoryIds([]);
     setKind('transfer');
     setError(null);
     closeSubPanel();
@@ -265,7 +284,7 @@ export default function BudgetPlanLineModal({
     // line of defense against a tap that lands before the disabled style commits.
     if (saving) return;
     Keyboard.dismiss();
-    if (kind === 'expense' && categoryId == null) {
+    if (kind === 'expense' && categoryIds.length === 0) {
       setError(t('allocation_needs_target'));
       return;
     }
@@ -290,16 +309,17 @@ export default function BudgetPlanLineModal({
       amount: String(amount),
       label: label.trim() || null,
       comment: comment.trim() || null,
-      categoryId: kind === 'transfer' ? null : (categoryId ?? null),
+      categoryIds: kind === 'transfer' ? [] : categoryIds,
       toAccountId: kind === 'transfer' ? (toAccountId ?? null) : null,
       accountId: accountId ?? null,
       isRecurring,
+      includeChildren,
       // An executable line is priced in its account's currency; a template-less
       // one-off line inherits the plan's (null).
       currency: effectiveCurrency,
     });
-  }, [saving, kind, amount, amountIsParseable, amountIsPositive, label, comment, categoryId, toAccountId, accountId,
-    isRecurring, effectiveCurrency, onSaveLine, t]);
+  }, [saving, kind, amount, amountIsParseable, amountIsPositive, label, comment, categoryIds, toAccountId, accountId,
+    isRecurring, includeChildren, effectiveCurrency, onSaveLine, t]);
 
   const handleDelete = useCallback(() => {
     if (!isEditingLine) return;
@@ -325,18 +345,24 @@ export default function BudgetPlanLineModal({
     }
   }, [activeSubPanel, closeSubPanel, onClose]);
 
-  // Selected-target summary for the picker row on the main form.
+  // Selected-target summary for the picker row on the main form. With several
+  // categories the row names the first and counts the rest ("Groceries +2") —
+  // spelling them all out would wrap the row for any realistic set.
   const targetSummary = useMemo(() => {
-    if (kind !== 'transfer' && categoryId != null) {
-      const cat = categoriesById.get(categoryId);
-      return { icon: cat?.icon || 'shape-outline', name: cat?.name || t('allocation_unlinked') };
+    if (kind !== 'transfer' && categoryIds.length > 0) {
+      const names = categoryIds.map(id => categoriesById.get(id)?.name || t('allocation_unlinked'));
+      const first = categoriesById.get(categoryIds[0]);
+      return {
+        icon: first?.icon || 'shape-outline',
+        name: names.length > 1 ? `${names[0]} +${names.length - 1}` : names[0],
+      };
     }
     if (kind === 'transfer' && toAccountId != null) {
       const acc = accountsById.get(toAccountId);
       return { icon: 'bank-transfer', name: acc?.name || t('allocation_unlinked') };
     }
     return null;
-  }, [kind, categoryId, toAccountId, categoriesById, accountsById, t]);
+  }, [kind, categoryIds, toAccountId, categoriesById, accountsById, t]);
 
   const executionAccount = accountId != null ? accountsById.get(accountId) : null;
 
@@ -347,25 +373,31 @@ export default function BudgetPlanLineModal({
 
   const renderTargetItem = useCallback(({ item }) => {
     const isCat = pickerKind === 'category';
-    const selected = isCat ? categoryId === item.id : toAccountId === item.id;
+    const selected = isCat ? categoryIds.includes(item.id) : toAccountId === item.id;
     return (
       <Pressable
-        onPress={() => (isCat ? handleSelectCategory(item) : handleSelectTransferTarget(item))}
+        onPress={() => (isCat ? handleToggleCategory(item) : handleSelectTransferTarget(item))}
         style={({ pressed }) => [
           styles.pickerOption,
           { borderColor: colors.border },
           pressed && { backgroundColor: colors.selected },
           selected && { backgroundColor: colors.selected },
         ]}
-        accessibilityRole="button"
+        // A category toggles in and out of the set; an account replaces the
+        // target outright, so they get different a11y roles.
+        accessibilityRole={isCat ? 'checkbox' : 'button'}
+        accessibilityState={isCat ? { checked: selected } : { selected }}
         accessibilityLabel={item.name}
         testID={`plan-target-option-${isCat ? 'cat' : 'acc'}-${item.id}`}
       >
         <Icon name={isCat ? (item.icon || 'shape-outline') : 'bank-transfer'} size={22} color={colors.text} />
         <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
+        {isCat && selected && (
+          <Icon name="check" size={20} color={colors.primary} />
+        )}
       </Pressable>
     );
-  }, [pickerKind, categoryId, toAccountId, colors, handleSelectCategory, handleSelectTransferTarget]);
+  }, [pickerKind, categoryIds, toAccountId, colors, handleToggleCategory, handleSelectTransferTarget]);
 
   const renderExecutionAccountItem = useCallback(({ item }) => (
     <Pressable
@@ -470,6 +502,46 @@ export default function BudgetPlanLineModal({
                       <Icon name="chevron-right" size={20} color={colors.mutedText} />
                     </Pressable>
                   </View>
+
+                  {/* Roll-up toggle. Only an expense line has a per-category
+                      actual to roll up: a transfer line tracks an account, and an
+                      income line is compared against the month's total income
+                      rather than per-category spending. */}
+                  {kind === 'expense' && categoryIds.length > 0 && (
+                    <View style={styles.field}>
+                      <Pressable
+                        style={[styles.recurringRow, styles.noBottomMargin, { borderColor: colors.border }]}
+                        onPress={() => setIncludeChildren(v => !v)}
+                        accessibilityRole="switch"
+                        accessibilityState={{ checked: includeChildren }}
+                        accessibilityLabel={t('include_subcategories')}
+                        testID="plan-line-include-children-toggle"
+                      >
+                        <View style={styles.recurringLabel}>
+                          <Icon name="file-tree-outline" size={20} color={colors.text} />
+                          <Text style={[styles.text16, { color: colors.text }]}>
+                            {t('include_subcategories')}
+                          </Text>
+                        </View>
+                        <View
+                          style={[
+                            styles.switchTrack,
+                            { backgroundColor: includeChildren ? colors.primary : colors.border },
+                          ]}
+                        >
+                          <View
+                            style={[
+                              styles.switchThumb,
+                              { transform: [{ translateX: includeChildren ? 18 : 2 }] },
+                            ]}
+                          />
+                        </View>
+                      </Pressable>
+                      <Text style={[styles.fieldHint, { color: colors.mutedText }]}>
+                        {t('include_subcategories_hint')}
+                      </Text>
+                    </View>
+                  )}
 
                   {/* Execution account — set one and the line becomes a one-tap
                       payable (the former planned operation). */}
@@ -676,6 +748,22 @@ export default function BudgetPlanLineModal({
                       <Icon name="arrow-left" size={24} color={colors.text} />
                     </Pressable>
                     <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('select_target')}</Text>
+                    {/* Categories toggle in place instead of closing the panel,
+                        so there has to be something that says "I'm finished
+                        picking". The account tab needs none — one tap there is
+                        the whole selection. */}
+                    {pickerKind === 'category' && (
+                      <Pressable
+                        onPress={closeSubPanel}
+                        style={styles.subPanelDone}
+                        hitSlop={8}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('done')}
+                        testID="plan-target-done"
+                      >
+                        <Text style={[styles.subPanelDoneText, { color: colors.primary }]}>{t('done')}</Text>
+                      </Pressable>
+                    )}
                   </View>
 
                   {/* Two-mode toggle: category OR destination account. An income
@@ -802,6 +890,8 @@ BudgetPlanLineModal.propTypes = {
     label: PropTypes.string,
     comment: PropTypes.string,
     categoryId: PropTypes.string,
+    categoryIds: PropTypes.arrayOf(PropTypes.string),
+    includeChildren: PropTypes.bool,
     toAccountId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     accountId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     kind: PropTypes.oneOf(KINDS),
@@ -911,6 +1001,9 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
   },
+  noBottomMargin: {
+    marginBottom: 0,
+  },
   optionText: {
     flex: 1,
     fontSize: 16,
@@ -969,6 +1062,14 @@ const styles = StyleSheet.create({
   subPanelBack: {
     marginRight: 8,
     padding: 4,
+  },
+  subPanelDone: {
+    marginLeft: 'auto',
+    paddingHorizontal: 4,
+  },
+  subPanelDoneText: {
+    fontSize: 16,
+    fontWeight: '600',
   },
   subPanelHeader: {
     alignItems: 'center',

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -397,7 +397,14 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   // usable title on its own. Hoisted above the handlers that consume it.
   const lineDisplayName = useCallback((line) => {
     if (line.label) return line.label;
-    if (line.categoryId != null) return categoriesById.get(line.categoryId)?.name || t('allocation_unlinked');
+    const categoryIds = line.categoryIds ?? (line.categoryId != null ? [line.categoryId] : []);
+    if (categoryIds.length > 0) {
+      const first = categoriesById.get(categoryIds[0])?.name || t('allocation_unlinked');
+      // A multi-category line names its first category and counts the rest, the
+      // same shorthand the editor's target row uses. The label field is right
+      // there for anyone who wants "Eating out" instead of "Groceries +2".
+      return categoryIds.length > 1 ? `${first} +${categoryIds.length - 1}` : first;
+    }
     if (line.toAccountId != null) return accountsById.get(line.toAccountId)?.name || t('allocation_unlinked');
     if (line.kind === 'income') return t('expected_income');
     return t('allocation_unlinked');

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index, unique } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, index, unique, primaryKey } from 'drizzle-orm/sqlite-core';
 
 /**
  * App metadata table for tracking database version and migration status
@@ -314,6 +314,12 @@ export const budgetPlanLines = sqliteTable('budget_plan_lines', {
   label: text('label'),
   amount: text('amount').notNull(),
   comment: text('comment'),
+  // The line's PRIMARY category. Since migration 0021 a line can track several
+  // categories and budget_plan_line_categories is the source of truth — this
+  // column is the denormalized first entry, kept for the CSV/backup shape and
+  // still written on every insert/update. Readers use the junction (see
+  // BudgetPlansDB.mapLineFields), which is why an ON DELETE SET NULL here cannot
+  // silently unlink a line that still tracks other categories.
   categoryId: text('category_id').references(() => categories.id, { onDelete: 'set null' }),
   toAccountId: integer('to_account_id').references(() => accounts.id, { onDelete: 'set null' }),
   sortOrder: integer('sort_order').notNull().default(0),
@@ -335,10 +341,38 @@ export const budgetPlanLines = sqliteTable('budget_plan_lines', {
   // YYYY-MM of the last execution (or manual "mark as done"), like the old
   // planned_operations.last_executed_month.
   lastExecutedMonth: text('last_executed_month'),
+  // 1 (default) = descendant categories roll up into this line's actual, which is
+  // what every pre-0021 line did implicitly; 0 = only the categories explicitly
+  // linked in budget_plan_line_categories count. Migration 0021.
+  includeChildren: integer('include_children').notNull().default(1),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => ({
   planIdx: index('idx_budget_plan_lines_plan').on(table.planId),
   recurringIdx: index('idx_budget_plan_lines_recurring').on(table.isRecurring),
   kindIdx: index('idx_budget_plan_lines_kind').on(table.kind),
+}));
+
+/**
+ * Budget Plan Line ↔ Categories junction (migration 0021)
+ *
+ * The set of expense categories a plan line tracks. Replaces the single
+ * `budget_plan_lines.category_id` as the source of truth, so a line can budget
+ * several sibling categories at once (e.g. Groceries + Cafes) instead of forcing
+ * the user to pick their common parent and swallow every other child with it.
+ *
+ * Both FKs cascade: deleting the line drops its links, and deleting a category
+ * merely SHRINKS the line's set. A line whose set becomes empty (and which has no
+ * transfer target) reads as "broken", the same state a nulled `category_id`
+ * produced before — see BudgetPlansDB.mapLineFields.
+ *
+ * Whether descendants of these categories also count is the line's
+ * `include_children` flag, not a property of the link.
+ */
+export const budgetPlanLineCategories = sqliteTable('budget_plan_line_categories', {
+  lineId: text('line_id').notNull().references(() => budgetPlanLines.id, { onDelete: 'cascade' }),
+  categoryId: text('category_id').notNull().references(() => categories.id, { onDelete: 'cascade' }),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.lineId, table.categoryId] }),
+  categoryIdx: index('idx_budget_plan_line_categories_category').on(table.categoryId),
 }));

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -30,7 +30,7 @@ export const createBackup = async () => {
     console.log('Creating database backup...');
 
     // Fetch all data from all tables
-    const [accounts, categories, operations, budgets, appMetadata, balanceHistory, plannedOperations, merchantRules, budgetPlans, budgetPlanLines] = await Promise.all([
+    const [accounts, categories, operations, budgets, appMetadata, balanceHistory, plannedOperations, merchantRules, budgetPlans, budgetPlanLines, budgetPlanLineCategories] = await Promise.all([
       queryAll('SELECT * FROM accounts ORDER BY created_at ASC'),
       queryAll('SELECT * FROM categories ORDER BY created_at ASC'),
       queryAll('SELECT * FROM operations ORDER BY created_at ASC'),
@@ -44,6 +44,10 @@ export const createBackup = async () => {
       // don't fail. Plans before lines so the FK order is preserved on restore.
       queryAll('SELECT * FROM budget_plans ORDER BY created_at ASC').catch(() => []),
       queryAll('SELECT * FROM budget_plan_lines ORDER BY sort_order ASC, created_at ASC').catch(() => []),
+      // Multi-category plan lines (migration 0021). Guarded like the tables above
+      // so a backup of a pre-0021 database still succeeds — restore rebuilds the
+      // links from each line's category_id when this section is absent.
+      queryAll('SELECT * FROM budget_plan_line_categories ORDER BY line_id ASC, category_id ASC').catch(() => []),
     ]);
 
     // Create backup object
@@ -65,6 +69,7 @@ export const createBackup = async () => {
         // Budgets v2 monthly plans and their allocation lines.
         budget_plans: budgetPlans || [],
         budget_plan_lines: budgetPlanLines || [],
+        budget_plan_line_categories: budgetPlanLineCategories || [],
       },
     };
 
@@ -77,6 +82,7 @@ export const createBackup = async () => {
       planned_operations: backup.data.planned_operations.length,
       budget_plans: backup.data.budget_plans.length,
       budget_plan_lines: backup.data.budget_plan_lines.length,
+      budget_plan_line_categories: backup.data.budget_plan_line_categories.length,
     });
 
     return backup;
@@ -100,7 +106,12 @@ const TABLE_FIELDS = {
   budget_plans: ['id', 'month', 'currency', 'expected_income', 'created_at', 'updated_at'],
   // `plan_id` is nullable (NULL for a recurring/global line, migration 0019).
   // `is_recurring` / `currency` were added by that same migration.
-  budget_plan_lines: ['id', 'plan_id', 'label', 'amount', 'comment', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'account_id', 'last_executed_month', 'created_at', 'updated_at'],
+  // `include_children` (migration 0021) says whether descendants of the linked
+  // categories roll up into the line's actual.
+  budget_plan_lines: ['id', 'plan_id', 'label', 'amount', 'comment', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'account_id', 'last_executed_month', 'include_children', 'created_at', 'updated_at'],
+  // The full category set of each line (migration 0021); `category_id` above is
+  // only its primary entry.
+  budget_plan_line_categories: ['line_id', 'category_id'],
 };
 
 /**
@@ -159,6 +170,7 @@ export const exportBackupCSV = async () => {
       'planned_operations.csv': convertToCSV(backup.data.planned_operations, TABLE_FIELDS.planned_operations),
       'budget_plans.csv': convertToCSV(backup.data.budget_plans, TABLE_FIELDS.budget_plans),
       'budget_plan_lines.csv': convertToCSV(backup.data.budget_plan_lines, TABLE_FIELDS.budget_plan_lines),
+      'budget_plan_line_categories.csv': convertToCSV(backup.data.budget_plan_line_categories, TABLE_FIELDS.budget_plan_line_categories),
       'backup_info.csv': `version,timestamp,platform\n${backup.version},${backup.timestamp},${backup.platform}`,
     };
 
@@ -175,7 +187,8 @@ export const exportBackupCSV = async () => {
     combinedCSV += `[BALANCE_HISTORY]\n${csvFiles['balance_history.csv']}\n\n`;
     combinedCSV += `[PLANNED_OPERATIONS]\n${csvFiles['planned_operations.csv']}\n\n`;
     combinedCSV += `[BUDGET_PLANS]\n${csvFiles['budget_plans.csv']}\n\n`;
-    combinedCSV += `[BUDGET_PLAN_LINES]\n${csvFiles['budget_plan_lines.csv']}\n`;
+    combinedCSV += `[BUDGET_PLAN_LINES]\n${csvFiles['budget_plan_lines.csv']}\n\n`;
+    combinedCSV += `[BUDGET_PLAN_LINE_CATEGORIES]\n${csvFiles['budget_plan_line_categories.csv']}\n`;
 
     const filename = `money_tracker_backup_${timestamp}.csv`;
     const fileUri = `${FileSystem.documentDirectory}${filename}`;
@@ -503,6 +516,10 @@ export const restoreBackup = async (backup, cancelToken) => {
       // Budgets v2: lines reference plans (cascade), categories and accounts (set
       // null), so clear lines before plans, and both before categories/accounts.
       // Guarded so a restore into a pre-0018 database doesn't fail.
+      // The junction cascades off both lines and categories, but clear it first
+      // and explicitly — relying on a cascade would leave stale links behind on
+      // any build where foreign_keys happens to be off.
+      await db.runAsync('DELETE FROM budget_plan_line_categories').catch(() => {});
       await db.runAsync('DELETE FROM budget_plan_lines').catch(() => {});
       await db.runAsync('DELETE FROM budget_plans').catch(() => {});
       await db.runAsync('DELETE FROM accounts_balance_history');
@@ -606,6 +623,10 @@ export const restoreBackup = async (backup, cancelToken) => {
         status: 'in_progress',
         data: backup.data.categories.length,
       });
+      // Which categories actually landed — plan-line category links (migration
+      // 0021) reference them through a NOT NULL FK, so a link to a category that
+      // was skipped here has to be dropped rather than abort the restore.
+      const restoredCategoryIds = new Set();
       for (const category of backup.data.categories) {
         // Validate required fields
         if (!category.id || !category.name) {
@@ -630,6 +651,7 @@ export const restoreBackup = async (backup, cancelToken) => {
             category.updated_at || new Date().toISOString(),
           ],
         );
+        restoredCategoryIds.add(category.id);
       }
       console.log(`Restored ${backup.data.categories.length} categories`);
       appEvents.emit(IMPORT_PROGRESS_EVENT, {
@@ -852,6 +874,9 @@ export const restoreBackup = async (backup, cancelToken) => {
         // orphaned line (dangling plan_id) is skipped rather than aborting the
         // whole import on an FK violation. A recurring (global) line has no
         // plan_id at all (migration 0019) and is restored regardless of `plans`.
+        // Same idea as restoredPlanIds, one level down: only a line that really
+        // made it into the table may be given category links.
+        const restoredLineIds = new Set();
         let restoredLines = 0;
         for (const line of lines) {
           // amount is a NOT NULL text column; treat null/empty as invalid and
@@ -885,7 +910,7 @@ export const restoreBackup = async (backup, cancelToken) => {
             mappedAccountId = accountIdMapping.get(String(line.account_id)) ?? null;
           }
           await db.runAsync(
-            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
               line.id,
               isRecurring ? null : line.plan_id,
@@ -903,13 +928,53 @@ export const restoreBackup = async (backup, cancelToken) => {
               VALID_OPERATION_TYPES.includes(line.kind) ? line.kind : null,
               mappedAccountId,
               line.last_executed_month || null,
+              // Absent on every pre-0021 backup, where descendants always rolled
+              // up — so absent restores as 1, not 0. A CSV backup yields '' for a
+              // missing column and `Number('')` is 0, so the blank case has to be
+              // caught before any numeric comparison.
+              (line.include_children === '' || line.include_children == null)
+                ? 1
+                : (Number(line.include_children) === 0 ? 0 : 1),
               line.created_at || new Date().toISOString(),
               line.updated_at || new Date().toISOString(),
             ],
           );
+          restoredLineIds.add(line.id);
           restoredLines++;
         }
-        console.log(`Restored ${restoredPlans} budget plans and ${restoredLines} plan lines`);
+
+        // Category links (migration 0021). A backup that carries the junction is
+        // restored from it; an older one has only each line's single category_id,
+        // so the links are rebuilt from that — without this, every line restored
+        // from a pre-0021 backup would read as broken and track nothing.
+        const backedUpLinks = backup.data.budget_plan_line_categories || [];
+        const linkRows = backedUpLinks.length > 0
+          ? backedUpLinks.map(link => ({ lineId: link.line_id, categoryId: link.category_id }))
+          : lines
+            .filter(line => restoredLineIds.has(line.id) && line.category_id)
+            .map(line => ({ lineId: line.id, categoryId: line.category_id }));
+
+        let restoredLinks = 0;
+        for (const { lineId, categoryId } of linkRows) {
+          // Skip a link whose line was skipped above or whose category the backup
+          // doesn't contain: the FKs are NOT NULL here, so an unknown reference
+          // would abort the entire restore rather than lose one link.
+          if (!lineId || !categoryId) continue;
+          if (!restoredLineIds.has(lineId)) {
+            console.warn('Skipping plan line category link for an unknown line:', lineId);
+            continue;
+          }
+          if (!restoredCategoryIds.has(categoryId)) {
+            console.warn('Skipping plan line category link for an unknown category:', categoryId);
+            continue;
+          }
+          await db.runAsync(
+            'INSERT OR IGNORE INTO budget_plan_line_categories (line_id, category_id) VALUES (?, ?)',
+            [lineId, categoryId],
+          );
+          restoredLinks++;
+        }
+        console.log(`Restored ${restoredPlans} budget plans, ${restoredLines} plan lines and ${restoredLinks} category links`);
         appEvents.emit(IMPORT_PROGRESS_EVENT, {
           stepId: 'budget_plans',
           status: 'completed',
@@ -1253,11 +1318,12 @@ const importBackupCSV = async (fileUri, cancelToken) => {
     planned_operations: [],
     budget_plans: [],
     budget_plan_lines: [],
+    budget_plan_line_categories: [],
   };
 
-  // Split by section markers. [BUDGET_PLANS] and [BUDGET_PLAN_LINES] don't
-  // collide: the marker + newline (`[BUDGET_PLANS]\n`) is not a substring of
-  // `[BUDGET_PLAN_LINES]`.
+  // Split by section markers. The three [BUDGET_PLAN*] markers don't collide:
+  // each marker + newline (`[BUDGET_PLANS]\n`, `[BUDGET_PLAN_LINES]\n`) is not a
+  // substring of any of the others.
   const accountsMatch = fileContent.match(/\[ACCOUNTS\]\n([\s\S]*?)(?=\n\[|$)/);
   const categoriesMatch = fileContent.match(/\[CATEGORIES\]\n([\s\S]*?)(?=\n\[|$)/);
   const operationsMatch = fileContent.match(/\[OPERATIONS\]\n([\s\S]*?)(?=\n\[|$)/);
@@ -1267,6 +1333,7 @@ const importBackupCSV = async (fileUri, cancelToken) => {
   const plannedOpsMatch = fileContent.match(/\[PLANNED_OPERATIONS\]\n([\s\S]*?)(?=\n\[|$)/);
   const budgetPlansMatch = fileContent.match(/\[BUDGET_PLANS\]\n([\s\S]*?)(?=\n\[|$)/);
   const budgetPlanLinesMatch = fileContent.match(/\[BUDGET_PLAN_LINES\]\n([\s\S]*?)(?=\n\[|$)/);
+  const budgetPlanLineCategoriesMatch = fileContent.match(/\[BUDGET_PLAN_LINE_CATEGORIES\]\n([\s\S]*?)(?=\n\[|$)/);
 
   if (accountsMatch) sections.accounts = parseCSV(accountsMatch[1]);
   if (categoriesMatch) sections.categories = parseCSV(categoriesMatch[1]);
@@ -1277,6 +1344,7 @@ const importBackupCSV = async (fileUri, cancelToken) => {
   if (plannedOpsMatch) sections.planned_operations = parseCSV(plannedOpsMatch[1]);
   if (budgetPlansMatch) sections.budget_plans = parseCSV(budgetPlansMatch[1]);
   if (budgetPlanLinesMatch) sections.budget_plan_lines = parseCSV(budgetPlanLinesMatch[1]);
+  if (budgetPlanLineCategoriesMatch) sections.budget_plan_line_categories = parseCSV(budgetPlanLineCategoriesMatch[1]);
 
   // Extract version from header
   const versionMatch = fileContent.match(/# Version: (\d+)/);
@@ -1401,6 +1469,18 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
       console.warn('No budget_plans/budget_plan_lines tables in imported database (older format)');
     }
 
+    // The multi-category junction (migration 0021) is newer still, so it gets its
+    // own guard: a database that has plan lines but no junction is a pre-0021 one
+    // whose links restoreBackup rebuilds from each line's category_id.
+    let budgetPlanLineCategories = [];
+    try {
+      budgetPlanLineCategories = await tempDb.getAllAsync(
+        'SELECT * FROM budget_plan_line_categories ORDER BY line_id ASC, category_id ASC',
+      );
+    } catch (e) {
+      console.warn('No budget_plan_line_categories table in imported database (older format)');
+    }
+
     // Create backup object
     const backup = {
       version: BACKUP_VERSION,
@@ -1417,6 +1497,7 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
         notification_merchant_rules: merchantRules || [],
         budget_plans: budgetPlans || [],
         budget_plan_lines: budgetPlanLines || [],
+        budget_plan_line_categories: budgetPlanLineCategories || [],
       },
     };
 

--- a/app/services/BudgetPlansDB.js
+++ b/app/services/BudgetPlansDB.js
@@ -11,8 +11,7 @@
 import uuid from 'react-native-uuid';
 import { executeQuery, queryAll, queryFirst, executeTransaction } from './db';
 import * as Currency from './currency';
-import * as CategoriesDB from './CategoriesDB';
-import { calculateSpendingForBudget, deriveSpendingStatus } from './BudgetsDB';
+import { calculateSpendingForCategories, expandCategoryIds, deriveSpendingStatus } from './BudgetsDB';
 import { formatDate as formatLocalDate } from './BalanceHistoryDB';
 import { sanitizeNewLabel } from '../utils/labelUtils';
 import {
@@ -30,6 +29,28 @@ const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 // stored `kind` (every pre-0020 row) is a pure analytic target whose effective
 // kind is inferred from its tracking target — see {@link mapLineFields}.
 const LINE_KINDS = ['income', 'expense', 'transfer'];
+
+/**
+ * Every line SELECT goes through this, so the category set (migration 0021's
+ * budget_plan_line_categories) always travels with the row instead of costing a
+ * follow-up query per line. GROUP_CONCAT joins with ',' and category IDs are
+ * UUIDs, so splitting back is unambiguous.
+ *
+ * Deliberately a plain correlated SCALAR subquery: SQLite has no LATERAL, so a
+ * derived table in FROM cannot reference `l.id` — the tidier
+ * `GROUP_CONCAT(...) FROM (SELECT ... ORDER BY ...)` spelling that would pin the
+ * concat order fails outright with `no such column: l.id`. The set's order is
+ * not meaningful anyway (the UI sorts by name), and the line's PRIMARY category
+ * comes from its own `category_id` column, not from this list's head.
+ *
+ * Callers append their own WHERE/ORDER BY against the `l` alias.
+ */
+const LINE_SELECT = `SELECT l.*, (
+      SELECT GROUP_CONCAT(lc.category_id)
+      FROM budget_plan_line_categories lc
+      WHERE lc.line_id = l.id
+    ) AS category_ids
+    FROM budget_plan_lines l`;
 
 /** Current month as YYYY-MM (local calendar) — mirrors utils/monthUtils. */
 const currentMonthKey = () => {
@@ -80,7 +101,15 @@ export const mapPlanFields = (row) => {
  */
 export const mapLineFields = (row) => {
   if (!row) return null;
-  const categoryId = row.category_id ?? null;
+  const categoryIds = readCategoryIds(row);
+  const primary = row.category_id ?? null;
+  // The junction wins: when the row's denormalized primary category has been
+  // deleted (its FK nulled, or it simply is not linked any more) but other
+  // categories remain, the line still tracks those — reporting `categoryId: null`
+  // would render it as broken while its actual keeps counting spending.
+  const categoryId = primary !== null && categoryIds.includes(primary)
+    ? primary
+    : (categoryIds[0] ?? null);
   const toAccountId = row.to_account_id ?? null;
   const accountId = row.account_id ?? null;
   const kind = LINE_KINDS.includes(row.kind) ? row.kind : (toAccountId !== null ? 'transfer' : 'expense');
@@ -91,9 +120,15 @@ export const mapLineFields = (row) => {
     amount: row.amount,
     comment: row.comment ?? null,
     categoryId,
+    categoryIds,
+    // Legacy rows (pre-0021, and any hand-built row in a test) have no column at
+    // all — they behaved as "roll descendants up", so absent reads as enabled.
+    // Only a stored 0 turns it off; the string form is accepted because a row
+    // that reached here through a CSV round trip carries text, not integers.
+    includeChildren: row.include_children !== 0 && row.include_children !== '0',
     toAccountId,
     sortOrder: row.sort_order ?? 0,
-    isBroken: kind !== 'income' && categoryId === null && toAccountId === null,
+    isBroken: kind !== 'income' && categoryIds.length === 0 && toAccountId === null,
     isRecurring: row.is_recurring === 1,
     currency: row.currency ?? null,
     kind,
@@ -107,6 +142,74 @@ export const mapLineFields = (row) => {
 
 // True when a target reference is meaningfully set (not null/undefined/'').
 const isSet = (value) => value !== null && value !== undefined && value !== '';
+
+/**
+ * De-duplicated list of set category IDs, order preserved.
+ * @param {Array|null|undefined} ids
+ * @returns {Array<string>}
+ */
+const uniqueCategoryIds = (ids) => {
+  const out = [];
+  for (const id of ids || []) {
+    if (!isSet(id) || out.includes(id)) continue;
+    out.push(id);
+  }
+  return out;
+};
+
+/**
+ * The category set a caller means, accepting either shape: the multi-category
+ * `categoryIds` array (since migration 0021) or the single legacy `categoryId`.
+ * `categoryIds` wins when present, so a caller that passes both cannot end up
+ * writing a set that disagrees with the primary it also asked for.
+ *
+ * Returns `undefined` when the caller mentioned NEITHER field — which for an
+ * update means "leave the links alone", as distinct from `[]` ("unlink all").
+ * @param {Object} line
+ * @returns {Array<string>|undefined}
+ */
+const resolveCategoryIds = (line) => {
+  if (Array.isArray(line?.categoryIds)) return uniqueCategoryIds(line.categoryIds);
+  if (line?.categoryId !== undefined) return uniqueCategoryIds([line.categoryId]);
+  return undefined;
+};
+
+/**
+ * Parse the `category_ids` GROUP_CONCAT column produced by {@link LINE_SELECT}.
+ * A row selected without it (an insert's in-memory row, a hand-built test row, a
+ * legacy `SELECT *`) falls back to the denormalized `category_id` column, so
+ * every read path yields the same shape.
+ * @param {Object} row - Raw budget_plan_lines row
+ * @returns {Array<string>}
+ */
+const readCategoryIds = (row) => {
+  if (Object.prototype.hasOwnProperty.call(row, 'category_ids')) {
+    const raw = row.category_ids;
+    if (Array.isArray(raw)) return uniqueCategoryIds(raw);
+    return typeof raw === 'string' && raw.length > 0
+      ? uniqueCategoryIds(raw.split(','))
+      : [];
+  }
+  return uniqueCategoryIds([row.category_id]);
+};
+
+/**
+ * Rewrite a line's category links inside an open transaction: drop what's there,
+ * insert the new set. Called with the already-normalized (de-duplicated) list.
+ * @param {Object} db - Transaction-scoped database handle
+ * @param {string} lineId
+ * @param {Array<string>} categoryIds
+ * @returns {Promise<void>}
+ */
+const writeLineCategoriesInTx = async (db, lineId, categoryIds) => {
+  await db.runAsync('DELETE FROM budget_plan_line_categories WHERE line_id = ?', [lineId]);
+  for (const categoryId of categoryIds) {
+    await db.runAsync(
+      'INSERT OR IGNORE INTO budget_plan_line_categories (line_id, category_id) VALUES (?, ?)',
+      [lineId, categoryId],
+    );
+  }
+};
 
 /**
  * Validate a plan.
@@ -148,7 +251,7 @@ export const validatePlanLine = (line) => {
   if (isSet(line.kind) && !LINE_KINDS.includes(line.kind)) {
     return 'A line must be an income, expense or transfer';
   }
-  const hasCategory = isSet(line.categoryId);
+  const hasCategory = (resolveCategoryIds(line) || []).length > 0;
   const hasAccount = isSet(line.toAccountId);
   if (line.kind === 'income') {
     if (hasAccount) {
@@ -352,7 +455,7 @@ export const deletePlan = async (id) => {
 export const getPlanLines = async (planId) => {
   try {
     const rows = await queryAll(
-      'SELECT * FROM budget_plan_lines WHERE plan_id = ? ORDER BY sort_order ASC, created_at ASC',
+      `${LINE_SELECT} WHERE l.plan_id = ? ORDER BY l.sort_order ASC, l.created_at ASC`,
       [planId],
     );
     return (rows || []).map(mapLineFields);
@@ -372,8 +475,17 @@ export const getBrokenLines = async (planId) => {
   try {
     // Income lines are excluded: they legitimately have no tracking target (see
     // validatePlanLine), so a targetless income line is not "broken".
+    //
+    // Since migration 0021 "no category" means the junction holds NO row for the
+    // line — not that `category_id` is null. A line whose primary category was
+    // deleted but which still tracks others is fine, and must not be offered up
+    // for re-linking.
     const rows = await queryAll(
-      "SELECT * FROM budget_plan_lines WHERE plan_id = ? AND category_id IS NULL AND to_account_id IS NULL AND (kind IS NULL OR kind != 'income') ORDER BY sort_order ASC",
+      `${LINE_SELECT} WHERE l.plan_id = ?
+         AND NOT EXISTS (SELECT 1 FROM budget_plan_line_categories lc WHERE lc.line_id = l.id)
+         AND l.to_account_id IS NULL
+         AND (l.kind IS NULL OR l.kind != 'income')
+       ORDER BY l.sort_order ASC`,
       [planId],
     );
     return (rows || []).map(mapLineFields);
@@ -406,13 +518,16 @@ const insertPlanLine = async (planId, line) => {
     }
 
     const now = new Date().toISOString();
+    const categoryIds = resolveCategoryIds(line) || [];
     const row = {
       id: line.id || uuid.v4(),
       plan_id: planId,
       label: line.label ?? null,
       amount: String(line.amount),
       comment: line.comment ?? null,
-      category_id: isSet(line.categoryId) ? line.categoryId : null,
+      // Primary = first of the set; the full set lives in the junction below.
+      category_id: categoryIds[0] ?? null,
+      category_ids: categoryIds,
       to_account_id: isSet(line.toAccountId) ? line.toAccountId : null,
       sort_order: Number.isInteger(line.sortOrder) ? line.sortOrder : 0,
       is_recurring: isRecurring ? 1 : 0,
@@ -423,18 +538,28 @@ const insertPlanLine = async (planId, line) => {
       kind: LINE_KINDS.includes(line.kind) ? line.kind : null,
       account_id: isSet(line.accountId) ? line.accountId : null,
       last_executed_month: line.lastExecutedMonth ?? null,
+      // Absent means "roll descendants up" — the pre-0021 behaviour, and what a
+      // caller that has never heard of the flag expects.
+      include_children: line.includeChildren === false ? 0 : 1,
       created_at: now,
       updated_at: now,
     };
 
-    await executeQuery(
-      'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-      [
-        row.id, row.plan_id, row.label, row.amount, row.comment, row.category_id,
-        row.to_account_id, row.sort_order, row.is_recurring, row.currency,
-        row.kind, row.account_id, row.last_executed_month, row.created_at, row.updated_at,
-      ],
-    );
+    // The row and its category links go in together: a line that committed
+    // without its links would read as broken (empty set, no transfer target) and
+    // silently stop tracking anything.
+    await executeTransaction(async (db) => {
+      await db.runAsync(
+        'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [
+          row.id, row.plan_id, row.label, row.amount, row.comment, row.category_id,
+          row.to_account_id, row.sort_order, row.is_recurring, row.currency,
+          row.kind, row.account_id, row.last_executed_month, row.include_children,
+          row.created_at, row.updated_at,
+        ],
+      );
+      await writeLineCategoriesInTx(db, row.id, categoryIds);
+    });
 
     return mapLineFields(row);
   } catch (error) {
@@ -470,7 +595,7 @@ export const addRecurringLine = async (line) => insertPlanLine(null, line);
 export const getRecurringLines = async () => {
   try {
     const rows = await queryAll(
-      'SELECT * FROM budget_plan_lines WHERE is_recurring = 1 ORDER BY sort_order ASC, created_at ASC',
+      `${LINE_SELECT} WHERE l.is_recurring = 1 ORDER BY l.sort_order ASC, l.created_at ASC`,
     );
     return (rows || []).map(mapLineFields);
   } catch (error) {
@@ -586,8 +711,12 @@ const convertLineAmount = async (rawAmount, fromCurrency, toCurrency) => {
  */
 export const updateLine = async (id, updates) => {
   try {
+    // `categoryIds` (the whole set) or the legacy single `categoryId`; undefined
+    // when the caller mentioned neither, which leaves the existing links alone.
+    const requestedCategoryIds = resolveCategoryIds(updates);
+
     // Reject setting both targets in a single update outright.
-    if (isSet(updates.categoryId) && isSet(updates.toAccountId)) {
+    if ((requestedCategoryIds || []).length > 0 && isSet(updates.toAccountId)) {
       throw new Error('A line must link to either a category or an account, not both');
     }
     if (updates.amount !== undefined
@@ -598,12 +727,12 @@ export const updateLine = async (id, updates) => {
     // Derive the target writes. Assigning one real target clears the opposite one,
     // even when the caller didn't mention it — that's what keeps a partial update
     // from leaving both set (the row may already hold the other target).
-    let categoryId = updates.categoryId;
+    let categoryIds = requestedCategoryIds;
     let toAccountId = updates.toAccountId;
-    if (isSet(updates.categoryId)) {
+    if ((categoryIds || []).length > 0) {
       toAccountId = null;
     } else if (isSet(updates.toAccountId)) {
-      categoryId = null;
+      categoryIds = [];
     }
 
     const fields = [];
@@ -617,13 +746,18 @@ export const updateLine = async (id, updates) => {
       fields.push('comment = ?');
       values.push(updates.comment ?? null);
     }
-    if (categoryId !== undefined) {
+    if (categoryIds !== undefined) {
+      // Keep the denormalized primary in step with the set it heads.
       fields.push('category_id = ?');
-      values.push(isSet(categoryId) ? categoryId : null);
+      values.push(categoryIds[0] ?? null);
     }
     if (toAccountId !== undefined) {
       fields.push('to_account_id = ?');
       values.push(isSet(toAccountId) ? toAccountId : null);
+    }
+    if (updates.includeChildren !== undefined) {
+      fields.push('include_children = ?');
+      values.push(updates.includeChildren ? 1 : 0);
     }
     if (updates.sortOrder !== undefined) {
       fields.push('sort_order = ?');
@@ -711,7 +845,19 @@ export const updateLine = async (id, updates) => {
     values.push(new Date().toISOString());
     values.push(id);
 
-    await executeQuery(`UPDATE budget_plan_lines SET ${fields.join(', ')} WHERE id = ?`, values);
+    const sql = `UPDATE budget_plan_lines SET ${fields.join(', ')} WHERE id = ?`;
+
+    if (categoryIds === undefined) {
+      await executeQuery(sql, values);
+      return;
+    }
+
+    // Row and links move together, so a failure can't leave the primary column
+    // pointing at a category the junction no longer holds.
+    await executeTransaction(async (db) => {
+      await db.runAsync(sql, values);
+      await writeLineCategoriesInTx(db, id, categoryIds);
+    });
   } catch (error) {
     console.error('Failed to update budget plan line:', error);
     throw error;
@@ -881,18 +1027,23 @@ export const copyPlan = async (fromMonth, toMonth) => {
 
         for (let i = 0; i < sourceLines.length; i++) {
           const line = sourceLines[i];
+          const clonedId = uuid.v4();
           // `last_executed_month` is written NULL: every line that reaches here is
           // pending already (see the filter above), and a clone starts the new
           // month pending too, exactly like a recurring line does when the month
           // rolls over.
           await db.runAsync(
-            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, ?, ?)',
+            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, ?, ?, ?)',
             [
-              uuid.v4(), newPlanId, line.label, line.amount, line.comment,
+              clonedId, newPlanId, line.label, line.amount, line.comment,
               line.categoryId, line.toAccountId, line.sortOrder ?? i,
-              line.currency, line.kind, line.accountId, now, now,
+              line.currency, line.kind, line.accountId,
+              line.includeChildren === false ? 0 : 1, now, now,
             ],
           );
+          // The clone must track the same SET of categories, not just the primary
+          // one the column carries.
+          await writeLineCategoriesInTx(db, clonedId, line.categoryIds || []);
         }
       });
     } catch (txError) {
@@ -949,9 +1100,11 @@ export const getMonthDateRange = (month) => {
 /**
  * Compute the actual amount tracked by one plan line for a month.
  *
- * - Category-linked line: expense spending of the category including descendants,
- *   via the shared convert-all engine ({@link calculateSpendingForBudget}). With
- *   `convertAll` off, only operations in accounts of `displayCurrency` count.
+ * - Category-linked line: expense spending across every category the line tracks
+ *   (migration 0021 allows several), including their descendants unless the
+ *   line's `includeChildren` is off, via the shared convert-all engine
+ *   ({@link calculateSpendingForCategories}). With `convertAll` off, only
+ *   operations in accounts of `displayCurrency` count.
  * - Account-linked line (transfer target): incoming transfers into the account
  *   ({@link getTransferTotals}; values are in the destination account's currency),
  *   converted into `displayCurrency` regardless of the toggle — a transfer target
@@ -980,13 +1133,14 @@ export const calculateLineActual = async (line, month, displayCurrency, convertA
       return { broken: false, actual: '0', skipped: true };
     }
 
-    if (isSet(line.categoryId)) {
-      const actual = await calculateSpendingForBudget(
-        line.categoryId,
+    const categoryIds = line.categoryIds ?? (isSet(line.categoryId) ? [line.categoryId] : []);
+    if (categoryIds.length > 0) {
+      const actual = await calculateSpendingForCategories(
+        categoryIds,
         displayCurrency,
         startDate,
         endDate,
-        true, // include descendant categories
+        line.includeChildren !== false, // descendants roll up unless switched off
         convertAll,
       );
       return { broken: false, actual: String(actual) };
@@ -1083,16 +1237,27 @@ const collectPlanSourceCurrencies = async (lines, startDate, endDate, convertAll
   const currencies = new Set(transferCurrencies);
 
   if (convertAll) {
-    const categoryIds = [];
+    // A Set, not an array: since migration 0021 each line contributes a whole
+    // category set (plus descendants), and plan lines routinely overlap — a
+    // parent here, one of its children there. Repeats would only pad the IN list
+    // toward SQLite's bound-parameter ceiling without changing the DISTINCT
+    // result.
+    const categoryIdSet = new Set();
     for (const line of lines) {
       // Income lines track no spending (their category, when set, is an income
       // one) — including them here would query expenses that cannot exist.
-      if (line.kind === 'income' || !isSet(line.categoryId)) continue;
-      categoryIds.push(line.categoryId);
-      const descendants = await CategoriesDB.getAllDescendants(line.categoryId);
-      categoryIds.push(...descendants.map(cat => cat.id));
+      if (line.kind === 'income') continue;
+      const linked = line.categoryIds ?? (isSet(line.categoryId) ? [line.categoryId] : []);
+      if (linked.length === 0) continue;
+      // Same expansion the line's own actual uses, so the currencies collected
+      // here are exactly the ones that can feed it — including the descendants
+      // only when that line actually rolls them up.
+      for (const id of await expandCategoryIds(linked, line.includeChildren !== false)) {
+        categoryIdSet.add(id);
+      }
     }
 
+    const categoryIds = [...categoryIdSet];
     if (categoryIds.length > 0) {
       const placeholders = categoryIds.map(() => '?').join(',');
       const rows = await queryAll(
@@ -1444,6 +1609,42 @@ export const unmarkLineExecuted = async (id) => {
 export const BUDGETS_MIGRATION_FLAG_KEY = 'post_migration_m0019_completed';
 
 /**
+ * Whether migration 0021's junction table exists yet, on a raw db handle.
+ *
+ * The bridges below run in two very different situations. During a fresh
+ * migrate() they run right after their own DDL, BEFORE 0021 — the table does not
+ * exist, and 0021's backfill will pick their rows up from `category_id` moments
+ * later. But a RETRY (a bridge that never completed, re-attempted on a later
+ * launch) and BackupRestore's restore-time bridge both run on a schema that is
+ * already at 0021, where nothing will backfill for them — there they must write
+ * the links themselves, or every bridged line reads as broken and tracks nothing.
+ * @param {Object} db - Raw SQLite database instance (or transaction handle)
+ * @returns {Promise<boolean>}
+ */
+const hasLineCategoriesTable = async (db) => {
+  const row = await db.getFirstAsync(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='budget_plan_line_categories'",
+  ).catch(() => null);
+  return !!row;
+};
+
+/**
+ * Link a bridged line to its single category when the junction table is there.
+ * @param {Object} db - Raw SQLite database instance (or transaction handle)
+ * @param {boolean} junctionExists - Result of {@link hasLineCategoriesTable}
+ * @param {string} lineId
+ * @param {string|null} categoryId
+ * @returns {Promise<void>}
+ */
+const linkBridgedLineCategory = async (db, junctionExists, lineId, categoryId) => {
+  if (!junctionExists || !isSet(categoryId)) return;
+  await db.runAsync(
+    'INSERT OR IGNORE INTO budget_plan_line_categories (line_id, category_id) VALUES (?, ?)',
+    [lineId, categoryId],
+  );
+};
+
+/**
  * Convert a legacy `budgets` (v1) amount into an equivalent MONTHLY amount, per
  * the product owner's decision:
  *   - weekly → amount × (365 / 12 / 7) ≈ ×4.345, computed as ×365÷84 (365/84 ==
@@ -1498,14 +1699,17 @@ export const migrateLegacyBudgetsToRecurringLines = async (db) => {
 
   const budgetRows = await db.getAllAsync('SELECT * FROM budgets').catch(() => []);
   const now = new Date().toISOString();
+  const junctionExists = await hasLineCategoriesTable(db);
   let migrated = 0;
 
   for (const budget of budgetRows || []) {
     const monthlyAmount = convertBudgetAmountToMonthly(budget.amount, budget.period_type, budget.currency);
+    const lineId = uuid.v4();
     await db.runAsync(
       'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, created_at, updated_at) VALUES (?, NULL, NULL, ?, NULL, ?, NULL, 0, 1, ?, ?, ?)',
-      [uuid.v4(), monthlyAmount, budget.category_id, budget.currency, now, now],
+      [lineId, monthlyAmount, budget.category_id, budget.currency, now, now],
     );
+    await linkBridgedLineCategory(db, junctionExists, lineId, budget.category_id);
     migrated++;
   }
 
@@ -1593,6 +1797,7 @@ export const migratePlannedOperationsToLines = async (db) => {
     'SELECT * FROM planned_operations ORDER BY display_order ASC, created_at ASC',
   ).catch(() => []);
 
+  const junctionExists = await hasLineCategoriesTable(db);
   const currencyByAccount = new Map((accountRows || []).map(a => [String(a.id), a.currency]));
   const fallbackCurrency = (plans || [])[0]?.currency || (accountRows || [])[0]?.currency || 'USD';
 
@@ -1631,15 +1836,17 @@ export const migratePlannedOperationsToLines = async (db) => {
       planId = currentPlanId;
     }
 
+    const lineId = uuid.v4();
+    const lineCategoryId = kind === 'transfer' ? null : (op.category_id ?? null);
     await db.runAsync(
       INSERT_LINE_SQL,
       [
-        uuid.v4(),
+        lineId,
         planId,
         op.name ?? null,
         String(op.amount ?? '0'),
         op.description ?? null,
-        kind === 'transfer' ? null : (op.category_id ?? null),
+        lineCategoryId,
         op.to_account_id ?? null,
         Number.isInteger(op.display_order) ? op.display_order : i,
         isRecurring ? 1 : 0,
@@ -1651,6 +1858,7 @@ export const migratePlannedOperationsToLines = async (db) => {
         now,
       ],
     );
+    await linkBridgedLineCategory(db, junctionExists, lineId, lineCategoryId);
     migratedTemplates++;
   }
 

--- a/app/services/BudgetsDB.js
+++ b/app/services/BudgetsDB.js
@@ -563,21 +563,60 @@ export const getPreviousPeriodDates = (periodType, currentStart) => {
 };
 
 /**
- * Calculate spending for a budget in current period
- * @param {string} categoryId - Category ID
+ * Expand a set of category IDs into the full set to sum over, optionally pulling
+ * in descendants, with duplicates removed.
+ *
+ * De-duplication is not cosmetic: a plan line may track a parent AND one of its
+ * own children (migration 0021 lets it track several categories at once), and
+ * with `includeChildren` on, the child would then appear twice in the IN list —
+ * SQLite's `IN` ignores the repeat, but the roll-up walk is O(duplicates) and any
+ * future GROUP BY over this list would double-count. Keeping the set clean here
+ * means every caller is safe by construction.
+ * @param {Array<string>} categoryIds - Explicitly tracked category IDs
+ * @param {boolean} includeChildren - Also count spending in descendant categories
+ * @returns {Promise<Array<string>>} Unique category IDs to sum over
+ */
+export const expandCategoryIds = async (categoryIds, includeChildren) => {
+  const seen = new Set();
+  const out = [];
+  const push = (id) => {
+    if (id === null || id === undefined || id === '' || seen.has(id)) return;
+    seen.add(id);
+    out.push(id);
+  };
+
+  for (const id of categoryIds || []) push(id);
+
+  if (includeChildren) {
+    // Snapshot first: `out` grows as descendants are appended, and re-walking a
+    // category that is itself a descendant of another is pure waste.
+    for (const id of [...out]) {
+      const descendants = await CategoriesDB.getAllDescendants(id);
+      for (const cat of descendants || []) push(cat.id);
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Calculate spending across a SET of categories in a date range. The
+ * multi-category form of {@link calculateSpendingForBudget} (migration 0021),
+ * used by plan lines that track several categories at once.
+ * @param {Array<string>} categoryIds - Category IDs to sum over
  * @param {string} currency - Currency code
  * @param {string} startDate - Period start (YYYY-MM-DD)
  * @param {string} endDate - Period end (YYYY-MM-DD)
- * @param {boolean} includeChildren - Include child category spending (default: true)
+ * @param {boolean} includeChildren - Include descendant category spending (default: true)
  * @param {boolean} convertAll - When true, spending from accounts in ANY
  *   currency counts toward the budget, converted into the budget's currency at
  *   the current rate (offline table first, live fallback) — the same
  *   conversion path Graphs uses, so the two surfaces agree. Currencies with no
  *   available rate are dropped from the sum, mirroring mergeConvertedByCategory.
- * @returns {Promise<number>} Total spending amount
+ * @returns {Promise<string>} Total spending amount (decimal string)
  */
-export const calculateSpendingForBudget = async (
-  categoryId,
+export const calculateSpendingForCategories = async (
+  categoryIds,
   currency,
   startDate,
   endDate,
@@ -585,15 +624,13 @@ export const calculateSpendingForBudget = async (
   convertAll = false,
 ) => {
   try {
-    let categoryIds = [categoryId];
+    const expandedIds = await expandCategoryIds(categoryIds, includeChildren);
 
-    // If including children, get all descendant category IDs
-    if (includeChildren) {
-      const descendants = await CategoriesDB.getAllDescendants(categoryId);
-      categoryIds = [...categoryIds, ...descendants.map(cat => cat.id)];
-    }
+    // No categories tracked (a line whose every category was deleted) — there is
+    // nothing to sum, and an empty IN () is a SQL syntax error.
+    if (expandedIds.length === 0) return '0';
 
-    const placeholders = categoryIds.map(() => '?').join(',');
+    const placeholders = expandedIds.map(() => '?').join(',');
 
     if (convertAll) {
       const rows = await queryAll(
@@ -605,7 +642,7 @@ export const calculateSpendingForBudget = async (
            AND o.date >= ?
            AND o.date <= ?
          GROUP BY a.currency`,
-        [...categoryIds, startDate, endDate],
+        [...expandedIds, startDate, endDate],
       );
 
       const rowList = rows || [];
@@ -631,7 +668,7 @@ export const calculateSpendingForBudget = async (
         AND o.date <= ?
     `;
 
-    const params = [...categoryIds, currency, startDate, endDate];
+    const params = [...expandedIds, currency, startDate, endDate];
     const result = await queryFirst(query, params);
 
     return result && result.total != null ? String(result.total) : '0';
@@ -640,6 +677,34 @@ export const calculateSpendingForBudget = async (
     throw error;
   }
 };
+
+/**
+ * Calculate spending for a single category in a date range — the single-category
+ * form kept for v1 budgets (one category by schema) and for callers that only
+ * ever have one. Delegates to {@link calculateSpendingForCategories}.
+ * @param {string} categoryId - Category ID
+ * @param {string} currency - Currency code
+ * @param {string} startDate - Period start (YYYY-MM-DD)
+ * @param {string} endDate - Period end (YYYY-MM-DD)
+ * @param {boolean} includeChildren - Include child category spending (default: true)
+ * @param {boolean} convertAll - See {@link calculateSpendingForCategories}
+ * @returns {Promise<string>} Total spending amount (decimal string)
+ */
+export const calculateSpendingForBudget = async (
+  categoryId,
+  currency,
+  startDate,
+  endDate,
+  includeChildren = true,
+  convertAll = false,
+) => calculateSpendingForCategories(
+  [categoryId],
+  currency,
+  startDate,
+  endDate,
+  includeChildren,
+  convertAll,
+);
 
 /**
  * Derive the spent-vs-amount progress metrics shared by budgets (v1) and

--- a/app/services/GoogleSheetsService.js
+++ b/app/services/GoogleSheetsService.js
@@ -78,11 +78,26 @@ export const signOut = async () => {
 export const buildSheetsData = (backup) => {
   const {
     accounts, categories, operations, budgets, balance_history,
-    budget_plans, budget_plan_lines,
+    budget_plans, budget_plan_lines, budget_plan_line_categories,
   } = backup.data;
 
   const accountNames = new Map(accounts.map(a => [a.id, a.name]));
   const categoryNames = new Map(categories.map(c => [c.id, c.name]));
+
+  // A line's full category set (migration 0021), keyed by line. Semicolon-joined
+  // rather than comma-joined because a category NAME may well contain a comma —
+  // and the two columns must split the same way to stay in step.
+  const categoryIdsByLine = new Map();
+  for (const link of budget_plan_line_categories || []) {
+    if (!link.line_id || !link.category_id) continue;
+    const current = categoryIdsByLine.get(link.line_id);
+    if (current) current.push(link.category_id);
+    else categoryIdsByLine.set(link.line_id, [link.category_id]);
+  }
+  // A backup taken before 0021 has no junction at all: fall back to the line's
+  // single category_id so the exported sheet still says what it tracks.
+  const lineCategoryIds = (line) => categoryIdsByLine.get(line.id)
+    || (line.category_id ? [line.category_id] : []);
 
   return [
     {
@@ -161,21 +176,30 @@ export const buildSheetsData = (backup) => {
     {
       range: 'Budget Plan Lines!A1',
       values: [
-        ['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month'],
-        ...(budget_plan_lines || []).map(l => [
-          l.id, l.plan_id || '', l.label || '', l.amount, l.comment || '',
-          categoryNames.get(l.category_id) || '',
-          l.to_account_id ? (accountNames.get(l.to_account_id) || '') : '',
-          l.category_id || '',
-          l.to_account_id || '',
-          l.sort_order ?? 0,
-          l.is_recurring ?? 0,
-          l.currency || '',
-          l.kind || '',
-          l.account_id ? (accountNames.get(l.account_id) || '') : '',
-          l.account_id || '',
-          l.last_executed_month || '',
-        ]),
+        ['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month', 'categories', 'category_ids', 'include_children'],
+        ...(budget_plan_lines || []).map(l => {
+          const ids = lineCategoryIds(l);
+          return [
+            l.id, l.plan_id || '', l.label || '', l.amount, l.comment || '',
+            categoryNames.get(l.category_id) || '',
+            l.to_account_id ? (accountNames.get(l.to_account_id) || '') : '',
+            l.category_id || '',
+            l.to_account_id || '',
+            l.sort_order ?? 0,
+            l.is_recurring ?? 0,
+            l.currency || '',
+            l.kind || '',
+            l.account_id ? (accountNames.get(l.account_id) || '') : '',
+            l.account_id || '',
+            l.last_executed_month || '',
+            // The whole set the line tracks: names for the reader, IDs for the
+            // round trip. `category`/`category_id` above stay as the primary one
+            // so an older sheet layout keeps working unchanged.
+            ids.map(id => categoryNames.get(id) || '').join(';'),
+            ids.join(';'),
+            l.include_children === 0 ? 0 : 1,
+          ];
+        }),
       ],
     },
   ];
@@ -278,6 +302,12 @@ export const importFromSheets = async (accessToken, onProgress) => {
     }
     return row[nameCol] ? (accountIdMap.get(row[nameCol]) ?? null) : null;
   };
+
+  // A blank/absent cell is "not stated" and reads as ON (the pre-0021
+  // behaviour); only an explicit 0 turns the descendant roll-up off.
+  const readIncludeChildren = (value) => (
+    value === '' || value == null ? 1 : (Number(value) === 0 ? 0 : 1)
+  );
 
   const resolveCategoryId = (row, idCol, nameCol) => {
     if (row[idCol] !== '' && row[idCol] != null) {
@@ -385,10 +415,44 @@ export const importFromSheets = async (accessToken, onProgress) => {
         ? resolveAccountId(l, 'account_id', 'execution_account')
         : null,
       last_executed_month: l.last_executed_month || null,
+      // Only an explicit 0 switches the roll-up off. A blank cell — every
+      // pre-0021 sheet, and any row a user added by hand — means "not stated",
+      // which is the default ON; `Number('')` is 0, so this cannot go through
+      // a plain numeric comparison.
+      include_children: readIncludeChildren(l.include_children),
       created_at: now,
       updated_at: now,
     };
   });
+
+  // Category links (migration 0021). Read from `category_ids` when the sheet has
+  // it, else from the human-facing `categories` names — someone editing the
+  // spreadsheet by hand will reach for the names column, and silently dropping
+  // what they typed there would be the worst kind of quiet. A sheet with neither
+  // (written before 0021) falls back to the single category the row already
+  // resolved, so a line never comes back from a round trip tracking nothing.
+  const budget_plan_line_categories = [];
+  const splitList = (value) => String(value || '').split(';').map(part => part.trim()).filter(Boolean);
+  for (let i = 0; i < budgetPlanLineRows.length; i++) {
+    const row = budgetPlanLineRows[i];
+    const line = budget_plan_lines[i];
+    if (!line.id) continue;
+    // Both columns go through categoryIdMap, which is keyed by ID *and* by name.
+    const listed = [...splitList(row.category_ids), ...splitList(row.categories)]
+      .map(token => categoryIdMap.get(token) ?? null)
+      .filter(Boolean);
+    const resolved = listed.length > 0 ? listed : (line.category_id ? [line.category_id] : []);
+    const seen = new Set();
+    for (const categoryId of resolved) {
+      if (seen.has(categoryId)) continue;
+      seen.add(categoryId);
+      budget_plan_line_categories.push({ line_id: line.id, category_id: categoryId });
+    }
+    // Keep the denormalized primary inside the set it heads: a sheet whose
+    // `category` cell was cleared while `categories` still lists targets would
+    // otherwise import a line whose column and junction disagree.
+    line.category_id = resolved[0] ?? null;
+  }
 
   // Preserve current app preferences (language, theme, etc.) so they survive the restore.
   // Do NOT catch DB errors here — a locked or corrupted DB must abort the import loudly
@@ -413,6 +477,7 @@ export const importFromSheets = async (accessToken, onProgress) => {
       planned_operations: [],
       budget_plans,
       budget_plan_lines,
+      budget_plan_line_categories,
     },
   };
 };

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -170,7 +170,7 @@ const isSchemaComplete = async (rawDb) => {
       'accounts', 'categories', 'operations', 'budgets',
       'app_metadata', 'accounts_balance_history', 'planned_operations',
       'notification_merchant_rules', 'pending_notifications',
-      'budget_plans', 'budget_plan_lines',
+      'budget_plans', 'budget_plan_lines', 'budget_plan_line_categories',
     ];
     const existingTables = await rawDb.getAllAsync(
       "SELECT name FROM sqlite_master WHERE type='table'",
@@ -286,6 +286,14 @@ const isSchemaComplete = async (rawDb) => {
     if (!planLineCols.some(c => c.name === 'kind')
       || !planLineCols.some(c => c.name === 'account_id')
       || !planLineCols.some(c => c.name === 'last_executed_month')) return false;
+
+    // Check budget_plan_lines has include_children (migration 0021). The
+    // accompanying budget_plan_line_categories table is covered by the
+    // expectedTables check above, but the column is a separate ADD COLUMN
+    // statement and applyPendingMigrations continues on failure — so a 0021 that
+    // created the table and failed the ALTER must not read as complete, or every
+    // line query would throw `no such column: include_children`.
+    if (!planLineCols.some(c => c.name === 'include_children')) return false;
 
     return true;
   } catch (error) {
@@ -608,6 +616,15 @@ const detectAppliedMigrations = async (rawDb) => {
       && planLineCols.some(c => c.name === 'account_id')
       && planLineCols.some(c => c.name === 'last_executed_month')) {
       applied.push(20);
+    }
+
+    // Migration 0021: creates budget_plan_line_categories AND adds
+    // budget_plan_lines.include_children. Require both — a half-applied 0021
+    // (table created, ALTER failed, or vice versa) must re-run. Re-running is
+    // safe: the CREATE is IF NOT EXISTS and the backfill is INSERT OR IGNORE.
+    if ((await tableExists('budget_plan_line_categories'))
+      && planLineCols.some(c => c.name === 'include_children')) {
+      applied.push(21);
     }
   }
 

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -550,6 +550,8 @@
   "no_template_account": "Keines (nur Nachverfolgung)",
   "edit_allocation": "Zuweisung bearbeiten",
   "tracking_target": "Tracking-Ziel",
+  "include_subcategories": "Unterkategorien einbeziehen",
+  "include_subcategories_hint": "Ausgaben in Kategorien unterhalb der ausgewählten zählen zu dieser Zeile.",
   "select_target": "Ziel auswählen",
   "allocation_label": "Bezeichnung",
   "allocation_comment": "Kommentar",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -553,6 +553,8 @@
   "no_template_account": "None (tracking only)",
   "edit_allocation": "Edit allocation",
   "tracking_target": "Tracking target",
+  "include_subcategories": "Include subcategories",
+  "include_subcategories_hint": "Spending in categories nested under the selected ones counts toward this line.",
   "select_target": "Select target",
   "allocation_label": "Label",
   "allocation_comment": "Comment",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -550,6 +550,8 @@
   "no_template_account": "Ninguna (solo seguimiento)",
   "edit_allocation": "Editar asignación",
   "tracking_target": "Objetivo de seguimiento",
+  "include_subcategories": "Incluir subcategorías",
+  "include_subcategories_hint": "Los gastos en categorías anidadas bajo las seleccionadas cuentan para esta línea.",
   "select_target": "Seleccionar objetivo",
   "allocation_label": "Etiqueta",
   "allocation_comment": "Comentario",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -550,6 +550,8 @@
   "no_template_account": "Aucun (suivi uniquement)",
   "edit_allocation": "Modifier la ligne",
   "tracking_target": "Cible de suivi",
+  "include_subcategories": "Inclure les sous-catégories",
+  "include_subcategories_hint": "Les dépenses des catégories imbriquées sous celles sélectionnées comptent dans cette ligne.",
   "select_target": "Sélectionner la cible",
   "allocation_label": "Libellé",
   "allocation_comment": "Commentaire",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -550,6 +550,8 @@
   "no_template_account": "Չկա (միայն հաշվառում)",
   "edit_allocation": "Խմբագրել բաշխումը",
   "tracking_target": "Հետևման նպատակ",
+  "include_subcategories": "Ներառել ենթակատեգորիաները",
+  "include_subcategories_hint": "Ընտրված կատեգորիաների ենթակատեգորիաների ծախսերը հաշվվում են այս տողում։",
   "select_target": "Ընտրել նպատակը",
   "allocation_label": "Պիտակ",
   "allocation_comment": "Մեկնաբանություն",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -550,6 +550,8 @@
   "no_template_account": "Nessuno (solo monitoraggio)",
   "edit_allocation": "Modifica voce",
   "tracking_target": "Obiettivo di tracciamento",
+  "include_subcategories": "Includi sottocategorie",
+  "include_subcategories_hint": "Le spese nelle categorie annidate sotto quelle selezionate contano in questa riga.",
   "select_target": "Seleziona obiettivo",
   "allocation_label": "Etichetta",
   "allocation_comment": "Commento",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -550,6 +550,8 @@
   "no_template_account": "なし（記録のみ）",
   "edit_allocation": "配分を編集",
   "tracking_target": "追跡対象",
+  "include_subcategories": "サブカテゴリを含める",
+  "include_subcategories_hint": "選択したカテゴリの下位カテゴリの支出もこの項目に含まれます。",
   "select_target": "対象を選択",
   "allocation_label": "ラベル",
   "allocation_comment": "コメント",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -550,6 +550,8 @@
   "no_template_account": "없음 (추적만)",
   "edit_allocation": "배정 편집",
   "tracking_target": "추적 대상",
+  "include_subcategories": "하위 카테고리 포함",
+  "include_subcategories_hint": "선택한 카테고리의 하위 카테고리 지출도 이 항목에 포함됩니다.",
   "select_target": "대상 선택",
   "allocation_label": "라벨",
   "allocation_comment": "메모",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -550,6 +550,8 @@
   "no_template_account": "Nenhuma (apenas acompanhamento)",
   "edit_allocation": "Editar alocação",
   "tracking_target": "Alvo de acompanhamento",
+  "include_subcategories": "Incluir subcategorias",
+  "include_subcategories_hint": "Os gastos em categorias aninhadas nas selecionadas contam para esta linha.",
   "select_target": "Selecionar alvo",
   "allocation_label": "Rótulo",
   "allocation_comment": "Comentário",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -553,6 +553,8 @@
   "no_template_account": "Нет (только учёт)",
   "edit_allocation": "Изменить статью",
   "tracking_target": "Цель отслеживания",
+  "include_subcategories": "Включая подкатегории",
+  "include_subcategories_hint": "Траты во вложенных категориях учитываются в этой строке.",
   "select_target": "Выберите цель",
   "allocation_label": "Название",
   "allocation_comment": "Комментарий",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -550,6 +550,8 @@
   "no_template_account": "无（仅跟踪）",
   "edit_allocation": "编辑分配",
   "tracking_target": "跟踪目标",
+  "include_subcategories": "包含子类别",
+  "include_subcategories_hint": "所选类别下嵌套类别的支出计入此行。",
   "select_target": "选择目标",
   "allocation_label": "标签",
   "allocation_comment": "备注",

--- a/drizzle/0021_plan_line_categories.js
+++ b/drizzle/0021_plan_line_categories.js
@@ -1,0 +1,52 @@
+/**
+ * Migration 0021: Let a plan line track SEVERAL categories
+ *
+ * Until now a `budget_plan_lines` row tracked exactly one target: one expense
+ * category or one destination account. A category target already rolled up its
+ * descendants (see BudgetsDB.calculateSpendingForBudget), so "budget a parent
+ * category" worked — but "budget Groceries + Cafes without their siblings" did
+ * not, and the roll-up could not be turned off.
+ *
+ * Two changes:
+ *
+ * 1. `budget_plan_line_categories` — a junction table, the source of truth for
+ *    which categories a line tracks. `line_id` cascades (dropping a line drops
+ *    its links); `category_id` cascades too, so deleting a category just shrinks
+ *    the set instead of nulling the whole line. A line left with NO categories
+ *    and no transfer target is "broken", exactly as before.
+ *
+ *    `budget_plan_lines.category_id` is KEPT and still written, holding the
+ *    line's primary (first) category. It stays for older backups, the CSV
+ *    export shape, and the ON DELETE SET NULL "broken" semantics — but readers
+ *    take the junction as authoritative (see BudgetPlansDB.mapLineFields), so
+ *    the two cannot drift into disagreement when the primary category is the one
+ *    that gets deleted.
+ *
+ * 2. `budget_plan_lines.include_children` — 1 (the default, and what every
+ *    pre-0021 line did implicitly) rolls descendant categories into the line's
+ *    actual; 0 counts only the categories explicitly linked. This is what makes
+ *    "just this parent, not its children" expressible.
+ *
+ * The backfill copies every existing non-null `category_id` into the junction,
+ * so a migrated line tracks exactly what it tracked before. `INSERT OR IGNORE`
+ * keeps it idempotent if the migration is retried after a partial apply.
+ *
+ * Append-only: never edit or revert an existing migration. This migration is also
+ * registered in app/services/db.js (isSchemaComplete + detectAppliedMigrations),
+ * otherwise existing installs would skip migrate() and crash with
+ * `no such table: budget_plan_line_categories`.
+ */
+
+const sql = `CREATE TABLE IF NOT EXISTS \`budget_plan_line_categories\` (
+	\`line_id\` text NOT NULL,
+	\`category_id\` text NOT NULL,
+	PRIMARY KEY (\`line_id\`, \`category_id\`),
+	FOREIGN KEY (\`line_id\`) REFERENCES \`budget_plan_lines\`(\`id\`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (\`category_id\`) REFERENCES \`categories\`(\`id\`) ON UPDATE no action ON DELETE cascade
+);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS \`idx_budget_plan_line_categories_category\` ON \`budget_plan_line_categories\` (\`category_id\`);--> statement-breakpoint
+ALTER TABLE \`budget_plan_lines\` ADD COLUMN \`include_children\` integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+INSERT OR IGNORE INTO \`budget_plan_line_categories\` (\`line_id\`, \`category_id\`)
+SELECT \`id\`, \`category_id\` FROM \`budget_plan_lines\` WHERE \`category_id\` IS NOT NULL`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1767500000000,
       "tag": "0020_plan_line_templates",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1767600000000,
+      "tag": "0021_plan_line_categories",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -22,6 +22,7 @@ import m0017 from './0017_add_pending_notification_location.js';
 import m0018 from './0018_budget_plans.js';
 import m0019, { postMigration as m0019PostMigration } from './0019_recurring_plan_lines.js';
 import m0020, { postMigration as m0020PostMigration } from './0020_plan_line_templates.js';
+import m0021 from './0021_plan_line_categories.js';
 
 export default {
   journal,
@@ -47,6 +48,7 @@ export default {
     m0018,
     m0019,
     m0020,
+    m0021,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,


### PR DESCRIPTION
## What

A `budget_plan_lines` row tracked exactly one target: one expense category or one destination account. Because a category target already rolled its descendants up, "budget a parent category" worked — but "budget Groceries + Cafes without their siblings" did not, and the roll-up could not be turned off.

Now a line tracks a **set** of categories, and whether descendants count is a per-line switch.

## How

**Migration 0021** adds `budget_plan_line_categories` (composite PK, both FKs cascade) and `budget_plan_lines.include_children` (`NOT NULL DEFAULT 1` — the pre-0021 behaviour, so existing lines are unchanged). The backfill copies every non-null `category_id` into the junction; `INSERT OR IGNORE` keeps it idempotent after a partial apply.

**The junction is the source of truth.** `category_id` stays as the denormalized primary entry (CSV/backup shape, cheap reads), but `mapLineFields` reads the set from the junction — so deleting the primary category *shrinks* the set instead of unlinking a line that still tracks others. "Broken" changed meaning accordingly: `getBrokenLines` now asks `NOT EXISTS (...)` rather than `category_id IS NULL`.

**Spending** goes through `BudgetsDB.calculateSpendingForCategories`, which de-duplicates the expanded set. That matters now: a line may track a parent *and* one of its own children, and with the roll-up on the child would otherwise appear twice. `calculateSpendingForBudget` remains as a single-category wrapper.

**UI**: the category picker is a multi-select (tap toggles, the panel stays open, "Done" closes it) plus an "include subcategories" switch on expense lines. Rows read `Groceries +2`. Strings added to all 11 locales.

**Round-trip**: backup/restore and Google Sheets carry the junction. A pre-0021 backup has none, so links are rebuilt from each line's `category_id` — without that, every restored line would come back broken. A link to a category or line the backup does not contain is dropped with a warning rather than aborting the restore (both FKs are `NOT NULL`). The Sheets import also resolves hand-typed names from the `categories` column, since that is what someone editing the spreadsheet reaches for.

The 0019/0020 bridges write their own links when the junction already exists — on a retry, or inside BackupRestore, they run on a schema that is already at 0021, where nothing will backfill for them.

## Notes for the reviewer

- `LINE_SELECT` uses a plain correlated **scalar** subquery on purpose: SQLite has no LATERAL, so the tidier `GROUP_CONCAT(...) FROM (SELECT ... ORDER BY ...)` spelling fails with `no such column: l.id`. Consequence: the set's order is not pinned. It does not matter — the UI sorts by name and the primary comes from its own column.
- Self-review caught a quiet one worth knowing about: `Number('') === 0`, so a blank CSV/Sheets cell for `include_children` would have silently switched the roll-up **off** for every line restored from a CSV backup. Blank now reads as "not stated" = on, with a regression test on the CSV path.

## Testing

`npm test` — 4762 passing, 162 suites, 0 failures. `npx eslint app __tests__` clean.

Not exercised on a device yet: the migration and the new SQL have only been run against mocks (no `sqlite3` or `node:sqlite` available on this host), so the first real launch is worth a look.
