### PR TITLE
feat(graphs): fade the chart tabs through instead of sliding them

### DIFF
--- a/__tests__/components/graphs/DonutChart.test.js
+++ b/__tests__/components/graphs/DonutChart.test.js
@@ -231,6 +231,31 @@ describe('DonutChart', () => {
       expect(queryAllByTestId('icon-car').length).toBeGreaterThan(0);
     });
 
+    // On a fade through the incoming donut has to sit still until the outgoing
+    // chart is gone, so the intro takes a delay alongside its key.
+    it('keeps the donut and its icons intact when a delayed intro replays', async () => {
+      const { getByTestId, queryAllByTestId, rerender } = await render(
+        <DonutChart data={mockData} introKey={0} introDelay={0} />,
+      );
+
+      await rerender(<DonutChart data={mockData} introKey={1} introDelay={120} />);
+
+      expect(getByTestId('donut-chart')).toBeTruthy();
+      expect(getByTestId('vn-pie')).toBeTruthy();
+      expect(queryAllByTestId('icon-food').length).toBeGreaterThan(0);
+      expect(queryAllByTestId('icon-car').length).toBeGreaterThan(0);
+    });
+
+    it('replays when only the delay changes, so a repeated key still animates', async () => {
+      const { getByTestId, rerender } = await render(
+        <DonutChart data={mockData} introKey={2} introDelay={0} />,
+      );
+
+      await rerender(<DonutChart data={mockData} introKey={2} introDelay={120} />);
+
+      expect(getByTestId('donut-chart')).toBeTruthy();
+    });
+
     it('starts from a scaled-down, rotated state so the donut spins up into place', () => {
       expect(INTRO_SCALE_FROM).toBeGreaterThan(0);
       expect(INTRO_SCALE_FROM).toBeLessThan(1);

--- a/__tests__/components/graphs/chartTransitions.test.js
+++ b/__tests__/components/graphs/chartTransitions.test.js
@@ -2,82 +2,117 @@
  * chartTransitions Tests
  *
  * The income/expense panel holds both charts stacked on top of each other, so a
- * transition is defined by where the incoming chart comes from and where the
- * outgoing one goes. These offsets are what makes a tab switch read as sideways
- * movement and an open/close read as vertical movement.
+ * transition is defined by how the incoming chart arrives and how the outgoing
+ * one leaves. Opening and closing the panel is vertical movement; switching
+ * between the two tabs is a fade through — the outgoing chart is completely gone
+ * before the incoming one starts, so the two are never on screen together.
  */
 
 import {
-  chartTransitionOffsets,
+  chartTransition,
   CHART_DROP,
-  CHART_SLIDE,
+  OPEN_DURATION,
+  CLOSE_DURATION,
+  FADE_ENTER_SCALE,
+  FADE_EXIT_SCALE,
+  FADE_ENTER_DURATION,
+  FADE_EXIT_DURATION,
+  FADE_ENTER_DELAY,
 } from '../../../app/components/graphs/chartTransitions';
 
 describe('chartTransitions', () => {
   describe('opening from collapsed', () => {
     it('drops the chart down and moves nothing out', () => {
-      expect(chartTransitionOffsets(null, 'income')).toEqual({
-        enter: { x: 0, y: CHART_DROP },
+      expect(chartTransition(null, 'income')).toEqual({
+        enter: { y: CHART_DROP, scale: 1, delay: 0, duration: OPEN_DURATION },
         exit: null,
       });
     });
 
     it('treats both tabs the same way', () => {
-      expect(chartTransitionOffsets(null, 'expense'))
-        .toEqual(chartTransitionOffsets(null, 'income'));
+      expect(chartTransition(null, 'expense'))
+        .toEqual(chartTransition(null, 'income'));
+    });
+
+    it('does not scale — the panel height is already animating', () => {
+      expect(chartTransition(null, 'income').enter.scale).toBe(1);
+    });
+
+    it('starts immediately, since nothing has to clear the screen first', () => {
+      expect(chartTransition(null, 'income').enter.delay).toBe(0);
     });
   });
 
   describe('collapsing', () => {
-    it('sinks the open chart back down', () => {
-      expect(chartTransitionOffsets('expense', null)).toEqual({
+    it('sinks the open chart back down without scaling it', () => {
+      expect(chartTransition('expense', null)).toEqual({
         enter: null,
-        exit: { x: 0, y: CHART_DROP },
+        exit: { y: CHART_DROP, scale: 1, duration: CLOSE_DURATION },
       });
     });
 
     it('moves nothing when there was no open tab', () => {
-      expect(chartTransitionOffsets(null, null)).toEqual({ enter: null, exit: null });
+      expect(chartTransition(null, null)).toEqual({ enter: null, exit: null });
     });
   });
 
   describe('switching tabs', () => {
-    // Income is the left tab: moving to expense is travel to the right, so the
-    // new chart arrives from the right edge and the old one exits left.
-    it('moves rightwards from income to expense', () => {
-      expect(chartTransitionOffsets('income', 'expense')).toEqual({
-        enter: { x: CHART_SLIDE, y: 0 },
-        exit: { x: -CHART_SLIDE, y: 0 },
+    it('fades the old chart out and grows the new one in', () => {
+      expect(chartTransition('income', 'expense')).toEqual({
+        enter: {
+          y: 0,
+          scale: FADE_ENTER_SCALE,
+          delay: FADE_ENTER_DELAY,
+          duration: FADE_ENTER_DURATION,
+        },
+        exit: { y: 0, scale: FADE_EXIT_SCALE, duration: FADE_EXIT_DURATION },
       });
     });
 
-    it('mirrors the direction going back', () => {
-      expect(chartTransitionOffsets('expense', 'income')).toEqual({
-        enter: { x: -CHART_SLIDE, y: 0 },
-        exit: { x: CHART_SLIDE, y: 0 },
-      });
+    // The slide this replaced was directional; a fade through is not. Both
+    // directions must produce the identical transition, or the panel would read
+    // as a pager again.
+    it('is the same transition whichever way you go', () => {
+      expect(chartTransition('expense', 'income'))
+        .toEqual(chartTransition('income', 'expense'));
     });
 
-    it('never mixes vertical movement into a sideways switch', () => {
-      const { enter, exit } = chartTransitionOffsets('income', 'expense');
+    it('never mixes vertical movement into a switch', () => {
+      const { enter, exit } = chartTransition('income', 'expense');
 
       expect(enter.y).toBe(0);
       expect(exit.y).toBe(0);
     });
 
-    it('sends the two charts in opposite directions so they do not overlap mid-flight', () => {
-      const { enter, exit } = chartTransitionOffsets('expense', 'income');
+    it('grows the incoming chart from below full size', () => {
+      const { enter } = chartTransition('income', 'expense');
 
-      expect(Math.sign(enter.x)).toBe(-Math.sign(exit.x));
+      expect(enter.scale).toBeGreaterThan(0);
+      expect(enter.scale).toBeLessThan(1);
+    });
+
+    it('shrinks the outgoing chart, but only barely', () => {
+      const { exit } = chartTransition('income', 'expense');
+
+      expect(exit.scale).toBeLessThan(1);
+      expect(exit.scale).toBeGreaterThan(FADE_ENTER_SCALE);
+    });
+
+    // This is the definition of a fade through, as opposed to a cross-fade.
+    it('does not start the incoming chart before the outgoing one has gone', () => {
+      const { enter, exit } = chartTransition('income', 'expense');
+
+      expect(enter.delay).toBeGreaterThanOrEqual(exit.duration);
+      expect(FADE_ENTER_DELAY).toBeGreaterThanOrEqual(FADE_EXIT_DURATION);
     });
   });
 
   describe('re-opening the tab that is already open', () => {
     // The screen turns this into a collapse before calling in, but the helper
-    // should still describe a sane transition rather than a sideways slide.
+    // should still describe a sane transition rather than a fade to itself.
     it('falls back to the vertical drop', () => {
-      expect(chartTransitionOffsets('income', 'income')).toEqual({
-        enter: { x: 0, y: CHART_DROP },
+      expect(chartTransition('income', 'income')).toEqual({
+        enter: { y: CHART_DROP, scale: 1, delay: 0, duration: OPEN_DURATION },
         exit: null,
       });
     });

--- a/app/components/graphs/DonutChart.js
+++ b/app/components/graphs/DonutChart.js
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback, useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, Easing } from 'react-native-reanimated';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, withDelay, interpolate, Easing } from 'react-native-reanimated';
 import { Pie, PolarChart } from 'victory-native';
 import { LinearGradient, vec } from '@shopify/react-native-skia';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
@@ -88,18 +88,22 @@ export const INTRO_DURATION = 460;
 export const INTRO_SCALE_FROM = 0.86;
 export const INTRO_ROTATION_FROM = -14;
 
-const DonutChart = ({ data, insetColor, introKey = 0 }) => {
+const DonutChart = ({ data, insetColor, introKey = 0, introDelay = 0 }) => {
   const pieData = useMemo(() => mapPieData(data), [data]);
   const markers = useMemo(() => computeIconMarkers(data), [data]);
   const intro = useSharedValue(0);
 
   // Replays whenever introKey changes — the screen bumps it as a tab opens, so
   // the donut animates when it becomes visible, not when it silently mounts
-  // behind a collapsed panel.
+  // behind a collapsed panel. introDelay holds it back until the chart it is
+  // replacing has faded out, so the spin-up is never played to an empty seat.
   useEffect(() => {
     intro.value = 0;
-    intro.value = withTiming(1, { duration: INTRO_DURATION, easing: Easing.out(Easing.cubic) });
-  }, [introKey, intro]);
+    intro.value = withDelay(
+      introDelay,
+      withTiming(1, { duration: INTRO_DURATION, easing: Easing.out(Easing.cubic) }),
+    );
+  }, [introKey, introDelay, intro]);
 
   const introStyle = useAnimatedStyle(() => ({
     opacity: intro.value,
@@ -171,6 +175,9 @@ DonutChart.propTypes = {
   insetColor: PropTypes.string,
   // Bump to replay the intro animation (e.g. when the owning tab is opened).
   introKey: PropTypes.number,
+  // Milliseconds to hold the intro back, so it starts once the outgoing chart
+  // has left rather than on top of it.
+  introDelay: PropTypes.number,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -17,6 +17,7 @@ const ExpensePieChart = ({
   operations = [],
   loadingOperations = false,
   introKey = 0,
+  introDelay = 0,
 }) => {
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
@@ -54,7 +55,12 @@ const ExpensePieChart = ({
 
   return (
     <View style={styles.row}>
-      <DonutChart data={chartData} insetColor={colors.surface} introKey={introKey} />
+      <DonutChart
+        data={chartData}
+        insetColor={colors.surface}
+        introKey={introKey}
+        introDelay={introDelay}
+      />
       <View style={styles.legendWrapper}>
         <CustomLegend
           data={chartData}
@@ -81,6 +87,8 @@ ExpensePieChart.propTypes = {
   loadingOperations: PropTypes.bool,
   // Bump to replay the donut intro when this chart's tab is opened.
   introKey: PropTypes.number,
+  // Holds that replay back until the outgoing chart has faded out.
+  introDelay: PropTypes.number,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -17,6 +17,7 @@ const IncomePieChart = ({
   operations = [],
   loadingOperations = false,
   introKey = 0,
+  introDelay = 0,
 }) => {
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
@@ -54,7 +55,12 @@ const IncomePieChart = ({
 
   return (
     <View style={styles.row}>
-      <DonutChart data={incomeChartData} insetColor={colors.surface} introKey={introKey} />
+      <DonutChart
+        data={incomeChartData}
+        insetColor={colors.surface}
+        introKey={introKey}
+        introDelay={introDelay}
+      />
       <View style={styles.legendWrapper}>
         <CustomLegend
           data={incomeChartData}
@@ -81,6 +87,8 @@ IncomePieChart.propTypes = {
   loadingOperations: PropTypes.bool,
   // Bump to replay the donut intro when this chart's tab is opened.
   introKey: PropTypes.number,
+  // Holds that replay back until the outgoing chart has faded out.
+  introDelay: PropTypes.number,
 };
 
 const styles = StyleSheet.create({

--- a/app/components/graphs/chartTransitions.js
+++ b/app/components/graphs/chartTransitions.js
@@ -1,42 +1,66 @@
-// Geometry of the income/expense panel's chart transitions.
+// Geometry and timing of the income/expense panel's chart transitions.
 //
 // The two charts overlap absolutely inside one panel, so a transition is a pair
-// of offsets: where the incoming chart travels from, and where the outgoing one
-// travels to. Both are expressed at progress 0 — the animated style interpolates
-// each towards {x: 0, y: 0} as its progress reaches 1.
+// of animations: how the incoming chart arrives and how the outgoing one leaves.
+// Positions are expressed at progress 0 — the animated style interpolates each
+// towards {y: 0, scale: 1} as its progress reaches 1.
 
 // Opening or closing moves the chart vertically, as if it slid out from under
-// the tab strip. Switching tabs moves it sideways, like a pager.
+// the tab strip. No scaling there: the panel height is already animating, and a
+// second size change on top of it reads as wobble.
 export const CHART_DROP = 16;
-export const CHART_SLIDE = 28;
+export const OPEN_DURATION = 320;
+export const CLOSE_DURATION = 220;
 
-// Income is the left tab, expense the right one.
-const TAB_ORDER = { income: 0, expense: 1 };
+// Switching tabs is a fade through: the outgoing chart dims and shrinks a hair,
+// and only once it is fully gone does the incoming one grow back in. Sliding
+// sideways implied a pager, which the tab strip does not deliver — nothing else
+// on the panel moves horizontally.
+export const FADE_EXIT_SCALE = 0.98;
+export const FADE_EXIT_DURATION = 120;
+export const FADE_ENTER_SCALE = 0.94;
+export const FADE_ENTER_DURATION = 260;
+// The handoff point. Must stay >= FADE_EXIT_DURATION — the moment the two charts
+// overlap on screen, this stops being a fade through and becomes a cross-fade.
+export const FADE_ENTER_DELAY = 120;
 
 /**
- * Offsets for a transition between tabs.
+ * The animation pair for a transition between tabs.
  *
  * @param {'income'|'expense'|null} from - tab that was open, null if collapsed
  * @param {'income'|'expense'|null} to - tab being opened, null when collapsing
- * @returns {{ enter: {x: number, y: number}|null, exit: {x: number, y: number}|null }}
+ * @returns {{
+ *   enter: {y: number, scale: number, delay: number, duration: number}|null,
+ *   exit: {y: number, scale: number, duration: number}|null,
+ * }}
  */
-export const chartTransitionOffsets = (from, to) => {
+export const chartTransition = (from, to) => {
   // Collapsing: the open chart sinks back under the strip, nothing enters.
   if (to === null) {
-    return { enter: null, exit: from ? { x: 0, y: CHART_DROP } : null };
+    return {
+      enter: null,
+      exit: from ? { y: CHART_DROP, scale: 1, duration: CLOSE_DURATION } : null,
+    };
   }
 
   // Opening from collapsed: the chart drops down, nothing leaves.
   if (from === null || from === to) {
-    return { enter: { x: 0, y: CHART_DROP }, exit: null };
+    return {
+      enter: { y: CHART_DROP, scale: 1, delay: 0, duration: OPEN_DURATION },
+      exit: null,
+    };
   }
 
-  // Switching: move in the direction of travel — right when going from the left
-  // tab to the right one, so the new chart arrives from the right edge and the
-  // old one leaves through the left.
-  const direction = TAB_ORDER[to] > TAB_ORDER[from] ? 1 : -1;
+  // Switching: the same fade through whichever way you go. Direction of travel
+  // is deliberately not encoded — the charts never share the screen, so there is
+  // no relative movement for the eye to read a direction from anyway.
   return {
-    enter: { x: direction * CHART_SLIDE, y: 0 },
-    exit: { x: -direction * CHART_SLIDE, y: 0 },
+    enter: {
+      y: 0,
+      scale: FADE_ENTER_SCALE,
+      delay: FADE_ENTER_DELAY,
+      duration: FADE_ENTER_DURATION,
+    },
+    exit: { y: 0, scale: FADE_EXIT_SCALE, duration: FADE_EXIT_DURATION },
   };
 };

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, runOnJS, Easing, SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, withDelay, interpolate, runOnJS, Easing, SlideInLeft, SlideInRight, SlideOutLeft, SlideOutRight } from 'react-native-reanimated';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import WheelPicker from '@quidone/react-native-wheel-picker';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -15,7 +15,7 @@ import currenciesJson from '../../assets/currencies.json';
 import EmptyState from '../components/EmptyState';
 import BalanceHistoryCard from '../components/graphs/BalanceHistoryCard';
 import CategoryBackChip from '../components/graphs/CategoryBackChip';
-import { chartTransitionOffsets, CHART_DROP } from '../components/graphs/chartTransitions';
+import { chartTransition, CHART_DROP } from '../components/graphs/chartTransitions';
 import CategorySpendingCard from '../components/graphs/CategorySpendingCard';
 import ExpenseSummaryCard from '../components/graphs/ExpenseSummaryCard';
 import IncomeSummaryCard from '../components/graphs/IncomeSummaryCard';
@@ -28,11 +28,8 @@ import useBalanceHistory from '../hooks/useBalanceHistory';
 
 const CARD_HEADER_HEIGHT = 56;
 const MAX_CHART_HEIGHT = 500;
-// How far a chart travels while fading: straight down when its tab opens,
-// sideways when you move between tabs.
-// Entry outlasts exit so the two overlap instead of leaving a blank frame.
-const CHART_IN_DURATION = 320;
-const CHART_OUT_DURATION = 200;
+// Chart-level timings live in chartTransitions.js — these two are the panel's
+// own height animation, which runs regardless of which chart is moving.
 const PANEL_OPEN_DURATION = 280;
 const PANEL_CLOSE_DURATION = 220;
 
@@ -77,18 +74,20 @@ const GraphsScreen = () => {
   // Reanimated shared values — all run on UI thread, immune to JS contention
   // Panel height: header only when collapsed, header + chart when open
   const panelHeight = useSharedValue(CARD_HEADER_HEIGHT);
-  // 0=hidden, 1=visible; drives each chart's opacity + slide. Both charts stay
-  // mounted and overlap absolutely, so switching tabs is a cross-fade.
+  // 0=hidden, 1=visible; drives each chart's opacity, drop and scale. Both
+  // charts stay mounted and overlap absolutely, so switching tabs is a fade
+  // through: one progress runs to 0 before the other starts climbing to 1.
   const incomeChartProgress = useSharedValue(0);
   const expenseChartProgress = useSharedValue(0);
-  // Where each chart travels from at progress 0. Opening drops the chart down
-  // from under the strip; switching tabs slides it in from the side you moved
-  // towards, so the panel reads as a pager rather than a blink.
-  const incomeChartOffset = useSharedValue({ x: 0, y: CHART_DROP });
-  const expenseChartOffset = useSharedValue({ x: 0, y: CHART_DROP });
+  // Where each chart sits at progress 0. Opening drops it down from under the
+  // strip at full size; switching tabs holds it in place and scales it instead.
+  const incomeChartOffset = useSharedValue({ y: CHART_DROP, scale: 1 });
+  const expenseChartOffset = useSharedValue({ y: CHART_DROP, scale: 1 });
   // Bumped every time a tab is opened so the donut replays its intro — the
   // charts are always mounted, so mounting alone can't drive that animation.
-  const [chartIntroKey, setChartIntroKey] = useState(0);
+  // The delay travels with it: on a fade through the donut must not spin up
+  // while the chart it is replacing is still on screen.
+  const [chartIntro, setChartIntro] = useState({ key: 0, delay: 0 });
   // Measured chart heights, kept in refs so the expand handler can read them
   // synchronously (they are written from the JS-side onContentSizeChange).
   const expenseChartHeightRef = useRef(0);
@@ -520,7 +519,7 @@ const GraphsScreen = () => {
 
     const closing = expandedCard === card;
     const nextTab = closing ? null : card;
-    const { enter, exit } = chartTransitionOffsets(expandedCard, nextTab);
+    const { enter, exit } = chartTransition(expandedCard, nextTab);
 
     // Leaving a tab always drops its drill-down so it reopens at the top level
     if (expandedCard) {
@@ -529,8 +528,8 @@ const GraphsScreen = () => {
       } else {
         resetIncomeCategory();
       }
-      offsetOf(expandedCard).value = exit;
-      progressOf(expandedCard).value = withTiming(0, { duration: CHART_OUT_DURATION, easing: Easing.in(Easing.quad) });
+      offsetOf(expandedCard).value = { y: exit.y, scale: exit.scale };
+      progressOf(expandedCard).value = withTiming(0, { duration: exit.duration, easing: Easing.in(Easing.quad) });
     }
 
     setExpandedCard(nextTab);
@@ -540,13 +539,18 @@ const GraphsScreen = () => {
       return;
     }
 
-    offsetOf(card).value = enter;
-    setChartIntroKey(key => key + 1);
+    offsetOf(card).value = { y: enter.y, scale: enter.scale };
+    setChartIntro(prev => ({ key: prev.key + 1, delay: enter.delay }));
     const chartHeight = card === 'income'
       ? incomeChartHeightRef.current
       : expenseChartHeightRef.current;
     panelHeight.value = withTiming(CARD_HEADER_HEIGHT + chartHeight, { duration: PANEL_OPEN_DURATION, easing: Easing.out(Easing.cubic) });
-    progressOf(card).value = withTiming(1, { duration: CHART_IN_DURATION, easing: Easing.out(Easing.cubic) });
+    // withDelay, not Animated.delay: this is a reanimated shared value, so the
+    // whole chain stays on the UI thread.
+    progressOf(card).value = withDelay(
+      enter.delay,
+      withTiming(1, { duration: enter.duration, easing: Easing.out(Easing.cubic) }),
+    );
   }, [expandedCard, panelHeight, incomeChartProgress, expenseChartProgress,
     incomeChartOffset, expenseChartOffset, resetExpenseCategory, resetIncomeCategory]);
 
@@ -584,24 +588,24 @@ const GraphsScreen = () => {
 
   const incomeChartAnimStyle = useAnimatedStyle(() => {
     const p = incomeChartProgress.value;
-    const { x, y } = incomeChartOffset.value;
+    const { y, scale } = incomeChartOffset.value;
     return {
       opacity: p,
       transform: [
-        { translateX: interpolate(p, [0, 1], [x, 0]) },
         { translateY: interpolate(p, [0, 1], [y, 0]) },
+        { scale: interpolate(p, [0, 1], [scale, 1]) },
       ],
     };
   });
 
   const expenseChartAnimStyle = useAnimatedStyle(() => {
     const p = expenseChartProgress.value;
-    const { x, y } = expenseChartOffset.value;
+    const { y, scale } = expenseChartOffset.value;
     return {
       opacity: p,
       transform: [
-        { translateX: interpolate(p, [0, 1], [x, 0]) },
         { translateY: interpolate(p, [0, 1], [y, 0]) },
+        { scale: interpolate(p, [0, 1], [scale, 1]) },
       ],
     };
   });
@@ -687,7 +691,7 @@ const GraphsScreen = () => {
             </View>
 
             {/* Both charts stay mounted and overlap, so they stay measured and
-                switching tabs cross-fades instead of remounting. The closed one is
+                switching tabs fades through instead of remounting. The closed one is
                 pulled out of the accessibility tree too — opacity 0 alone still
                 lets TalkBack read its legend. */}
             <Animated.View
@@ -720,7 +724,8 @@ const GraphsScreen = () => {
                     isLeafCategory={incomeCategoryIsLeaf}
                     operations={incomeOperations}
                     loadingOperations={loadingIncomeOperations}
-                    introKey={chartIntroKey}
+                    introKey={chartIntro.key}
+                    introDelay={chartIntro.delay}
                   />
                 </Animated.View>
               </ScrollView>
@@ -756,7 +761,8 @@ const GraphsScreen = () => {
                     isLeafCategory={expenseCategoryIsLeaf}
                     operations={expenseOperations}
                     loadingOperations={loadingExpenseOperations}
-                    introKey={chartIntroKey}
+                    introKey={chartIntro.key}
+                    introDelay={chartIntro.delay}
                   />
                 </Animated.View>
               </ScrollView>


### PR DESCRIPTION
Follow-up to #1449 (already merged), so this lands as its own PR.

## Why

The horizontal slide from #1449 read as a pager. The panel isn't one — nothing
else in it moves sideways, so the incoming chart appeared to arrive from
somewhere that doesn't exist. Owner asked for a fade through instead.

## What

Switching between the income and expense tabs is now a fade through:

- outgoing chart: opacity → 0 with scale 1 → 0.98, over 120ms
- incoming chart: starts after the outgoing one is gone, opacity → 1 with
  scale 0.94 → 1, over 260ms

The two charts are never visible at the same time — that's the whole point of a
fade through, and `chartTransitions.test.js` asserts it
(`FADE_ENTER_DELAY >= FADE_EXIT_DURATION`).

Opening and closing the panel is unchanged: still the vertical 16px drop.

**One deviation from the brief:** the ask was a 120ms exit with the entry
starting at 80ms. Those two can't both hold — an 80ms handoff against a 120ms
exit overlaps the charts for 40ms, which is a cross-fade, not a fade through.
Kept the 120ms exit and moved the handoff to 120ms so the stated intent ("they
are never visible at the same time") survives. Total switch is 380ms.

## Changes

- `chartTransitions.js`: `chartTransitionOffsets` → `chartTransition`, now
  returns `{enter: {y, scale, delay, duration}, exit: {y, scale, duration}}`.
  Timings live here rather than in the screen, `CHART_SLIDE` is gone.
- `GraphsScreen.js`: chart transform is translateY + scale (no more translateX);
  entry runs through `withDelay` (reanimated's, so it stays on the UI thread —
  not `Animated.delay`); `chartIntroKey` became `chartIntro = {key, delay}`.
- `DonutChart.js`: new `introDelay` prop, so the donut doesn't spin up while the
  chart it replaces is still on screen. Plumbed through both pie charts.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/ --silent` → 164 suites,
  4844 tests, all passing
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` → clean
- `chartTransitions.test.js` rewritten for the fade-through contract (both
  directions produce the identical transition; open/close stay scale-free)
- `DonutChart.test.js` covers a delayed intro replay
