### PR TITLE
feat(graphs): anchor the donut and animate the panel's tab transitions

### DIFF
--- a/__tests__/components/graphs/DonutChart.test.js
+++ b/__tests__/components/graphs/DonutChart.test.js
@@ -7,6 +7,9 @@ import DonutChart, {
   CENTER,
   ICON_RADIUS,
   ICON_THRESHOLD,
+  INTRO_DURATION,
+  INTRO_SCALE_FROM,
+  INTRO_ROTATION_FROM,
 } from '../../../app/components/graphs/DonutChart';
 
 describe('mapPieData', () => {
@@ -203,5 +206,36 @@ describe('DonutChart', () => {
     const { getByTestId } = await render(<DonutChart data={mockData} insetColor="#ffffff" />);
     expect(getByTestId('donut-chart')).toBeTruthy();
     expect(getByTestId('vn-pie')).toBeTruthy();
+  });
+
+  describe('intro animation', () => {
+    it('renders without an introKey', async () => {
+      const { getByTestId } = await render(<DonutChart data={mockData} />);
+
+      expect(getByTestId('donut-chart')).toBeTruthy();
+    });
+
+    // The charts are mounted for both tabs at all times, so the animation cannot
+    // key off mounting — the screen bumps introKey when a tab actually opens.
+    // Replaying it must not disturb the rendered donut.
+    it('keeps the donut and its icons intact when introKey changes', async () => {
+      const { getByTestId, queryAllByTestId, rerender } = await render(
+        <DonutChart data={mockData} introKey={0} />,
+      );
+
+      await rerender(<DonutChart data={mockData} introKey={1} />);
+
+      expect(getByTestId('donut-chart')).toBeTruthy();
+      expect(getByTestId('vn-pie')).toBeTruthy();
+      expect(queryAllByTestId('icon-food').length).toBeGreaterThan(0);
+      expect(queryAllByTestId('icon-car').length).toBeGreaterThan(0);
+    });
+
+    it('starts from a scaled-down, rotated state so the donut spins up into place', () => {
+      expect(INTRO_SCALE_FROM).toBeGreaterThan(0);
+      expect(INTRO_SCALE_FROM).toBeLessThan(1);
+      expect(INTRO_ROTATION_FROM).not.toBe(0);
+      expect(INTRO_DURATION).toBeGreaterThan(0);
+    });
   });
 });

--- a/__tests__/components/graphs/ExpensePieChart.test.js
+++ b/__tests__/components/graphs/ExpensePieChart.test.js
@@ -56,6 +56,19 @@ describe('ExpensePieChart', () => {
     expect(getByTestId('donut-chart')).toBeTruthy();
   });
 
+  // Regression: the row used to centre its children, so the donut's vertical
+  // offset followed the legend's height and it jumped whenever the category
+  // count changed — most visibly when switching between the income and expense
+  // tabs of the same panel.
+  it('anchors the donut to the top of the row so it does not move with the legend', async () => {
+    const { getByTestId } = await render(<ExpensePieChart {...defaultProps} />);
+
+    const row = getByTestId('donut-chart').parent;
+    const rowStyle = Object.assign({}, ...[].concat(row.props.style));
+
+    expect(rowStyle.alignItems).toBe('flex-start');
+  });
+
   it('renders legend category names', async () => {
     const { getByText } = await render(<ExpensePieChart {...defaultProps} />);
     expect(getByText('Food')).toBeTruthy();

--- a/__tests__/components/graphs/IncomePieChart.test.js
+++ b/__tests__/components/graphs/IncomePieChart.test.js
@@ -56,6 +56,19 @@ describe('IncomePieChart', () => {
     expect(getByTestId('donut-chart')).toBeTruthy();
   });
 
+  // Regression: the row used to centre its children, so the donut's vertical
+  // offset followed the legend's height and it jumped whenever the category
+  // count changed — most visibly when switching between the income and expense
+  // tabs of the same panel.
+  it('anchors the donut to the top of the row so it does not move with the legend', async () => {
+    const { getByTestId } = await render(<IncomePieChart {...defaultProps} />);
+
+    const row = getByTestId('donut-chart').parent;
+    const rowStyle = Object.assign({}, ...[].concat(row.props.style));
+
+    expect(rowStyle.alignItems).toBe('flex-start');
+  });
+
   it('renders legend category names', async () => {
     const { getByText } = await render(<IncomePieChart {...defaultProps} />);
     expect(getByText('Salary')).toBeTruthy();

--- a/__tests__/components/graphs/chartTransitions.test.js
+++ b/__tests__/components/graphs/chartTransitions.test.js
@@ -1,0 +1,85 @@
+/**
+ * chartTransitions Tests
+ *
+ * The income/expense panel holds both charts stacked on top of each other, so a
+ * transition is defined by where the incoming chart comes from and where the
+ * outgoing one goes. These offsets are what makes a tab switch read as sideways
+ * movement and an open/close read as vertical movement.
+ */
+
+import {
+  chartTransitionOffsets,
+  CHART_DROP,
+  CHART_SLIDE,
+} from '../../../app/components/graphs/chartTransitions';
+
+describe('chartTransitions', () => {
+  describe('opening from collapsed', () => {
+    it('drops the chart down and moves nothing out', () => {
+      expect(chartTransitionOffsets(null, 'income')).toEqual({
+        enter: { x: 0, y: CHART_DROP },
+        exit: null,
+      });
+    });
+
+    it('treats both tabs the same way', () => {
+      expect(chartTransitionOffsets(null, 'expense'))
+        .toEqual(chartTransitionOffsets(null, 'income'));
+    });
+  });
+
+  describe('collapsing', () => {
+    it('sinks the open chart back down', () => {
+      expect(chartTransitionOffsets('expense', null)).toEqual({
+        enter: null,
+        exit: { x: 0, y: CHART_DROP },
+      });
+    });
+
+    it('moves nothing when there was no open tab', () => {
+      expect(chartTransitionOffsets(null, null)).toEqual({ enter: null, exit: null });
+    });
+  });
+
+  describe('switching tabs', () => {
+    // Income is the left tab: moving to expense is travel to the right, so the
+    // new chart arrives from the right edge and the old one exits left.
+    it('moves rightwards from income to expense', () => {
+      expect(chartTransitionOffsets('income', 'expense')).toEqual({
+        enter: { x: CHART_SLIDE, y: 0 },
+        exit: { x: -CHART_SLIDE, y: 0 },
+      });
+    });
+
+    it('mirrors the direction going back', () => {
+      expect(chartTransitionOffsets('expense', 'income')).toEqual({
+        enter: { x: -CHART_SLIDE, y: 0 },
+        exit: { x: CHART_SLIDE, y: 0 },
+      });
+    });
+
+    it('never mixes vertical movement into a sideways switch', () => {
+      const { enter, exit } = chartTransitionOffsets('income', 'expense');
+
+      expect(enter.y).toBe(0);
+      expect(exit.y).toBe(0);
+    });
+
+    it('sends the two charts in opposite directions so they do not overlap mid-flight', () => {
+      const { enter, exit } = chartTransitionOffsets('expense', 'income');
+
+      expect(Math.sign(enter.x)).toBe(-Math.sign(exit.x));
+    });
+  });
+
+  describe('re-opening the tab that is already open', () => {
+    // The screen turns this into a collapse before calling in, but the helper
+    // should still describe a sane transition rather than a sideways slide.
+    it('falls back to the vertical drop', () => {
+      expect(chartTransitionOffsets('income', 'income')).toEqual({
+        enter: { x: 0, y: CHART_DROP },
+        exit: null,
+      });
+    });
+  });
+});

--- a/app/components/graphs/DonutChart.js
+++ b/app/components/graphs/DonutChart.js
@@ -1,5 +1,6 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useMemo, useCallback, useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, Easing } from 'react-native-reanimated';
 import { Pie, PolarChart } from 'victory-native';
 import { LinearGradient, vec } from '@shopify/react-native-skia';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
@@ -79,9 +80,34 @@ export const computeSliceGradient = (slice) => {
 const SLICE_FADE_ALPHA = '80';
 const INSET_WIDTH = 2;
 
-const DonutChart = ({ data, insetColor }) => {
+// The donut spins up into place rather than snapping in. Victory Native has no
+// entering animation for Pie.Chart, and its `startAngle` is a plain prop — driving
+// it per frame would re-render the chart on the JS thread. Animating the container
+// instead keeps the whole thing on the UI thread for the cost of one transform.
+export const INTRO_DURATION = 460;
+export const INTRO_SCALE_FROM = 0.86;
+export const INTRO_ROTATION_FROM = -14;
+
+const DonutChart = ({ data, insetColor, introKey = 0 }) => {
   const pieData = useMemo(() => mapPieData(data), [data]);
   const markers = useMemo(() => computeIconMarkers(data), [data]);
+  const intro = useSharedValue(0);
+
+  // Replays whenever introKey changes — the screen bumps it as a tab opens, so
+  // the donut animates when it becomes visible, not when it silently mounts
+  // behind a collapsed panel.
+  useEffect(() => {
+    intro.value = 0;
+    intro.value = withTiming(1, { duration: INTRO_DURATION, easing: Easing.out(Easing.cubic) });
+  }, [introKey, intro]);
+
+  const introStyle = useAnimatedStyle(() => ({
+    opacity: intro.value,
+    transform: [
+      { scale: interpolate(intro.value, [0, 1], [INTRO_SCALE_FROM, 1]) },
+      { rotate: `${interpolate(intro.value, [0, 1], [INTRO_ROTATION_FROM, 0])}deg` },
+    ],
+  }));
 
   const renderSlice = useCallback(({ slice }) => {
     const { start, end } = computeSliceGradient(slice);
@@ -105,7 +131,7 @@ const DonutChart = ({ data, insetColor }) => {
   }, [insetColor]);
 
   return (
-    <View testID="donut-chart" style={styles.container} accessibilityRole="image">
+    <Animated.View testID="donut-chart" style={[styles.container, introStyle]} accessibilityRole="image">
       <PolarChart data={pieData} labelKey="label" valueKey="value" colorKey="color">
         <Pie.Chart innerRadius={INNER_RADIUS}>
           {renderSlice}
@@ -129,7 +155,7 @@ const DonutChart = ({ data, insetColor }) => {
             <Icon name={marker.icon} size={ICON_SIZE} color="#fff" />
           </View>
         ))}
-    </View>
+    </Animated.View>
   );
 };
 
@@ -143,6 +169,8 @@ DonutChart.propTypes = {
   ).isRequired,
   // Colour of the hairline drawn between slices; omit to draw none.
   insetColor: PropTypes.string,
+  // Bump to replay the intro animation (e.g. when the owning tab is opened).
+  introKey: PropTypes.number,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -16,6 +16,7 @@ const ExpensePieChart = ({
   isLeafCategory = false,
   operations = [],
   loadingOperations = false,
+  introKey = 0,
 }) => {
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
@@ -53,7 +54,7 @@ const ExpensePieChart = ({
 
   return (
     <View style={styles.row}>
-      <DonutChart data={chartData} insetColor={colors.surface} />
+      <DonutChart data={chartData} insetColor={colors.surface} introKey={introKey} />
       <View style={styles.legendWrapper}>
         <CustomLegend
           data={chartData}
@@ -78,6 +79,8 @@ ExpensePieChart.propTypes = {
   isLeafCategory: PropTypes.bool,
   operations: PropTypes.array,
   loadingOperations: PropTypes.bool,
+  // Bump to replay the donut intro when this chart's tab is opened.
+  introKey: PropTypes.number,
 };
 
 const styles = StyleSheet.create({
@@ -98,7 +101,10 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   row: {
-    alignItems: 'center',
+    // Top-aligned, not centred: the legend's height follows the category count,
+    // so centring made the donut sit at a different offset on each tab and jump
+    // as you switched between them.
+    alignItems: 'flex-start',
     flex: 1,
     flexDirection: 'row',
     gap: 10,

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -16,6 +16,7 @@ const IncomePieChart = ({
   isLeafCategory = false,
   operations = [],
   loadingOperations = false,
+  introKey = 0,
 }) => {
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
@@ -53,7 +54,7 @@ const IncomePieChart = ({
 
   return (
     <View style={styles.row}>
-      <DonutChart data={incomeChartData} insetColor={colors.surface} />
+      <DonutChart data={incomeChartData} insetColor={colors.surface} introKey={introKey} />
       <View style={styles.legendWrapper}>
         <CustomLegend
           data={incomeChartData}
@@ -78,6 +79,8 @@ IncomePieChart.propTypes = {
   isLeafCategory: PropTypes.bool,
   operations: PropTypes.array,
   loadingOperations: PropTypes.bool,
+  // Bump to replay the donut intro when this chart's tab is opened.
+  introKey: PropTypes.number,
 };
 
 const styles = StyleSheet.create({
@@ -98,7 +101,10 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   row: {
-    alignItems: 'center',
+    // Top-aligned, not centred: the legend's height follows the category count,
+    // so centring made the donut sit at a different offset on each tab and jump
+    // as you switched between them.
+    alignItems: 'flex-start',
     flex: 1,
     flexDirection: 'row',
     gap: 10,

--- a/app/components/graphs/chartTransitions.js
+++ b/app/components/graphs/chartTransitions.js
@@ -1,0 +1,42 @@
+// Geometry of the income/expense panel's chart transitions.
+//
+// The two charts overlap absolutely inside one panel, so a transition is a pair
+// of offsets: where the incoming chart travels from, and where the outgoing one
+// travels to. Both are expressed at progress 0 — the animated style interpolates
+// each towards {x: 0, y: 0} as its progress reaches 1.
+
+// Opening or closing moves the chart vertically, as if it slid out from under
+// the tab strip. Switching tabs moves it sideways, like a pager.
+export const CHART_DROP = 16;
+export const CHART_SLIDE = 28;
+
+// Income is the left tab, expense the right one.
+const TAB_ORDER = { income: 0, expense: 1 };
+
+/**
+ * Offsets for a transition between tabs.
+ *
+ * @param {'income'|'expense'|null} from - tab that was open, null if collapsed
+ * @param {'income'|'expense'|null} to - tab being opened, null when collapsing
+ * @returns {{ enter: {x: number, y: number}|null, exit: {x: number, y: number}|null }}
+ */
+export const chartTransitionOffsets = (from, to) => {
+  // Collapsing: the open chart sinks back under the strip, nothing enters.
+  if (to === null) {
+    return { enter: null, exit: from ? { x: 0, y: CHART_DROP } : null };
+  }
+
+  // Opening from collapsed: the chart drops down, nothing leaves.
+  if (from === null || from === to) {
+    return { enter: { x: 0, y: CHART_DROP }, exit: null };
+  }
+
+  // Switching: move in the direction of travel — right when going from the left
+  // tab to the right one, so the new chart arrives from the right edge and the
+  // old one leaves through the left.
+  const direction = TAB_ORDER[to] > TAB_ORDER[from] ? 1 : -1;
+  return {
+    enter: { x: direction * CHART_SLIDE, y: 0 },
+    exit: { x: -direction * CHART_SLIDE, y: 0 },
+  };
+};

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -15,6 +15,7 @@ import currenciesJson from '../../assets/currencies.json';
 import EmptyState from '../components/EmptyState';
 import BalanceHistoryCard from '../components/graphs/BalanceHistoryCard';
 import CategoryBackChip from '../components/graphs/CategoryBackChip';
+import { chartTransitionOffsets, CHART_DROP } from '../components/graphs/chartTransitions';
 import CategorySpendingCard from '../components/graphs/CategorySpendingCard';
 import ExpenseSummaryCard from '../components/graphs/ExpenseSummaryCard';
 import IncomeSummaryCard from '../components/graphs/IncomeSummaryCard';
@@ -27,6 +28,13 @@ import useBalanceHistory from '../hooks/useBalanceHistory';
 
 const CARD_HEADER_HEIGHT = 56;
 const MAX_CHART_HEIGHT = 500;
+// How far a chart travels while fading: straight down when its tab opens,
+// sideways when you move between tabs.
+// Entry outlasts exit so the two overlap instead of leaving a blank frame.
+const CHART_IN_DURATION = 320;
+const CHART_OUT_DURATION = 200;
+const PANEL_OPEN_DURATION = 280;
+const PANEL_CLOSE_DURATION = 220;
 
 const GraphsScreen = () => {
   const { colors } = useThemeColors();
@@ -73,6 +81,14 @@ const GraphsScreen = () => {
   // mounted and overlap absolutely, so switching tabs is a cross-fade.
   const incomeChartProgress = useSharedValue(0);
   const expenseChartProgress = useSharedValue(0);
+  // Where each chart travels from at progress 0. Opening drops the chart down
+  // from under the strip; switching tabs slides it in from the side you moved
+  // towards, so the panel reads as a pager rather than a blink.
+  const incomeChartOffset = useSharedValue({ x: 0, y: CHART_DROP });
+  const expenseChartOffset = useSharedValue({ x: 0, y: CHART_DROP });
+  // Bumped every time a tab is opened so the donut replays its intro — the
+  // charts are always mounted, so mounting alone can't drive that animation.
+  const [chartIntroKey, setChartIntroKey] = useState(0);
   // Measured chart heights, kept in refs so the expand handler can read them
   // synchronously (they are written from the JS-side onContentSizeChange).
   const expenseChartHeightRef = useRef(0);
@@ -499,36 +515,40 @@ const GraphsScreen = () => {
   const resetIncomeCategory = useCallback(() => setIncomeDrillReq({ dir: 'none', target: 'all' }), []);
 
   const toggleCard = useCallback((card) => {
+    const progressOf = (tab) => (tab === 'income' ? incomeChartProgress : expenseChartProgress);
+    const offsetOf = (tab) => (tab === 'income' ? incomeChartOffset : expenseChartOffset);
+
+    const closing = expandedCard === card;
+    const nextTab = closing ? null : card;
+    const { enter, exit } = chartTransitionOffsets(expandedCard, nextTab);
+
     // Leaving a tab always drops its drill-down so it reopens at the top level
-    const closeTab = (tab) => {
-      if (tab === 'expense') {
+    if (expandedCard) {
+      if (expandedCard === 'expense') {
         resetExpenseCategory();
-        expenseChartProgress.value = withTiming(0, { duration: 150, easing: Easing.in(Easing.quad) });
       } else {
         resetIncomeCategory();
-        incomeChartProgress.value = withTiming(0, { duration: 150, easing: Easing.in(Easing.quad) });
       }
-    };
+      offsetOf(expandedCard).value = exit;
+      progressOf(expandedCard).value = withTiming(0, { duration: CHART_OUT_DURATION, easing: Easing.in(Easing.quad) });
+    }
 
-    if (expandedCard === card) {
-      closeTab(card);
-      setExpandedCard(null);
-      panelHeight.value = withTiming(CARD_HEADER_HEIGHT, { duration: 220, easing: Easing.in(Easing.quad) });
+    setExpandedCard(nextTab);
+
+    if (closing) {
+      panelHeight.value = withTiming(CARD_HEADER_HEIGHT, { duration: PANEL_CLOSE_DURATION, easing: Easing.in(Easing.quad) });
       return;
     }
 
-    if (expandedCard) {
-      closeTab(expandedCard);
-    }
-    setExpandedCard(card);
+    offsetOf(card).value = enter;
+    setChartIntroKey(key => key + 1);
     const chartHeight = card === 'income'
       ? incomeChartHeightRef.current
       : expenseChartHeightRef.current;
-    panelHeight.value = withTiming(CARD_HEADER_HEIGHT + chartHeight, { duration: 280, easing: Easing.out(Easing.cubic) });
-    const progress = card === 'income' ? incomeChartProgress : expenseChartProgress;
-    progress.value = withTiming(1, { duration: 260, easing: Easing.out(Easing.cubic) });
+    panelHeight.value = withTiming(CARD_HEADER_HEIGHT + chartHeight, { duration: PANEL_OPEN_DURATION, easing: Easing.out(Easing.cubic) });
+    progressOf(card).value = withTiming(1, { duration: CHART_IN_DURATION, easing: Easing.out(Easing.cubic) });
   }, [expandedCard, panelHeight, incomeChartProgress, expenseChartProgress,
-    resetExpenseCategory, resetIncomeCategory]);
+    incomeChartOffset, expenseChartOffset, resetExpenseCategory, resetIncomeCategory]);
 
   const handleToggleIncome = useCallback(() => toggleCard('income'), [toggleCard]);
   const handleToggleExpense = useCallback(() => toggleCard('expense'), [toggleCard]);
@@ -562,15 +582,29 @@ const GraphsScreen = () => {
   // the available width changes, so rotation needs no special handling here.
   const panelAnimStyle = useAnimatedStyle(() => ({ height: panelHeight.value }));
 
-  const incomeChartAnimStyle = useAnimatedStyle(() => ({
-    opacity: incomeChartProgress.value,
-    transform: [{ translateY: interpolate(incomeChartProgress.value, [0, 1], [16, 0]) }],
-  }));
+  const incomeChartAnimStyle = useAnimatedStyle(() => {
+    const p = incomeChartProgress.value;
+    const { x, y } = incomeChartOffset.value;
+    return {
+      opacity: p,
+      transform: [
+        { translateX: interpolate(p, [0, 1], [x, 0]) },
+        { translateY: interpolate(p, [0, 1], [y, 0]) },
+      ],
+    };
+  });
 
-  const expenseChartAnimStyle = useAnimatedStyle(() => ({
-    opacity: expenseChartProgress.value,
-    transform: [{ translateY: interpolate(expenseChartProgress.value, [0, 1], [16, 0]) }],
-  }));
+  const expenseChartAnimStyle = useAnimatedStyle(() => {
+    const p = expenseChartProgress.value;
+    const { x, y } = expenseChartOffset.value;
+    return {
+      opacity: p,
+      transform: [
+        { translateX: interpolate(p, [0, 1], [x, 0]) },
+        { translateY: interpolate(p, [0, 1], [y, 0]) },
+      ],
+    };
+  });
 
   // Keeps the panel sized to whatever the visible chart currently measures —
   // covers the first measurement and every drill-down that changes its height.
@@ -686,6 +720,7 @@ const GraphsScreen = () => {
                     isLeafCategory={incomeCategoryIsLeaf}
                     operations={incomeOperations}
                     loadingOperations={loadingIncomeOperations}
+                    introKey={chartIntroKey}
                   />
                 </Animated.View>
               </ScrollView>
@@ -721,6 +756,7 @@ const GraphsScreen = () => {
                     isLeafCategory={expenseCategoryIsLeaf}
                     operations={expenseOperations}
                     loadingOperations={loadingExpenseOperations}
+                    introKey={chartIntroKey}
                   />
                 </Animated.View>
               </ScrollView>


### PR DESCRIPTION
## 1. The donut no longer jumps between tabs

`ExpensePieChart` / `IncomePieChart` laid the donut and the legend out in a row with `alignItems: 'center'`. The legend's height follows its category count, and income and expense rarely have the same number of categories — so the donut sat at a different vertical offset on each tab and visibly jumped when you switched.

The row now anchors to the top, pinning the donut to one position regardless of how long the legend is.

## 2. Tab transitions are directional instead of a blink

Switching tabs was a plain cross-fade, and opening one dropped the chart in with a small vertical nudge. Now:

- **Opening / closing** moves the chart vertically, as if it slid out from under the tab strip.
- **Switching** moves both charts sideways in the direction of travel — income is the left tab, so going to expense brings the new chart in from the right and takes the old one out through the left. The panel reads as a pager rather than a flash.
- The incoming chart outlasts the outgoing one (320ms vs 200ms) and both start together, so there is no blank frame in between.

Transition geometry lives in `chartTransitions.js` as a pure function, so the direction logic is testable without driving animations.

## 3. The donut spins up into place

Victory Native XL has no entering animation for `Pie.Chart`, and its `startAngle` is a plain prop — driving it per frame would re-render the chart on the JS thread every frame. So the intro animates the *container* instead: scale `0.86 → 1`, rotation `-14° → 0`, fade in, 460ms `Easing.out(cubic)`, entirely on the UI thread for the cost of one transform.

Both tabs' charts are mounted at all times, so the animation cannot key off mounting — it would play behind a collapsed panel and never replay. `GraphsScreen` bumps an `introKey` when a tab actually opens, and `DonutChart` replays on that. Drill-down already remounts the chart via its `key`, so it animates there for free.

## Testing

- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean
- Full suite: **164 suites / 4836 tests** passing
- New `chartTransitions.test.js` covers each direction, that a switch stays purely horizontal, and that the two charts always travel opposite ways
- Both pie-chart suites gained a regression test asserting the donut is top-anchored
- `DonutChart` gained coverage for replaying on `introKey` without disturbing the rendered slices or icons
