### PR TITLE
fix(graphs): unnest the drill-down chip and hide the closed chart from a11y

### DIFF
--- a/__tests__/components/graphs/CategoryBackChip.test.js
+++ b/__tests__/components/graphs/CategoryBackChip.test.js
@@ -1,0 +1,99 @@
+/**
+ * CategoryBackChip Component Tests
+ *
+ * The chip shows which category a summary tab is drilled into and pops back to
+ * its parent. It is rendered as an overlay above the tab strip rather than
+ * inside a tab, so it must stay tappable without swallowing taps meant for the
+ * tab underneath it.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import CategoryBackChip from '../../../app/components/graphs/CategoryBackChip';
+
+describe('CategoryBackChip', () => {
+  const defaultProps = {
+    colors: {
+      altRow: '#FAFAFA',
+      border: '#CCCCCC',
+      mutedText: '#888888',
+      text: '#000000',
+    },
+    label: 'Food',
+    backLabel: 'back',
+    onPress: jest.fn(),
+    side: 'left',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Basic Rendering', () => {
+    it('renders the category name', async () => {
+      const { getByText } = await render(<CategoryBackChip {...defaultProps} />);
+
+      expect(getByText('Food')).toBeTruthy();
+    });
+
+    it('truncates a long category name to a single line', async () => {
+      const { getByText } = await render(
+        <CategoryBackChip {...defaultProps} label="A very long category name indeed" />,
+      );
+
+      expect(getByText('A very long category name indeed').props.numberOfLines).toBe(1);
+    });
+  });
+
+  describe('Press Interaction', () => {
+    it('calls onPress when the chip is pressed', async () => {
+      const onPress = jest.fn();
+      const { getByRole } = await render(
+        <CategoryBackChip {...defaultProps} onPress={onPress} />,
+      );
+
+      await fireEvent.press(getByRole('button'));
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Overlay behaviour', () => {
+    // Without box-none the wrapper would blanket half the tab strip and eat
+    // every tap aimed at the tab beneath it.
+    it('lets taps that miss the chip fall through to the tab underneath', async () => {
+      const { getByTestId } = await render(
+        <CategoryBackChip {...defaultProps} testID="chip" />,
+      );
+
+      const wrapper = getByTestId('chip').parent;
+
+      expect(wrapper.props.pointerEvents).toBe('box-none');
+    });
+
+    it('sits over the half of the strip that owns it', async () => {
+      const { getByTestId, rerender } = await render(
+        <CategoryBackChip {...defaultProps} side="left" testID="chip" />,
+      );
+
+      const styleOf = () => {
+        const style = getByTestId('chip').parent.props.style;
+        return Object.assign({}, ...[].concat(style));
+      };
+
+      expect(styleOf()).toEqual(expect.objectContaining({ left: 0, width: '50%' }));
+
+      await rerender(<CategoryBackChip {...defaultProps} side="right" testID="chip" />);
+
+      expect(styleOf()).toEqual(expect.objectContaining({ right: 0, width: '50%' }));
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('exposes the back action rather than the category name', async () => {
+      const { getByLabelText } = await render(<CategoryBackChip {...defaultProps} />);
+
+      expect(getByLabelText('back')).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/components/graphs/ExpenseSummaryCard.test.js
+++ b/__tests__/components/graphs/ExpenseSummaryCard.test.js
@@ -243,20 +243,14 @@ describe('ExpenseSummaryCard', () => {
     });
   });
 
-  describe('categoryName / onBack overlay', () => {
-    it('shows category chip when both categoryName and onBack are provided', async () => {
-      const onBack = jest.fn();
-      const { getByText } = await render(
-        <ExpenseSummaryCard {...defaultProps} categoryName="Food" onBack={onBack} />,
-      );
-      expect(getByText('Food')).toBeTruthy();
-    });
+  // The drill-down chip used to be an overlay inside this card. It now lives in
+  // CategoryBackChip, rendered by GraphsScreen above the tab strip, so that a
+  // button is never nested inside the tab button — see CategoryBackChip.test.js.
+  describe('nested controls', () => {
+    it('renders no button other than the tab itself', async () => {
+      const { getAllByRole } = await render(<ExpenseSummaryCard {...defaultProps} />);
 
-    it('does not show category chip when categoryName provided but onBack is null', async () => {
-      const { queryByText } = await render(
-        <ExpenseSummaryCard {...defaultProps} categoryName="Food" onBack={null} />,
-      );
-      expect(queryByText('Food')).toBeNull();
+      expect(getAllByRole('button')).toHaveLength(1);
     });
   });
 });

--- a/__tests__/components/graphs/IncomeSummaryCard.test.js
+++ b/__tests__/components/graphs/IncomeSummaryCard.test.js
@@ -235,20 +235,14 @@ describe('IncomeSummaryCard', () => {
     });
   });
 
-  describe('categoryName / onBack overlay', () => {
-    it('shows category chip when both categoryName and onBack are provided', async () => {
-      const onBack = jest.fn();
-      const { getByText } = await render(
-        <IncomeSummaryCard {...defaultProps} categoryName="Salary" onBack={onBack} />,
-      );
-      expect(getByText('Salary')).toBeTruthy();
-    });
+  // The drill-down chip used to be an overlay inside this card. It now lives in
+  // CategoryBackChip, rendered by GraphsScreen above the tab strip, so that a
+  // button is never nested inside the tab button — see CategoryBackChip.test.js.
+  describe('nested controls', () => {
+    it('renders no button other than the tab itself', async () => {
+      const { getAllByRole } = await render(<IncomeSummaryCard {...defaultProps} />);
 
-    it('does not show category chip when categoryName provided but onBack is null', async () => {
-      const { queryByText } = await render(
-        <IncomeSummaryCard {...defaultProps} categoryName="Salary" onBack={null} />,
-      );
-      expect(queryByText('Salary')).toBeNull();
+      expect(getAllByRole('button')).toHaveLength(1);
     });
   });
 });

--- a/__tests__/screens/GraphsScreen.test.js
+++ b/__tests__/screens/GraphsScreen.test.js
@@ -822,12 +822,16 @@ describe('GraphsScreen', () => {
       expect(getByTestId('expense-summary-card')).toBeTruthy();
     });
 
+    // A closed chart is hidden from the accessibility tree, and RNTL honours that
+    // by excluding it from queries — so these lookups opt hidden elements back in.
+    const HIDDEN = { includeHiddenElements: true };
+
     it('starts collapsed with neither chart interactive', async () => {
       const GraphsScreen = require('../../app/screens/GraphsScreen').default;
       const { getByTestId } = await render(<GraphsScreen />);
 
-      expect(getByTestId('income-chart-content').props.pointerEvents).toBe('none');
-      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('income-chart-content', HIDDEN).props.pointerEvents).toBe('none');
+      expect(getByTestId('expense-chart-content', HIDDEN).props.pointerEvents).toBe('none');
       expect(getByTestId('income-summary-card').props.accessibilityState.expanded).toBe(false);
       expect(getByTestId('expense-summary-card').props.accessibilityState.expanded).toBe(false);
     });
@@ -838,14 +842,14 @@ describe('GraphsScreen', () => {
 
       await fireEvent.press(getByTestId('income-summary-card'));
 
-      expect(getByTestId('income-chart-content').props.pointerEvents).toBe('auto');
-      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('income-chart-content', HIDDEN).props.pointerEvents).toBe('auto');
+      expect(getByTestId('expense-chart-content', HIDDEN).props.pointerEvents).toBe('none');
       expect(getByTestId('income-summary-card').props.accessibilityState.expanded).toBe(true);
 
       await fireEvent.press(getByTestId('expense-summary-card'));
 
-      expect(getByTestId('income-chart-content').props.pointerEvents).toBe('none');
-      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('auto');
+      expect(getByTestId('income-chart-content', HIDDEN).props.pointerEvents).toBe('none');
+      expect(getByTestId('expense-chart-content', HIDDEN).props.pointerEvents).toBe('auto');
       expect(getByTestId('expense-summary-card').props.accessibilityState.expanded).toBe(true);
     });
 
@@ -856,8 +860,23 @@ describe('GraphsScreen', () => {
       await fireEvent.press(getByTestId('expense-summary-card'));
       await fireEvent.press(getByTestId('expense-summary-card'));
 
-      expect(getByTestId('expense-chart-content').props.pointerEvents).toBe('none');
+      expect(getByTestId('expense-chart-content', HIDDEN).props.pointerEvents).toBe('none');
       expect(getByTestId('expense-summary-card').props.accessibilityState.expanded).toBe(false);
+    });
+
+    // A screen reader must not read the legend of a chart the user has closed.
+    it('keeps the closed chart out of the accessibility tree', async () => {
+      const GraphsScreen = require('../../app/screens/GraphsScreen').default;
+      const { getByTestId, queryByTestId } = await render(<GraphsScreen />);
+
+      expect(queryByTestId('income-chart-content')).toBeNull();
+      expect(queryByTestId('expense-chart-content')).toBeNull();
+
+      await fireEvent.press(getByTestId('income-summary-card'));
+
+      // The open one is exposed again, the closed one stays hidden
+      expect(queryByTestId('income-chart-content')).toBeTruthy();
+      expect(queryByTestId('expense-chart-content')).toBeNull();
     });
   });
 

--- a/app/components/graphs/CategoryBackChip.js
+++ b/app/components/graphs/CategoryBackChip.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import PropTypes from 'prop-types';
+
+/**
+ * Shows the category a summary tab is currently drilled into, and pops back to
+ * its parent when tapped.
+ *
+ * Rendered by GraphsScreen as an overlay above the tab strip rather than inside
+ * the tab itself: the tab is already a button, and a button nested in a button
+ * reads as two controls to a screen reader. `box-none` on the wrapper lets taps
+ * that miss the chip fall through to the tab underneath.
+ */
+const CategoryBackChip = ({ colors, label, backLabel, onPress, side, testID }) => (
+  <View
+    style={[styles.overlay, side === 'left' ? styles.overlayLeft : styles.overlayRight]}
+    pointerEvents="box-none"
+  >
+    <TouchableOpacity
+      testID={testID}
+      onPress={onPress}
+      style={[styles.chip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={backLabel}
+    >
+      <Text style={[styles.chipText, { color: colors.text }]} numberOfLines={1}>
+        {label}
+      </Text>
+      <Icon name="close-circle" size={14} color={colors.mutedText} />
+    </TouchableOpacity>
+  </View>
+);
+
+CategoryBackChip.propTypes = {
+  colors: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired,
+  backLabel: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired,
+  side: PropTypes.oneOf(['left', 'right']).isRequired,
+  testID: PropTypes.string,
+};
+
+const styles = StyleSheet.create({
+  chip: {
+    alignItems: 'center',
+    borderRadius: 20,
+    borderWidth: 1,
+    flexDirection: 'row',
+    gap: 4,
+    maxWidth: '75%',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  chipText: {
+    flexShrink: 1,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  overlay: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    position: 'absolute',
+    top: 0,
+    // Each tab owns half the strip, so the chip is centred over its own half
+    width: '50%',
+  },
+  overlayLeft: {
+    left: 0,
+  },
+  overlayRight: {
+    right: 0,
+  },
+});
+
+export default CategoryBackChip;

--- a/app/components/graphs/ExpenseSummaryCard.js
+++ b/app/components/graphs/ExpenseSummaryCard.js
@@ -1,26 +1,9 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
-import currencies from '../../../assets/currencies.json';
-import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+import SummaryTab from './SummaryTab';
 
 // Expense red is intentionally theme-independent — it matches the arrow badge.
-const EXPENSE_ACCENT = '#d93025';
-
-const formatCurrency = (amount, currency) => {
-  const currencyInfo = currencies[currency];
-  const symbol = currencyInfo?.symbol ?? currency;
-  const value = parseFloat(amount);
-  if (value >= 1000000) {
-    return `${symbol}${(value / 1000000).toFixed(1)}M`;
-  }
-  if (value >= 1000) {
-    return `${symbol}${(value / 1000).toFixed(1)}K`;
-  }
-  const decimals = currencyInfo?.decimal_digits ?? 2;
-  return `${symbol}${value.toFixed(decimals)}`;
-};
+export const EXPENSE_ACCENT = '#d93025';
 
 const ExpenseSummaryCard = ({
   colors,
@@ -30,54 +13,21 @@ const ExpenseSummaryCard = ({
   selectedCurrency,
   onPress,
   expanded = false,
-  categoryName = null,
-  onBack = null,
-}) => {
-  const { hideBalances } = useDisplaySettings();
-  return (
-    <TouchableOpacity
-      testID="expense-summary-card"
-      style={[
-        styles.summaryCard,
-        expanded && { backgroundColor: colors.altRow, borderBottomColor: EXPENSE_ACCENT },
-      ]}
-      onPress={onPress}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityState={{ expanded }}
-      accessibilityLabel={t('expenses_by_category')}
-    >
-      <View style={styles.iconBadge}>
-        <Icon name="arrow-top-right" size={16} color={EXPENSE_ACCENT} />
-      </View>
-      <View style={styles.textContent}>
-        <Text style={[styles.label, { color: colors.mutedText }]}>{t('expense').toUpperCase()}</Text>
-        <Text style={[styles.amount, { color: colors.text }]}>
-          {hideBalances ? '••••' : (loading ? '...' : formatCurrency(totalExpenses, selectedCurrency))}
-        </Text>
-      </View>
-      {categoryName && onBack && (
-        <View style={styles.categoryBackOverlay} pointerEvents="box-none">
-          <TouchableOpacity
-            onPress={onBack}
-            style={[styles.filterChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
-            activeOpacity={0.7}
-            accessibilityRole="button"
-            accessibilityLabel={t('back')}
-          >
-            <Text style={[styles.filterChipText, { color: colors.text }]} numberOfLines={1}>
-              {categoryName}
-            </Text>
-            <Icon name="close-circle" size={14} color={colors.mutedText} />
-          </TouchableOpacity>
-        </View>
-      )}
-      <View style={styles.chevron} pointerEvents="none">
-        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-      </View>
-    </TouchableOpacity>
-  );
-};
+}) => (
+  <SummaryTab
+    testID="expense-summary-card"
+    colors={colors}
+    icon="arrow-top-right"
+    accent={EXPENSE_ACCENT}
+    label={t('expense').toUpperCase()}
+    accessibilityLabel={t('expenses_by_category')}
+    amount={totalExpenses}
+    loading={loading}
+    selectedCurrency={selectedCurrency}
+    onPress={onPress}
+    expanded={expanded}
+  />
+);
 
 ExpenseSummaryCard.propTypes = {
   colors: PropTypes.object.isRequired,
@@ -87,73 +37,6 @@ ExpenseSummaryCard.propTypes = {
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   expanded: PropTypes.bool,
-  categoryName: PropTypes.string,
-  onBack: PropTypes.func,
 };
-
-const styles = StyleSheet.create({
-  amount: {
-    fontSize: 16,
-    fontWeight: '700',
-    letterSpacing: -0.3,
-    marginTop: 1,
-  },
-  categoryBackOverlay: {
-    alignItems: 'center',
-    bottom: 0,
-    justifyContent: 'center',
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
-  chevron: {
-    alignItems: 'center',
-    alignSelf: 'stretch',
-    justifyContent: 'center',
-    width: 20,
-  },
-  filterChip: {
-    alignItems: 'center',
-    borderRadius: 20,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 4,
-    maxWidth: '75%',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  filterChipText: {
-    flexShrink: 1,
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  iconBadge: {
-    alignItems: 'center',
-    height: 26,
-    justifyContent: 'center',
-    width: 26,
-  },
-  label: {
-    fontSize: 10,
-    fontWeight: '500',
-    letterSpacing: 0.3,
-  },
-  summaryCard: {
-    alignItems: 'center',
-    // Transparent by default so activating the tab doesn't shift its height
-    borderBottomColor: 'transparent',
-    borderBottomWidth: 2,
-    flex: 1,
-    flexDirection: 'row',
-    gap: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-  },
-  textContent: {
-    flex: 1,
-    minWidth: 0,
-  },
-});
 
 export default ExpenseSummaryCard;

--- a/app/components/graphs/IncomeSummaryCard.js
+++ b/app/components/graphs/IncomeSummaryCard.js
@@ -1,23 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
-import currencies from '../../../assets/currencies.json';
-import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
-
-const formatCurrency = (amount, currency) => {
-  const currencyInfo = currencies[currency];
-  const symbol = currencyInfo?.symbol ?? currency;
-  const value = parseFloat(amount);
-  if (value >= 1000000) {
-    return `${symbol}${(value / 1000000).toFixed(1)}M`;
-  }
-  if (value >= 1000) {
-    return `${symbol}${(value / 1000).toFixed(1)}K`;
-  }
-  const decimals = currencyInfo?.decimal_digits ?? 2;
-  return `${symbol}${value.toFixed(decimals)}`;
-};
+import SummaryTab from './SummaryTab';
 
 const IncomeSummaryCard = ({
   colors,
@@ -27,54 +10,21 @@ const IncomeSummaryCard = ({
   selectedCurrency,
   onPress,
   expanded = false,
-  categoryName = null,
-  onBack = null,
-}) => {
-  const { hideBalances } = useDisplaySettings();
-  return (
-    <TouchableOpacity
-      testID="income-summary-card"
-      style={[
-        styles.summaryCard,
-        expanded && { backgroundColor: colors.altRow, borderBottomColor: colors.income },
-      ]}
-      onPress={onPress}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityState={{ expanded }}
-      accessibilityLabel={t('income_by_category')}
-    >
-      <View style={styles.iconBadge}>
-        <Icon name="arrow-bottom-left" size={16} color={colors.income} />
-      </View>
-      <View style={styles.textContent}>
-        <Text style={[styles.label, { color: colors.mutedText }]}>{t('income').toUpperCase()}</Text>
-        <Text style={[styles.amount, { color: colors.text }]}>
-          {hideBalances ? '••••' : (loadingIncome ? '...' : formatCurrency(totalIncome, selectedCurrency))}
-        </Text>
-      </View>
-      {categoryName && onBack && (
-        <View style={styles.categoryBackOverlay} pointerEvents="box-none">
-          <TouchableOpacity
-            onPress={onBack}
-            style={[styles.filterChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
-            activeOpacity={0.7}
-            accessibilityRole="button"
-            accessibilityLabel={t('back')}
-          >
-            <Text style={[styles.filterChipText, { color: colors.text }]} numberOfLines={1}>
-              {categoryName}
-            </Text>
-            <Icon name="close-circle" size={14} color={colors.mutedText} />
-          </TouchableOpacity>
-        </View>
-      )}
-      <View style={styles.chevron} pointerEvents="none">
-        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
-      </View>
-    </TouchableOpacity>
-  );
-};
+}) => (
+  <SummaryTab
+    testID="income-summary-card"
+    colors={colors}
+    icon="arrow-bottom-left"
+    accent={colors.income}
+    label={t('income').toUpperCase()}
+    accessibilityLabel={t('income_by_category')}
+    amount={totalIncome}
+    loading={loadingIncome}
+    selectedCurrency={selectedCurrency}
+    onPress={onPress}
+    expanded={expanded}
+  />
+);
 
 IncomeSummaryCard.propTypes = {
   colors: PropTypes.object.isRequired,
@@ -84,73 +34,6 @@ IncomeSummaryCard.propTypes = {
   selectedCurrency: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
   expanded: PropTypes.bool,
-  categoryName: PropTypes.string,
-  onBack: PropTypes.func,
 };
-
-const styles = StyleSheet.create({
-  amount: {
-    fontSize: 16,
-    fontWeight: '700',
-    letterSpacing: -0.3,
-    marginTop: 1,
-  },
-  categoryBackOverlay: {
-    alignItems: 'center',
-    bottom: 0,
-    justifyContent: 'center',
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
-  chevron: {
-    alignItems: 'center',
-    alignSelf: 'stretch',
-    justifyContent: 'center',
-    width: 20,
-  },
-  filterChip: {
-    alignItems: 'center',
-    borderRadius: 20,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 4,
-    maxWidth: '75%',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  filterChipText: {
-    flexShrink: 1,
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  iconBadge: {
-    alignItems: 'center',
-    height: 26,
-    justifyContent: 'center',
-    width: 26,
-  },
-  label: {
-    fontSize: 10,
-    fontWeight: '500',
-    letterSpacing: 0.3,
-  },
-  summaryCard: {
-    alignItems: 'center',
-    // Transparent by default so activating the tab doesn't shift its height
-    borderBottomColor: 'transparent',
-    borderBottomWidth: 2,
-    flex: 1,
-    flexDirection: 'row',
-    gap: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-  },
-  textContent: {
-    flex: 1,
-    minWidth: 0,
-  },
-});
 
 export default IncomeSummaryCard;

--- a/app/components/graphs/SummaryTab.js
+++ b/app/components/graphs/SummaryTab.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import PropTypes from 'prop-types';
+import currencies from '../../../assets/currencies.json';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+
+const formatCurrency = (amount, currency) => {
+  const currencyInfo = currencies[currency];
+  const symbol = currencyInfo?.symbol ?? currency;
+  const value = parseFloat(amount);
+  if (value >= 1000000) {
+    return `${symbol}${(value / 1000000).toFixed(1)}M`;
+  }
+  if (value >= 1000) {
+    return `${symbol}${(value / 1000).toFixed(1)}K`;
+  }
+  const decimals = currencyInfo?.decimal_digits ?? 2;
+  return `${symbol}${value.toFixed(decimals)}`;
+};
+
+/**
+ * One half of the income/expense tab strip. The whole tab is the press target —
+ * the chevron is decoration, not a separate button — and the active tab is
+ * marked with a tinted background plus an accent underline.
+ *
+ * The drill-down "back" chip deliberately lives OUTSIDE this component (it is an
+ * overlay owned by GraphsScreen): nesting a button inside this button would give
+ * screen readers nested controls and would flash the parent's activeOpacity on
+ * every chip tap.
+ */
+const SummaryTab = ({
+  colors,
+  testID,
+  icon,
+  accent,
+  label,
+  accessibilityLabel,
+  amount,
+  loading,
+  selectedCurrency,
+  onPress,
+  expanded = false,
+}) => {
+  const { hideBalances } = useDisplaySettings();
+  return (
+    <TouchableOpacity
+      testID={testID}
+      style={[
+        styles.summaryCard,
+        expanded && { backgroundColor: colors.altRow, borderBottomColor: accent },
+      ]}
+      onPress={onPress}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityState={{ expanded }}
+      accessibilityLabel={accessibilityLabel}
+    >
+      <View style={styles.iconBadge}>
+        <Icon name={icon} size={16} color={accent} />
+      </View>
+      <View style={styles.textContent}>
+        <Text style={[styles.label, { color: colors.mutedText }]}>{label}</Text>
+        <Text style={[styles.amount, { color: colors.text }]}>
+          {hideBalances ? '••••' : (loading ? '...' : formatCurrency(amount, selectedCurrency))}
+        </Text>
+      </View>
+      <View style={styles.chevron} pointerEvents="none">
+        <Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={colors.mutedText} />
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+SummaryTab.propTypes = {
+  colors: PropTypes.object.isRequired,
+  testID: PropTypes.string.isRequired,
+  icon: PropTypes.string.isRequired,
+  accent: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  accessibilityLabel: PropTypes.string.isRequired,
+  amount: PropTypes.number.isRequired,
+  loading: PropTypes.bool.isRequired,
+  selectedCurrency: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired,
+  expanded: PropTypes.bool,
+};
+
+const styles = StyleSheet.create({
+  amount: {
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    marginTop: 1,
+  },
+  chevron: {
+    alignItems: 'center',
+    alignSelf: 'stretch',
+    justifyContent: 'center',
+    width: 20,
+  },
+  iconBadge: {
+    alignItems: 'center',
+    height: 26,
+    justifyContent: 'center',
+    width: 26,
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: '500',
+    letterSpacing: 0.3,
+  },
+  summaryCard: {
+    alignItems: 'center',
+    // Transparent by default so activating the tab doesn't shift its height
+    borderBottomColor: 'transparent',
+    borderBottomWidth: 2,
+    flex: 1,
+    flexDirection: 'row',
+    gap: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  textContent: {
+    flex: 1,
+    minWidth: 0,
+  },
+});
+
+export default SummaryTab;

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -14,6 +14,7 @@ import { formatAmount } from '../services/currency';
 import currenciesJson from '../../assets/currencies.json';
 import EmptyState from '../components/EmptyState';
 import BalanceHistoryCard from '../components/graphs/BalanceHistoryCard';
+import CategoryBackChip from '../components/graphs/CategoryBackChip';
 import CategorySpendingCard from '../components/graphs/CategorySpendingCard';
 import ExpenseSummaryCard from '../components/graphs/ExpenseSummaryCard';
 import IncomeSummaryCard from '../components/graphs/IncomeSummaryCard';
@@ -615,8 +616,6 @@ const GraphsScreen = () => {
                 selectedCurrency={selectedCurrency}
                 onPress={handleToggleIncome}
                 expanded={expandedCard === 'income'}
-                categoryName={selectedIncomeCategoryName}
-                onBack={handleBackToIncomeParent}
               />
               <View style={[styles.tabDivider, { backgroundColor: colors.border }]} />
               <ExpenseSummaryCard
@@ -627,16 +626,41 @@ const GraphsScreen = () => {
                 selectedCurrency={selectedCurrency}
                 onPress={handleToggleExpense}
                 expanded={expandedCard === 'expense'}
-                categoryName={selectedCategoryName}
-                onBack={handleBackToExpenseParent}
               />
+
+              {/* Drill-down chips sit above the strip, not inside a tab — a button
+                  nested in a button reads as two controls to a screen reader. */}
+              {selectedIncomeCategoryName && (
+                <CategoryBackChip
+                  testID="income-category-chip"
+                  colors={colors}
+                  side="left"
+                  label={selectedIncomeCategoryName}
+                  backLabel={t('back')}
+                  onPress={handleBackToIncomeParent}
+                />
+              )}
+              {selectedCategoryName && (
+                <CategoryBackChip
+                  testID="expense-category-chip"
+                  colors={colors}
+                  side="right"
+                  label={selectedCategoryName}
+                  backLabel={t('back')}
+                  onPress={handleBackToExpenseParent}
+                />
+              )}
             </View>
 
             {/* Both charts stay mounted and overlap, so they stay measured and
-                switching tabs cross-fades instead of remounting. */}
+                switching tabs cross-fades instead of remounting. The closed one is
+                pulled out of the accessibility tree too — opacity 0 alone still
+                lets TalkBack read its legend. */}
             <Animated.View
               testID="income-chart-content"
               pointerEvents={expandedCard === 'income' ? 'auto' : 'none'}
+              accessibilityElementsHidden={expandedCard !== 'income'}
+              importantForAccessibility={expandedCard === 'income' ? 'auto' : 'no-hide-descendants'}
               style={[styles.chartContent, incomeChartAnimStyle]}
             >
               <ScrollView
@@ -670,6 +694,8 @@ const GraphsScreen = () => {
             <Animated.View
               testID="expense-chart-content"
               pointerEvents={expandedCard === 'expense' ? 'auto' : 'none'}
+              accessibilityElementsHidden={expandedCard !== 'expense'}
+              importantForAccessibility={expandedCard === 'expense' ? 'auto' : 'no-hide-descendants'}
               style={[styles.chartContent, expenseChartAnimStyle]}
             >
               <ScrollView


### PR DESCRIPTION
Follow-up to #1439, addressing the review findings on that PR.

## 1. Button nested inside a button

Since #1439 the summary tab is itself a `TouchableOpacity`, and the drill-down category chip was an overlay rendered *inside* it. Two problems: TalkBack sees nested controls, and the parent's `activeOpacity` flashed the whole tab on every chip tap.

The chip moves out into `CategoryBackChip`, rendered by `GraphsScreen` above the tab strip and positioned over the half of the strip that owns it. `pointerEvents="box-none"` on the wrapper keeps taps that miss the chip falling through to the tab underneath.

## 2. Closed chart was still readable by a screen reader

`opacity: 0` and `pointerEvents="none"` do not remove a view from the accessibility tree, so TalkBack read the legend of whichever chart was closed — both of them when the panel is collapsed, which is the default state.

Both chart containers now derive `accessibilityElementsHidden` / `importantForAccessibility` from the open tab.

## 3. Two near-identical card components

`IncomeSummaryCard` and `ExpenseSummaryCard` were ~90% the same file — `formatCurrency` and the entire `StyleSheet` copied verbatim — and had already drifted: income pulled its accent from the theme, expense hardcoded `#d93025`.

Both are now thin wrappers over a shared `SummaryTab` that owns the layout and formatting. Their public props and testIDs are unchanged, so callers and existing tests are untouched.

Deliberately **not** changed here: the local `formatCurrency` is not swapped for `services/currency.js`'s `formatCompact`. The two disagree on output (`¥150.0K` vs `150K`) and unifying them changes what users see — that belongs in its own PR.

## Testing

- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean
- Full suite: **163 suites / 4805 tests** passing
- New `CategoryBackChip.test.js` covers rendering, press, the `box-none` fall-through and left/right placement
- New `keeps the closed chart out of the accessibility tree` asserts finding 2 directly — it passes because RNTL excludes a11y-hidden elements from queries, which is also why the existing chart-container assertions now opt in with `includeHiddenElements`
- Both card suites gained `renders no button other than the tab itself`, which fails if a nested control is ever reintroduced
