### PR TITLE
fix(budgets): quiet the plan rows down

### DIFF
--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -368,20 +368,18 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId, getByText, queryByText } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
       // The amount column carries the pair — actual against target, the two
-      // figures a person compares. Insignificant ".00" is trimmed so the pair
-      // fits beside the row's name; a real fractional part is kept.
+      // figures a person compares, as compact magnitudes: a row is scanned, not
+      // audited, and the pair shares one line with the category name.
       expect(getByText('150 / 300')).toBeTruthy();
-      // "remaining: 150" is gone with the bar: it is target minus actual, both
-      // of which are right there. So is the "50%" badge — the fill encodes the
-      // ratio, and a fourth encoding of one number is what made a row four text
-      // lines tall.
+      // "remaining: 150" is gone with the bar (target minus actual, both right
+      // there), so is the "50%" badge (the fill encodes the ratio), and so is
+      // "over budget by 50" — it made an overspent row two lines tall while
+      // every other row was one, restating a subtraction the pair already shows.
       expect(queryByText('remaining_budget: 150.00')).toBeNull();
       expect(queryByText('50%')).toBeNull();
-      // Overspend does keep its own words: a negative remainder is not something
-      // you subtract in your head while looking at a red row.
-      expect(getByText('over_budget_by 50')).toBeTruthy();
-      // ...and the row's fill is drawn in the overspend tone, with a "today"
-      // marker across it (the shown month is the current one).
+      expect(queryByText('over_budget_by 50')).toBeNull();
+      // The overspent row says so with its tone instead, and carries a "today"
+      // marker across the fill (the shown month is the current one).
       expect(getByTestId('plan-line-fill-l2')).toBeTruthy();
       expect(getByTestId('plan-line-fill-l2-pace')).toBeTruthy();
     });
@@ -977,7 +975,7 @@ describe('MonthlyPlanSection', () => {
       // a row stops being worth reading.
       expect(getByText('420 / 300')).toBeTruthy();
       expect(getByTestId('plan-line-fill-l-done')).toBeTruthy();
-      expect(getByTestId('plan-line-overspend-l-done')).toBeTruthy();
+      expect(fillTone(getByTestId, 'l-done')).toContain(COLORS.overspend);
     });
 
     // The row's fill IS its progress bar, and the hairline across it is today.
@@ -1034,12 +1032,17 @@ describe('MonthlyPlanSection', () => {
     // Three signals, replacing four fixed spent-percentage bands. The old scale
     // graded how much of the envelope was gone without knowing the date, so 99%
     // on the 27th and 76% on the 3rd came out the same shade of "fine".
-    it('tints a line that is behind the month pace with the calm tone', async () => {
-      // 1% spent — behind any pace, on any day.
+    it('leaves a line that is behind the month pace untinted', async () => {
+      // 1% spent — behind any pace, on any day. Colour is spent only where there
+      // is something to say: with every row tinted, ten coloured blocks sat side
+      // by side and none of them stood out.
       setPlans(pacedLine('l-calm', '1', '100'));
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-fill-l-calm')).toBeTruthy());
-      expect(fillTone(getByTestId, 'l-calm')).toContain(COLORS.primary);
+      const tone = fillTone(getByTestId, 'l-calm');
+      expect(tone).toContain(COLORS.mutedText);
+      expect(tone).not.toContain(COLORS.warning);
+      expect(tone).not.toContain(COLORS.overspend);
     });
 
     it('tints a line that is ahead of the month pace with the warning tone', async () => {
@@ -1055,6 +1058,23 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-fill-l-over')).toBeTruthy());
       expect(fillTone(getByTestId, 'l-over')).toContain(COLORS.overspend);
+    });
+
+    it('states the ratio once in the template strip', async () => {
+      setPlans({
+        plans: [],
+        lines: [
+          TEMPLATE_LINE,
+          { ...TEMPLATE_LINE, id: 'l-tpl2', lastExecutedMonth: THIS_MONTH },
+        ],
+      });
+      const { getByTestId, queryByText } = await renderSection();
+      await waitFor(() => expect(getByTestId('summary-done-count')).toHaveTextContent('1 / 2'));
+      // The bar under it draws the same ratio; a "done: 1 / remaining: 1" line
+      // below that was a third and fourth statement of one fact.
+      expect(getByTestId('summary-progress-bar')).toBeTruthy();
+      expect(queryByText('done_count: 1')).toBeNull();
+      expect(queryByText('remaining_count: 1')).toBeNull();
     });
 
     it('has no add rows — the screen FAB owns adding', async () => {
@@ -1084,8 +1104,9 @@ describe('MonthlyPlanSection', () => {
     it('converts a foreign-currency line into the plan currency and prints no foreign code', async () => {
       rubPlanWithAmdLine();
       const { getByTestId } = await renderSection(undefined, { currency: 'RUB' });
-      await waitFor(() => expect(getByTestId('plan-line-l-amd')).toHaveTextContent(/69000/));
-      expect(getByTestId('plan-line-l-amd')).not.toHaveTextContent(/300000/);
+      // 69000 RUB, as the compact magnitude a row prints.
+      await waitFor(() => expect(getByTestId('plan-line-l-amd')).toHaveTextContent(/69K/));
+      expect(getByTestId('plan-line-l-amd')).not.toHaveTextContent(/300/);
       expect(getByTestId('plan-line-l-amd')).not.toHaveTextContent(/AMD/);
     });
 

--- a/__tests__/screens/BudgetScreen.test.js
+++ b/__tests__/screens/BudgetScreen.test.js
@@ -264,8 +264,21 @@ describe('BudgetScreen', () => {
       const { getByTestId } = await render(<BudgetScreen />);
       await waitFor(() => expect(getByTestId('mock-report-remainder')).toBeTruthy());
       fireEvent.press(getByTestId('mock-report-remainder'));
-      // Trimmed of an all-zero decimal part, with the plan's currency beside it.
+      // Trimmed of an all-zero decimal part, and with no currency code: the chip
+      // sits a centimetre to its right and already names the unit.
+      await waitFor(() => expect(getByTestId('budget-remainder')).toHaveTextContent('-85745'));
+      expect(getByTestId('budget-remainder')).not.toHaveTextContent('AMD');
+    });
+
+    it('keeps the currency code on the hero when there is no chip to carry it', async () => {
+      // One account currency means no picker — and then the hero is the only
+      // place the screen names its unit at all.
+      setAccounts([{ id: 'a1', name: 'Ameria', currency: 'AMD' }]);
+      const { getByTestId, queryByTestId } = await render(<BudgetScreen />);
+      await waitFor(() => expect(getByTestId('mock-report-remainder')).toBeTruthy());
+      fireEvent.press(getByTestId('mock-report-remainder'));
       await waitFor(() => expect(getByTestId('budget-remainder')).toHaveTextContent('-85745 AMD'));
+      expect(queryByTestId('budget-currency-chip')).toBeNull();
     });
 
     it('replaces a negative remainder with the overspend colour', async () => {

--- a/app/components/budgets/EnvelopeFill.js
+++ b/app/components/budgets/EnvelopeFill.js
@@ -2,11 +2,17 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-// Tint strength for the fill, as a hex alpha channel appended to a 6-digit
-// colour. Low enough that the row's name and figures keep their contrast on top
-// of it, high enough to read as a filled bar at a glance on both themes.
-const FILL_ALPHA = '26'; // ~15%
-const PACE_ALPHA = '99'; // ~60%
+// Tint strength as a hex alpha channel appended to a 6-digit colour.
+//
+// Two strengths, not one. The first pass washed EVERY row at a single ~15%:
+// ten coloured blocks butted together, so nothing stood out and the eye had
+// nowhere to land — the exact hierarchy problem the redesign set out to fix,
+// re-created in colour. A row that is simply on pace now gets a neutral grey
+// wash that reads as a bar and nothing more; the tone (and the strength) is
+// spent only where there is something to say.
+const CALM_ALPHA = '14'; // ~8%, neutral grey
+const SIGNAL_ALPHA = '2E'; // ~18%, warning / overspend
+const PACE_ALPHA = '59'; // ~35%
 
 /**
  * A plan row's progress, drawn as the row's own background rather than as a
@@ -14,39 +20,32 @@ const PACE_ALPHA = '99'; // ~60%
  *
  * A 6dp track plus its own label was a third and fourth line in a row that was
  * already four lines tall; as a background wash the same information costs no
- * vertical space at all, and ten envelopes read as ten filled bars in one
- * glance instead of ten paragraphs.
+ * vertical space at all.
  *
- * The vertical hairline is TODAY. Without it a percentage is not a judgement:
- * 99% of an envelope spent is unremarkable on the 27th and alarming on the 3rd,
- * and the old four-band colour scale could not tell those apart because it never
- * knew the date. Fill to the left of the marker means on pace; fill past it
- * means spending faster than the month is passing.
+ * The dashed vertical line is TODAY. Without it a percentage is not a judgement:
+ * 99% of an envelope spent is unremarkable on the 27th and alarming on the 3rd.
+ * Fill short of the marker means on pace; fill past it means spending faster
+ * than the month is passing.
  *
  * @param {number} fraction - Spent / target, 0..1+ (clamped when drawn)
  * @param {?number} paceFraction - How far through the month today is, or null
  *   when the shown month is not the current one and pace means nothing
- * @param {string} tone - 6-digit hex signal colour for the fill and its edge
+ * @param {?string} tone - 6-digit hex signal colour, or null for a row with
+ *   nothing to flag, which is washed in neutral grey instead
  */
-const EnvelopeFill = ({ fraction, paceFraction, tone, mutedColor, testID }) => {
+const EnvelopeFill = ({ fraction, paceFraction, tone = null, mutedColor, testID }) => {
   const fillPercent = Math.min(Math.max(fraction, 0), 1) * 100;
   // Hidden at the very edges: a marker pinned to either end of the row reads as
   // a border, not as a date.
   const showPace = paceFraction != null && paceFraction > 0.02 && paceFraction < 0.98;
+  const fillColor = tone ? `${tone}${SIGNAL_ALPHA}` : `${mutedColor}${CALM_ALPHA}`;
 
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="none" testID={testID}>
       {fillPercent > 0 && (
         <View
           testID={testID ? `${testID}-bar` : undefined}
-          style={[
-            styles.fill,
-            {
-              width: `${fillPercent}%`,
-              backgroundColor: `${tone}${FILL_ALPHA}`,
-              borderRightColor: tone,
-            },
-          ]}
+          style={[styles.fill, { width: `${fillPercent}%`, backgroundColor: fillColor }]}
         />
       )}
       {showPace && (
@@ -54,7 +53,7 @@ const EnvelopeFill = ({ fraction, paceFraction, tone, mutedColor, testID }) => {
           testID={testID ? `${testID}-pace` : undefined}
           style={[
             styles.pace,
-            { left: `${paceFraction * 100}%`, backgroundColor: `${mutedColor}${PACE_ALPHA}` },
+            { left: `${paceFraction * 100}%`, borderLeftColor: `${mutedColor}${PACE_ALPHA}` },
           ]}
         />
       )}
@@ -65,7 +64,7 @@ const EnvelopeFill = ({ fraction, paceFraction, tone, mutedColor, testID }) => {
 EnvelopeFill.propTypes = {
   fraction: PropTypes.number.isRequired,
   paceFraction: PropTypes.number,
-  tone: PropTypes.string.isRequired,
+  tone: PropTypes.string,
   mutedColor: PropTypes.string.isRequired,
   testID: PropTypes.string,
 };
@@ -74,18 +73,23 @@ export default EnvelopeFill;
 
 const styles = StyleSheet.create({
   fill: {
-    // The leading edge, at full strength: the wash alone reads as a soft
-    // gradient at the boundary, and the boundary is the whole point.
-    borderRightWidth: 2,
+    // No hard leading edge. A 2dp bar at full strength sat right next to the
+    // pace marker on every row — two unexplained vertical lines a few
+    // millimetres apart, competing for the reading the marker exists to give.
+    // The wash boundary is the boundary.
     bottom: 0,
     left: 0,
     position: 'absolute',
     top: 0,
   },
   pace: {
+    // Dashed, so it reads as an annotation on the bar rather than as a divider
+    // or a rendering artefact — which is exactly what a solid full-height
+    // hairline looked like when every row had one at the same x.
+    borderLeftWidth: 1,
+    borderStyle: 'dashed',
     bottom: 0,
     position: 'absolute',
     top: 0,
-    width: 1,
   },
 });

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -115,6 +115,13 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   const planId = plan?.id ?? null;
   const planCurrency = plan?.currency || currency;
 
+  // The screen shows one currency and the host header names it, next to the
+  // control that changes it. Repeating the code on the summary strip, the income
+  // header and both totals printed "RUB" five times on one screen for a fact
+  // that cannot vary within it. Uncontrolled mode has no host header, so there
+  // the code stays — it would otherwise appear nowhere at all.
+  const currencySuffix = controlledMonth ? '' : ` ${planCurrency}`;
+
   // Plan-vs-actual status for the shown month (may be null while computing).
   const planStatus = (planId && planStatuses && planStatuses.get(planId)) || null;
 
@@ -624,6 +631,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         month={month}
         amountById={amountById}
         planCurrency={planCurrency}
+        currencySuffix={currencySuffix}
         colors={colors}
         t={t}
       />
@@ -672,8 +680,8 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
               exact income is one tap away on the lines themselves. */}
           <Text style={[styles.sectionAmount, { color: colors.text }]} testID="plan-income-total">
             {planStatus
-              ? `${Currency.formatCompact(planStatus.totals.actualIncome)} / ${Currency.formatCompact(displayExpectedIncome)} ${planCurrency}`
-              : `${Currency.formatCompact(displayExpectedIncome)} ${planCurrency}`}
+              ? `${Currency.formatCompact(planStatus.totals.actualIncome)} / ${Currency.formatCompact(displayExpectedIncome)}${currencySuffix}`
+              : `${Currency.formatCompact(displayExpectedIncome)}${currencySuffix}`}
           </Text>
         </View>
 
@@ -751,7 +759,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
                 stays exact. */}
             <View style={[styles.totalsRow, { borderTopColor: colors.border }]} testID="plan-totals">
               <Text style={[styles.totalsLabel, { color: colors.mutedText }]} numberOfLines={1}>
-                {t('allocated')}: {Currency.formatCompact(displayAllocated)} {planCurrency}
+                {t('allocated')}: {Currency.formatCompact(displayAllocated)}{currencySuffix}
               </Text>
               {planStatus && (
                 <Text
@@ -759,7 +767,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
                   numberOfLines={1}
                   testID="plan-actual-total"
                 >
-                  {t('actual')}: {Currency.formatCompact(planStatus.totals.totalActual)} {planCurrency}
+                  {t('actual')}: {Currency.formatCompact(planStatus.totals.totalActual)}{currencySuffix}
                 </Text>
               )}
             </View>

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -78,14 +78,14 @@ const PlanLineRow = memo(function PlanLineRow({
   const tracked = showProgress && !!status && !isBroken && !isUnconvertible;
   const showFill = tracked && (!executed || status.isExceeded);
 
-  // Three signals, not four spent-percentage bands. The old scale (green /
-  // amber / orange / red at fixed thresholds) graded how much of the envelope
-  // was gone without knowing what day it was, so 99% on the 27th and 76% on the
-  // 3rd came out the same shade of "fine". Over target is over target; short of
-  // it, the only thing worth flagging is spending faster than the month passes.
+  // Tone is spent only on a row with something to say — over target, or ahead of
+  // the month's pace. A row that is simply on track gets no colour at all: with
+  // every row tinted, ten coloured blocks sat side by side and none of them
+  // stood out, which is the hierarchy problem the fill was supposed to solve.
+  // A null tone tells EnvelopeFill to wash the row in neutral grey instead.
   const paceFraction = tracked ? pace : null;
   const spentFraction = tracked ? status.percentage / 100 : 0;
-  let tone = colors.primary;
+  let tone = null;
   if (tracked && status.isExceeded) {
     tone = colors.overspend;
   } else if (tracked && paceFraction != null && spentFraction > paceFraction) {
@@ -95,17 +95,24 @@ const PlanLineRow = memo(function PlanLineRow({
   // The amount column carries the PAIR when the line is tracked — actual against
   // target, the two figures a person compares. The target alone appears only
   // where there is no actual to compare it with (income lines, a status still
-  // computing, an unconvertible line). It used to print the target here and the
-  // pair again on the line below, which is the same number twice.
+  // computing, an unconvertible line).
+  //
+  // Compact magnitudes (10.1K / 8.5K), not exact figures: a row is scanned, not
+  // audited, and the pair has to share one line with the category name in every
+  // shipped locale. The exact amounts are one tap away in the editor. No
+  // currency code either — the screen shows one currency, and the header states
+  // which. An unconvertible line is the exception on both counts: with no rate
+  // there is nothing to convert, so it keeps its stored figure in full and says
+  // what unit that is.
   let amountText;
   if (isUnconvertible) {
     amountText = `${Currency.formatAmount(line.amount, lineCurrency)} ${lineCurrency}`;
   } else if (displayAmount == null) {
     amountText = CONVERTING_PLACEHOLDER;
   } else if (tracked) {
-    amountText = `${Currency.formatAmountTrimmed(status.actual, planCurrency)} / ${Currency.formatAmountTrimmed(displayAmount, planCurrency)}`;
+    amountText = `${Currency.formatCompact(status.actual)} / ${Currency.formatCompact(displayAmount)}`;
   } else {
-    amountText = Currency.formatAmount(displayAmount, planCurrency);
+    amountText = Currency.formatCompact(displayAmount);
   }
 
   // Acting on a row leaves the Swipeable open otherwise: the actions are replaced
@@ -229,20 +236,13 @@ const PlanLineRow = memo(function PlanLineRow({
             {t('graphs_currencies_not_converted')}
           </Text>
         </View>
-      ) : tracked && status.isExceeded ? (
-        // The only figure that still earns a second line. "Remaining: 1355" was
-        // dropped with the bar: it is target minus actual, both of which sit an
-        // inch above it on the same row. A negative remainder is not something
-        // you subtract in your head while looking at a red row, so overspend
-        // keeps its own words.
-        <Text
-          style={[styles.overspendText, { color: colors.overspend }]}
-          numberOfLines={1}
-          testID={`plan-line-overspend-${line.id}`}
-        >
-          {t('over_budget_by')} {Currency.formatAmountTrimmed(Currency.abs(status.remaining), planCurrency)}
-        </Text>
       ) : null}
+      {/* No "over budget by 1575" line. It made an overspent row two lines tall
+          while every other row was one, so the list came out ragged, and it
+          restated a subtraction the reader can already see: the pair above it
+          reads 10.1K / 8.5K, left larger than right, on a red row. The two
+          remaining second lines are both errors — a broken link and a missing
+          exchange rate — which is what a second line should be for. */}
     </Pressable>
   );
 
@@ -400,12 +400,6 @@ const styles = StyleSheet.create({
   lineTop: {
     alignItems: 'center',
     flexDirection: 'row',
-  },
-  overspendText: {
-    fontSize: 12,
-    fontWeight: '600',
-    marginTop: 3,
-    textAlign: 'right',
   },
   swipeAction: {
     alignItems: 'center',

--- a/app/components/budgets/PlanTemplateSummary.js
+++ b/app/components/budgets/PlanTemplateSummary.js
@@ -39,7 +39,9 @@ SummaryItem.propTypes = {
  * month. Precise decimal math and one labelled currency now, matching the totals
  * row below exactly.
  */
-export default function PlanTemplateSummary({ lines, month, amountById, planCurrency, colors, t }) {
+export default function PlanTemplateSummary({
+  lines, month, amountById, planCurrency, currencySuffix = '', colors, t,
+}) {
   const summary = useMemo(() => {
     let pendingOut = '0';
     let pendingIn = '0';
@@ -87,7 +89,7 @@ export default function PlanTemplateSummary({ lines, month, amountById, planCurr
           testID="summary-pending-out"
           color={colors.expense}
           mutedColor={colors.mutedText}
-          value={`${Currency.formatCompact(summary.pendingOut)} / ${Currency.formatCompact(summary.totalOut)} ${planCurrency}`}
+          value={`${Currency.formatCompact(summary.pendingOut)} / ${Currency.formatCompact(summary.totalOut)}${currencySuffix}`}
           label={t('pending_out')}
         />
         <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
@@ -103,7 +105,7 @@ export default function PlanTemplateSummary({ lines, month, amountById, planCurr
           testID="summary-pending-in"
           color={colors.income}
           mutedColor={colors.mutedText}
-          value={`${Currency.formatCompact(summary.pendingIn)} / ${Currency.formatCompact(summary.totalIn)} ${planCurrency}`}
+          value={`${Currency.formatCompact(summary.pendingIn)} / ${Currency.formatCompact(summary.totalIn)}${currencySuffix}`}
           label={t('pending_in')}
         />
       </View>
@@ -118,17 +120,10 @@ export default function PlanTemplateSummary({ lines, month, amountById, planCurr
           ]}
         />
       </View>
-      {/* "<n> <word>" needs a counter form, not the button caption `done` or the
-          noun `remaining`: those produced "3 Готово" / "2 остаток" in Russian.
-          Label-first keeps every language grammatical. */}
-      <View style={styles.progressLabels}>
-        <Text style={[styles.progressLabel, { color: colors.mutedText }]}>
-          {`${t('done_count')}: ${summary.doneCount}`}
-        </Text>
-        <Text style={[styles.progressLabel, { color: colors.mutedText }]}>
-          {`${t('remaining_count')}: ${summary.total - summary.doneCount}`}
-        </Text>
-      </View>
+      {/* No "done: 2 / remaining: 1" line under the bar. The middle column
+          already reads "2 / 3" and the bar already draws the same ratio — a
+          third and fourth statement of one fact, in a strip whose whole job is
+          to state it once. */}
     </View>
   );
 }
@@ -138,6 +133,7 @@ PlanTemplateSummary.propTypes = {
   month: PropTypes.string.isRequired,
   amountById: PropTypes.instanceOf(Map).isRequired,
   planCurrency: PropTypes.string.isRequired,
+  currencySuffix: PropTypes.string,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
 };
@@ -146,14 +142,6 @@ const styles = StyleSheet.create({
   progressFill: {
     borderRadius: 2,
     height: 3,
-  },
-  progressLabel: {
-    fontSize: 11,
-  },
-  progressLabels: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginTop: 3,
   },
   progressTrack: {
     borderRadius: 2,

--- a/app/screens/BudgetScreen.js
+++ b/app/screens/BudgetScreen.js
@@ -206,8 +206,13 @@ const BudgetScreen = () => {
               numberOfLines={1}
               testID="budget-remainder"
             >
+              {/* The code hangs off the hero only when there is no chip beside
+                  it to carry it — with a chip, printing it here says "RUB" twice
+                  a centimetre apart. With a single account currency there is no
+                  chip, and then this is the only place the screen names its
+                  unit at all. */}
               {planTotals
-                ? `${Currency.formatAmountTrimmed(planTotals.remainder, planTotals.currency)} ${planTotals.currency}`
+                ? `${Currency.formatAmountTrimmed(planTotals.remainder, planTotals.currency)}${currencies.length > 1 ? '' : ` ${planTotals.currency}`}`
                 : PENDING_PLACEHOLDER}
             </Text>
           )}
@@ -225,10 +230,14 @@ const BudgetScreen = () => {
               <Text style={[styles.currencyChipText, { color: colors.text }]}>{selectedCurrency}</Text>
               <Icon name="chevron-down" size={14} color={colors.mutedText} />
             </Pressable>
+            {/* Outlined, not a solid accent disc. Filled, it was the most
+                saturated thing on the screen — a secondary toggle outweighing
+                the month's headline figure right beside it. On state is carried
+                by the icon's colour and the border, which is as much weight as
+                a toggle needs. */}
             <Pressable
               onPress={handleToggleConvert}
               style={[styles.convertToggle, {
-                backgroundColor: convertAllBudgets ? colors.primary : colors.background,
                 borderColor: convertAllBudgets ? colors.primary : colors.border,
               }]}
               hitSlop={6}
@@ -237,7 +246,7 @@ const BudgetScreen = () => {
               accessibilityLabel={t('graphs_convert_currencies')}
               testID="budget-convert-toggle"
             >
-              <Icon name="cash-sync" size={16} color={convertAllBudgets ? colors.surface : colors.mutedText} />
+              <Icon name="cash-sync" size={16} color={convertAllBudgets ? colors.primary : colors.mutedText} />
             </Pressable>
           </View>
         )}


### PR DESCRIPTION
## What went wrong

Shipping the row fill on *every* row re-created, in colour, the exact hierarchy problem it was meant to solve: ten saturated blocks butted together, none of them standing out, in a muddy olive/maroon wash at 15% over a near-black surface. Plus two unexplained vertical lines a few millimetres apart on every row — the fill's 2dp leading edge and the pace marker, competing for the one reading the marker exists to give.

The pace logic was right (Развлечения at 76% on day 27 correctly read calm, Еда at 98.6% correctly read warning). The presentation was not.

## Change

**Colour is spent only where there's something to say.** A row that is simply on track gets a neutral grey wash at ~8% — it reads as a bar and nothing more. Ahead of pace and over target go to ~18% in their tone. Three red rows now carry because everything around them is quiet.

**The hard leading edge is gone.** The wash boundary is the boundary; a 2dp bar at full strength next to the pace marker was two vertical lines saying different things with the same weight.

**The pace marker is dashed and lighter**, so it reads as an annotation on the bar rather than as a divider or a rendering artefact — which is what a solid full-height hairline at the same x on every row looked like.

**Every row is one line again.** `Превышение на 1575` is dropped: it made an overspent row two lines tall while every other row was one, and restated a subtraction the pair above it already shows (`10.1K / 8.5K`, left larger than right, on a red row). The only second lines left are the two real errors — a broken link and a missing exchange rate — which is what a second line should be for.

**Row amounts become compact magnitudes** (`10.1K / 8.5K`). A row is scanned, not audited, and the pair shares one line with the category name in every shipped locale. Exact figures are one tap away in the editor.

> Note: under a consistent three-significant-digits rule `10085` renders as **10.1K**, not `10K`; `98645` → `98.6K` as expected. Exactly `10K` comes from `10000`. Say the word and I'll switch to integer-K rounding.

**Currency codes come off** the summary strip, the income header, both totals and the header figure. The screen shows one currency and the chip beside the headline names it — "RUB" was printed five times on one screen for a fact that cannot vary within it. Kept where nothing else would carry it: a single account currency (no chip is rendered), or the section rendered uncontrolled.

**`Выполнено: 2 / Осталось: 1` is dropped** from under the template strip's bar, which already reads `2 / 3` and draws the same ratio. Third and fourth statement of one fact, in a strip whose whole job is to state it once.

**The convert-all toggle is outlined**, not a solid accent disc. Filled, it was the most saturated thing on the screen — a secondary toggle outweighing the month's headline figure right beside it.

Not changed, by request: the `repeat` glyph for a recurring line stays as is.

## Tests

163 suites / 4824 passing. Updated: the tone assertions (calm is now untinted), the compact pair, the dropped overspend line, the dropped code on the header figure. New: the code surviving on the hero when there is no chip to carry it, and the strip stating its ratio once.
