### PR TITLE
feat(budgets): lift the remainder into the sticky header

### DIFF
--- a/__tests__/screens/BudgetScreen.test.js
+++ b/__tests__/screens/BudgetScreen.test.js
@@ -2,30 +2,39 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { StyleSheet } from 'react-native';
 import BudgetScreen from '../../app/screens/BudgetScreen';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────
+const COLORS = {
+  background: '#111318',
+  surface: '#1a1d24',
+  card: '#1a1d24',
+  text: '#e8eaf0',
+  mutedText: '#7a7f8e',
+  border: '#252830',
+  primary: '#4A90D9',
+  selected: '#2a2e38',
+  altRow: '#16191f',
+  income: '#4caf50',
+  expense: '#f44336',
+  transfer: '#2196f3',
+  overspend: '#FF6B6B',
+};
+
 jest.mock('../../app/contexts/ThemeColorsContext', () => ({
-  useThemeColors: () => ({
-    colors: {
-      background: '#111318',
-      surface: '#1a1d24',
-      card: '#1a1d24',
-      text: '#e8eaf0',
-      mutedText: '#7a7f8e',
-      border: '#252830',
-      primary: '#4A90D9',
-      selected: '#2a2e38',
-      altRow: '#16191f',
-      income: '#4caf50',
-      expense: '#f44336',
-      transfer: '#2196f3',
-    },
-  }),
+  useThemeColors: () => ({ colors: COLORS }),
 }));
 
 jest.mock('../../app/contexts/LocalizationContext', () => ({
   useLocalization: () => ({ t: (k) => k }),
+}));
+
+// The header's currency chip opens an action sheet rather than parking a wheel
+// picker over the list, so the screen now needs the dialog context.
+const mockShowDialog = jest.fn();
+jest.mock('../../app/contexts/DialogContext', () => ({
+  useDialog: () => ({ showDialog: mockShowDialog }),
 }));
 
 const mockSetConvertAll = jest.fn();
@@ -97,32 +106,38 @@ jest.mock('../../app/components/budgets/MonthlyPlanSection', () => {
       React.createElement(Pressable, {
         testID: 'mock-notify',
         onPress: () => props.onNotify?.('added_to_operations'),
-      }, React.createElement(Text, {}, 'notify')));
+      }, React.createElement(Text, {}, 'notify')),
+      // The section reports the month's remainder up so the header can print it
+      // — the figure a person acts on belongs where it is always on screen, not
+      // at the bottom of a long scrolling card.
+      React.createElement(Pressable, {
+        testID: 'mock-report-remainder',
+        onPress: () => props.onTotalsChange?.({
+          remainder: '-85745', hasIncomeBasis: true, currency: 'AMD',
+        }),
+      }, React.createElement(Text, {}, 'report')),
+      React.createElement(Pressable, {
+        testID: 'mock-report-no-income',
+        onPress: () => props.onTotalsChange?.({
+          remainder: '0', hasIncomeBasis: false, currency: 'AMD',
+        }),
+      }, React.createElement(Text, {}, 'report none')));
   });
 });
 
-// The native wheel renders nothing under Jest, so stand in a tappable row per
-// option — that is the only way a test can drive the selection the way a user does.
-jest.mock('@quidone/react-native-wheel-picker', () => {
-  const React = require('react');
-  const { View, Pressable } = require('react-native');
-  return {
-    __esModule: true,
-    default: function MockWheelPicker({ data = [], onValueChanged }) {
-      return React.createElement(
-        View,
-        { testID: 'currency-wheel' },
-        data.map((item) => React.createElement(Pressable, {
-          key: item.value,
-          testID: `currency-option-${item.value}`,
-          onPress: () => onValueChanged?.({ item }),
-        })),
-      );
-    },
-  };
-});
-
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+// Currency is picked from the header chip's action sheet now, not a wheel parked
+// over the list. `t` is the identity function here, so an option's text is its
+// currency code.
+const pickCurrency = (getByTestId, code) => {
+  fireEvent.press(getByTestId('budget-currency-chip'));
+  const calls = mockShowDialog.mock.calls;
+  const option = calls[calls.length - 1][2].find(b => b.text === code);
+  if (!option) throw new Error(`No "${code}" option in the currency sheet`);
+  option.onPress();
+};
+
 const setBudgetsData = ({ loading = false, convertAll = true } = {}) => {
   mockBudgetsData = {
     loading,
@@ -194,28 +209,28 @@ describe('BudgetScreen', () => {
 
     it('hands the picked currency down to the list', async () => {
       const { getByTestId } = await render(<BudgetScreen />);
-      await waitFor(() => expect(getByTestId('currency-option-RUB')).toBeTruthy());
-      fireEvent.press(getByTestId('currency-option-RUB'));
+      await waitFor(() => expect(getByTestId('budget-currency-chip')).toBeTruthy());
+      pickCurrency(getByTestId, 'RUB');
       await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
     });
 
     // Regression: the init effect only re-seeded when accounts went empty, so a
-    // selection whose last account was deleted survived — and since the wheel is
-    // only rendered while currencyItems.length > 1, deleting down to one currency
+    // selection whose last account was deleted survived — and since the picker is
+    // only offered while there is more than one currency, deleting down to one
     // took away the only control that could have corrected it. The stale value kept
     // flowing into MonthlyPlanSection as the currency of any plan it creates.
     it('re-seeds when the selected currency loses its last account', async () => {
       const { getByTestId, queryByTestId, rerender } = await render(<BudgetScreen />);
-      await waitFor(() => expect(getByTestId('currency-option-RUB')).toBeTruthy());
-      fireEvent.press(getByTestId('currency-option-RUB'));
+      await waitFor(() => expect(getByTestId('budget-currency-chip')).toBeTruthy());
+      pickCurrency(getByTestId, 'RUB');
       await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
 
       setAccounts([{ id: 'a1', name: 'Ameria', currency: 'AMD' }]);
       await rerender(<BudgetScreen />);
 
       await waitFor(() => expect(capturedSectionProps.currency).toBe('AMD'));
-      // And the wheel really is gone, which is what made this unrecoverable.
-      expect(queryByTestId('currency-option-RUB')).toBeNull();
+      // And the picker really is gone, which is what made this unrecoverable.
+      expect(queryByTestId('budget-currency-chip')).toBeNull();
     });
 
     it('clears the selection when the last account of any kind is deleted', async () => {
@@ -230,8 +245,8 @@ describe('BudgetScreen', () => {
 
     it('leaves a still-valid selection alone when an unrelated account is deleted', async () => {
       const { getByTestId, rerender } = await render(<BudgetScreen />);
-      await waitFor(() => expect(getByTestId('currency-option-RUB')).toBeTruthy());
-      fireEvent.press(getByTestId('currency-option-RUB'));
+      await waitFor(() => expect(getByTestId('budget-currency-chip')).toBeTruthy());
+      pickCurrency(getByTestId, 'RUB');
       await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
 
       setAccounts([
@@ -241,6 +256,35 @@ describe('BudgetScreen', () => {
       await rerender(<BudgetScreen />);
 
       await waitFor(() => expect(capturedSectionProps.currency).toBe('RUB'));
+    });
+  });
+
+  describe('Header remainder', () => {
+    it('prints the remainder reported by the list', async () => {
+      const { getByTestId } = await render(<BudgetScreen />);
+      await waitFor(() => expect(getByTestId('mock-report-remainder')).toBeTruthy());
+      fireEvent.press(getByTestId('mock-report-remainder'));
+      // Trimmed of an all-zero decimal part, with the plan's currency beside it.
+      await waitFor(() => expect(getByTestId('budget-remainder')).toHaveTextContent('-85745 AMD'));
+    });
+
+    it('replaces a negative remainder with the overspend colour', async () => {
+      const { getByTestId } = await render(<BudgetScreen />);
+      await waitFor(() => expect(getByTestId('mock-report-remainder')).toBeTruthy());
+      fireEvent.press(getByTestId('mock-report-remainder'));
+      await waitFor(() => expect(getByTestId('budget-remainder')).toBeTruthy());
+      expect(StyleSheet.flatten(getByTestId('budget-remainder').props.style).color)
+        .toBe(COLORS.overspend);
+    });
+
+    it('shows the add-income prompt instead of a figure when no income is declared', async () => {
+      const { getByTestId, queryByTestId, getByText } = await render(<BudgetScreen />);
+      await waitFor(() => expect(getByTestId('mock-report-no-income')).toBeTruthy());
+      fireEvent.press(getByTestId('mock-report-no-income'));
+      // With nothing to allocate FROM, the remainder degenerates into "minus
+      // everything you planned" — a number in alarm red is worse than a prompt.
+      await waitFor(() => expect(getByText('add_income_for_remainder')).toBeTruthy());
+      expect(queryByTestId('budget-remainder')).toBeNull();
     });
   });
 

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -52,6 +52,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   accounts = [],
   month: monthProp = null,
   onNotify = null,
+  onTotalsChange = null,
 }, ref) {
   const { colors } = useThemeColors();
   const { t, language } = useLocalization();
@@ -248,6 +249,15 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   // can never disagree (deriving it from the lines separately would count an
   // income line in another currency that `totals` deliberately skipped).
   const hasIncomeBasis = !Currency.isZero(displayExpectedIncome);
+
+  // The remainder is the one figure on this screen a person acts on — "what can
+  // I still commit this month" — so the host lifts it into the sticky header
+  // rather than leaving it in muted 14px at the bottom of a long scrolling card.
+  // Reported rather than lifted wholesale: computing it needs the lines, the
+  // plan status and the staleness gate above, all of which live here.
+  useEffect(() => {
+    onTotalsChange?.({ remainder: displayRemainder, hasIncomeBasis, currency: planCurrency });
+  }, [onTotalsChange, displayRemainder, hasIncomeBasis, planCurrency]);
 
   // Only invoked from the section's own header, which renders in uncontrolled
   // mode only; in controlled mode the host header drives month navigation.
@@ -753,22 +763,28 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
                 </Text>
               )}
             </View>
-            <View style={styles.remainderRow}>
-              {hasIncomeBasis ? (
-                <Text
-                  style={[styles.totalsRemainder, {
-                    color: Currency.isNegative(displayRemainder) ? colors.danger : colors.text,
-                  }]}
-                  testID="plan-remainder"
-                >
-                  {t('remainder')}: {Currency.formatAmount(displayRemainder, planCurrency)} {planCurrency}
-                </Text>
-              ) : (
-                <Text style={[styles.totalsHint, { color: colors.mutedText }]} testID="plan-remainder-hint">
-                  {t('add_income_for_remainder')}
-                </Text>
-              )}
-            </View>
+            {/* The remainder is reported to the host, which prints it in the
+                sticky header where the figure you act on belongs. Rendered here
+                only in uncontrolled mode (no host header to carry it), so the
+                two never appear at once. */}
+            {!controlledMonth && (
+              <View style={styles.remainderRow}>
+                {hasIncomeBasis ? (
+                  <Text
+                    style={[styles.totalsRemainder, {
+                      color: Currency.isNegative(displayRemainder) ? colors.danger : colors.text,
+                    }]}
+                    testID="plan-remainder"
+                  >
+                    {t('remainder')}: {Currency.formatAmount(displayRemainder, planCurrency)} {planCurrency}
+                  </Text>
+                ) : (
+                  <Text style={[styles.totalsHint, { color: colors.mutedText }]} testID="plan-remainder-hint">
+                    {t('add_income_for_remainder')}
+                  </Text>
+                )}
+              </View>
+            )}
             {planStatus?.unconvertible?.length > 0 && (
               <View style={styles.convertWarning} testID="plan-unconverted-warning">
                 <Icon name="alert-circle-outline" size={14} color={colors.mutedText} />
@@ -806,6 +822,7 @@ MonthlyPlanSection.propTypes = {
   accounts: PropTypes.array,
   month: PropTypes.string,
   onNotify: PropTypes.func,
+  onTotalsChange: PropTypes.func,
 };
 
 export default MonthlyPlanSection;

--- a/app/screens/BudgetScreen.js
+++ b/app/screens/BudgetScreen.js
@@ -1,16 +1,17 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { View, StyleSheet, FlatList, Pressable, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, FlatList, Pressable } from 'react-native';
 import { Text, Snackbar } from 'react-native-paper';
-import WheelPicker from '@quidone/react-native-wheel-picker';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
+import { useDialog } from '../contexts/DialogContext';
 import { useBudgetsData } from '../contexts/BudgetsDataContext';
 import { useCategories } from '../contexts/CategoriesContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
 import MonthlyPlanSection from '../components/budgets/MonthlyPlanSection';
 import AddFAB from '../components/AddFAB';
 import LoadingView from '../components/LoadingView';
+import * as Currency from '../services/currency';
 import { SPACING } from '../styles/layout';
 import { currentMonthKey, addMonths, formatMonthLabel } from '../utils/monthUtils';
 
@@ -22,6 +23,10 @@ import { currentMonthKey, addMonths, formatMonthLabel } from '../utils/monthUtil
 const EMPTY_LIST = [];
 const renderNothing = () => null;
 
+// Stands in for the header's remainder until the plan section has computed and
+// reported one.
+const PENDING_PLACEHOLDER = '—';
+
 const BudgetScreen = () => {
   const { colors } = useThemeColors();
   const { t, language } = useLocalization();
@@ -32,6 +37,7 @@ const BudgetScreen = () => {
   const { loading, convertAllBudgets, setConvertAllBudgets } = useBudgetsData();
   const { categories } = useCategories();
   const { accounts } = useAccountsData();
+  const { showDialog } = useDialog();
 
   // The whole screen is scoped to one month via a single shared ‹ Month › header;
   // MonthlyPlanSection is controlled from here.
@@ -55,6 +61,22 @@ const BudgetScreen = () => {
   }, []);
   const handleDismissSnackbar = useCallback(() => setSnackbarVisible(false), []);
 
+  // The month's remainder, reported up from the plan section so the header can
+  // print it. Replaced only when a field actually differs: the section re-reports
+  // on every recompute, and swapping in an equal-but-new object each time would
+  // re-render this screen (and the whole plan below it) for nothing.
+  const [planTotals, setPlanTotals] = useState(null);
+  const handleTotalsChange = useCallback((next) => {
+    setPlanTotals(prev => (
+      prev
+        && prev.remainder === next.remainder
+        && prev.hasIncomeBasis === next.hasIncomeBasis
+        && prev.currency === next.currency
+        ? prev
+        : next
+    ));
+  }, []);
+
   const handlePrevMonth = useCallback(() => setMonth(m => addMonths(m, -1)), []);
   const handleNextMonth = useCallback(() => setMonth(m => addMonths(m, 1)), []);
   // Explicit affordance for Fix 4: the screen stays mounted across tab
@@ -71,10 +93,22 @@ const BudgetScreen = () => {
   [accounts],
   );
 
-  const currencyItems = useMemo(() =>
-    currencies.map(cur => ({ label: cur, value: cur })),
-  [currencies],
-  );
+  // Picking the display currency used to be a floating wheel parked over the
+  // plan card's bottom rows, with a convert-all badge tucked into its corner —
+  // an always-on overlay for a setting changed once in a while, which also
+  // forced 260dp of dead scroll padding so the card's own totals could be
+  // scrolled out from under it. It is a header control now: an action sheet,
+  // like every other whole-screen choice in the app.
+  const handleOpenCurrencyPicker = useCallback(() => {
+    showDialog(
+      t('currency'),
+      null,
+      [
+        ...currencies.map(cur => ({ text: cur, onPress: () => setSelectedCurrency(cur) })),
+        { text: t('cancel'), style: 'cancel' },
+      ],
+    );
+  }, [showDialog, t, currencies]);
 
   // Seed the currency from the first account, and re-seed whenever the selected
   // one stops existing (its last account was deleted). The membership check is not
@@ -150,9 +184,69 @@ const BudgetScreen = () => {
           </Text>
         </Pressable>
       )}
+      {/* The month's headline figure. It used to sit at the very bottom of the
+          plan card in 14px muted text, below every row and the allocated/actual
+          totals — the one number a person acts on, placed where they would reach
+          it last. Here it is always on screen, whatever the list is scrolled to. */}
+      <View style={styles.heroRow}>
+        <View style={styles.heroFigure}>
+          <Text style={[styles.heroLabel, { color: colors.mutedText }]} numberOfLines={1}>
+            {planTotals?.hasIncomeBasis === false ? t('add_income_for_remainder') : t('remainder')}
+          </Text>
+          {/* An em dash until the section has reported: the label alone would
+              read as a value that failed to load, and reserving the line keeps
+              the header from jumping a row taller once the figure arrives. */}
+          {planTotals?.hasIncomeBasis !== false && (
+            <Text
+              style={[styles.heroValue, {
+                color: planTotals && Currency.isNegative(planTotals.remainder)
+                  ? colors.overspend
+                  : colors.text,
+              }]}
+              numberOfLines={1}
+              testID="budget-remainder"
+            >
+              {planTotals
+                ? `${Currency.formatAmountTrimmed(planTotals.remainder, planTotals.currency)} ${planTotals.currency}`
+                : PENDING_PLACEHOLDER}
+            </Text>
+          )}
+        </View>
+        {currencies.length > 1 && (
+          <View style={styles.heroControls}>
+            <Pressable
+              onPress={handleOpenCurrencyPicker}
+              style={[styles.currencyChip, { borderColor: colors.border }]}
+              hitSlop={6}
+              accessibilityRole="button"
+              accessibilityLabel={`${t('currency')}: ${selectedCurrency}`}
+              testID="budget-currency-chip"
+            >
+              <Text style={[styles.currencyChipText, { color: colors.text }]}>{selectedCurrency}</Text>
+              <Icon name="chevron-down" size={14} color={colors.mutedText} />
+            </Pressable>
+            <Pressable
+              onPress={handleToggleConvert}
+              style={[styles.convertToggle, {
+                backgroundColor: convertAllBudgets ? colors.primary : colors.background,
+                borderColor: convertAllBudgets ? colors.primary : colors.border,
+              }]}
+              hitSlop={6}
+              accessibilityRole="switch"
+              accessibilityState={{ checked: convertAllBudgets }}
+              accessibilityLabel={t('graphs_convert_currencies')}
+              testID="budget-convert-toggle"
+            >
+              <Icon name="cash-sync" size={16} color={convertAllBudgets ? colors.surface : colors.mutedText} />
+            </Pressable>
+          </View>
+        )}
+      </View>
     </View>
-  ), [colors.background, colors.text, colors.primary, month, isCurrentMonth, t, language,
-    handlePrevMonth, handleNextMonth, handleJumpToCurrentMonth]);
+  ), [colors.background, colors.text, colors.primary, colors.mutedText, colors.border,
+    colors.overspend, colors.surface, month, isCurrentMonth, t, language, planTotals,
+    currencies.length, selectedCurrency, convertAllBudgets, handleOpenCurrencyPicker,
+    handleToggleConvert, handlePrevMonth, handleNextMonth, handleJumpToCurrentMonth]);
 
   const listHeader = useMemo(() => (
     <MonthlyPlanSection
@@ -163,8 +257,10 @@ const BudgetScreen = () => {
       accounts={accounts}
       month={month}
       onNotify={handleNotify}
+      onTotalsChange={handleTotalsChange}
     />
-  ), [selectedCurrency, expenseCategories, incomeCategories, accounts, month, handleNotify]);
+  ), [selectedCurrency, expenseCategories, incomeCategories, accounts, month, handleNotify,
+    handleTotalsChange]);
 
   if (loading) {
     return <LoadingView testID="budget-screen-loading" />;
@@ -180,51 +276,6 @@ const BudgetScreen = () => {
         ListHeaderComponent={listHeader}
         contentContainerStyle={styles.listContent}
       />
-
-      {/* Floating currency wheel — same control as the Graphs screen. Only shown
-          with something to pick between: it is an opaque overlay sitting on top
-          of the plan card's bottom edge (it was covering the totals row), and
-          with a single currency it offered no choice to justify that. */}
-      {currencyItems.length > 1 && (
-        <View style={[styles.fabWheel, { backgroundColor: colors.surface + 'DE', borderColor: colors.border + '80' }]}>
-          <WheelPicker
-            data={currencyItems}
-            value={selectedCurrency}
-            onValueChanged={({ item }) => item && setSelectedCurrency(item.value)}
-            itemHeight={28}
-            visibleItemCount={3}
-            itemTextStyle={[styles.wheelItemText, { color: colors.text }]}
-            overlayItemStyle={[styles.wheelOverlayItem, { backgroundColor: colors.selected }]}
-            enableScrollByTapOnItem
-            keyExtractor={(item, index) => `currency-${index}`}
-          />
-        </View>
-      )}
-
-      {/* Convert-other-currencies toggle — badge tucked into the wheel's corner */}
-      {currencyItems.length > 1 && (
-        <TouchableOpacity
-          style={[
-            styles.fabToggle,
-            {
-              backgroundColor: convertAllBudgets ? colors.primary : colors.surface,
-              borderColor: convertAllBudgets ? colors.primary : colors.border,
-            },
-          ]}
-          onPress={handleToggleConvert}
-          activeOpacity={0.7}
-          accessibilityRole="switch"
-          accessibilityState={{ checked: convertAllBudgets }}
-          accessibilityLabel={t('graphs_convert_currencies')}
-          testID="budget-convert-toggle"
-        >
-          <Icon
-            name="cash-sync"
-            size={18}
-            color={convertAllBudgets ? colors.surface : colors.mutedText}
-          />
-        </TouchableOpacity>
-      )}
 
       <AddFAB
         onPress={handleOpenAddAllocation}
@@ -248,36 +299,48 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  fabToggle: {
+  convertToggle: {
     alignItems: 'center',
-    borderRadius: 16,
+    borderRadius: 14,
     borderWidth: 1,
-    bottom: 104,
-    elevation: 12,
-    height: 32,
+    height: 28,
     justifyContent: 'center',
-    left: 82,
-    position: 'absolute',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.35,
-    shadowRadius: 4,
-    width: 32,
-    zIndex: 2,
+    width: 28,
   },
-  fabWheel: {
-    borderRadius: 40,
+  currencyChip: {
+    alignItems: 'center',
+    borderRadius: 14,
     borderWidth: 1,
-    bottom: 116,
-    elevation: 8,
-    left: 16,
-    overflow: 'hidden',
-    position: 'absolute',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    width: 80,
+    flexDirection: 'row',
+    gap: 2,
+    height: 28,
+    paddingHorizontal: SPACING.sm,
+  },
+  currencyChipText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  heroControls: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+  },
+  heroFigure: {
+    flexShrink: 1,
+  },
+  heroLabel: {
+    fontSize: 12,
+  },
+  heroRow: {
+    alignItems: 'flex-end',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: SPACING.sm,
+  },
+  heroValue: {
+    fontSize: 24,
+    fontWeight: '700',
+    letterSpacing: -0.5,
   },
   jumpToCurrentButton: {
     alignItems: 'center',
@@ -293,13 +356,15 @@ const styles = StyleSheet.create({
   },
   listContent: {
     flexGrow: 1,
-    // Clears the tab bar, the FAB and the currency wheel, so the plan card's
-    // totals can always be scrolled out from under the floating controls.
-    paddingBottom: 260,
+    // Clears the tab bar and the FAB. It was 260 to also clear the floating
+    // currency wheel, which left roughly a quarter of the screen as dead space
+    // at the end of the list; the wheel moved into the header.
+    paddingBottom: 180,
     paddingHorizontal: SPACING.md,
     paddingTop: SPACING.md,
   },
   monthHeaderContainer: {
+    paddingBottom: SPACING.sm,
     paddingHorizontal: SPACING.md,
     paddingTop: SPACING.md,
   },
@@ -317,12 +382,6 @@ const styles = StyleSheet.create({
   },
   snackbar: {
     marginBottom: 100,
-  },
-  wheelItemText: {
-    fontSize: 14,
-  },
-  wheelOverlayItem: {
-    borderRadius: 8,
   },
 });
 


### PR DESCRIPTION
## Problem

The month's headline figure — *what can I still commit* — sat at the very bottom of the plan card in 14dp muted text, below every row and the allocated/actual totals. The one number a person acts on, placed where they'd reach it last. Above it, the top strip led with **execution counters**. Inverted priority.

Meanwhile the display-currency wheel floated over the card's bottom rows with a convert-all badge tucked into its corner — an always-on overlay for a setting changed once in a while, which also forced `paddingBottom: 260` so the card's own totals could be scrolled out from under it. About a quarter of a screen of dead space at the end of every list.

## Change

```
┌─ sticky ─────────────────────────────────────┐
│  ‹          Июль 2026               ›        │
│  Остаток                                     │
│  −85 745 AMD                  [AMD ⌄]  [⇄]   │
└──────────────────────────────────────────────┘
```

- **The remainder moves into the sticky header** at 24dp, in the overspend colour when negative, with the add-income prompt in its place when no income is declared yet. Always on screen, whatever the list is scrolled to.
- **The currency wheel becomes a header chip** opening an action sheet, and the convert-all badge a toggle beside it — the same pattern as every other whole-screen choice in the app.
- **Scroll padding 260 → 180**, which is what the tab bar and FAB actually need.

## On the plumbing

`MonthlyPlanSection` **reports** the remainder via `onTotalsChange` rather than having the figure lifted wholesale into the screen: computing it needs the lines, the plan status and the staleness gate, all of which live there, and moving that up would have dragged the plan contexts with it. The host replaces its state only when a field actually differs, so the section re-reporting on every recompute costs no render.

The card keeps rendering the remainder in **uncontrolled** mode (used standalone / in tests, where there is no host header to carry it), so the two never appear at once.

## Tests

162 suites / 4800 passing. New coverage: the reported remainder rendering in the header, the overspend colour on a negative one, the add-income prompt replacing it, and the currency sheet driving the selection (the screen's tests dropped the wheel-picker mock for the dialog).

*Last of four PRs reshaping this screen: ~~currency truth~~ (#1435) → ~~row density~~ (#1440) → ~~envelope fill~~ (#1442) → header hierarchy.*
