### PR TITLE
feat(budgets): show every plan amount in the selected currency

### DIFF
--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -330,14 +330,18 @@ describe('MonthlyPlanSection', () => {
       setPlanWithStatus();
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
-      expect(getByTestId('plan-income-total')).toHaveTextContent(/800\.00 \/ 1000\.00 USD/);
+      // Compact magnitudes: the income header is a context figure, and two exact
+      // 6-digit amounts plus a currency code did not fit beside the section title.
+      expect(getByTestId('plan-income-total')).toHaveTextContent(/800 \/ 1K USD/);
     });
 
     it('renders the totals row with allocated, actual, and planned remainder', async () => {
       setPlanWithStatus();
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-actual-total')).toBeTruthy());
-      expect(getByTestId('plan-actual-total')).toHaveTextContent(/400\.00/);
+      // Allocated/actual are compact (orientation), the remainder stays exact —
+      // it is the number the user acts on.
+      expect(getByTestId('plan-actual-total')).toHaveTextContent(/400 USD/);
       expect(getByTestId('plan-remainder')).toHaveTextContent(/500\.00/);
     });
 
@@ -611,8 +615,8 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
 
-      expect(getByTestId('plan-totals')).toHaveTextContent(/410\.00/);
-      expect(getByTestId('plan-totals')).not.toHaveTextContent(/300\.00 USD/);
+      expect(getByTestId('plan-totals')).toHaveTextContent(/410 USD/);
+      expect(getByTestId('plan-totals')).not.toHaveTextContent(/300 USD/);
       expect(getByTestId('plan-remainder')).toHaveTextContent(/590\.00/);
     });
   });
@@ -650,7 +654,7 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId } = await renderSection();
 
       // Before any mutation: the (not-yet-stale) planStatus totals show as-is.
-      await waitFor(() => expect(getByTestId('plan-totals')).toHaveTextContent(/999\.00/));
+      await waitFor(() => expect(getByTestId('plan-totals')).toHaveTextContent(/999 USD/));
 
       await fireEvent.press(getByTestId('plan-add-line'));
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
@@ -659,8 +663,8 @@ describe('MonthlyPlanSection', () => {
 
       // allocated = 300 (the new line), remainder = 1000 - 300 = 700 — the
       // fresh LOCAL estimate, not the stale planStatus's 999.00 / 1.00.
-      await waitFor(() => expect(getByTestId('plan-totals')).toHaveTextContent(/300\.00/));
-      expect(getByTestId('plan-totals')).not.toHaveTextContent(/999\.00/);
+      await waitFor(() => expect(getByTestId('plan-totals')).toHaveTextContent(/300 USD/));
+      expect(getByTestId('plan-totals')).not.toHaveTextContent(/999 USD/);
       expect(getByTestId('plan-remainder')).toHaveTextContent(/700\.00/);
     });
 
@@ -695,7 +699,7 @@ describe('MonthlyPlanSection', () => {
 
       // allocated = 0, remainder = 1000 — fresh, not the stale 300.00 / 700.00.
       await waitFor(() => expect(getByTestId('plan-remainder')).toHaveTextContent(/1000\.00/));
-      expect(getByTestId('plan-totals')).not.toHaveTextContent(/300\.00 USD/);
+      expect(getByTestId('plan-totals')).not.toHaveTextContent(/300 USD/);
     });
   });
 
@@ -835,6 +839,56 @@ describe('MonthlyPlanSection', () => {
     });
   });
 
+  describe('Single-currency display', () => {
+    // The screen is scoped to one selected currency, so no amount on it may be
+    // printed in another. A recurring line that stores its own currency used to
+    // render the STORED figure ("300000 AMD") directly above a progress bar built
+    // from the converted one ("69000 / 69000" in RUB) — two units stacked with
+    // nothing saying which was which. AMD→RUB is 0.23 in the bundled offline rate
+    // table, so 300000 AMD is exactly the 69000 RUB the bar was already showing.
+    const rubPlanWithAmdLine = () => setPlans({
+      plans: [{ id: 'p1', month: THIS_MONTH, currency: 'RUB', expectedIncome: '450000' }],
+      lines: [{
+        id: 'l-amd', planId: null, amount: '300000', label: 'Rent', comment: null,
+        kind: 'expense', categoryId: 'cat1', toAccountId: null, sortOrder: 0,
+        isBroken: false, isRecurring: true, currency: 'AMD',
+      }],
+    });
+
+    it('converts a foreign-currency line into the plan currency and prints no foreign code', async () => {
+      rubPlanWithAmdLine();
+      const { getByTestId } = await renderSection(undefined, { currency: 'RUB' });
+      await waitFor(() => expect(getByTestId('plan-line-l-amd')).toHaveTextContent(/69000/));
+      expect(getByTestId('plan-line-l-amd')).not.toHaveTextContent(/300000/);
+      expect(getByTestId('plan-line-l-amd')).not.toHaveTextContent(/AMD/);
+    });
+
+    it('counts a converted line in the local allocated total instead of skipping it', async () => {
+      rubPlanWithAmdLine();
+      const { getByTestId } = await renderSection(undefined, { currency: 'RUB' });
+      // The local estimate used to skip any line whose currency differed from the
+      // plan's, so this row contributed 0 and the remainder read the full 450000.
+      await waitFor(() => expect(getByTestId('plan-totals')).toHaveTextContent(/69K RUB/));
+      expect(getByTestId('plan-remainder')).toHaveTextContent(/381000/);
+    });
+
+    it('sums the template summary strip in the plan currency, not raw stored amounts', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'RUB', expectedIncome: '450000' }],
+        lines: [{
+          id: 'l-amd', planId: null, amount: '300000', label: 'Rent', comment: null,
+          kind: 'expense', categoryId: 'cat1', toAccountId: null, accountId: 1,
+          sortOrder: 0, isBroken: false, isRecurring: true, currency: 'AMD',
+          hasTemplate: true, lastExecutedMonth: null,
+        }],
+      });
+      const { getByTestId } = await renderSection(undefined, { currency: 'RUB' });
+      // 300000 AMD = 69000 RUB. The strip used to add the bare stored number and
+      // print "300K" with no unit at all, contradicting every other figure here.
+      await waitFor(() => expect(getByTestId('summary-pending-out')).toHaveTextContent(/69K \/ 69K RUB/));
+    });
+  });
+
   describe('Unconvertible recurring line (Bug 5, adversarial review)', () => {
     it('shows the line\'s own currency/amount instead of mislabeling it as the plan currency', async () => {
       setPlans({
@@ -859,8 +913,14 @@ describe('MonthlyPlanSection', () => {
       });
       const { getByTestId, queryByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-unconvertible-l-jpy')).toBeTruthy());
-      expect(getByTestId('plan-line-unconvertible-l-jpy')).toHaveTextContent(/10000/);
-      expect(getByTestId('plan-line-unconvertible-l-jpy')).toHaveTextContent(/JPY/);
+      // The screen is single-currency, so the amount column normally prints a
+      // bare number in the plan currency. This is the one exception: with no rate
+      // there is nothing to convert, so the row keeps the stored figure AND its
+      // own code — a labelled foreign number is honest, an unlabelled one is not.
+      // The warning sub-row just explains it, without repeating the amount.
+      expect(getByTestId('plan-line-l-jpy')).toHaveTextContent(/10000 JPY/);
+      expect(getByTestId('plan-line-unconvertible-l-jpy'))
+        .toHaveTextContent(/graphs_currencies_not_converted/);
       // Not rendered as a normal progress bar (which would mislabel it as USD).
       expect(queryByTestId('plan-line-broken-l-jpy')).toBeNull();
     });
@@ -935,9 +995,12 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('planned-summary-strip')).toBeTruthy());
       expect(getByTestId('summary-done-count')).toHaveTextContent('1 / 2');
-      expect(getByTestId('summary-pending-out')).toHaveTextContent('65K / 65K');
+      // The strip now labels its currency, and sums with the same precise decimal
+      // math as the totals row — it used to add bare parseFloat values across
+      // whatever currencies the templates stored and print them with no unit.
+      expect(getByTestId('summary-pending-out')).toHaveTextContent(/65K \/ 65K USD/);
       // The income template is already done, so nothing is pending in.
-      expect(getByTestId('summary-pending-in')).toHaveTextContent('0 / 220K');
+      expect(getByTestId('summary-pending-in')).toHaveTextContent(/0 \/ 220K USD/);
     });
 
     it('has no summary strip when no line carries a template', async () => {
@@ -983,8 +1046,8 @@ describe('MonthlyPlanSection', () => {
       await waitFor(() => expect(getByTestId('plan-line-i1')).toBeTruthy());
       // Expected income = 220 + 180 = 400; income lines are NOT allocations, so
       // allocated stays 300 and the remainder is 100.
-      expect(getByTestId('plan-income-total')).toHaveTextContent(/400\.00 USD/);
-      expect(getByTestId('plan-totals')).toHaveTextContent(/300\.00/);
+      expect(getByTestId('plan-income-total')).toHaveTextContent(/400 USD/);
+      expect(getByTestId('plan-totals')).toHaveTextContent(/300 USD/);
       expect(getByTestId('plan-remainder')).toHaveTextContent(/100\.00/);
     });
 
@@ -995,7 +1058,7 @@ describe('MonthlyPlanSection', () => {
       });
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-income-total')).toBeTruthy());
-      expect(getByTestId('plan-income-total')).toHaveTextContent(/1000\.00 USD/);
+      expect(getByTestId('plan-income-total')).toHaveTextContent(/1K USD/);
     });
 
     it('renders no progress bar for an income line', async () => {
@@ -1017,7 +1080,7 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId, queryByText } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-i1')).toBeTruthy());
       expect(queryByText('0 / 220')).toBeNull();
-      expect(getByTestId('plan-income-total')).toHaveTextContent(/150\.00 \/ 220\.00 USD/);
+      expect(getByTestId('plan-income-total')).toHaveTextContent(/150 \/ 220 USD/);
     });
   });
 });

--- a/__tests__/services/currency.test.js
+++ b/__tests__/services/currency.test.js
@@ -95,6 +95,52 @@ describe('Currency Service', () => {
     });
   });
 
+  describe('formatCompact', () => {
+    it('leaves amounts below a thousand exact and integral', async () => {
+      expect(Currency.formatCompact('0')).toBe('0');
+      expect(Currency.formatCompact('842')).toBe('842');
+      expect(Currency.formatCompact('842.60')).toBe('843');
+      expect(Currency.formatCompact('999')).toBe('999');
+    });
+
+    it('abbreviates thousands and millions', async () => {
+      expect(Currency.formatCompact('1000')).toBe('1K');
+      expect(Currency.formatCompact('1575')).toBe('1.58K');
+      expect(Currency.formatCompact('69000')).toBe('69K');
+      expect(Currency.formatCompact('535745')).toBe('536K');
+      expect(Currency.formatCompact('1240000')).toBe('1.24M');
+      expect(Currency.formatCompact('12400000')).toBe('12.4M');
+      expect(Currency.formatCompact('2500000000')).toBe('2.5B');
+    });
+
+    it('keeps three significant characters across magnitudes', async () => {
+      // Precision follows the leading digit, so outputs stay the same width and
+      // the column of figures they form stays readable.
+      expect(Currency.formatCompact('9990')).toBe('9.99K');
+      expect(Currency.formatCompact('99900')).toBe('99.9K');
+      expect(Currency.formatCompact('999000')).toBe('999K');
+    });
+
+    it('strips trailing zeros only after a decimal point', async () => {
+      expect(Currency.formatCompact('1200000')).toBe('1.2M');
+      expect(Currency.formatCompact('10000')).toBe('10K');
+      // Past the largest unit the value is a bare integer: its zeros are
+      // significant digits, not padding.
+      expect(Currency.formatCompact('12000000000000')).toBe('12000B');
+    });
+
+    it('keeps the sign on negative amounts', async () => {
+      expect(Currency.formatCompact('-85745')).toBe('-85.7K');
+      expect(Currency.formatCompact('-42')).toBe('-42');
+    });
+
+    it('handles invalid amounts gracefully', async () => {
+      expect(Currency.formatCompact(null)).toBe('0');
+      expect(Currency.formatCompact('invalid')).toBe('0');
+      expect(Currency.formatCompact(NaN)).toBe('0');
+    });
+  });
+
   describe('toCents', () => {
     it('converts string amounts to cents correctly', async () => {
       expect(Currency.toCents('10.50')).toBe(1050);

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -9,6 +9,7 @@ import { useLocalization } from '../../contexts/LocalizationContext';
 import { useDialog } from '../../contexts/DialogContext';
 import { useBudgetPlans } from '../../contexts/BudgetPlansContext';
 import * as Currency from '../../services/currency';
+import usePlanLineAmounts from '../../hooks/usePlanLineAmounts';
 import { SPACING } from '../../styles/layout';
 import BudgetPlanLineModal from './BudgetPlanLineModal';
 import PlanLineRow from './PlanLineRow';
@@ -187,26 +188,31 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   const recurringLines = useMemo(() => allocationLines.filter(l => l.isRecurring), [allocationLines]);
   const oneOffLines = useMemo(() => allocationLines.filter(l => !l.isRecurring), [allocationLines]);
 
+  // Every line's target amount expressed in the screen's single currency. Rows,
+  // the live totals below and the template summary strip all read from this one
+  // map, so no two of them can print the same line in different units.
+  const { amountById, converting } = usePlanLineAmounts(lines, planCurrency);
+
   // Live totals: allocated = Σ allocation amounts, expected = Σ income lines,
   // remainder = expected − allocated. Same precise decimal math as
   // BudgetPlansDB.getPlanTotals, computed locally so the numbers update
-  // immediately as lines change, BEFORE the async plan status lands. A line in
-  // another currency is skipped in this local estimate (converting it needs an
-  // exchange-rate lookup, which is exactly what planStatus already did
-  // asynchronously) — the render below prefers planStatus.totals once available.
+  // immediately as lines change, BEFORE the async plan status lands. A line
+  // whose currency has no rate is absent from `amountById` and drops out of the
+  // estimate — the render below prefers planStatus.totals once available, and
+  // those flag the currency via the unconvertible warning.
   const totals = useMemo(() => {
     let allocated = '0';
     let income = '0';
     let hasIncomeLine = false;
     for (const line of lines) {
-      const lineCurrency = line.currency || planCurrency;
-      if (lineCurrency !== planCurrency) continue;
+      const amount = amountById.get(line.id);
+      if (amount == null) continue;
       if (line.kind === 'income') {
         hasIncomeLine = true;
-        income = Currency.add(income, line.amount, planCurrency);
+        income = Currency.add(income, amount, planCurrency);
         continue;
       }
-      allocated = Currency.add(allocated, line.amount, planCurrency);
+      allocated = Currency.add(allocated, amount, planCurrency);
     }
     // Fallback for a plan whose expected income was never bridged into lines
     // (migration 0020 only skips that when income templates already exist).
@@ -215,7 +221,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     }
     const remainder = Currency.subtract(income, allocated, planCurrency);
     return { income, allocated, remainder };
-  }, [plan, lines, planCurrency]);
+  }, [plan, lines, amountById, planCurrency]);
 
   // Once the plan status has resolved (and is not stale — see freshPlanStatus
   // above), prefer its totals: those are computed with correct cross-currency
@@ -557,6 +563,8 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         icon={lineIcon(line)}
         status={lineStatusById.get(line.id) || null}
         planCurrency={planCurrency}
+        displayAmount={amountById.get(line.id) ?? null}
+        converting={converting}
         colors={colors}
         t={t}
         executed={executed}
@@ -572,9 +580,9 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         onUndo={handleUndoExecuted}
       />
     );
-  }, [colors, t, month, isCurrentMonth, lineStatusById, planCurrency, openEditLine,
-    handleLongPressLine, lineDisplayName, lineIcon, handleExecute, handleMarkExecuted,
-    handleUndoExecuted]);
+  }, [colors, t, month, isCurrentMonth, lineStatusById, planCurrency, amountById, converting,
+    openEditLine, handleLongPressLine, lineDisplayName, lineIcon, handleExecute,
+    handleMarkExecuted, handleUndoExecuted]);
 
   const hasAnyLines = lines.length > 0;
 
@@ -593,7 +601,14 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
 
   return (
     <>
-      <PlanTemplateSummary lines={lines} month={month} colors={colors} t={t} />
+      <PlanTemplateSummary
+        lines={lines}
+        month={month}
+        amountById={amountById}
+        planCurrency={planCurrency}
+        colors={colors}
+        t={t}
+      />
 
       <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]} testID="monthly-plan-section">
         {/* Month header with ‹ › navigation — rendered only when the section owns
@@ -633,10 +648,14 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
             <Icon name="cash-plus" size={20} color={colors.text} />
             <Text style={[styles.sectionTitle, { color: colors.text }]}>{t('income')}</Text>
           </View>
+          {/* Compact magnitudes, not exact figures: this is a context number
+              ("am I roughly on track for the month"), and two 6-digit amounts
+              plus a currency code did not fit beside the section title. The
+              exact income is one tap away on the lines themselves. */}
           <Text style={[styles.sectionAmount, { color: colors.text }]} testID="plan-income-total">
             {planStatus
-              ? `${Currency.formatAmount(planStatus.totals.actualIncome, planCurrency)} / ${Currency.formatAmount(displayExpectedIncome, planCurrency)} ${planCurrency}`
-              : `${Currency.formatAmount(displayExpectedIncome, planCurrency)} ${planCurrency}`}
+              ? `${Currency.formatCompact(planStatus.totals.actualIncome)} / ${Currency.formatCompact(displayExpectedIncome)} ${planCurrency}`
+              : `${Currency.formatCompact(displayExpectedIncome)} ${planCurrency}`}
           </Text>
         </View>
 
@@ -707,10 +726,13 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
             {/* Totals: allocated vs actual, then the planned remainder.
                 Both labels get flexShrink + a gap: in Russian they are long
                 enough that a bare space-between row let them collide into
-                "…800.00 USDФактический: …". */}
+                "…800.00 USDФактический: …". Compact magnitudes here for the
+                same reason as the income header — these two are orientation,
+                and the remainder below is the figure to act on, so that one
+                stays exact. */}
             <View style={[styles.totalsRow, { borderTopColor: colors.border }]} testID="plan-totals">
               <Text style={[styles.totalsLabel, { color: colors.mutedText }]} numberOfLines={1}>
-                {t('allocated')}: {Currency.formatAmount(displayAllocated, planCurrency)} {planCurrency}
+                {t('allocated')}: {Currency.formatCompact(displayAllocated)} {planCurrency}
               </Text>
               {planStatus && (
                 <Text
@@ -718,7 +740,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
                   numberOfLines={1}
                   testID="plan-actual-total"
                 >
-                  {t('actual')}: {Currency.formatAmount(planStatus.totals.totalActual, planCurrency)} {planCurrency}
+                  {t('actual')}: {Currency.formatCompact(planStatus.totals.totalActual)} {planCurrency}
                 </Text>
               )}
             </View>

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -7,6 +7,11 @@ import * as Currency from '../../services/currency';
 import StatusProgressBar from '../StatusProgressBar';
 import { SPACING } from '../../styles/layout';
 
+// Stands in for a foreign-currency amount while its exchange rate resolves — an
+// em dash rather than the stored figure, which would read as a number in the
+// screen's currency for the frame or two before the real one replaces it.
+const CONVERTING_PLACEHOLDER = '—';
+
 /**
  * One row of the unified Budgets list (Budgets v3 phase 3).
  *
@@ -32,6 +37,8 @@ const PlanLineRow = memo(function PlanLineRow({
   icon,
   status = null,
   planCurrency,
+  displayAmount = null,
+  converting = false,
   colors,
   t,
   executed = false,
@@ -48,6 +55,26 @@ const PlanLineRow = memo(function PlanLineRow({
 }) {
   const lineCurrency = line.currency || planCurrency;
   const isBroken = line.isBroken || status?.broken;
+  // The screen shows exactly one currency, so a row prints a bare number in it —
+  // no per-row code to read, and never the stored figure of a line that keeps its
+  // own currency (a 300000 AMD target rendered next to a RUB progress bar was two
+  // different units stacked with nothing saying so).
+  //
+  // `displayAmount` is the converted figure supplied by the host; it is absent
+  // only while rates are still resolving or when no rate exists at all. Those two
+  // are NOT the same: converting shows a placeholder, unconvertible falls back to
+  // the stored amount WITH its own code, because a labelled foreign number is
+  // honest and an unlabelled one is not.
+  const isUnconvertible = status?.status === 'unconvertible'
+    || (displayAmount == null && lineCurrency !== planCurrency && !converting);
+  let amountText;
+  if (isUnconvertible) {
+    amountText = `${Currency.formatAmount(line.amount, lineCurrency)} ${lineCurrency}`;
+  } else if (displayAmount != null) {
+    amountText = Currency.formatAmount(displayAmount, planCurrency);
+  } else {
+    amountText = CONVERTING_PLACEHOLDER;
+  }
   // Both gates are decided by the host (they depend on the month being shown):
   // execution only makes sense for the current month, and so does undoing it.
   const swipeEnabled = canExecute || canUndo;
@@ -106,7 +133,7 @@ const PlanLineRow = memo(function PlanLineRow({
           )}
         </View>
         <Text style={[styles.lineAmount, { color: executed ? colors.mutedText : colors.text }]}>
-          {Currency.formatAmount(line.amount, lineCurrency)} {line.currency ? lineCurrency : ''}
+          {amountText}
         </Text>
         {showMove && onMove && (
           <View style={styles.moveButtons}>
@@ -142,14 +169,16 @@ const PlanLineRow = memo(function PlanLineRow({
             {t('relink_target')}
           </Text>
         </View>
-      ) : status?.status === 'unconvertible' ? (
-        // calculatePlanStatus found no rate to express this line's own currency in
-        // the plan's currency — showing its amount labeled as planCurrency (like
-        // the progress bar below does) would silently mislabel the real value.
+      ) : isUnconvertible ? (
+        // No rate to express this line's own currency in the screen's — so the
+        // amount column above kept the stored figure and its own code, and this
+        // row explains why it is the one number on screen in a foreign unit.
+        // There is deliberately no progress bar: comparing it against actuals in
+        // another currency is exactly the mismatch this branch exists to avoid.
         <View style={styles.brokenRow} testID={`plan-line-unconvertible-${line.id}`}>
           <Icon name="alert-circle-outline" size={14} color={colors.mutedText} />
           <Text style={[styles.brokenText, { color: colors.mutedText }]} numberOfLines={1}>
-            {t('graphs_currencies_not_converted')}: {Currency.formatAmount(status.amount, lineCurrency)} {lineCurrency}
+            {t('graphs_currencies_not_converted')}
           </Text>
         </View>
       ) : showProgress && status ? (
@@ -246,6 +275,8 @@ PlanLineRow.propTypes = {
   icon: PropTypes.string.isRequired,
   status: PropTypes.object,
   planCurrency: PropTypes.string.isRequired,
+  displayAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  converting: PropTypes.bool,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   executed: PropTypes.bool,

--- a/app/components/budgets/PlanTemplateSummary.js
+++ b/app/components/budgets/PlanTemplateSummary.js
@@ -1,14 +1,8 @@
 import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
+import * as Currency from '../../services/currency';
 import { SPACING } from '../../styles/layout';
-
-const formatSummaryAmount = (amount) => {
-  if (amount === 0) return '0';
-  if (amount >= 1000000) return `${(amount / 1000000).toFixed(1)}M`;
-  if (amount >= 1000) return `${Math.round(amount / 1000)}K`;
-  return String(Math.round(amount));
-};
 
 /** One of the strip's three identical value-over-label columns. */
 const SummaryItem = ({ testID, color, mutedColor, value, label }) => (
@@ -37,42 +31,49 @@ SummaryItem.propTypes = {
  * how many are done, pending money in — ported from the former Planned tab and
  * now computed from the plan lines that carry a template (Budgets v3 phase 3).
  *
- * Amounts are summed as plain numbers, matching the strip's original behaviour:
- * it is a coarse "how much is still to pay this month" gauge, not an accounting
- * figure (the per-line amounts and the totals row below are). With templates in
- * several currencies the sum mixes them — the same caveat the Planned tab had.
+ * Amounts come from `amountById`, already converted into the screen's single
+ * currency by the host. They used to be summed as bare `parseFloat` values across
+ * whatever currencies the templates happened to store, and printed with no unit
+ * at all — so a 300000 AMD rent showed up as "300K" one row above an income
+ * header reading "535745 / 450000 RUB", two panels disagreeing about the same
+ * month. Precise decimal math and one labelled currency now, matching the totals
+ * row below exactly.
  */
-export default function PlanTemplateSummary({ lines, month, colors, t }) {
+export default function PlanTemplateSummary({ lines, month, amountById, planCurrency, colors, t }) {
   const summary = useMemo(() => {
-    let pendingOut = 0;
-    let pendingIn = 0;
-    let totalOut = 0;
-    let totalIn = 0;
+    let pendingOut = '0';
+    let pendingIn = '0';
+    let totalOut = '0';
+    let totalIn = '0';
     let doneCount = 0;
     let total = 0;
     for (const line of lines) {
       if (!line.hasTemplate) continue;
       total++;
-      const amount = parseFloat(line.amount || '0');
-      const isIn = line.kind === 'income';
-      if (isIn) {
-        totalIn += amount;
-      } else {
-        totalOut += amount;
-      }
       if (line.lastExecutedMonth === month) {
         doneCount++;
-      } else if (isIn) {
-        pendingIn += amount;
+      }
+      // A line with no rate into the screen's currency has no figure that can be
+      // added here; it drops out of the money columns (the row itself carries the
+      // "not converted" warning) but still counts toward the execution tally,
+      // which is currency-free.
+      const amount = amountById.get(line.id);
+      if (amount == null) continue;
+      const isIn = line.kind === 'income';
+      const pending = line.lastExecutedMonth !== month;
+      if (isIn) {
+        totalIn = Currency.add(totalIn, amount, planCurrency);
+        if (pending) pendingIn = Currency.add(pendingIn, amount, planCurrency);
       } else {
-        pendingOut += amount;
+        totalOut = Currency.add(totalOut, amount, planCurrency);
+        if (pending) pendingOut = Currency.add(pendingOut, amount, planCurrency);
       }
     }
     return {
       pendingOut, pendingIn, totalOut, totalIn, doneCount, total,
       progressFraction: total > 0 ? doneCount / total : 0,
     };
-  }, [lines, month]);
+  }, [lines, month, amountById, planCurrency]);
 
   if (summary.total === 0) return null;
 
@@ -86,7 +87,7 @@ export default function PlanTemplateSummary({ lines, month, colors, t }) {
           testID="summary-pending-out"
           color={colors.expense}
           mutedColor={colors.mutedText}
-          value={`${formatSummaryAmount(summary.pendingOut)} / ${formatSummaryAmount(summary.totalOut)}`}
+          value={`${Currency.formatCompact(summary.pendingOut)} / ${Currency.formatCompact(summary.totalOut)} ${planCurrency}`}
           label={t('pending_out')}
         />
         <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
@@ -102,7 +103,7 @@ export default function PlanTemplateSummary({ lines, month, colors, t }) {
           testID="summary-pending-in"
           color={colors.income}
           mutedColor={colors.mutedText}
-          value={`${formatSummaryAmount(summary.pendingIn)} / ${formatSummaryAmount(summary.totalIn)}`}
+          value={`${Currency.formatCompact(summary.pendingIn)} / ${Currency.formatCompact(summary.totalIn)} ${planCurrency}`}
           label={t('pending_in')}
         />
       </View>
@@ -135,6 +136,8 @@ export default function PlanTemplateSummary({ lines, month, colors, t }) {
 PlanTemplateSummary.propTypes = {
   lines: PropTypes.array.isRequired,
   month: PropTypes.string.isRequired,
+  amountById: PropTypes.instanceOf(Map).isRequired,
+  planCurrency: PropTypes.string.isRequired,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
 };

--- a/app/hooks/usePlanLineAmounts.js
+++ b/app/hooks/usePlanLineAmounts.js
@@ -1,0 +1,115 @@
+import { useState, useEffect, useMemo } from 'react';
+import { fetchRatesToTarget, convertWithRateMap } from '../services/OperationsDB';
+
+// Module-level so the "nothing to convert" result keeps a stable identity and
+// consumers memoizing on it don't rebuild every render.
+const EMPTY_SET = new Set();
+
+/**
+ * Target amounts for a month's plan lines, every one expressed in a SINGLE
+ * currency.
+ *
+ * The Budgets screen is scoped to one selected currency, so a line that stores
+ * its own (e.g. "Rent, 300000 AMD" while the screen shows RUB) must be converted
+ * before it is printed — showing the stored figure meant the screen mixed units
+ * silently: the amount was AMD, the progress bar beneath it was RUB, and neither
+ * said which.
+ *
+ * `calculatePlanStatus` already converts the same way, but only for a month that
+ * HAS a plan row; recurring lines render for plan-less months too, and the
+ * screen's own live totals recompute before the async status lands. This hook is
+ * the one source of converted target amounts for both cases, so a row, the
+ * totals and the summary strip can never disagree.
+ *
+ * Rates come from the shared offline-first lookup ({@link fetchRatesToTarget}),
+ * the same one the status path uses — identical inputs give identical figures.
+ *
+ * @param {Array<{id: string, amount: string, currency: ?string}>} lines
+ * @param {string} targetCurrency - The currency the screen is showing
+ * @returns {{
+ *   amountById: Map<string, string>,
+ *   unconvertibleIds: Set<string>,
+ *   converting: boolean,
+ * }} `amountById` holds every line whose amount could be expressed in
+ *   `targetCurrency`; a line with no available rate is absent from it and
+ *   present in `unconvertibleIds` instead, so callers must decide explicitly
+ *   what to do rather than silently printing a mislabeled number.
+ */
+export default function usePlanLineAmounts(lines, targetCurrency) {
+  // Lines in the target currency need no rate at all, so they are resolved
+  // synchronously on first render — the common case never flashes an empty map.
+  const local = useMemo(() => {
+    const amountById = new Map();
+    const foreign = [];
+    for (const line of lines) {
+      const lineCurrency = line.currency || targetCurrency;
+      if (lineCurrency === targetCurrency) {
+        amountById.set(line.id, String(line.amount ?? '0'));
+      } else {
+        foreign.push({ id: line.id, amount: String(line.amount ?? '0'), currency: lineCurrency });
+      }
+    }
+    return { amountById, foreign };
+  }, [lines, targetCurrency]);
+
+  const [converted, setConverted] = useState(null);
+
+  useEffect(() => {
+    if (!targetCurrency || local.foreign.length === 0) {
+      // Nothing to fetch. Clear any result left from a previous currency so a
+      // stale conversion can't leak into the render below.
+      setConverted(prev => (prev === null ? prev : null));
+      return undefined;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const rateByCurrency = await fetchRatesToTarget(
+          local.foreign.map(l => l.currency),
+          targetCurrency,
+        );
+        if (cancelled) return;
+        const amountById = new Map();
+        const unconvertibleIds = new Set();
+        for (const line of local.foreign) {
+          const value = convertWithRateMap(line.amount, line.currency, targetCurrency, rateByCurrency);
+          if (value === null) {
+            unconvertibleIds.add(line.id);
+          } else {
+            amountById.set(line.id, value);
+          }
+        }
+        setConverted({ amountById, unconvertibleIds });
+      } catch (error) {
+        console.error('Failed to convert plan line amounts:', error);
+        if (!cancelled) {
+          // Every foreign line is unconvertible rather than wrong: a failed rate
+          // lookup must not fall back to printing the raw amount as if it were
+          // already in the target currency.
+          setConverted({
+            amountById: new Map(),
+            unconvertibleIds: new Set(local.foreign.map(l => l.id)),
+          });
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [local, targetCurrency]);
+
+  return useMemo(() => {
+    if (local.foreign.length === 0) {
+      return { amountById: local.amountById, unconvertibleIds: EMPTY_SET, converting: false };
+    }
+    if (!converted) {
+      // Rates still in flight: same-currency lines are already final, foreign
+      // ones are withheld (not guessed) until the conversion resolves.
+      return { amountById: local.amountById, unconvertibleIds: EMPTY_SET, converting: true };
+    }
+    const amountById = new Map(local.amountById);
+    for (const [id, value] of converted.amountById) {
+      amountById.set(id, value);
+    }
+    return { amountById, unconvertibleIds: converted.unconvertibleIds, converting: false };
+  }, [local, converted]);
+}

--- a/app/services/currency.js
+++ b/app/services/currency.js
@@ -92,6 +92,55 @@ export const formatAmount = (amount, currencyOrDecimals = 2) => {
   return formatted;
 };
 
+// Thresholds for formatCompact, largest first, so the loop below picks the first
+// unit whose magnitude the amount reaches.
+const COMPACT_UNITS = [
+  { suffix: 'B', divisor: 1e9 },
+  { suffix: 'M', divisor: 1e6 },
+  { suffix: 'K', divisor: 1e3 },
+];
+
+/**
+ * Format an amount as a short magnitude for AGGREGATE figures — summary strips,
+ * headers, totals — where space is tight and the minor units carry no decision
+ * value: 842 → "842", 1575 → "1.58K", 98645 → "98.6K", 1240000 → "1.24M".
+ *
+ * Deliberately NOT for per-line amounts: an envelope's "98 645 / 100 000" is a
+ * number the user compares against their own spending, and "99K / 100K" throws
+ * away exactly the digits that make the comparison possible.
+ *
+ * Precision follows the leading digit rather than a fixed decimal count, so
+ * every output is 3-4 significant characters wide regardless of magnitude
+ * (a fixed 1 decimal would render 1.6K next to 986.5K, which don't align).
+ *
+ * @param {Decimal|string|number} amount - Amount to format
+ * @returns {string} Compact representation, with a leading '-' for negatives
+ */
+export const formatCompact = (amount) => {
+  const decimal = toDecimal(amount);
+  const sign = decimal.isNegative() ? '-' : '';
+  const magnitude = decimal.abs();
+  const value = magnitude.toNumber();
+
+  for (const { suffix, divisor } of COMPACT_UNITS) {
+    if (value < divisor) continue;
+    // Scaled with Decimal, not native division: 1575/1000 is a hair under 1.575
+    // in binary, so Number#toFixed(2) rounds it DOWN to "1.57" while the
+    // arbitrary-precision path gives the "1.58" a reader expects.
+    const scaled = magnitude.div(divisor);
+    const scaledValue = scaled.toNumber();
+    // Keep roughly three significant digits: 1.24M, 12.4M, 124M.
+    const decimals = scaledValue < 10 ? 2 : scaledValue < 100 ? 1 : 0;
+    // Strip trailing zeros so 1.00M reads "1M" and 1.20M reads "1.2M". Anchored
+    // on the decimal point: a bare integer (12000B, past the largest unit) must
+    // keep its zeros.
+    const text = scaled.toFixed(decimals).replace(/\.(\d*?)0+$/, (_, keep) => (keep ? `.${keep}` : ''));
+    return `${sign}${text}${suffix}`;
+  }
+
+  return `${sign}${magnitude.toFixed(0)}`;
+};
+
 // Maps a rounding-mode name to the decimal.js rounding constant applied when
 // dividing the amount by the step. Amounts are non-negative magnitudes here, so
 // ROUND_UP/ROUND_DOWN (away from / toward zero) behave as ceil/floor.


### PR DESCRIPTION
## Problem

The Budgets screen is scoped to one selected currency, but three of its panels printed amounts in whatever currency each line happened to store — and two of them printed no unit at all.

With RUB selected and a `300000 AMD` rent line, the screen showed four numbers about the same month, in two units, with nothing saying which was which:

| panel | showed | actually |
|---|---|---|
| summary strip | `0 / 300K` | bare AMD, unlabelled |
| income header | `535745 / 450000 RUB` | RUB |
| rent row | `300000 AMD` | AMD |
| rent row's progress bar | `69000 / 69000` | the same rent, in RUB |

`PlanTemplateSummary` summed `parseFloat(line.amount)` across currencies (its own docstring admitted it), and `PlanLineRow` printed the stored amount directly above a progress bar built from the converted one.

## Change

- **New `usePlanLineAmounts` hook** — one batched, offline-first rate lookup that expresses every line's target amount in the screen's currency. It covers the case `calculatePlanStatus` cannot: recurring lines render for months with no plan row, and the screen's live totals recompute before the async status lands. Rows, totals and the strip now read from one map and can't disagree.
- **`PlanLineRow`** prints a bare converted number — no per-row currency code, since there is only one currency on screen. A line with no available rate is the single exception: it keeps its stored figure *with* its own code (a labelled foreign number is honest, an unlabelled one is not), and the warning sub-row stops repeating the amount.
- **`PlanTemplateSummary`** sums with precise decimal math and labels its currency.
- **Local totals** count converted foreign lines instead of skipping them.

## K/M abbreviations

New `Currency.formatCompact`, applied to the summary strip, the income header and the allocated/actual totals — all context figures in tight rows. Precision follows the leading digit (`1.24M`, `12.4M`, `124M`) so a column of them stays the same width.

The **remainder stays exact**: it is the number the user acts on. Per-line amounts stay exact too — `99K / 100K` throws away exactly the digits that make an envelope comparison possible.

## Tests

162 suites / 4772 passing. New: `formatCompact` unit coverage, and a `Single-currency display` block asserting an AMD line renders as `69000` in a RUB plan (0.23 is the bundled offline rate — which is precisely the figure the progress bar was already showing), that it counts toward the local allocated total, and that the strip sums it in RUB.

Existing assertions on the old formatting were updated, with the reason recorded inline.

*First of four PRs reshaping this screen: currency truth → row density → envelope fill → header hierarchy.*
