### PR TITLE
feat(budgets): compact the plan rows

### DIFF
--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -196,6 +196,55 @@ const renderSection = (ref, extraProps = {}) => render(
 
 const flatColor = (node) => StyleSheet.flatten(node.props.style)?.color;
 
+// The dashed "+ Add income" / "+ Add allocation" rows are gone: the screen's
+// single FAB opens the same editor through the section's imperative handle, and
+// the editor's own kind segment picks income vs expense. Tests drive it the way
+// the host does.
+const openEditor = async (ref, kind = 'expense') => {
+  await act(async () => {
+    if (kind === 'income') {
+      ref.current.openAddIncome();
+    } else {
+      ref.current.openAddLine();
+    }
+  });
+};
+
+// Reordering moved off the rows (a chevron pair on every one) and into the
+// long-press action sheet. `t` is the identity function here, so an action's
+// text is its translation key.
+const lastDialogAction = (key) => {
+  const calls = mockShowDialog.mock.calls;
+  const buttons = calls[calls.length - 1][2];
+  const action = buttons.find(b => b.text === key);
+  if (!action) {
+    throw new Error(`No "${key}" action in the last dialog: ${buttons.map(b => b.text).join(', ')}`);
+  }
+  return action;
+};
+
+const hasDialogAction = (key) => {
+  const calls = mockShowDialog.mock.calls;
+  return calls[calls.length - 1][2].some(b => b.text === key);
+};
+
+// Always act()-wrapped: several tests here long-press a row while its own
+// reorder/save round trip is still in flight, and firing an event outside act()
+// in that state leaves React work half-committed — which showed up not as a
+// failure here but as the NEXT test rendering an empty tree.
+const longPressLine = async (getByTestId, lineId) => {
+  await act(async () => {
+    fireEvent(getByTestId(`plan-line-${lineId}`), 'longPress');
+  });
+};
+
+const moveLine = async (getByTestId, lineId, direction) => {
+  await longPressLine(getByTestId, lineId);
+  await act(async () => {
+    lastDialogAction(direction === -1 ? 'move_up' : 'move_down').onPress();
+  });
+};
+
 describe('MonthlyPlanSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -314,14 +363,17 @@ describe('MonthlyPlanSection', () => {
 
     it('renders per-line progress with actuals and status details', async () => {
       setPlanWithStatus();
-      const { getByTestId, getByText } = await renderSection();
+      const { getByTestId, getByText, queryByText } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
       // StatusProgressBar details: "actual / amount" and the remaining text.
       // Both sides are formatted — the right-hand figure used to be the raw DB
       // string, so a row read "150.00 / 300".
       expect(getByText('150.00 / 300.00')).toBeTruthy();
       expect(getByText('remaining_budget: 150.00')).toBeTruthy();
-      expect(getByText('50%')).toBeTruthy();
+      // No percentage label: the fill encodes the ratio and the two figures
+      // above spell it out twice more. A fourth encoding of one number is what
+      // made a row four text lines tall.
+      expect(queryByText('50%')).toBeNull();
       // The exceeded transfer line shows the over-budget wording.
       expect(getByText('over_budget_by 50.00')).toBeTruthy();
     });
@@ -373,8 +425,9 @@ describe('MonthlyPlanSection', () => {
 
     it('triggers a status refresh after saving a line', async () => {
       setPlanWithStatus();
-      const { getByTestId } = await renderSection();
-      await fireEvent.press(getByTestId('plan-add-line'));
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
+      await openEditor(ref);
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
       await fireEvent.press(getByTestId('mock-save-line'));
       await waitFor(() => expect(mockPlans.addLine).toHaveBeenCalled());
@@ -385,8 +438,9 @@ describe('MonthlyPlanSection', () => {
   describe('Interactions', () => {
     it('adds a line and reloads', async () => {
       setPlans({ plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }], lines: [] });
-      const { getByTestId } = await renderSection();
-      await fireEvent.press(getByTestId('plan-add-line'));
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
+      await openEditor(ref);
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
       await fireEvent.press(getByTestId('mock-save-line'));
       await waitFor(() => expect(mockPlans.addLine).toHaveBeenCalled());
@@ -395,8 +449,9 @@ describe('MonthlyPlanSection', () => {
 
     it('adds an income line from the income section (Budgets v3 phase 3)', async () => {
       setPlans({ plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }], lines: [] });
-      const { getByTestId } = await renderSection();
-      await fireEvent.press(getByTestId('plan-add-income'));
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
+      await openEditor(ref, 'income');
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
       // The editor opens pre-set to the income kind.
       expect(capturedModalProps.initialKind).toBe('income');
@@ -432,7 +487,8 @@ describe('MonthlyPlanSection', () => {
       await waitFor(() => expect(getByTestId('plan-line-l-rec')).toBeTruthy());
       expect(getByTestId('plan-empty-state')).toBeTruthy();
       expect(queryByTestId('plan-line-execute-l-rec')).toBeNull(); // no template → not executable
-      expect(getByText('recurring')).toBeTruthy();
+      // Scope is a glyph beside the name now, not an uppercase text line.
+      expect(getByTestId('plan-line-recurring-l-rec')).toBeTruthy();
       // ...but NOT the "no plan yet" copy: it sat directly under a populated
       // list and above a totals row, contradicting both.
       expect(queryByTestId('plan-create-empty')).toBeTruthy();
@@ -448,8 +504,9 @@ describe('MonthlyPlanSection', () => {
 
     it('adding a recurring allocation calls addRecurringLine, not addLine, and needs no plan', async () => {
       setPlans({ plans: [], lines: [] });
-      const { getByTestId } = await renderSection();
-      await fireEvent.press(getByTestId('plan-add-line'));
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
+      await openEditor(ref);
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
       await fireEvent.press(getByTestId('mock-save-recurring-line'));
       await waitFor(() => expect(mockPlans.addRecurringLine).toHaveBeenCalled());
@@ -461,8 +518,9 @@ describe('MonthlyPlanSection', () => {
 
     it('saving a one-off allocation for a plan-less month lazily creates the plan first', async () => {
       setPlans({ plans: [], lines: [recurringLine] });
-      const { getByTestId } = await renderSection();
-      await fireEvent.press(getByTestId('plan-add-line'));
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
+      await openEditor(ref);
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
       await fireEvent.press(getByTestId('mock-save-line'));
       await waitFor(() => expect(mockPlans.addPlan).toHaveBeenCalledWith({ month: THIS_MONTH, currency: 'USD' }));
@@ -651,12 +709,13 @@ describe('MonthlyPlanSection', () => {
         .mockResolvedValue([
           { id: 'l1', planId: 'p1', amount: '300', label: 'New', comment: null, categoryId: 'cat1', toAccountId: null, sortOrder: 0, isBroken: false },
         ]);
-      const { getByTestId } = await renderSection();
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
 
       // Before any mutation: the (not-yet-stale) planStatus totals show as-is.
       await waitFor(() => expect(getByTestId('plan-totals')).toHaveTextContent(/999 USD/));
 
-      await fireEvent.press(getByTestId('plan-add-line'));
+      await openEditor(ref);
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
       await fireEvent.press(getByTestId('mock-save-line'));
       await waitFor(() => expect(mockPlans.addLine).toHaveBeenCalled());
@@ -708,8 +767,9 @@ describe('MonthlyPlanSection', () => {
       setPlans({ plans: [], lines: [] });
       let resolveAddPlan;
       mockPlans.addPlan = jest.fn(() => new Promise((resolve) => { resolveAddPlan = resolve; }));
-      const { getByTestId } = await renderSection();
-      await fireEvent.press(getByTestId('plan-add-line'));
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
+      await openEditor(ref);
       await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
 
       // First tap: starts handleSaveLine, which sets the busy flag synchronously
@@ -760,25 +820,35 @@ describe('MonthlyPlanSection', () => {
           { id: 'l-b', planId: null, amount: '20', label: 'B', comment: null, categoryId: 'cat2', toAccountId: null, sortOrder: 1, isBroken: false, isRecurring: true, currency: 'USD' },
         ],
       });
-      // Never resolves during this test — proves the visible order change comes
-      // from the optimistic setLines(), not from awaiting this call + reloadLines().
-      mockPlans.reorderRecurringLines = jest.fn(() => new Promise(() => {}));
+      // Held open across the assertions below — proves the visible order change
+      // comes from the optimistic setLines(), not from awaiting this call +
+      // reloadLines(). Released at the end of the test rather than left dangling:
+      // a promise that never settles leaves React work in flight past teardown,
+      // which corrupted every test that ran after this one.
+      let releaseReorder;
+      mockPlans.reorderRecurringLines = jest.fn(
+        () => new Promise((resolve) => { releaseReorder = resolve; }),
+      );
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l-a')).toBeTruthy());
-      // Before the move: l-a is first (its up-arrow is disabled), l-b is second.
-      expect(getByTestId('plan-line-up-l-a').props.accessibilityState.disabled).toBe(true);
-      expect(getByTestId('plan-line-up-l-b').props.accessibilityState.disabled).toBe(false);
+      // Before the move: l-a is first, so its action sheet offers only "down".
+      // (The sheet omits a move that has nowhere to land — it used to be a pair
+      // of chevrons whose disabled state said the same thing.)
+      await longPressLine(getByTestId, 'l-a');
+      expect(hasDialogAction('move_up')).toBe(false);
+      expect(hasDialogAction('move_down')).toBe(true);
 
-      fireEvent.press(getByTestId('plan-line-down-l-a'));
+      await moveLine(getByTestId, 'l-a', 1);
 
       // reorderRecurringLines never resolves in this test, so reloadLines()
-      // (which runs AFTER awaiting it) never runs either — the only way this
-      // assertion can pass at all is the optimistic setLines() call that
-      // happens BEFORE that await. Without it, this would time out.
-      await waitFor(() => {
-        expect(getByTestId('plan-line-up-l-a').props.accessibilityState.disabled).toBe(false);
-        expect(getByTestId('plan-line-up-l-b').props.accessibilityState.disabled).toBe(true);
-      });
+      // (which runs AFTER awaiting it) never runs either — the only way the
+      // order below can have changed is the optimistic setLines() call that
+      // happens BEFORE that await.
+      await longPressLine(getByTestId, 'l-a');
+      expect(hasDialogAction('move_up')).toBe(true);
+      expect(hasDialogAction('move_down')).toBe(false);
+
+      await act(async () => { releaseReorder(); });
     });
   });
 
@@ -806,9 +876,19 @@ describe('MonthlyPlanSection', () => {
 
       // Two taps in immediate succession (same JS task, before either resolves)
       // — a state-only guard would not catch this; only a synchronous ref does.
+      // The action is grabbed once and fired twice, which is what a real double
+      // tap on one sheet button does; re-opening the sheet in between would
+      // instead exercise the sheet's own bounds check.
+      // Two taps in immediate succession (same JS task, before either resolves)
+      // — a state-only guard would not catch this; only a synchronous ref does.
+      // The action is grabbed once and fired twice, which is what a real double
+      // tap on one sheet button does; re-opening the sheet in between would
+      // instead exercise the sheet's own bounds check.
+      await longPressLine(getByTestId, 'l-a');
+      const moveDown = lastDialogAction('move_down');
       await act(async () => {
-        fireEvent.press(getByTestId('plan-line-down-l-a'));
-        fireEvent.press(getByTestId('plan-line-down-l-a'));
+        moveDown.onPress();
+        moveDown.onPress();
       });
 
       await waitFor(() => expect(mockPlans.getLinesForMonth).toHaveBeenCalledTimes(2)); // mount + one reconcile
@@ -828,14 +908,73 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
 
+      await longPressLine(getByTestId, 'l1');
+      const moveDown = lastDialogAction('move_down');
       await act(async () => {
-        fireEvent.press(getByTestId('plan-line-down-l1'));
-        fireEvent.press(getByTestId('plan-line-down-l1'));
+        moveDown.onPress();
+        moveDown.onPress();
       });
 
       await waitFor(() => expect(mockPlans.getLinesForMonth).toHaveBeenCalledTimes(2));
 
       expect(mockPlans.reorderLines).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Row density', () => {
+    const doneLine = {
+      id: 'l-done', planId: null, amount: '300', label: 'Rent', comment: 'monthly',
+      kind: 'expense', categoryId: 'cat1', toAccountId: null, accountId: 1, sortOrder: 0,
+      isBroken: false, isRecurring: true, currency: 'USD',
+      hasTemplate: true, lastExecutedMonth: THIS_MONTH,
+    };
+    const statusFor = (actual, amount, isExceeded) => new Map([['p1', {
+      planId: 'p1', month: THIS_MONTH, currency: 'USD', convertAll: false,
+      lines: [{
+        lineId: 'l-done', broken: false, amount, actual,
+        remaining: String(Number(amount) - Number(actual)), percentage: (actual / amount) * 100,
+        isExceeded, status: isExceeded ? 'exceeded' : 'safe',
+      }],
+      totals: {
+        expectedIncome: '1000.00', actualIncome: '0.00', allocated: amount,
+        totalActual: actual, plannedRemainder: '700.00', actualRemainder: '1000.00',
+      },
+      unconvertible: [],
+    }]]);
+
+    it('collapses a done row to a single line — no bar, no comment', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }],
+        lines: [doneLine],
+        planStatuses: statusFor('300', '300', false),
+      });
+      const { getByTestId, queryByText } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l-done')).toBeTruthy());
+      // A done line's bar reads 100% by construction of "executed" — which is
+      // what the check badge already says.
+      expect(queryByText('300.00 / 300.00')).toBeNull();
+      expect(queryByText('monthly')).toBeNull();
+      expect(getByTestId('plan-line-check-l-done')).toBeTruthy();
+    });
+
+    it('still shows the bar on a done row that went over target', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }],
+        lines: [doneLine],
+        planStatuses: statusFor('420', '300', true),
+      });
+      const { getByTestId, getByText } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l-done')).toBeTruthy());
+      // Overspend is news; burying it under a state the user set by hand is how
+      // a row stops being worth reading.
+      expect(getByText('420.00 / 300.00')).toBeTruthy();
+    });
+
+    it('has no add rows — the screen FAB owns adding', async () => {
+      setPlans({ plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }], lines: [] });
+      const { queryByTestId } = await renderSection();
+      expect(queryByTestId('plan-add-line')).toBeNull();
+      expect(queryByTestId('plan-add-income')).toBeNull();
     });
   });
 
@@ -1016,19 +1155,29 @@ describe('MonthlyPlanSection', () => {
     // Regression: the row's meta line reused the `execute` button caption, so it
     // read as a command sitting where its sibling branch prints a state ("done")
     // — and it kept saying so on months where execution is disabled anyway.
-    it('labels a pending template with a state, not the execute command', async () => {
+    // The uppercase "RECURRING · PENDING_EXECUTION" line under every row is gone
+    // — it repeated the default on nearly all of them while being the loudest
+    // thing after the amount. Scope is a glyph beside the name, template state is
+    // a badge on the category icon, and both are spelled out in the row's
+    // accessibility label, which a screen reader reads and a glyph cannot say.
+    it('marks a pending template with a badge and names the state for a screen reader', async () => {
       setPlans({ plans: [], lines: [TEMPLATE_LINE] });
-      const { getByText, queryByText, getByTestId } = await renderSection();
+      const { queryByText, getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l-tpl')).toBeTruthy());
-      expect(getByText('recurring · pending_execution')).toBeTruthy();
-      expect(queryByText('recurring · execute')).toBeNull();
+      expect(getByTestId('plan-line-pending-l-tpl')).toBeTruthy();
+      expect(getByTestId('plan-line-recurring-l-tpl')).toBeTruthy();
+      expect(getByTestId('plan-line-l-tpl').props.accessibilityLabel)
+        .toContain('recurring, pending_execution');
+      expect(queryByText('recurring · pending_execution')).toBeNull();
     });
 
-    it('labels an executed template as done', async () => {
+    it('marks an executed template as done and drops the pending badge', async () => {
       setPlans({ plans: [], lines: [{ ...TEMPLATE_LINE, lastExecutedMonth: THIS_MONTH }] });
-      const { getByText, getByTestId } = await renderSection();
+      const { queryByTestId, getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l-tpl')).toBeTruthy());
-      expect(getByText('recurring · done')).toBeTruthy();
+      expect(getByTestId('plan-line-check-l-tpl')).toBeTruthy();
+      expect(queryByTestId('plan-line-pending-l-tpl')).toBeNull();
+      expect(getByTestId('plan-line-l-tpl').props.accessibilityLabel).toContain('recurring, done');
     });
   });
 

--- a/app/components/StatusProgressBar.js
+++ b/app/components/StatusProgressBar.js
@@ -46,10 +46,10 @@ const StatusProgressBar = ({ status, compact = false, showDetails = true, style 
 
   return (
     <View style={[styles.container, style]}>
-      {/* Progress bar, with the compact-mode percentage beside it rather than
-          absolutely positioned over it — the old badge sat on the track's right
-          end with no space reserved, so it overlapped both the bar and the
-          details line below (worst where the right-hand detail is long). */}
+      {/* Progress bar. No percentage label: the fill already encodes the ratio,
+          and the details line below spells out the same fact twice more
+          ("98645 / 100000" and "remaining: 1355") — a fourth encoding of one
+          number is what made a plan row four text lines tall. */}
       <View style={styles.trackRow}>
         <View style={[styles.progressTrack, { backgroundColor: colors.border }]}>
           <View
@@ -62,17 +62,6 @@ const StatusProgressBar = ({ status, compact = false, showDetails = true, style 
             ]}
           />
         </View>
-        {compact && (
-          <Text
-            variant="bodySmall"
-            style={[
-              styles.percentageText,
-              status.isExceeded ? styles.exceededText : { color: colors.mutedText },
-            ]}
-          >
-            {Math.round(status.percentage)}%
-          </Text>
-        )}
       </View>
 
       {/* Details */}
@@ -117,12 +106,6 @@ const styles = StyleSheet.create({
   },
   exceededText: {
     color: '#F44336',
-  },
-  percentageText: {
-    fontWeight: '500',
-    minWidth: 34,
-    textAlign: 'right',
-    // color set dynamically
   },
   progressFill: {
     borderRadius: 3,

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -458,7 +458,12 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     runExecutionAction(() => unmarkLineExecuted(line.id), 'marked_as_pending')
   ), [runExecutionAction, unmarkLineExecuted]);
 
-  const handleLongPressLine = useCallback((line) => {
+  // `context` carries the line's position in its own block plus that block's move
+  // handler — reordering used to be a pair of chevrons on every row, which cost
+  // 40dp of horizontal space next to the amount on all of them and took one tap
+  // per position moved. It lives here now, where it is out of the way until asked
+  // for and sits next to the other whole-row actions.
+  const handleLongPressLine = useCallback((line, index, listLength, onMove) => {
     const executed = line.lastExecutedMonth === month;
     const executionActions = [];
     if (line.hasTemplate && isCurrentMonth) {
@@ -474,12 +479,24 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         );
       }
     }
+    const moveActions = [];
+    if (onMove) {
+      // Offered only where the move can actually land, so the sheet never shows
+      // an action that silently does nothing.
+      if (index > 0) {
+        moveActions.push({ text: t('move_up'), onPress: () => onMove(index, -1) });
+      }
+      if (index < listLength - 1) {
+        moveActions.push({ text: t('move_down'), onPress: () => onMove(index, 1) });
+      }
+    }
     showDialog(
       t('select_action'),
       lineDisplayName(line),
       [
         ...executionActions,
         { text: t('edit'), onPress: () => openEditLine(line) },
+        ...moveActions,
         { text: t('delete'), style: 'destructive', onPress: () => confirmDeleteLine(line) },
         { text: t('cancel'), style: 'cancel' },
       ],
@@ -558,7 +575,6 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         key={line.id}
         line={line}
         index={index}
-        listLength={list.length}
         name={lineDisplayName(line)}
         icon={lineIcon(line)}
         status={lineStatusById.get(line.id) || null}
@@ -571,10 +587,10 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         canExecute={line.hasTemplate && isCurrentMonth && !executed}
         canUndo={line.hasTemplate && isCurrentMonth && executed}
         showProgress={line.kind !== 'income'}
-        showMove={!!onMove}
+        listLength={list.length}
+        onMove={onMove}
         onPress={openEditLine}
         onLongPress={handleLongPressLine}
-        onMove={onMove}
         onExecute={handleExecute}
         onMarkExecuted={handleMarkExecuted}
         onUndo={handleUndoExecuted}
@@ -585,19 +601,6 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     handleMarkExecuted, handleUndoExecuted]);
 
   const hasAnyLines = lines.length > 0;
-
-  const renderAddRow = (label, onPress, testID) => (
-    <Pressable
-      style={[styles.addRow, { borderColor: colors.border }]}
-      onPress={onPress}
-      accessibilityRole="button"
-      accessibilityLabel={label}
-      testID={testID}
-    >
-      <Icon name="plus" size={20} color={colors.primary} />
-      <Text style={[styles.addText, { color: colors.primary }]}>{label}</Text>
-    </Pressable>
-  );
 
   return (
     <>
@@ -661,8 +664,6 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
 
         {incomeLines.map((line, index) => renderLine(line, index, incomeLines, null))}
 
-        {renderAddRow(t('add_income'), openAddIncome, 'plan-add-income')}
-
         {/* Allocations: recurring (global) ones apply to every month, one-off ones
             belong to this month's plan. */}
         <View style={[styles.sectionHeader, styles.sectionHeaderSpaced, { borderBottomColor: colors.border }]} testID="plan-allocations-header">
@@ -675,9 +676,12 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         {recurringLines.map((line, index) => renderLine(line, index, recurringLines, handleMoveRecurring))}
         {oneOffLines.map((line, index) => renderLine(line, index, oneOffLines, handleMoveOneOff))}
 
-        {/* Add allocation — always available: a recurring line needs no plan, a
-            one-off one lazily creates the month's plan on save. */}
-        {renderAddRow(t('add_allocation'), openAddLine, 'plan-add-line')}
+        {/* No add rows here: the screen's single FAB opens this same editor, and
+            the editor's own income/expense/transfer segment picks the kind — two
+            dashed "+ Add …" buttons inside a card that already sits under a FAB
+            were a third way to do one thing. Adding a line is always available:
+            a recurring one needs no plan, a one-off one lazily creates the
+            month's plan on save. */}
 
         {!plan && (
           <View style={styles.emptyPlan} testID="plan-empty-state">
@@ -802,21 +806,6 @@ MonthlyPlanSection.propTypes = {
 export default MonthlyPlanSection;
 
 const styles = StyleSheet.create({
-  addRow: {
-    alignItems: 'center',
-    borderRadius: 8,
-    borderStyle: 'dashed',
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 8,
-    justifyContent: 'center',
-    marginTop: SPACING.sm,
-    paddingVertical: SPACING.sm,
-  },
-  addText: {
-    fontSize: 15,
-    fontWeight: '600',
-  },
   card: {
     borderRadius: 16,
     borderWidth: 1,

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -32,7 +32,6 @@ const CONVERTING_PLACEHOLDER = '—';
 const PlanLineRow = memo(function PlanLineRow({
   line,
   index,
-  listLength,
   name,
   icon,
   status = null,
@@ -45,10 +44,10 @@ const PlanLineRow = memo(function PlanLineRow({
   canExecute = false,
   canUndo = false,
   showProgress = true,
-  showMove = true,
+  listLength,
+  onMove = null,
   onPress,
   onLongPress,
-  onMove = null,
   onExecute = null,
   onMarkExecuted = null,
   onUndo = null,
@@ -79,6 +78,12 @@ const PlanLineRow = memo(function PlanLineRow({
   // execution only makes sense for the current month, and so does undoing it.
   const swipeEnabled = canExecute || canUndo;
 
+  // A done row collapses to a single line: its bar would read 100% by
+  // construction of "executed", which is what the check badge already says. The
+  // exception is real overspend — actual above target is news, and burying it
+  // under a state the user set by hand is how a row stops being worth reading.
+  const showBar = showProgress && !!status && (!executed || status.isExceeded);
+
   // Acting on a row leaves the Swipeable open otherwise: the actions are replaced
   // (execute -> undo) but the row stays dragged aside, so its name and progress
   // figures remain clipped until the user swipes back by hand.
@@ -92,41 +97,77 @@ const PlanLineRow = memo(function PlanLineRow({
     handler?.(line);
   };
 
+  // The scope and template state moved from a text line into a glyph and an icon
+  // badge, which a screen reader cannot announce — so they are spelled out here
+  // instead. Sighted density and non-visual completeness are not the same
+  // problem and don't get the same answer.
+  const stateWords = [
+    line.isRecurring ? t('recurring') : t('one_time'),
+    line.hasTemplate ? (executed ? t('done') : t('pending_execution')) : null,
+  ].filter(Boolean).join(', ');
+
   const content = (
     <Pressable
       style={[styles.lineRow, index % 2 === 1 && { backgroundColor: colors.altRow }]}
       onPress={() => onPress(line)}
-      onLongPress={() => onLongPress(line)}
+      // The row renders nothing from `listLength`/`onMove` — it forwards them so
+      // the host can build the move actions. Keeping them as props (rather than
+      // having the host close over them in an inline callback) is what lets
+      // `onLongPress` stay a stable reference, and therefore what keeps this
+      // component's memo() from being defeated on every parent render.
+      onLongPress={() => onLongPress(line, index, listLength, onMove)}
       accessibilityRole="button"
-      accessibilityLabel={`${t('edit_allocation')}: ${name}`}
+      accessibilityLabel={`${t('edit_allocation')}: ${name}, ${amountText}, ${stateWords}`}
       testID={`plan-line-${line.id}`}
     >
       <View style={styles.lineTop}>
         <View>
           <Icon name={icon} size={20} color={executed ? colors.mutedText : colors.text} />
-          {executed && (
+          {/* Template state rides on the category icon instead of a text line:
+              done is a check, still-to-run is a dot in the accent colour. Both
+              occupy the same 13dp corner, so the row height doesn't move
+              between states. */}
+          {executed ? (
             <View
               testID={`plan-line-check-${line.id}`}
               style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.income }]}
             >
               <Icon name="check" size={7} color="white" />
             </View>
-          )}
+          ) : line.hasTemplate ? (
+            <View
+              testID={`plan-line-pending-${line.id}`}
+              style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.primary }]}
+            >
+              <Icon name="play" size={7} color="white" />
+            </View>
+          ) : null}
         </View>
         <View style={styles.lineBody}>
-          <Text
-            style={[styles.lineName, { color: executed ? colors.mutedText : colors.text }]}
-            numberOfLines={1}
-          >
-            {name}
-          </Text>
-          {/* Both halves are STATES, not commands: reusing the `execute` button
-              caption here invited a tap on months where execution is disabled. */}
-          <Text style={[styles.lineMeta, { color: colors.mutedText }]} numberOfLines={1}>
-            {line.isRecurring ? t('recurring') : t('one_time')}
-            {line.hasTemplate ? ` · ${executed ? t('done') : t('pending_execution')}` : ''}
-          </Text>
-          {!!line.comment && (
+          <View style={styles.lineNameRow}>
+            <Text
+              style={[styles.lineName, { color: colors.text }]}
+              numberOfLines={1}
+            >
+              {name}
+            </Text>
+            {/* Replaces a full uppercase "RECURRING" line that sat on nearly
+                every row, saying the same thing each time while being the
+                loudest thing after the amount. A one-off line gets no marker:
+                the glyph is the exception, not the label. */}
+            {line.isRecurring && (
+              <Icon
+                name="repeat"
+                size={13}
+                color={colors.mutedText}
+                testID={`plan-line-recurring-${line.id}`}
+              />
+            )}
+          </View>
+          {/* User-authored, so it never repeats what the row already says —
+              unlike the scope/state line it now sits alone under. Hidden on a
+              done row, which collapses to a single line. */}
+          {!!line.comment && !executed && (
             <Text style={[styles.lineComment, { color: colors.mutedText }]} numberOfLines={1}>
               {line.comment}
             </Text>
@@ -135,32 +176,6 @@ const PlanLineRow = memo(function PlanLineRow({
         <Text style={[styles.lineAmount, { color: executed ? colors.mutedText : colors.text }]}>
           {amountText}
         </Text>
-        {showMove && onMove && (
-          <View style={styles.moveButtons}>
-            <Pressable
-              onPress={() => onMove(index, -1)}
-              disabled={index === 0}
-              hitSlop={6}
-              style={styles.moveButton}
-              accessibilityRole="button"
-              accessibilityLabel={t('move_up')}
-              testID={`plan-line-up-${line.id}`}
-            >
-              <Icon name="chevron-up" size={20} color={index === 0 ? colors.border : colors.mutedText} />
-            </Pressable>
-            <Pressable
-              onPress={() => onMove(index, 1)}
-              disabled={index === listLength - 1}
-              hitSlop={6}
-              style={styles.moveButton}
-              accessibilityRole="button"
-              accessibilityLabel={t('move_down')}
-              testID={`plan-line-down-${line.id}`}
-            >
-              <Icon name="chevron-down" size={20} color={index === listLength - 1 ? colors.border : colors.mutedText} />
-            </Pressable>
-          </View>
-        )}
       </View>
       {isBroken ? (
         <View style={styles.brokenRow} testID={`plan-line-broken-${line.id}`}>
@@ -181,7 +196,7 @@ const PlanLineRow = memo(function PlanLineRow({
             {t('graphs_currencies_not_converted')}
           </Text>
         </View>
-      ) : showProgress && status ? (
+      ) : showBar ? (
         <StatusProgressBar
           status={{ ...status, spent: status.actual, currency: planCurrency }}
           compact
@@ -240,22 +255,20 @@ const PlanLineRow = memo(function PlanLineRow({
     );
 
   return (
-    <View style={executed ? styles.executedWrapper : undefined}>
-      <Swipeable
-        ref={swipeableRef}
-        renderRightActions={rightActions}
-        overshootRight={false}
-        friction={2}
-        rightThreshold={60}
-        // Only leftward drags reveal actions; leave rightward unrecognized so a
-        // rightward swipe passes through to the tab-strip swipe navigation.
-        dragOffsetFromLeftEdge={Number.MAX_SAFE_INTEGER}
-      >
-        <View style={[styles.swipeRowCover, { backgroundColor: colors.surface }]}>
-          {content}
-        </View>
-      </Swipeable>
-    </View>
+    <Swipeable
+      ref={swipeableRef}
+      renderRightActions={rightActions}
+      overshootRight={false}
+      friction={2}
+      rightThreshold={60}
+      // Only leftward drags reveal actions; leave rightward unrecognized so a
+      // rightward swipe passes through to the tab-strip swipe navigation.
+      dragOffsetFromLeftEdge={Number.MAX_SAFE_INTEGER}
+    >
+      <View style={[styles.swipeRowCover, { backgroundColor: colors.surface }]}>
+        {content}
+      </View>
+    </Swipeable>
   );
 });
 
@@ -283,10 +296,9 @@ PlanLineRow.propTypes = {
   canExecute: PropTypes.bool,
   canUndo: PropTypes.bool,
   showProgress: PropTypes.bool,
-  showMove: PropTypes.bool,
+  onMove: PropTypes.func,
   onPress: PropTypes.func.isRequired,
   onLongPress: PropTypes.func.isRequired,
-  onMove: PropTypes.func,
   onExecute: PropTypes.func,
   onMarkExecuted: PropTypes.func,
   onUndo: PropTypes.func,
@@ -316,9 +328,6 @@ const styles = StyleSheet.create({
     right: -6,
     width: 13,
   },
-  executedWrapper: {
-    opacity: 0.5,
-  },
   lineAmount: {
     fontSize: 15,
     fontWeight: '600',
@@ -332,14 +341,14 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginTop: 1,
   },
-  lineMeta: {
-    fontSize: 11,
-    fontWeight: '600',
-    marginTop: 1,
-    textTransform: 'uppercase',
-  },
   lineName: {
+    flexShrink: 1,
     fontSize: 15,
+  },
+  lineNameRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 5,
   },
   lineProgress: {
     marginBottom: 0,
@@ -353,13 +362,6 @@ const styles = StyleSheet.create({
   lineTop: {
     alignItems: 'center',
     flexDirection: 'row',
-  },
-  moveButton: {
-    paddingHorizontal: 2,
-  },
-  moveButtons: {
-    flexDirection: 'row',
-    marginLeft: 6,
   },
   swipeAction: {
     alignItems: 'center',


### PR DESCRIPTION
## Problem

A plan row was four stacked text lines for one envelope — about 92dp tall — with a 40dp chevron pair beside the amount:

```
🍽 Food
   RECURRING · PENDING_EXECUTION           ← the default, on nearly every row
   ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░  99%             ← the ratio, encoded once
   98645 / 100000       remaining: 1355    ← the ratio, encoded twice more
```

Six or seven envelopes filled the screen. Meanwhile done rows carried `opacity: 0.5` on top of already-muted text, which lands below 3:1 contrast on the dark theme — so "Аванс" and "Зарплата" were two full-size rows of text nobody could read.

## Change

| what | before | after |
|---|---|---|
| scope | `RECURRING` uppercase line | `repeat` glyph beside the name; a one-off line gets no marker |
| template state | `· PENDING_EXECUTION` | badge on the category icon — check when done, accent dot when still to run |
| ratio | bar **+** `99%` **+** `98645 / 100000` **+** `remaining: 1355` | bar + the two figures |
| done row | `opacity: 0.5`, full height | one line at normal contrast: no bar, no comment, muted amount, check badge |
| reorder | chevron pair on every row | long-press sheet, offering only the direction that has somewhere to land |
| adding | two dashed `+ Add …` rows | the screen's FAB (the editor's kind segment picks income vs expense) |

Row height: **~92dp → ~52dp** pending, **~34dp** done.

Two deliberate exceptions:

- **A done row that went over target keeps its bar.** Overspend is news; burying it under a state the user set by hand is how a row stops being worth reading.
- **The glyph and the badge are spelled out in the row's `accessibilityLabel`** (`"Food, 98645.00, recurring, pending_execution"`). Sighted density and non-visual completeness are different problems and don't get the same answer.

## Test note

The reorder tests now drive the long-press sheet, and their helpers `act()`-wrap every event. Firing an event outside `act()` while a row's reorder is in flight leaves React work half-committed — which surfaced not as a failure in that test, but as the *next* test rendering an empty tree. Cost a while to find; worth the comment left in the helper.

162 suites / 4778 passing. New coverage: done-row collapse, the over-target exception, the absent add rows, and the badge/glyph + accessibility-label pair.

*Second of four PRs reshaping this screen: ~~currency truth~~ (#1435) → row density → envelope fill → header hierarchy.*
