### PR TITLE
feat(budgets): always roll subcategory spending into a plan line

### DIFF
--- a/__tests__/components/budgets/BudgetPlanLineModal.test.js
+++ b/__tests__/components/budgets/BudgetPlanLineModal.test.js
@@ -111,22 +111,21 @@ describe('BudgetPlanLineModal', () => {
     }));
   });
 
-  it('defaults includeChildren on and lets it be switched off', async () => {
+  it('offers no roll-up toggle — descendants always count', async () => {
     const props = baseProps();
     const { getByTestId, queryByTestId } = await render(<BudgetPlanLineModal {...props} />);
-    // The roll-up toggle only exists once the line tracks a category.
     expect(queryByTestId('plan-line-include-children-toggle')).toBeNull();
     await fireEvent.press(getByTestId('plan-target-picker'));
     await waitFor(() => expect(getByTestId('plan-target-option-cat-cat1')).toBeTruthy());
     await fireEvent.press(getByTestId('plan-target-option-cat-cat1'));
     await fireEvent.press(getByTestId('plan-target-done'));
     await fireEvent.changeText(getByTestId('plan-line-amount'), '150');
-    await waitFor(() => expect(getByTestId('plan-line-include-children-toggle')).toBeTruthy());
-    await fireEvent.press(getByTestId('plan-line-include-children-toggle'));
+    // Still absent with a category picked — the flag is gone from the UI entirely.
+    expect(queryByTestId('plan-line-include-children-toggle')).toBeNull();
     await fireEvent.press(getByTestId('plan-line-save'));
-    expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
-      includeChildren: false,
-    }));
+    expect(props.onSaveLine).toHaveBeenCalledWith(
+      expect.not.objectContaining({ includeChildren: expect.anything() }),
+    );
   });
 
   it('seeds the picker from an edited line\'s stored category set', async () => {
@@ -138,7 +137,7 @@ describe('BudgetPlanLineModal', () => {
       ],
       line: {
         id: 'l1', amount: '150', kind: 'expense',
-        categoryId: 'cat1', categoryIds: ['cat1', 'cat2'], includeChildren: false,
+        categoryId: 'cat1', categoryIds: ['cat1', 'cat2'],
       },
     };
     const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
@@ -146,7 +145,6 @@ describe('BudgetPlanLineModal', () => {
     await fireEvent.press(getByTestId('plan-line-save'));
     expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
       categoryIds: ['cat1', 'cat2'],
-      includeChildren: false,
     }));
   });
 

--- a/__tests__/services/BudgetPlansDB.status.test.js
+++ b/__tests__/services/BudgetPlansDB.status.test.js
@@ -136,13 +136,13 @@ describe('BudgetPlansDB plan-vs-actual', () => {
       );
     });
 
-    it('passes includeChildren=false through so only the picked categories count', async () => {
+    it('always rolls descendants up, even for a line stored with the old flag off', async () => {
       await BudgetPlansDB.calculateLineActual(
         categoryLine({ categoryIds: ['cat1'], includeChildren: false }), '2026-07', 'USD', false,
       );
 
       expect(calculateSpendingForCategories).toHaveBeenCalledWith(
-        ['cat1'], 'USD', '2026-07-01', '2026-07-31', false, false,
+        ['cat1'], 'USD', '2026-07-01', '2026-07-31', true, false,
       );
     });
 

--- a/__tests__/services/BudgetPlansDB.test.js
+++ b/__tests__/services/BudgetPlansDB.test.js
@@ -169,10 +169,10 @@ describe('BudgetPlansDB', () => {
         expect(line.isBroken).toBe(true);
       });
 
-      it('reads includeChildren from the column, defaulting to on', () => {
-        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1' }).includeChildren).toBe(true);
-        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1', include_children: 1 }).includeChildren).toBe(true);
-        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1', include_children: 0 }).includeChildren).toBe(false);
+      it('does not surface include_children — descendants always roll up', () => {
+        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1' })).not.toHaveProperty('includeChildren');
+        expect(BudgetPlansDB.mapLineFields({ id: 'l1', amount: '1', include_children: 0 }))
+          .not.toHaveProperty('includeChildren');
       });
     });
   });
@@ -390,14 +390,12 @@ describe('BudgetPlansDB', () => {
       expect(line.categoryIds).toEqual(['c1', 'c2']);
     });
 
-    it('addLine defaults includeChildren on and stores the flag', async () => {
-      const rolled = await BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1' });
-      expect(rolled.includeChildren).toBe(true);
-      const flat = await BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1', includeChildren: false });
-      expect(flat.includeChildren).toBe(false);
-      const rowInserts = mockRunAsync.mock.calls.filter(([sql]) => sql.includes('INSERT INTO budget_plan_lines'));
-      expect(rowInserts[1][0]).toContain('include_children');
-      expect(rowInserts[1][1]).toEqual(expect.arrayContaining([0]));
+    it('addLine always stores include_children on, even when a caller asks for off', async () => {
+      await BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1', includeChildren: false });
+      const [sql, params] = mockRunAsync.mock.calls.find(([s]) => s.includes('INSERT INTO budget_plan_lines'));
+      expect(sql).toContain('include_children');
+      // Column order: ..., last_executed_month, include_children, created_at, updated_at
+      expect(params[params.length - 3]).toBe(1);
     });
 
     // Bug 10 (adversarial review): addLine/addRecurringLine share one insertPlanLine
@@ -500,11 +498,10 @@ describe('BudgetPlansDB', () => {
       expect(mockRunAsync).not.toHaveBeenCalled();
     });
 
-    it('updateLine persists includeChildren', async () => {
-      await BudgetPlansDB.updateLine('l1', { includeChildren: false });
-      const [sql, params] = executeQuery.mock.calls[0];
-      expect(sql).toContain('include_children = ?');
-      expect(params).toEqual(expect.arrayContaining([0, 'l1']));
+    it('updateLine ignores an includeChildren update — the flag is gone', async () => {
+      await BudgetPlansDB.updateLine('l1', { amount: '200', includeChildren: false });
+      const [sql] = executeQuery.mock.calls[0];
+      expect(sql).not.toContain('include_children');
     });
 
     it('updateLine clears the category link when an account is (re)assigned', async () => {

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -34,8 +34,8 @@ const KINDS = ['income', 'expense', 'transfer'];
  *
  * `kind` decides what the line means and what an execution would create:
  *   - expense  → tracks spending across ONE OR MORE expense categories (at least
- *     one required); the picker toggles them, and `includeChildren` says whether
- *     their descendants roll up too (migration 0021),
+ *     one required); the picker toggles them, and spending in their descendants
+ *     always rolls up (a parent category IS its subtree — nothing to configure),
  *   - transfer → tracks incoming transfers into ONE destination account (required),
  *   - income   → declares part of the month's expected income; categories are
  *     optional context (income is compared against the month's real income as a
@@ -81,9 +81,6 @@ export default function BudgetPlanLineModal({
   // 0021 the category side is a SET — several categories can share one budget.
   const [categoryIds, setCategoryIds] = useState([]);
   const [toAccountId, setToAccountId] = useState(null);
-  // Whether descendants of the picked categories count too. On by default, which
-  // is what every line did before the flag existed.
-  const [includeChildren, setIncludeChildren] = useState(true);
   // Execution account — set means "this line is executable".
   const [accountId, setAccountId] = useState(null);
   const [isRecurring, setIsRecurring] = useState(false);
@@ -140,7 +137,6 @@ export default function BudgetPlanLineModal({
       setComment(line.comment || '');
       // Older callers (and stored lines read before 0021) only carry categoryId.
       setCategoryIds(line.categoryIds ?? (line.categoryId != null ? [line.categoryId] : []));
-      setIncludeChildren(line.includeChildren !== false);
       setToAccountId(line.toAccountId ?? null);
       setAccountId(line.accountId ?? null);
       setIsRecurring(!!line.isRecurring);
@@ -151,7 +147,6 @@ export default function BudgetPlanLineModal({
       setLabel('');
       setComment('');
       setCategoryIds([]);
-      setIncludeChildren(true);
       setToAccountId(null);
       setAccountId(null);
       setIsRecurring(false);
@@ -313,13 +308,12 @@ export default function BudgetPlanLineModal({
       toAccountId: kind === 'transfer' ? (toAccountId ?? null) : null,
       accountId: accountId ?? null,
       isRecurring,
-      includeChildren,
       // An executable line is priced in its account's currency; a template-less
       // one-off line inherits the plan's (null).
       currency: effectiveCurrency,
     });
   }, [saving, kind, amount, amountIsParseable, amountIsPositive, label, comment, categoryIds, toAccountId, accountId,
-    isRecurring, includeChildren, effectiveCurrency, onSaveLine, t]);
+    isRecurring, effectiveCurrency, onSaveLine, t]);
 
   const handleDelete = useCallback(() => {
     if (!isEditingLine) return;
@@ -502,46 +496,6 @@ export default function BudgetPlanLineModal({
                       <Icon name="chevron-right" size={20} color={colors.mutedText} />
                     </Pressable>
                   </View>
-
-                  {/* Roll-up toggle. Only an expense line has a per-category
-                      actual to roll up: a transfer line tracks an account, and an
-                      income line is compared against the month's total income
-                      rather than per-category spending. */}
-                  {kind === 'expense' && categoryIds.length > 0 && (
-                    <View style={styles.field}>
-                      <Pressable
-                        style={[styles.recurringRow, styles.noBottomMargin, { borderColor: colors.border }]}
-                        onPress={() => setIncludeChildren(v => !v)}
-                        accessibilityRole="switch"
-                        accessibilityState={{ checked: includeChildren }}
-                        accessibilityLabel={t('include_subcategories')}
-                        testID="plan-line-include-children-toggle"
-                      >
-                        <View style={styles.recurringLabel}>
-                          <Icon name="file-tree-outline" size={20} color={colors.text} />
-                          <Text style={[styles.text16, { color: colors.text }]}>
-                            {t('include_subcategories')}
-                          </Text>
-                        </View>
-                        <View
-                          style={[
-                            styles.switchTrack,
-                            { backgroundColor: includeChildren ? colors.primary : colors.border },
-                          ]}
-                        >
-                          <View
-                            style={[
-                              styles.switchThumb,
-                              { transform: [{ translateX: includeChildren ? 18 : 2 }] },
-                            ]}
-                          />
-                        </View>
-                      </Pressable>
-                      <Text style={[styles.fieldHint, { color: colors.mutedText }]}>
-                        {t('include_subcategories_hint')}
-                      </Text>
-                    </View>
-                  )}
 
                   {/* Execution account — set one and the line becomes a one-tap
                       payable (the former planned operation). */}
@@ -891,7 +845,6 @@ BudgetPlanLineModal.propTypes = {
     comment: PropTypes.string,
     categoryId: PropTypes.string,
     categoryIds: PropTypes.arrayOf(PropTypes.string),
-    includeChildren: PropTypes.bool,
     toAccountId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     accountId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     kind: PropTypes.oneOf(KINDS),
@@ -1000,9 +953,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'center',
-  },
-  noBottomMargin: {
-    marginBottom: 0,
   },
   optionText: {
     flex: 1,

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -341,9 +341,10 @@ export const budgetPlanLines = sqliteTable('budget_plan_lines', {
   // YYYY-MM of the last execution (or manual "mark as done"), like the old
   // planned_operations.last_executed_month.
   lastExecutedMonth: text('last_executed_month'),
-  // 1 (default) = descendant categories roll up into this line's actual, which is
-  // what every pre-0021 line did implicitly; 0 = only the categories explicitly
-  // linked in budget_plan_line_categories count. Migration 0021.
+  // Migration 0021. Legacy since the toggle was dropped: descendant categories
+  // ALWAYS roll up into a line's actual (picking a parent category means its
+  // subtree; a leaf has no subtree), so the app writes 1 and ignores a stored 0.
+  // The column stays for the backup/Sheets shape — see BudgetPlansDB.mapLineFields.
   includeChildren: integer('include_children').notNull().default(1),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),

--- a/app/services/BudgetPlansDB.js
+++ b/app/services/BudgetPlansDB.js
@@ -121,11 +121,11 @@ export const mapLineFields = (row) => {
     comment: row.comment ?? null,
     categoryId,
     categoryIds,
-    // Legacy rows (pre-0021, and any hand-built row in a test) have no column at
-    // all — they behaved as "roll descendants up", so absent reads as enabled.
-    // Only a stored 0 turns it off; the string form is accepted because a row
-    // that reached here through a CSV round trip carries text, not integers.
-    includeChildren: row.include_children !== 0 && row.include_children !== '0',
+    // NOTE: `include_children` is deliberately NOT surfaced. Descendant spending
+    // always rolls up now — picking a parent category means its subtree, and a
+    // leaf category has no subtree, so the flag never expressed a real choice.
+    // The column stays (append-only, still round-tripped by backups/Sheets) but
+    // a stored 0 no longer changes how a line counts.
     toAccountId,
     sortOrder: row.sort_order ?? 0,
     isBroken: kind !== 'income' && categoryIds.length === 0 && toAccountId === null,
@@ -538,9 +538,9 @@ const insertPlanLine = async (planId, line) => {
       kind: LINE_KINDS.includes(line.kind) ? line.kind : null,
       account_id: isSet(line.accountId) ? line.accountId : null,
       last_executed_month: line.lastExecutedMonth ?? null,
-      // Absent means "roll descendants up" — the pre-0021 behaviour, and what a
-      // caller that has never heard of the flag expects.
-      include_children: line.includeChildren === false ? 0 : 1,
+      // Always 1: descendant spending always rolls up (see mapLineFields). The
+      // column is kept written so the backup/Sheets shape stays stable.
+      include_children: 1,
       created_at: now,
       updated_at: now,
     };
@@ -754,10 +754,6 @@ export const updateLine = async (id, updates) => {
     if (toAccountId !== undefined) {
       fields.push('to_account_id = ?');
       values.push(isSet(toAccountId) ? toAccountId : null);
-    }
-    if (updates.includeChildren !== undefined) {
-      fields.push('include_children = ?');
-      values.push(updates.includeChildren ? 1 : 0);
     }
     if (updates.sortOrder !== undefined) {
       fields.push('sort_order = ?');
@@ -1038,7 +1034,7 @@ export const copyPlan = async (fromMonth, toMonth) => {
               clonedId, newPlanId, line.label, line.amount, line.comment,
               line.categoryId, line.toAccountId, line.sortOrder ?? i,
               line.currency, line.kind, line.accountId,
-              line.includeChildren === false ? 0 : 1, now, now,
+              1, now, now, // include_children: always on, see mapLineFields
             ],
           );
           // The clone must track the same SET of categories, not just the primary
@@ -1101,8 +1097,8 @@ export const getMonthDateRange = (month) => {
  * Compute the actual amount tracked by one plan line for a month.
  *
  * - Category-linked line: expense spending across every category the line tracks
- *   (migration 0021 allows several), including their descendants unless the
- *   line's `includeChildren` is off, via the shared convert-all engine
+ *   (migration 0021 allows several), always including their descendants, via the
+ *   shared convert-all engine
  *   ({@link calculateSpendingForCategories}). With `convertAll` off, only
  *   operations in accounts of `displayCurrency` count.
  * - Account-linked line (transfer target): incoming transfers into the account
@@ -1140,7 +1136,7 @@ export const calculateLineActual = async (line, month, displayCurrency, convertA
         displayCurrency,
         startDate,
         endDate,
-        line.includeChildren !== false, // descendants roll up unless switched off
+        true, // descendants always roll up into the categories a line tracks
         convertAll,
       );
       return { broken: false, actual: String(actual) };
@@ -1250,9 +1246,8 @@ const collectPlanSourceCurrencies = async (lines, startDate, endDate, convertAll
       const linked = line.categoryIds ?? (isSet(line.categoryId) ? [line.categoryId] : []);
       if (linked.length === 0) continue;
       // Same expansion the line's own actual uses, so the currencies collected
-      // here are exactly the ones that can feed it — including the descendants
-      // only when that line actually rolls them up.
-      for (const id of await expandCategoryIds(linked, line.includeChildren !== false)) {
+      // here are exactly the ones that can feed it — descendants included.
+      for (const id of await expandCategoryIds(linked, true)) {
         categoryIdSet.add(id);
       }
     }

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -550,8 +550,6 @@
   "no_template_account": "Keines (nur Nachverfolgung)",
   "edit_allocation": "Zuweisung bearbeiten",
   "tracking_target": "Tracking-Ziel",
-  "include_subcategories": "Unterkategorien einbeziehen",
-  "include_subcategories_hint": "Ausgaben in Kategorien unterhalb der ausgewählten zählen zu dieser Zeile.",
   "select_target": "Ziel auswählen",
   "allocation_label": "Bezeichnung",
   "allocation_comment": "Kommentar",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -553,8 +553,6 @@
   "no_template_account": "None (tracking only)",
   "edit_allocation": "Edit allocation",
   "tracking_target": "Tracking target",
-  "include_subcategories": "Include subcategories",
-  "include_subcategories_hint": "Spending in categories nested under the selected ones counts toward this line.",
   "select_target": "Select target",
   "allocation_label": "Label",
   "allocation_comment": "Comment",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -550,8 +550,6 @@
   "no_template_account": "Ninguna (solo seguimiento)",
   "edit_allocation": "Editar asignación",
   "tracking_target": "Objetivo de seguimiento",
-  "include_subcategories": "Incluir subcategorías",
-  "include_subcategories_hint": "Los gastos en categorías anidadas bajo las seleccionadas cuentan para esta línea.",
   "select_target": "Seleccionar objetivo",
   "allocation_label": "Etiqueta",
   "allocation_comment": "Comentario",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -550,8 +550,6 @@
   "no_template_account": "Aucun (suivi uniquement)",
   "edit_allocation": "Modifier la ligne",
   "tracking_target": "Cible de suivi",
-  "include_subcategories": "Inclure les sous-catégories",
-  "include_subcategories_hint": "Les dépenses des catégories imbriquées sous celles sélectionnées comptent dans cette ligne.",
   "select_target": "Sélectionner la cible",
   "allocation_label": "Libellé",
   "allocation_comment": "Commentaire",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -550,8 +550,6 @@
   "no_template_account": "Չկա (միայն հաշվառում)",
   "edit_allocation": "Խմբագրել բաշխումը",
   "tracking_target": "Հետևման նպատակ",
-  "include_subcategories": "Ներառել ենթակատեգորիաները",
-  "include_subcategories_hint": "Ընտրված կատեգորիաների ենթակատեգորիաների ծախսերը հաշվվում են այս տողում։",
   "select_target": "Ընտրել նպատակը",
   "allocation_label": "Պիտակ",
   "allocation_comment": "Մեկնաբանություն",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -550,8 +550,6 @@
   "no_template_account": "Nessuno (solo monitoraggio)",
   "edit_allocation": "Modifica voce",
   "tracking_target": "Obiettivo di tracciamento",
-  "include_subcategories": "Includi sottocategorie",
-  "include_subcategories_hint": "Le spese nelle categorie annidate sotto quelle selezionate contano in questa riga.",
   "select_target": "Seleziona obiettivo",
   "allocation_label": "Etichetta",
   "allocation_comment": "Commento",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -550,8 +550,6 @@
   "no_template_account": "なし（記録のみ）",
   "edit_allocation": "配分を編集",
   "tracking_target": "追跡対象",
-  "include_subcategories": "サブカテゴリを含める",
-  "include_subcategories_hint": "選択したカテゴリの下位カテゴリの支出もこの項目に含まれます。",
   "select_target": "対象を選択",
   "allocation_label": "ラベル",
   "allocation_comment": "コメント",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -550,8 +550,6 @@
   "no_template_account": "없음 (추적만)",
   "edit_allocation": "배정 편집",
   "tracking_target": "추적 대상",
-  "include_subcategories": "하위 카테고리 포함",
-  "include_subcategories_hint": "선택한 카테고리의 하위 카테고리 지출도 이 항목에 포함됩니다.",
   "select_target": "대상 선택",
   "allocation_label": "라벨",
   "allocation_comment": "메모",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -550,8 +550,6 @@
   "no_template_account": "Nenhuma (apenas acompanhamento)",
   "edit_allocation": "Editar alocação",
   "tracking_target": "Alvo de acompanhamento",
-  "include_subcategories": "Incluir subcategorias",
-  "include_subcategories_hint": "Os gastos em categorias aninhadas nas selecionadas contam para esta linha.",
   "select_target": "Selecionar alvo",
   "allocation_label": "Rótulo",
   "allocation_comment": "Comentário",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -553,8 +553,6 @@
   "no_template_account": "Нет (только учёт)",
   "edit_allocation": "Изменить статью",
   "tracking_target": "Цель отслеживания",
-  "include_subcategories": "Включая подкатегории",
-  "include_subcategories_hint": "Траты во вложенных категориях учитываются в этой строке.",
   "select_target": "Выберите цель",
   "allocation_label": "Название",
   "allocation_comment": "Комментарий",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -550,8 +550,6 @@
   "no_template_account": "无（仅跟踪）",
   "edit_allocation": "编辑分配",
   "tracking_target": "跟踪目标",
-  "include_subcategories": "包含子类别",
-  "include_subcategories_hint": "所选类别下嵌套类别的支出计入此行。",
   "select_target": "选择目标",
   "allocation_label": "标签",
   "allocation_comment": "备注",


### PR DESCRIPTION
## What

Removes the **Include subcategories** switch from the budget line editor and makes descendant roll-up unconditional.

The toggle never expressed a real choice: if the picked category is a parent, the line is *about* its subtree; if it's a leaf, there is no subtree to include. Two states, one meaningful outcome.

## Changes

- `BudgetPlanLineModal` — toggle, its state and the `includeChildren` payload field are gone (plus the now-unused style and `line` propType).
- `BudgetPlansDB` — `mapLineFields` no longer surfaces `includeChildren`; `calculateLineActual` and `getUnconvertibleCurrencies` always expand descendants; `addLine`/`copyPlan` write `include_children = 1`; `updateLine` dropped its branch for the flag.
- `budget_plan_lines.include_children` is **kept** (append-only column, still round-tripped by backup/restore and Sheets export) — the app just writes 1 and ignores a stored 0, so a line someone saved with the flag off starts counting its subcategories again.
- `include_subcategories` / `include_subcategories_hint` removed from all 11 locales.

## Testing

- `npx jest` — 162 suites / 4763 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.
- Test updates: the modal test now asserts the toggle is absent in both states, the DB tests assert the flag is written on regardless of caller input and that a legacy `include_children = 0` row still rolls descendants up.
