### PR TITLE
fix(budgets): read the whole tab in the currency the chip names

### DIFF
--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -378,10 +378,8 @@ describe('MonthlyPlanSection', () => {
       expect(queryByText('remaining_budget: 150.00')).toBeNull();
       expect(queryByText('50%')).toBeNull();
       expect(queryByText('over_budget_by 50')).toBeNull();
-      // The overspent row says so with its tone instead, and carries a "today"
-      // marker across the fill (the shown month is the current one).
+      // The overspent row says so with its tone instead.
       expect(getByTestId('plan-line-fill-l2')).toBeTruthy();
-      expect(getByTestId('plan-line-fill-l2-pace')).toBeTruthy();
     });
 
     it('shows actual income against expected income in the header', async () => {
@@ -685,6 +683,81 @@ describe('MonthlyPlanSection', () => {
     });
   });
 
+  // Regression: switching the header's currency chip to AMD left the whole tab
+  // reading in the plan's stored currency. The section resolved its unit as
+  // `plan.currency || currency`, so a plan created back when the only account
+  // was in RUB pinned every figure to RUB whatever the chip said.
+  describe('Display currency (host chip) wins over the plan\'s stored currency', () => {
+    const planInRub = (extra = {}) => setPlans({
+      plans: [{ id: 'p1', month: THIS_MONTH, currency: 'RUB', expectedIncome: '1000' }],
+      lines: [{
+        id: 'l1', planId: 'p1', amount: '300', label: 'Groceries', comment: null,
+        categoryId: 'cat1', toAccountId: null, sortOrder: 0, isBroken: false,
+      }],
+      ...extra,
+    });
+
+    it('reports the chip currency, not the plan\'s, to the host header', async () => {
+      planInRub();
+      const onTotalsChange = jest.fn();
+      const { getByTestId } = await renderSection(undefined, {
+        currency: 'AMD', month: THIS_MONTH, onTotalsChange,
+      });
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+      await waitFor(() => expect(onTotalsChange).toHaveBeenCalledWith(
+        expect.objectContaining({ currency: 'AMD' }),
+      ));
+    });
+
+    it('ignores a plan status still computed in the previous currency', async () => {
+      // The context recomputes statuses in the newly picked currency, but that
+      // is async: for a render or two the map still holds RUB figures. Printing
+      // those beside rows already converted to AMD is exactly the mixed-units
+      // bug the conversion exists to prevent — so the section falls back to its
+      // own same-currency estimate (300) and hides the actual column entirely.
+      planInRub({
+        planStatuses: new Map([['p1', {
+          planId: 'p1', month: THIS_MONTH, currency: 'RUB', convertAll: false,
+          lines: [],
+          totals: {
+            expectedIncome: '1000.00', actualIncome: '0.00', allocated: '99999.00',
+            totalActual: '88888.00', plannedRemainder: '-98999.00', actualRemainder: '0.00',
+          },
+          unconvertible: [],
+        }]]),
+      });
+      const { getByTestId, queryByTestId } = await renderSection(undefined, {
+        currency: 'AMD', month: THIS_MONTH,
+      });
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+
+      expect(getByTestId('plan-totals')).toHaveTextContent(/300/);
+      expect(getByTestId('plan-totals')).not.toHaveTextContent(/99999|100K/);
+      expect(queryByTestId('plan-actual-total')).toBeNull();
+    });
+
+    it('uses a status once it arrives in the chip currency', async () => {
+      planInRub({
+        planStatuses: new Map([['p1', {
+          planId: 'p1', month: THIS_MONTH, currency: 'AMD', convertAll: false,
+          lines: [],
+          totals: {
+            expectedIncome: '1000.00', actualIncome: '0.00', allocated: '410.00',
+            totalActual: '250.00', plannedRemainder: '590.00', actualRemainder: '750.00',
+          },
+          unconvertible: [],
+        }]]),
+      });
+      const { getByTestId } = await renderSection(undefined, {
+        currency: 'AMD', month: THIS_MONTH,
+      });
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+
+      expect(getByTestId('plan-totals')).toHaveTextContent(/410/);
+      expect(getByTestId('plan-actual-total')).toHaveTextContent(/250/);
+    });
+  });
+
   describe('Totals freshness after a mutation (Fix 2, adversarial review round 2)', () => {
     // Mirrors Bug 3 above but from the OTHER direction: refreshPlanStatuses()
     // is fired-and-forgotten by the save/delete handlers (never awaited), so a
@@ -978,11 +1051,11 @@ describe('MonthlyPlanSection', () => {
       expect(fillTone(getByTestId, 'l-done')).toContain(COLORS.overspend);
     });
 
-    // The row's fill IS its progress bar, and the hairline across it is today.
-    // Without that marker a percentage is not a judgement: 99% of an envelope
-    // spent is unremarkable on the 27th and alarming on the 3rd, and the old
-    // four-band colour scale could not tell those apart because it never knew
-    // the date.
+    // The row's fill IS its progress bar. Whether the spend is ahead of the
+    // month's pace is said in the fill's TONE — there is no vertical "today"
+    // marker anymore: Android draws a 1dp dashed border solid, so one per row at
+    // the same x stacked into an unbroken grey line down the card that read as a
+    // rendering artefact rather than as a date.
     const pacedLine = (id, actual, amount, isExceeded = false) => ({
       plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }],
       lines: [{
@@ -1008,14 +1081,14 @@ describe('MonthlyPlanSection', () => {
     const fillTone = (getByTestId, id) =>
       StyleSheet.flatten(getByTestId(`plan-line-fill-${id}-bar`).props.style).backgroundColor;
 
-    it('draws the today marker on the current month', async () => {
+    it('draws no vertical today marker across the fill on the current month', async () => {
       setPlans(pacedLine('l-pace', '10', '100'));
-      const { getByTestId } = await renderSection();
+      const { getByTestId, queryByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-fill-l-pace')).toBeTruthy());
-      expect(getByTestId('plan-line-fill-l-pace-pace')).toBeTruthy();
+      expect(queryByTestId('plan-line-fill-l-pace-pace')).toBeNull();
     });
 
-    it('omits the today marker on a month that is not the current one', async () => {
+    it('draws no vertical today marker on a month that is not the current one either', async () => {
       const previous = pacedLine('l-pace', '10', '100');
       previous.plans[0].month = PREV_MONTH;
       previous.planStatuses = new Map([['p1', {
@@ -1024,8 +1097,6 @@ describe('MonthlyPlanSection', () => {
       setPlans(previous);
       const { getByTestId, queryByTestId } = await renderSection(undefined, { month: PREV_MONTH });
       await waitFor(() => expect(getByTestId('plan-line-fill-l-pace')).toBeTruthy());
-      // A past month is fully spent and a future one hasn't started; in neither
-      // case does "are you ahead of pace" mean anything.
       expect(queryByTestId('plan-line-fill-l-pace-pace')).toBeNull();
     });
 

--- a/__tests__/contexts/BudgetPlansContext.test.js
+++ b/__tests__/contexts/BudgetPlansContext.test.js
@@ -21,6 +21,15 @@ jest.mock('../../app/contexts/DialogContext', () => ({
   useDialog: () => ({ showDialog: mockShowDialog, hideDialog: jest.fn() }),
 }));
 
+// The plans context reads the shared convert-all toggle AND the Budgets tab's
+// display currency from BudgetsDataContext. Undefined by default (rendered
+// standalone, as in the app's own fallback path); individual tests install a
+// host value.
+let mockBudgetsData;
+jest.mock('../../app/contexts/BudgetsDataContext', () => ({
+  useBudgetsData: () => mockBudgetsData,
+}));
+
 let mockUuidCounter = 0;
 jest.mock('react-native-uuid', () => ({
   v4: jest.fn(() => `plan-uuid-${++mockUuidCounter}`),
@@ -33,6 +42,7 @@ describe('BudgetPlansContext', () => {
     jest.clearAllMocks();
     mockShowDialog.mockClear();
     mockUuidCounter = 0;
+    mockBudgetsData = undefined;
 
     appEvents.on.mockReturnValue(jest.fn());
     BudgetPlansDB.getAllPlans.mockResolvedValue([]);
@@ -299,7 +309,26 @@ describe('BudgetPlansContext', () => {
       const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
 
       await waitFor(() => expect(result.current.planStatuses.get('p1')).toEqual(STATUS));
-      expect(BudgetPlansDB.calculateAllPlanStatuses).toHaveBeenCalledWith(true);
+      // No display currency chosen (no BudgetsData host here): every plan keeps
+      // its own stored currency, which `null` selects.
+      expect(BudgetPlansDB.calculateAllPlanStatuses).toHaveBeenCalledWith(true, null);
+    });
+
+    // Regression: the Budgets tab's currency chip was decorative. It converted
+    // the rows but not the statuses, which stayed in each plan's stored
+    // currency — so picking AMD over a plan created in RUB left every total,
+    // and the header's remainder, reading in RUB under an AMD chip.
+    it('computes statuses in the display currency chosen on the Budgets tab', async () => {
+      mockBudgetsData = { convertAllBudgets: true, displayCurrency: 'AMD' };
+      BudgetPlansDB.getAllPlans.mockResolvedValue([
+        { id: 'p1', month: '2026-07', currency: 'RUB', expectedIncome: '0' },
+      ]);
+      BudgetPlansDB.calculateAllPlanStatuses.mockResolvedValue(new Map());
+
+      const { result } = await renderHook(() => useBudgetPlans(), { wrapper });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(BudgetPlansDB.calculateAllPlanStatuses).toHaveBeenCalledWith(true, 'AMD');
     });
 
     it('refreshes statuses when an operation changes (integration-style)', async () => {

--- a/__tests__/screens/BudgetScreen.test.js
+++ b/__tests__/screens/BudgetScreen.test.js
@@ -39,9 +39,19 @@ jest.mock('../../app/contexts/DialogContext', () => ({
 
 const mockSetConvertAll = jest.fn();
 let mockBudgetsData;
-jest.mock('../../app/contexts/BudgetsDataContext', () => ({
-  useBudgetsData: () => mockBudgetsData,
-}));
+// The display currency lives in BudgetsDataContext now (the plan statuses have
+// to be recomputed in it), so the mock has to behave like real state rather than
+// a frozen value — the screen seeds it from the accounts and the header chip
+// writes to it, and both have to re-render the screen.
+jest.mock('../../app/contexts/BudgetsDataContext', () => {
+  const ReactModule = require('react');
+  return {
+    useBudgetsData: () => {
+      const [displayCurrency, setDisplayCurrency] = ReactModule.useState('');
+      return { ...mockBudgetsData, displayCurrency, setDisplayCurrency };
+    },
+  };
+});
 
 // Context values must be referentially stable across renders (the real
 // providers memoize them): a fresh accounts array on every render gives the

--- a/__tests__/services/BudgetPlansDB.status.test.js
+++ b/__tests__/services/BudgetPlansDB.status.test.js
@@ -528,5 +528,30 @@ describe('BudgetPlansDB plan-vs-actual', () => {
       expect(map.get('p1').currency).toBe('USD');
       expect(map.get('p2').currency).toBe('EUR');
     });
+
+    // Regression: the Budgets tab's currency chip converted the rows but not the
+    // statuses, so the totals under them stayed in each plan's stored currency.
+    it('computes every status in the display currency when one is given', async () => {
+      const planRows = [
+        { id: 'p1', month: '2026-07', currency: 'USD', expected_income: '100', created_at: 't', updated_at: 't' },
+        { id: 'p2', month: '2026-06', currency: 'EUR', expected_income: '200', created_at: 't', updated_at: 't' },
+      ];
+      queryAll.mockImplementation(async (sql) => {
+        if (sql.includes('FROM budget_plans ORDER BY')) return planRows;
+        return [];
+      });
+      queryFirst.mockImplementation(async (sql, params) => {
+        if (sql.includes('FROM budget_plans WHERE id')) {
+          return planRows.find(p => p.id === params[0]) || null;
+        }
+        if (sql.includes("o.type = 'income'")) return { total: 0 };
+        return null;
+      });
+
+      const map = await BudgetPlansDB.calculateAllPlanStatuses(false, 'AMD');
+
+      expect(map.get('p1').currency).toBe('AMD');
+      expect(map.get('p2').currency).toBe('AMD');
+    });
   });
 });

--- a/app/components/budgets/EnvelopeFill.js
+++ b/app/components/budgets/EnvelopeFill.js
@@ -12,7 +12,6 @@ import PropTypes from 'prop-types';
 // spent only where there is something to say.
 const CALM_ALPHA = '14'; // ~8%, neutral grey
 const SIGNAL_ALPHA = '2E'; // ~18%, warning / overspend
-const PACE_ALPHA = '59'; // ~35%
 
 /**
  * A plan row's progress, drawn as the row's own background rather than as a
@@ -22,22 +21,19 @@ const PACE_ALPHA = '59'; // ~35%
  * already four lines tall; as a background wash the same information costs no
  * vertical space at all.
  *
- * The dashed vertical line is TODAY. Without it a percentage is not a judgement:
- * 99% of an envelope spent is unremarkable on the 27th and alarming on the 3rd.
- * Fill short of the marker means on pace; fill past it means spending faster
- * than the month is passing.
+ * There is no "today" marker on the fill anymore. It was meant to read as a
+ * dashed annotation, but Android draws a 1dp dashed border solid, so every row
+ * carried a full-height hairline at the same x — which stacked into one
+ * unbroken grey line down the whole card and read as a rendering artefact
+ * rather than as a date. Being ahead of the month's pace still shows: the row
+ * takes the warning tone (see PlanLineRow), which needs no extra geometry.
  *
  * @param {number} fraction - Spent / target, 0..1+ (clamped when drawn)
- * @param {?number} paceFraction - How far through the month today is, or null
- *   when the shown month is not the current one and pace means nothing
  * @param {?string} tone - 6-digit hex signal colour, or null for a row with
  *   nothing to flag, which is washed in neutral grey instead
  */
-const EnvelopeFill = ({ fraction, paceFraction, tone = null, mutedColor, testID }) => {
+const EnvelopeFill = ({ fraction, tone = null, mutedColor, testID }) => {
   const fillPercent = Math.min(Math.max(fraction, 0), 1) * 100;
-  // Hidden at the very edges: a marker pinned to either end of the row reads as
-  // a border, not as a date.
-  const showPace = paceFraction != null && paceFraction > 0.02 && paceFraction < 0.98;
   const fillColor = tone ? `${tone}${SIGNAL_ALPHA}` : `${mutedColor}${CALM_ALPHA}`;
 
   return (
@@ -48,22 +44,12 @@ const EnvelopeFill = ({ fraction, paceFraction, tone = null, mutedColor, testID 
           style={[styles.fill, { width: `${fillPercent}%`, backgroundColor: fillColor }]}
         />
       )}
-      {showPace && (
-        <View
-          testID={testID ? `${testID}-pace` : undefined}
-          style={[
-            styles.pace,
-            { left: `${paceFraction * 100}%`, borderLeftColor: `${mutedColor}${PACE_ALPHA}` },
-          ]}
-        />
-      )}
     </View>
   );
 };
 
 EnvelopeFill.propTypes = {
   fraction: PropTypes.number.isRequired,
-  paceFraction: PropTypes.number,
   tone: PropTypes.string,
   mutedColor: PropTypes.string.isRequired,
   testID: PropTypes.string,
@@ -73,22 +59,10 @@ export default EnvelopeFill;
 
 const styles = StyleSheet.create({
   fill: {
-    // No hard leading edge. A 2dp bar at full strength sat right next to the
-    // pace marker on every row — two unexplained vertical lines a few
-    // millimetres apart, competing for the reading the marker exists to give.
-    // The wash boundary is the boundary.
+    // No hard leading edge: the wash boundary is the boundary. A 2dp bar at full
+    // strength was one more vertical line on a row that already had too many.
     bottom: 0,
     left: 0,
-    position: 'absolute',
-    top: 0,
-  },
-  pace: {
-    // Dashed, so it reads as an annotation on the bar rather than as a divider
-    // or a rendering artefact — which is exactly what a solid full-height
-    // hairline looked like when every row had one at the same x.
-    borderLeftWidth: 1,
-    borderStyle: 'dashed',
-    bottom: 0,
     position: 'absolute',
     top: 0,
   },

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -113,7 +113,14 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   const pace = useMemo(() => monthProgressFraction(month), [month]);
 
   const planId = plan?.id ?? null;
-  const planCurrency = plan?.currency || currency;
+  // The currency the section READS in, which is the one the host's chip names —
+  // not the one the plan happens to be stored in. Those are different things: a
+  // plan created back when the only account was in RUB stays a RUB row forever,
+  // while the person looking at it today wants the month in AMD. Reading the
+  // stored currency first made the chip decorative — every figure kept coming out
+  // in the plan's currency however the chip was set. `plan?.currency` survives
+  // only as the fallback for a host that names no currency at all.
+  const planCurrency = currency || plan?.currency || '';
 
   // The screen shows one currency and the host header names it, next to the
   // control that changes it. Repeating the code on the summary strip, the income
@@ -123,7 +130,17 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   const currencySuffix = controlledMonth ? '' : ` ${planCurrency}`;
 
   // Plan-vs-actual status for the shown month (may be null while computing).
-  const planStatus = (planId && planStatuses && planStatuses.get(planId)) || null;
+  const storedPlanStatus = (planId && planStatuses && planStatuses.get(planId)) || null;
+  // A status computed in another currency is not this section's status. The
+  // context recomputes them whenever the display currency changes, but that is
+  // async: for a render or two after the chip is switched the map still holds the
+  // previous currency's figures, and printing those under rows already converted
+  // to the new one is the mixed-units bug the conversion exists to prevent. Treat
+  // a currency mismatch exactly like "not computed yet" — the local same-currency
+  // estimate below covers the gap.
+  const planStatus = storedPlanStatus && storedPlanStatus.currency === planCurrency
+    ? storedPlanStatus
+    : null;
 
   // Freshness tracking (Fix 2, adversarial review round 2 — mirrors Bug 3):
   // refreshPlanStatuses() is fired-and-forgotten by the mutation handlers below
@@ -669,7 +686,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
 
         {/* Income: the month's expected income is the sum of these lines, shown
             against the income actually received. */}
-        <View style={[styles.sectionHeader, { borderBottomColor: colors.border }]} testID="plan-income-header">
+        <View style={styles.sectionHeader} testID="plan-income-header">
           <View style={styles.sectionTitleGroup}>
             <Icon name="cash-plus" size={20} color={colors.text} />
             <Text style={[styles.sectionTitle, { color: colors.text }]}>{t('income')}</Text>
@@ -689,7 +706,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
 
         {/* Allocations: recurring (global) ones apply to every month, one-off ones
             belong to this month's plan. */}
-        <View style={[styles.sectionHeader, styles.sectionHeaderSpaced, { borderBottomColor: colors.border }]} testID="plan-allocations-header">
+        <View style={[styles.sectionHeader, styles.sectionHeaderSpaced]} testID="plan-allocations-header">
           <View style={styles.sectionTitleGroup}>
             <Icon name="chart-donut" size={20} color={colors.text} />
             <Text style={[styles.sectionTitle, { color: colors.text }]}>{t('allocations')}</Text>
@@ -913,8 +930,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   sectionHeader: {
+    // No rule under the title. At the card's border colour it was barely visible
+    // — enough to register as a stray line, not enough to separate anything the
+    // uppercase title and the spacing above it don't already separate.
     alignItems: 'center',
-    borderBottomWidth: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',
     paddingBottom: SPACING.xs,

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -83,6 +83,8 @@ const PlanLineRow = memo(function PlanLineRow({
   // every row tinted, ten coloured blocks sat side by side and none of them
   // stood out, which is the hierarchy problem the fill was supposed to solve.
   // A null tone tells EnvelopeFill to wash the row in neutral grey instead.
+  // Pace is only read here now — the fill itself no longer draws a "today"
+  // marker (see EnvelopeFill), so being ahead of the month shows as tone alone.
   const paceFraction = tracked ? pace : null;
   const spentFraction = tracked ? status.percentage / 100 : 0;
   let tone = null;
@@ -154,7 +156,6 @@ const PlanLineRow = memo(function PlanLineRow({
       {showFill && (
         <EnvelopeFill
           fraction={spentFraction}
-          paceFraction={paceFraction}
           tone={tone}
           mutedColor={colors.mutedText}
           testID={`plan-line-fill-${line.id}`}

--- a/app/contexts/BudgetPlansDataContext.js
+++ b/app/contexts/BudgetPlansDataContext.js
@@ -27,6 +27,12 @@ export const BudgetPlansDataProvider = ({ children }) => {
   const budgetsData = useBudgetsData();
   const convertAllPlans = budgetsData?.convertAllBudgets ?? true;
   const convertAllRef = useRef(convertAllPlans);
+  // The currency the Budgets tab is being read in (see BudgetsDataContext). Every
+  // status is computed in it rather than in each plan's stored currency, so the
+  // totals the screen prints are in the same unit as the rows above them. Empty
+  // (screen hasn't seeded it yet) falls back to the plan's own currency.
+  const displayCurrency = budgetsData?.displayCurrency || null;
+  const displayCurrencyRef = useRef(displayCurrency);
 
   // Monotonic token guarding against out-of-order status refreshes. Two
   // independent triggers race here — the convert-all toggle and OPERATION_CHANGED
@@ -36,13 +42,17 @@ export const BudgetPlansDataProvider = ({ children }) => {
   const refreshTokenRef = useRef(0);
 
   /**
-   * Recompute plan-vs-actual statuses for all plans (each in its own currency).
+   * Recompute plan-vs-actual statuses for all plans, in the tab's display
+   * currency (falling back to each plan's own currency when none is chosen).
    * Only the newest in-flight refresh is allowed to commit its result.
    */
   const refreshPlanStatuses = useCallback(async () => {
     const token = ++refreshTokenRef.current;
     try {
-      const statusMap = await BudgetPlansDB.calculateAllPlanStatuses(convertAllRef.current);
+      const statusMap = await BudgetPlansDB.calculateAllPlanStatuses(
+        convertAllRef.current,
+        displayCurrencyRef.current,
+      );
       if (token === refreshTokenRef.current) {
         setPlanStatuses(statusMap);
       }
@@ -73,13 +83,14 @@ export const BudgetPlansDataProvider = ({ children }) => {
     reloadPlans();
   }, [reloadPlans]);
 
-  // Recompute statuses whenever the plans list or the convert toggle changes.
-  // The ref is synced first so the event-driven refresh below always uses the
-  // latest toggle value.
+  // Recompute statuses whenever the plans list, the convert toggle or the tab's
+  // display currency changes. The refs are synced first so the event-driven
+  // refresh below always uses the latest values.
   useEffect(() => {
     convertAllRef.current = convertAllPlans;
+    displayCurrencyRef.current = displayCurrency;
     refreshPlanStatuses();
-  }, [plans, convertAllPlans, refreshPlanStatuses]);
+  }, [plans, convertAllPlans, displayCurrency, refreshPlanStatuses]);
 
   // Refresh statuses when operations change, so actuals track reality live.
   useEffect(() => {

--- a/app/contexts/BudgetsDataContext.js
+++ b/app/contexts/BudgetsDataContext.js
@@ -23,6 +23,15 @@ export const BudgetsDataProvider = ({ children }) => {
   // stable identity (its consumers subscribe to events with it as a dep).
   const convertAllRef = useRef(true);
   const [convertAllBudgets, setConvertAllBudgetsState] = useState(true);
+  // The currency the Budgets tab is READ in. Empty until the screen seeds it from
+  // the accounts. It is a display setting, not data: picking AMD converts every
+  // figure on the tab into AMD at the current rate, it does not rewrite the
+  // currency the plan (or any line) is stored in. Lives here, next to the
+  // convert-all toggle, because BudgetPlansDataContext has to recompute its plan
+  // statuses in the same unit the screen prints — a status computed in the plan's
+  // stored currency while the rows convert to the chosen one is how the tab ended
+  // up showing RUB totals under an AMD chip.
+  const [displayCurrency, setDisplayCurrency] = useState('');
   // Reference date the budget statuses are computed for. `undefined` means
   // "today" (default). The merged Budgets screen sets this to a mid-month date
   // when the user navigates to another month, so per-category spent/exceeded
@@ -148,6 +157,8 @@ export const BudgetsDataProvider = ({ children }) => {
     saveError,
     convertAllBudgets,
     setConvertAllBudgets,
+    displayCurrency,
+    setDisplayCurrency,
     setBudgetStatusMonth,
     reloadBudgets,
     refreshBudgetStatuses,
@@ -162,6 +173,7 @@ export const BudgetsDataProvider = ({ children }) => {
     saveError,
     convertAllBudgets,
     setConvertAllBudgets,
+    displayCurrency,
     setBudgetStatusMonth,
     reloadBudgets,
     refreshBudgetStatuses,

--- a/app/screens/BudgetScreen.js
+++ b/app/screens/BudgetScreen.js
@@ -34,7 +34,14 @@ const BudgetScreen = () => {
   // owned here (BudgetsDataContext) and consumed by BudgetPlansDataContext, so
   // the whole merged screen converts consistently. `loading` is a proxy for "DB
   // ready" (BudgetsDataContext still loads the legacy `budgets` table on mount).
-  const { loading, convertAllBudgets, setConvertAllBudgets } = useBudgetsData();
+  // selectedCurrency lives in the context rather than in this screen's state:
+  // BudgetPlansDataContext has to recompute its plan statuses in the very
+  // currency the chip names, or the card prints converted rows above totals
+  // still computed in each plan's stored currency.
+  const {
+    loading, convertAllBudgets, setConvertAllBudgets,
+    displayCurrency: selectedCurrency, setDisplayCurrency: setSelectedCurrency,
+  } = useBudgetsData();
   const { categories } = useCategories();
   const { accounts } = useAccountsData();
   const { showDialog } = useDialog();
@@ -44,7 +51,6 @@ const BudgetScreen = () => {
   const [month, setMonth] = useState(currentMonthKey);
   const isCurrentMonth = month === currentMonthKey();
 
-  const [selectedCurrency, setSelectedCurrency] = useState('');
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
 
@@ -114,7 +120,8 @@ const BudgetScreen = () => {
   // one stops existing (its last account was deleted). The membership check is not
   // cosmetic: the picker is only rendered while currencyItems.length > 1, so a
   // stale selection could otherwise survive with no UI left to change it, and it
-  // is still handed to MonthlyPlanSection as the currency of any plan it creates.
+  // is the currency the whole tab is read in (and the one any plan it creates is
+  // stored in).
   useEffect(() => {
     if (accounts.length === 0) {
       if (selectedCurrency) setSelectedCurrency('');

--- a/app/services/BudgetPlansDB.js
+++ b/app/services/BudgetPlansDB.js
@@ -1446,19 +1446,24 @@ export const calculatePlanStatus = async (planId, displayCurrency = null, conver
 };
 
 /**
- * Compute plan-vs-actual statuses for all plans, keyed by plan ID. Each plan's
- * status is expressed in its own currency. A single failing plan is logged and
- * skipped so the rest still refresh (same contract as calculateAllBudgetStatuses).
+ * Compute plan-vs-actual statuses for all plans, keyed by plan ID. A single
+ * failing plan is logged and skipped so the rest still refresh (same contract as
+ * calculateAllBudgetStatuses).
  * @param {boolean} [convertAll=false]
+ * @param {?string} [displayCurrency=null] - Currency to express every status in.
+ *   Null (the default) keeps each plan in its own stored currency. The Budgets
+ *   screen passes the currency it is being read in: its rows convert to that
+ *   currency, so its totals have to be computed in it too, or the card prints
+ *   converted rows above unconverted totals.
  * @returns {Promise<Map<string, Object>>}
  */
-export const calculateAllPlanStatuses = async (convertAll = false) => {
+export const calculateAllPlanStatuses = async (convertAll = false, displayCurrency = null) => {
   try {
     const plans = await getAllPlans();
     const statusMap = new Map();
     for (const plan of plans) {
       try {
-        const status = await calculatePlanStatus(plan.id, plan.currency, convertAll);
+        const status = await calculatePlanStatus(plan.id, displayCurrency || plan.currency, convertAll);
         statusMap.set(plan.id, status);
       } catch (error) {
         console.error(`Failed to calculate status for plan ${plan.id}:`, error);


### PR DESCRIPTION
## What

Switching the Budgets header chip to AMD left every figure on the tab reading in RUB.

`MonthlyPlanSection` resolved its unit as `plan.currency || currency` — so for any month that already had a plan, the stored currency won and the chip was decorative. A plan created back when the only account was in RUB pinned the rows, both totals and the hero remainder to RUB whatever the chip said.

Display currency and stored currency are different things, so they are read in that order now: the chip wins, `plan.currency` survives only as the fallback for a host that names no currency at all.

## How

- The selection moved from `BudgetScreen`'s local state into `BudgetsDataContext`, next to the shared convert-all toggle. It has to live there because `BudgetPlansDataContext` needs it: the statuses have to be recomputed in the very currency the rows convert to, or the card prints converted rows above totals computed per-plan.
- `calculateAllPlanStatuses(convertAll, displayCurrency)` — a display currency instead of pinning each plan to `plan.currency`. `null` (no chip yet, or standalone use) keeps the old behaviour.
- The recompute is async, so for a render or two after a switch the status map still holds the previous currency's figures. `MonthlyPlanSection` now treats a currency mismatch exactly like "not computed yet" and falls back to its own same-currency estimate — mixing units is the one thing the conversion exists to prevent.

## Also (reported from the same screenshot)

- **Vertical grey line down the card** — the per-row "today" pace marker. It was meant to read as a dashed annotation, but Android draws a 1dp dashed border solid, so one per row at the same x stacked into an unbroken hairline that read as a rendering artefact rather than as a date. Removed; being ahead of the month's pace still shows in the row's warning tone.
- **Hairline under the ДОХОД / СТАТЬИ ПЛАНА titles** — at the card's border colour it was barely visible, and it separated nothing the uppercase title and the spacing above it don't already separate.

## Tests

- New regression coverage: statuses computed in the chosen display currency (context + DB layer), the chip currency reported up to the host header, a stale-currency status ignored, and a matching-currency one used.
- Pace-marker tests inverted to assert the marker is gone.
- Full suite: 4849 passed / 164 suites. `eslint --max-warnings 0` clean.
