### PR TITLE
feat(graphs): merge income and expense cards into one tabbed panel

### DIFF
--- a/__tests__/components/graphs/ExpenseSummaryCard.test.js
+++ b/__tests__/components/graphs/ExpenseSummaryCard.test.js
@@ -149,6 +149,22 @@ describe('ExpenseSummaryCard', () => {
 
       expect(onPress).toHaveBeenCalledTimes(1);
     });
+
+    // The tab is the whole card, not just the chevron — pressing anywhere on it
+    // (icon, amount, empty space) must toggle the panel.
+    it('makes the entire tab the press target', async () => {
+      const onPress = jest.fn();
+      const { getByTestId, getByText } = await render(
+        <ExpenseSummaryCard {...defaultProps} onPress={onPress} />,
+      );
+
+      await fireEvent.press(getByTestId('expense-summary-card'));
+      expect(onPress).toHaveBeenCalledTimes(1);
+
+      // Pressing the amount text bubbles to the same tab handler
+      await fireEvent.press(getByText(/\$1\.5K/));
+      expect(onPress).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('Accessibility', () => {
@@ -156,6 +172,18 @@ describe('ExpenseSummaryCard', () => {
       const { getByRole } = await render(<ExpenseSummaryCard {...defaultProps} />);
 
       expect(getByRole('button')).toBeTruthy();
+    });
+
+    it('exposes the expanded state of the tab', async () => {
+      const { getByTestId, rerender } = await render(<ExpenseSummaryCard {...defaultProps} />);
+
+      expect(getByTestId('expense-summary-card').props.accessibilityState)
+        .toEqual(expect.objectContaining({ expanded: false }));
+
+      await rerender(<ExpenseSummaryCard {...defaultProps} expanded />);
+
+      expect(getByTestId('expense-summary-card').props.accessibilityState)
+        .toEqual(expect.objectContaining({ expanded: true }));
     });
 
     it('has accessibility label', async () => {

--- a/__tests__/components/graphs/IncomeSummaryCard.test.js
+++ b/__tests__/components/graphs/IncomeSummaryCard.test.js
@@ -141,6 +141,22 @@ describe('IncomeSummaryCard', () => {
 
       expect(onPress).toHaveBeenCalledTimes(1);
     });
+
+    // The tab is the whole card, not just the chevron — pressing anywhere on it
+    // (icon, amount, empty space) must toggle the panel.
+    it('makes the entire tab the press target', async () => {
+      const onPress = jest.fn();
+      const { getByTestId, getByText } = await render(
+        <IncomeSummaryCard {...defaultProps} onPress={onPress} />,
+      );
+
+      await fireEvent.press(getByTestId('income-summary-card'));
+      expect(onPress).toHaveBeenCalledTimes(1);
+
+      // Pressing the amount text bubbles to the same tab handler
+      await fireEvent.press(getByText(/\$3\.5K/));
+      expect(onPress).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('Accessibility', () => {
@@ -148,6 +164,18 @@ describe('IncomeSummaryCard', () => {
       const { getByRole } = await render(<IncomeSummaryCard {...defaultProps} />);
 
       expect(getByRole('button')).toBeTruthy();
+    });
+
+    it('exposes the expanded state of the tab', async () => {
+      const { getByTestId, rerender } = await render(<IncomeSummaryCard {...defaultProps} />);
+
+      expect(getByTestId('income-summary-card').props.accessibilityState)
+        .toEqual(expect.objectContaining({ expanded: false }));
+
+      await rerender(<IncomeSummaryCard {...defaultProps} expanded />);
+
+      expect(getByTestId('income-summary-card').props.accessibilityState)
+        .toEqual(expect.objectContaining({ expanded: true }));
     });
 
     it('has accessibility label', async () => {

--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -821,6 +821,44 @@ describe('GraphsScreen', () => {
       expect(getByTestId('income-summary-card')).toBeTruthy();
       expect(getByTestId('expense-summary-card')).toBeTruthy();
     });
+
+    it('starts collapsed with neither chart interactive', async () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = await render(<GraphsScreen />);
+
+      expect(getByTestId('income-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('income-summary-card').props.accessibilityState.expanded).toBe(false);
+      expect(getByTestId('expense-summary-card').props.accessibilityState.expanded).toBe(false);
+    });
+
+    it('opens only the pressed tab and moves the open state when the other is pressed', async () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = await render(<GraphsScreen />);
+
+      await fireEvent.press(getByTestId('income-summary-card'));
+
+      expect(getByTestId('income-chart-content').props.pointerEvents).toBe('auto');
+      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('income-summary-card').props.accessibilityState.expanded).toBe(true);
+
+      await fireEvent.press(getByTestId('expense-summary-card'));
+
+      expect(getByTestId('income-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('auto');
+      expect(getByTestId('expense-summary-card').props.accessibilityState.expanded).toBe(true);
+    });
+
+    it('collapses the panel back to the tab strip when the open tab is pressed again', async () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId } = await render(<GraphsScreen />);
+
+      await fireEvent.press(getByTestId('expense-summary-card'));
+      await fireEvent.press(getByTestId('expense-summary-card'));
+
+      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('expense-summary-card').props.accessibilityState.expanded).toBe(false);
+    });
   });
 
   describe('Balance History Empty State (QoL-11)', () => {

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -5,6 +5,9 @@ import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 
+// Expense red is intentionally theme-independent — it matches the arrow badge.
+const EXPENSE_ACCENT = '#d93025';
+
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
   const symbol = currencyInfo?.symbol ?? currency;
@@ -32,12 +35,20 @@ const ExpenseSummaryCard = ({
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <View
+    <TouchableOpacity
       testID="expense-summary-card"
-      style={styles.summaryCard}
+      style={[
+        styles.summaryCard,
+        expanded && { backgroundColor: colors.altRow, borderBottomColor: EXPENSE_ACCENT },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityState={{ expanded }}
+      accessibilityLabel={t('expenses_by_category')}
     >
       <View style={styles.iconBadge}>
-        <Icon name="arrow-top-right" size={16} color="#d93025" />
+        <Icon name="arrow-top-right" size={16} color={EXPENSE_ACCENT} />
       </View>
       <View style={styles.textContent}>
         <Text style={[styles.label, { color: colors.mutedText }]}>{t('expense').toUpperCase()}</Text>
@@ -61,16 +72,10 @@ const ExpenseSummaryCard = ({
           </TouchableOpacity>
         </View>
       )}
-      <TouchableOpacity
-        onPress={onPress}
-        style={styles.collapseButton}
-        activeOpacity={0.7}
-        accessibilityRole="button"
-        accessibilityLabel={t('expenses_by_category')}
-      >
+      <View style={styles.chevron} pointerEvents="none">
         <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-      </TouchableOpacity>
-    </View>
+      </View>
+    </TouchableOpacity>
   );
 };
 
@@ -102,11 +107,11 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
   },
-  collapseButton: {
+  chevron: {
     alignItems: 'center',
     alignSelf: 'stretch',
     justifyContent: 'center',
-    width: '15%',
+    width: 20,
   },
   filterChip: {
     alignItems: 'center',
@@ -136,10 +141,14 @@ const styles = StyleSheet.create({
   },
   summaryCard: {
     alignItems: 'center',
+    // Transparent by default so activating the tab doesn't shift its height
+    borderBottomColor: 'transparent',
+    borderBottomWidth: 2,
     flex: 1,
     flexDirection: 'row',
     gap: 8,
-    padding: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
   },
   textContent: {
     flex: 1,

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -32,9 +32,17 @@ const IncomeSummaryCard = ({
 }) => {
   const { hideBalances } = useDisplaySettings();
   return (
-    <View
+    <TouchableOpacity
       testID="income-summary-card"
-      style={styles.summaryCard}
+      style={[
+        styles.summaryCard,
+        expanded && { backgroundColor: colors.altRow, borderBottomColor: colors.income },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityState={{ expanded }}
+      accessibilityLabel={t('income_by_category')}
     >
       <View style={styles.iconBadge}>
         <Icon name="arrow-bottom-left" size={16} color={colors.income} />
@@ -61,16 +69,10 @@ const IncomeSummaryCard = ({
           </TouchableOpacity>
         </View>
       )}
-      <TouchableOpacity
-        onPress={onPress}
-        style={styles.collapseButton}
-        activeOpacity={0.7}
-        accessibilityRole="button"
-        accessibilityLabel={t('income_by_category')}
-      >
+      <View style={styles.chevron} pointerEvents="none">
         <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-      </TouchableOpacity>
-    </View>
+      </View>
+    </TouchableOpacity>
   );
 };
 
@@ -102,11 +104,11 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
   },
-  collapseButton: {
+  chevron: {
     alignItems: 'center',
     alignSelf: 'stretch',
     justifyContent: 'center',
-    width: '15%',
+    width: 20,
   },
   filterChip: {
     alignItems: 'center',
@@ -136,10 +138,14 @@ const styles = StyleSheet.create({
   },
   summaryCard: {
     alignItems: 'center',
+    // Transparent by default so activating the tab doesn't shift its height
+    borderBottomColor: 'transparent',
+    borderBottomWidth: 2,
     flex: 1,
     flexDirection: 'row',
     gap: 8,
-    padding: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
   },
   textContent: {
     flex: 1,

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, useWindowDimensions } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing, SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import WheelPicker from '@quidone/react-native-wheel-picker';
@@ -26,16 +26,11 @@ import useBalanceHistory from '../hooks/useBalanceHistory';
 
 const CARD_HEADER_HEIGHT = 56;
 const MAX_CHART_HEIGHT = 500;
-const CARD_GAP = 8;
 
 const GraphsScreen = () => {
   const { colors } = useThemeColors();
   const { t, language } = useLocalization();
   const { accounts } = useAccountsData();
-
-  const { width: windowWidth } = useWindowDimensions();
-  const rowWidth = windowWidth - TOP_CONTENT_SPACING * 2;
-  const halfWidth = (rowWidth - CARD_GAP) / 2;
 
   // Get current month and year
   const now = new Date();
@@ -66,27 +61,21 @@ const GraphsScreen = () => {
   // Account selection state
   const [selectedAccount, setSelectedAccount] = useState(null);
 
-  // Inline chart expansion state
-  // null = neither expanded, 'income' | 'expense' = that card is expanded/expanding
+  // Income/expense live in one panel with two tabs. Collapsed, the panel is just
+  // the tab strip; tapping a tab drops its chart down underneath it.
+  // null = collapsed, 'income' | 'expense' = that tab is open
   const [expandedCard, setExpandedCard] = useState(null);
   // Reanimated shared values — all run on UI thread, immune to JS contention
-  // Sequential animation: width first, then height
-  // 0=collapsed, 1=expanded; drives width/opacity (phase 1)
-  const widthProgress = useSharedValue(0);
-  // 0=collapsed, 1=expanded; drives height (phase 2)
-  const heightProgress = useSharedValue(0);
-  // 0=hidden, 1=visible; drives chart content opacity + slide (phase 2)
-  const chartProgress = useSharedValue(0);
-  // 0=none, 1=income expanding, 2=expense expanding
-  const expandingCard = useSharedValue(0);
-  // Dimension values updated on orientation change
-  const halfWidthSV = useSharedValue(halfWidth);
-  const rowWidthSV = useSharedValue(rowWidth);
-  // Dynamic chart heights — updated by onContentSizeChange on each chart's ScrollView
-  const expenseChartHeightSV = useSharedValue(0);
-  const incomeChartHeightSV = useSharedValue(0);
-  const expenseHeightInitialized = useRef(false);
-  const incomeHeightInitialized = useRef(false);
+  // Panel height: header only when collapsed, header + chart when open
+  const panelHeight = useSharedValue(CARD_HEADER_HEIGHT);
+  // 0=hidden, 1=visible; drives each chart's opacity + slide. Both charts stay
+  // mounted and overlap absolutely, so switching tabs is a cross-fade.
+  const incomeChartProgress = useSharedValue(0);
+  const expenseChartProgress = useSharedValue(0);
+  // Measured chart heights, kept in refs so the expand handler can read them
+  // synchronously (they are written from the JS-side onContentSizeChange).
+  const expenseChartHeightRef = useRef(0);
+  const incomeChartHeightRef = useRef(0);
   // dir + target bundled so a single setState triggers a render that refreshes
   // the exiting prop on the old component BEFORE the key changes in the next render
   const [expenseDrillReq, setExpenseDrillReq] = useState({ dir: 'in', target: null });
@@ -509,40 +498,35 @@ const GraphsScreen = () => {
   const resetIncomeCategory = useCallback(() => setIncomeDrillReq({ dir: 'none', target: 'all' }), []);
 
   const toggleCard = useCallback((card) => {
-    if (expandedCard === card) {
-      // Reset category first, then collapse
-      if (card === 'expense') {
+    // Leaving a tab always drops its drill-down so it reopens at the top level
+    const closeTab = (tab) => {
+      if (tab === 'expense') {
         resetExpenseCategory();
+        expenseChartProgress.value = withTiming(0, { duration: 150, easing: Easing.in(Easing.quad) });
       } else {
         resetIncomeCategory();
+        incomeChartProgress.value = withTiming(0, { duration: 150, easing: Easing.in(Easing.quad) });
       }
-      // Collapse: fade chart + shrink height first (180ms), then restore width (200ms)
-      chartProgress.value = withTiming(0, { duration: 150, easing: Easing.in(Easing.quad) });
-      heightProgress.value = withTiming(0, { duration: 180, easing: Easing.in(Easing.quad) }, (finished) => {
-        if (finished) {
-          widthProgress.value = withTiming(0, { duration: 200, easing: Easing.in(Easing.quad) }, (done) => {
-            if (done) {
-              expandingCard.value = 0;
-              runOnJS(setExpandedCard)(null);
-            }
-          });
-        }
-      });
-    } else {
-      // Expand phase 1: animate width (200ms), then phase 2: animate height + chart (280ms)
-      widthProgress.value = 0;
-      heightProgress.value = 0;
-      chartProgress.value = 0;
-      expandingCard.value = card === 'income' ? 1 : 2;
-      setExpandedCard(card);
-      widthProgress.value = withTiming(1, { duration: 200, easing: Easing.out(Easing.cubic) }, (finished) => {
-        if (finished) {
-          heightProgress.value = withTiming(1, { duration: 280, easing: Easing.out(Easing.cubic) });
-          chartProgress.value = withTiming(1, { duration: 260, easing: Easing.out(Easing.cubic) });
-        }
-      });
+    };
+
+    if (expandedCard === card) {
+      closeTab(card);
+      setExpandedCard(null);
+      panelHeight.value = withTiming(CARD_HEADER_HEIGHT, { duration: 220, easing: Easing.in(Easing.quad) });
+      return;
     }
-  }, [expandedCard, widthProgress, heightProgress, chartProgress, expandingCard,
+
+    if (expandedCard) {
+      closeTab(expandedCard);
+    }
+    setExpandedCard(card);
+    const chartHeight = card === 'income'
+      ? incomeChartHeightRef.current
+      : expenseChartHeightRef.current;
+    panelHeight.value = withTiming(CARD_HEADER_HEIGHT + chartHeight, { duration: 280, easing: Easing.out(Easing.cubic) });
+    const progress = card === 'income' ? incomeChartProgress : expenseChartProgress;
+    progress.value = withTiming(1, { duration: 260, easing: Easing.out(Easing.cubic) });
+  }, [expandedCard, panelHeight, incomeChartProgress, expenseChartProgress,
     resetExpenseCategory, resetIncomeCategory]);
 
   const handleToggleIncome = useCallback(() => toggleCard('income'), [toggleCard]);
@@ -573,77 +557,31 @@ const GraphsScreen = () => {
   const hintAnimStyle = useAnimatedStyle(() => ({ opacity: hintOpacity.value }));
 
 
-  // Reset expansion and update dimension shared values on orientation change
-  useEffect(() => {
-    halfWidthSV.value = halfWidth;
-    rowWidthSV.value = rowWidth;
-    widthProgress.value = 0;
-    heightProgress.value = 0;
-    chartProgress.value = 0;
-    expandingCard.value = 0;
-    setExpandedCard(null);
-  }, [windowWidth]); // intentionally omit stable shared value refs
+  // Chart heights are re-reported by onContentSizeChange whenever the content or
+  // the available width changes, so rotation needs no special handling here.
+  const panelAnimStyle = useAnimatedStyle(() => ({ height: panelHeight.value }));
 
-  // Animated styles via Reanimated — all run on UI thread, no JS contention
-  const incomeCardAnimStyle = useAnimatedStyle(() => {
-    const ev = expandingCard.value;
-    const wp = widthProgress.value;
-    const hp = heightProgress.value;
-    const hw = halfWidthSV.value;
-    const rw = rowWidthSV.value;
-    const chartH = incomeChartHeightSV.value;
-    if (ev === 1) {
-      return {
-        width: interpolate(wp, [0, 1], [hw, rw]),
-        height: interpolate(hp, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + chartH]),
-        opacity: 1,
-      };
-    }
-    if (ev === 2) {
-      return {
-        width: interpolate(wp, [0, 1], [hw, 0]),
-        height: CARD_HEADER_HEIGHT,
-        opacity: interpolate(wp, [0, 1], [1, 0]),
-      };
-    }
-    return { width: hw, height: CARD_HEADER_HEIGHT, opacity: 1 };
-  });
-
-  const expenseCardAnimStyle = useAnimatedStyle(() => {
-    const ev = expandingCard.value;
-    const wp = widthProgress.value;
-    const hp = heightProgress.value;
-    const hw = halfWidthSV.value;
-    const rw = rowWidthSV.value;
-    const chartH = expenseChartHeightSV.value;
-    if (ev === 2) {
-      return {
-        width: interpolate(wp, [0, 1], [hw, rw]),
-        height: interpolate(hp, [0, 1], [CARD_HEADER_HEIGHT, CARD_HEADER_HEIGHT + chartH]),
-        opacity: 1,
-      };
-    }
-    if (ev === 1) {
-      return {
-        width: interpolate(wp, [0, 1], [hw, 0]),
-        height: CARD_HEADER_HEIGHT,
-        opacity: interpolate(wp, [0, 1], [1, 0]),
-      };
-    }
-    return { width: hw, height: CARD_HEADER_HEIGHT, opacity: 1 };
-  });
-
-  const spacerAnimStyle = useAnimatedStyle(() => {
-    if (expandingCard.value !== 0) {
-      return { width: interpolate(widthProgress.value, [0, 1], [CARD_GAP, 0]) };
-    }
-    return { width: CARD_GAP };
-  });
-
-  const chartContentAnimStyle = useAnimatedStyle(() => ({
-    opacity: chartProgress.value,
-    transform: [{ translateY: interpolate(chartProgress.value, [0, 1], [16, 0]) }],
+  const incomeChartAnimStyle = useAnimatedStyle(() => ({
+    opacity: incomeChartProgress.value,
+    transform: [{ translateY: interpolate(incomeChartProgress.value, [0, 1], [16, 0]) }],
   }));
+
+  const expenseChartAnimStyle = useAnimatedStyle(() => ({
+    opacity: expenseChartProgress.value,
+    transform: [{ translateY: interpolate(expenseChartProgress.value, [0, 1], [16, 0]) }],
+  }));
+
+  // Keeps the panel sized to whatever the visible chart currently measures —
+  // covers the first measurement and every drill-down that changes its height.
+  const handleChartMeasured = useCallback((card, contentHeight) => {
+    const target = Math.min(contentHeight, MAX_CHART_HEIGHT);
+    const ref = card === 'income' ? incomeChartHeightRef : expenseChartHeightRef;
+    if (ref.current === target) return;
+    ref.current = target;
+    if (expandedCard === card) {
+      panelHeight.value = withTiming(CARD_HEADER_HEIGHT + target, { duration: 280, easing: Easing.out(Easing.cubic) });
+    }
+  }, [expandedCard, panelHeight]);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -659,135 +597,109 @@ const GraphsScreen = () => {
             </View>
           )}
 
-          {/* Summary Cards Row — always-mounted, width/height driven by Animated */}
-          <View style={styles.summaryCardsRow}>
-            {/* Income card */}
+          {/* Income/expense summary — one panel, two tabs. Collapsed by default:
+              only the tab strip shows, each tab tappable across its full width. */}
+          <Animated.View
+            style={[
+              styles.summaryPanel,
+              panelAnimStyle,
+              { backgroundColor: colors.surface, borderColor: colors.border },
+            ]}
+          >
+            <View style={styles.tabsRow}>
+              <IncomeSummaryCard
+                colors={colors}
+                t={t}
+                loadingIncome={loadingIncome}
+                totalIncome={totalIncome}
+                selectedCurrency={selectedCurrency}
+                onPress={handleToggleIncome}
+                expanded={expandedCard === 'income'}
+                categoryName={selectedIncomeCategoryName}
+                onBack={handleBackToIncomeParent}
+              />
+              <View style={[styles.tabDivider, { backgroundColor: colors.border }]} />
+              <ExpenseSummaryCard
+                colors={colors}
+                t={t}
+                loading={loading}
+                totalExpenses={totalExpenses}
+                selectedCurrency={selectedCurrency}
+                onPress={handleToggleExpense}
+                expanded={expandedCard === 'expense'}
+                categoryName={selectedCategoryName}
+                onBack={handleBackToExpenseParent}
+              />
+            </View>
+
+            {/* Both charts stay mounted and overlap, so they stay measured and
+                switching tabs cross-fades instead of remounting. */}
             <Animated.View
-              style={[
-                styles.summaryCardBase,
-                incomeCardAnimStyle,
-                { backgroundColor: colors.surface, borderColor: colors.border },
-              ]}
+              testID="income-chart-content"
+              pointerEvents={expandedCard === 'income' ? 'auto' : 'none'}
+              style={[styles.chartContent, incomeChartAnimStyle]}
             >
-              <View style={styles.cardHeader}>
-                <IncomeSummaryCard
-                  colors={colors}
-                  t={t}
-                  loadingIncome={loadingIncome}
-                  totalIncome={totalIncome}
-                  selectedCurrency={selectedCurrency}
-                  onPress={handleToggleIncome}
-                  expanded={expandedCard === 'income'}
-                  categoryName={selectedIncomeCategoryName}
-                  onBack={handleBackToIncomeParent}
-                />
-              </View>
-              <Animated.View
-                testID="income-chart-content"
-                style={[styles.chartContent, chartContentAnimStyle]}
+              <ScrollView
+                style={styles.chartScrollView}
+                contentContainerStyle={styles.chartScrollContent}
+                nestedScrollEnabled
+                showsVerticalScrollIndicator={false}
+                onContentSizeChange={(_, h) => handleChartMeasured('income', h)}
               >
-                <ScrollView
-                  style={styles.chartScrollView}
-                  contentContainerStyle={styles.chartScrollContent}
-                  nestedScrollEnabled
-                  showsVerticalScrollIndicator={false}
-                  onContentSizeChange={(_, h) => {
-                    const target = Math.min(h, MAX_CHART_HEIGHT);
-                    if (!incomeHeightInitialized.current) {
-                      incomeChartHeightSV.value = target;
-                      incomeHeightInitialized.current = true;
-                    } else {
-                      incomeChartHeightSV.value = withTiming(target, { duration: 280, easing: Easing.out(Easing.cubic) });
-                    }
-                  }}
+                <Animated.View
+                  key={selectedIncomeCategory}
+                  entering={incomeDrillReq.dir === 'none' ? undefined : incomeDrillReq.dir === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
+                  exiting={incomeDrillReq.dir === 'none' ? undefined : incomeDrillReq.dir === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
                 >
-                  <Animated.View
-                    key={selectedIncomeCategory}
-                    entering={incomeDrillReq.dir === 'none' ? undefined : incomeDrillReq.dir === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
-                    exiting={incomeDrillReq.dir === 'none' ? undefined : incomeDrillReq.dir === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
-                  >
-                    <IncomePieChart
-                      colors={colors}
-                      t={t}
-                      language={language}
-                      loadingIncome={loadingIncome}
-                      incomeChartData={incomeChartData}
-                      selectedCurrency={selectedCurrency}
-                      onLegendItemPress={handleIncomeLegendItemPress}
-                      isLeafCategory={incomeCategoryIsLeaf}
-                      operations={incomeOperations}
-                      loadingOperations={loadingIncomeOperations}
-                    />
-                  </Animated.View>
-                </ScrollView>
-              </Animated.View>
+                  <IncomePieChart
+                    colors={colors}
+                    t={t}
+                    language={language}
+                    loadingIncome={loadingIncome}
+                    incomeChartData={incomeChartData}
+                    selectedCurrency={selectedCurrency}
+                    onLegendItemPress={handleIncomeLegendItemPress}
+                    isLeafCategory={incomeCategoryIsLeaf}
+                    operations={incomeOperations}
+                    loadingOperations={loadingIncomeOperations}
+                  />
+                </Animated.View>
+              </ScrollView>
             </Animated.View>
 
-            {/* Spacer that collapses as one card expands */}
-            <Animated.View style={spacerAnimStyle} />
-
-            {/* Expense card */}
             <Animated.View
-              style={[
-                styles.summaryCardBase,
-                expenseCardAnimStyle,
-                { backgroundColor: colors.surface, borderColor: colors.border },
-              ]}
+              testID="expense-chart-content"
+              pointerEvents={expandedCard === 'expense' ? 'auto' : 'none'}
+              style={[styles.chartContent, expenseChartAnimStyle]}
             >
-              <View style={styles.cardHeader}>
-                <ExpenseSummaryCard
-                  colors={colors}
-                  t={t}
-                  loading={loading}
-                  totalExpenses={totalExpenses}
-                  selectedCurrency={selectedCurrency}
-                  onPress={handleToggleExpense}
-                  expanded={expandedCard === 'expense'}
-                  categoryName={selectedCategoryName}
-                  onBack={handleBackToExpenseParent}
-                />
-              </View>
-              <Animated.View
-                testID="expense-chart-content"
-                style={[styles.chartContent, chartContentAnimStyle]}
+              <ScrollView
+                style={styles.chartScrollView}
+                contentContainerStyle={styles.chartScrollContent}
+                nestedScrollEnabled
+                showsVerticalScrollIndicator={false}
+                onContentSizeChange={(_, h) => handleChartMeasured('expense', h)}
               >
-                <ScrollView
-                  style={styles.chartScrollView}
-                  contentContainerStyle={styles.chartScrollContent}
-                  nestedScrollEnabled
-                  showsVerticalScrollIndicator={false}
-                  onContentSizeChange={(_, h) => {
-                    const target = Math.min(h, MAX_CHART_HEIGHT);
-                    if (!expenseHeightInitialized.current) {
-                      expenseChartHeightSV.value = target;
-                      expenseHeightInitialized.current = true;
-                    } else {
-                      expenseChartHeightSV.value = withTiming(target, { duration: 280, easing: Easing.out(Easing.cubic) });
-                    }
-                  }}
+                <Animated.View
+                  key={selectedCategory}
+                  entering={expenseDrillReq.dir === 'none' ? undefined : expenseDrillReq.dir === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
+                  exiting={expenseDrillReq.dir === 'none' ? undefined : expenseDrillReq.dir === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
                 >
-                  <Animated.View
-                    key={selectedCategory}
-                    entering={expenseDrillReq.dir === 'none' ? undefined : expenseDrillReq.dir === 'in' ? SlideInRight.duration(280) : SlideInLeft.duration(280)}
-                    exiting={expenseDrillReq.dir === 'none' ? undefined : expenseDrillReq.dir === 'in' ? SlideOutLeft.duration(220) : SlideOutRight.duration(220)}
-                  >
-                    <ExpensePieChart
-                      colors={colors}
-                      t={t}
-                      language={language}
-                      loading={loading}
-                      chartData={chartData}
-                      selectedCurrency={selectedCurrency}
-                      onLegendItemPress={handleExpenseLegendItemPress}
-                      isLeafCategory={expenseCategoryIsLeaf}
-                      operations={expenseOperations}
-                      loadingOperations={loadingExpenseOperations}
-                    />
-                  </Animated.View>
-                </ScrollView>
-              </Animated.View>
+                  <ExpensePieChart
+                    colors={colors}
+                    t={t}
+                    language={language}
+                    loading={loading}
+                    chartData={chartData}
+                    selectedCurrency={selectedCurrency}
+                    onLegendItemPress={handleExpenseLegendItemPress}
+                    isLeafCategory={expenseCategoryIsLeaf}
+                    operations={expenseOperations}
+                    loadingOperations={loadingExpenseOperations}
+                  />
+                </Animated.View>
+              </ScrollView>
             </Animated.View>
-          </View>
+          </Animated.View>
 
           {/* Balance History Card — shown for a specific month. When no account is
               available, render an explicit empty state instead of silently dropping
@@ -966,9 +878,6 @@ const GraphsScreen = () => {
 };
 
 const styles = StyleSheet.create({
-  cardHeader: {
-    height: CARD_HEADER_HEIGHT,
-  },
   chartContent: {
     bottom: 0,
     left: 0,
@@ -1064,14 +973,19 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
   },
-  summaryCardBase: {
+  summaryPanel: {
     borderRadius: 16,
     borderWidth: 1,
+    marginBottom: 16,
     overflow: 'hidden',
   },
-  summaryCardsRow: {
+  tabDivider: {
+    marginVertical: 10,
+    width: StyleSheet.hairlineWidth,
+  },
+  tabsRow: {
     flexDirection: 'row',
-    marginBottom: 16,
+    height: CARD_HEADER_HEIGHT,
   },
   toggleHint: {
     borderRadius: 10,


### PR DESCRIPTION
## What

The income and expense summaries on the Graphs tab are now **one panel with two tabs** instead of two separate cards.

Collapsed — the default — the panel is just the two-tab strip. Tapping a tab drops its chart down underneath it; tapping the open tab collapses it again.

## Why

The old layout was two cards that each animated their width between half and full to make room for the chart, shoving the sibling off screen. And only the small chevron (~15% of the card width) was tappable.

## Changes

- **Tappable area is the whole tab.** `IncomeSummaryCard`/`ExpenseSummaryCard` are now `TouchableOpacity` roots; the chevron is `pointerEvents="none"`, purely an indicator.
- **Active tab is marked** with an `altRow` background and a 2px accent underline (green for income, red for expense). The border is transparent when inactive so the tab height never shifts.
- **`accessibilityState={{ expanded }}`** on each tab — the correct disclosure pattern for TalkBack.
- **Both charts stay mounted** and overlap absolutely, so a tab switch cross-fades rather than remounting; `pointerEvents` is `auto` only on the open one.
- **Simpler animation.** Panel height is a single shared value. The two-phase width-then-height sequence, the collapsing spacer and the per-card dimension shared values are all gone.
- **Rotation no longer force-closes the panel** — chart heights come from `onContentSizeChange`, which re-fires on resize, so `useWindowDimensions` and the reset effect were dropped.

## Testing

- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean
- Full suite: **162 suites / 4782 tests** passing
- New coverage: whole-tab press target on both cards, `accessibilityState.expanded`, and the collapsed → income → expense → collapsed transitions asserted via the chart containers' `pointerEvents`
