### PR TITLE
feat(motion): carry gesture velocity into releases and soften edges

### DIFF
--- a/__tests__/hooks/useSwipeDismiss.test.js
+++ b/__tests__/hooks/useSwipeDismiss.test.js
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { Gesture } from 'react-native-gesture-handler';
+import { withSpring } from 'react-native-reanimated';
 import { useSwipeDismiss } from '../../app/hooks/useSwipeDismiss';
 
 // react-native-reanimated and react-native-gesture-handler are mocked globally
@@ -79,6 +80,103 @@ describe('useSwipeDismiss', () => {
       const onDismiss = jest.fn();
       const { result } = await renderHook(() => useSwipeDismiss({ onDismiss }));
       await act(() => result.current.dismiss());
+    });
+  });
+
+  describe('Release behaviour', () => {
+    const WIDTH = 400;
+    // useSwipeDismiss defaults `width` to the window width; pass it explicitly so
+    // the distance threshold (32% of width) is predictable here.
+    const PAST_THRESHOLD = WIDTH * 0.5;
+    const SHORT_OF_THRESHOLD = WIDTH * 0.1;
+
+    // Drives a full gesture against the mocked Pan builder and returns every
+    // withSpring call it produced.
+    const release = async ({ translationX, velocityX, ...options }) => {
+      const panBuilder = Gesture.Pan();
+      Gesture.Pan.mockClear();
+      Gesture.Pan.mockReturnValueOnce(panBuilder);
+
+      await renderHook(() =>
+        useSwipeDismiss({ onDismiss: jest.fn(), width: WIDTH, ...options }),
+      );
+
+      const onStart = panBuilder.onStart.mock.calls.at(-1)[0];
+      const onEnd = panBuilder.onEnd.mock.calls.at(-1)[0];
+      withSpring.mockClear();
+
+      const event = { x: 0, translationX, velocityX };
+      await act(() => {
+        onStart({ ...event, translationX: 0 });
+        onEnd(event);
+      });
+
+      return withSpring.mock.calls;
+    };
+
+    it('hands the release velocity to the spring instead of a fixed curve', async () => {
+      const calls = await release({ translationX: PAST_THRESHOLD, velocityX: 1500 });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toMatchObject({ velocity: 1500 });
+    });
+
+    it('slides the panel off when the drag passes the distance threshold', async () => {
+      const calls = await release({ translationX: PAST_THRESHOLD, velocityX: 0 });
+
+      expect(calls[0][0]).toBe(WIDTH);
+    });
+
+    it('springs back to rest when the drag falls short', async () => {
+      const calls = await release({ translationX: SHORT_OF_THRESHOLD, velocityX: 0 });
+
+      expect(calls[0][0]).toBe(0);
+    });
+
+    it('dismisses on a flick even when the drag distance is short', async () => {
+      const calls = await release({ translationX: SHORT_OF_THRESHOLD, velocityX: 2000 });
+
+      expect(calls[0][0]).toBe(WIDTH);
+    });
+
+    it('carries the velocity into a spring-back too, so a recalled panel keeps moving', async () => {
+      const calls = await release({ translationX: SHORT_OF_THRESHOLD, velocityX: -400 });
+
+      expect(calls[0][0]).toBe(0);
+      expect(calls[0][1]).toMatchObject({ velocity: -400 });
+    });
+
+    describe('Regression: direction of travel outranks distance travelled', () => {
+      it('recalls a panel released while heading back, despite being past the threshold', async () => {
+        const calls = await release({ translationX: PAST_THRESHOLD, velocityX: -2000 });
+
+        // Position alone said "dismiss"; the finger was moving the other way.
+        expect(calls[0][0]).toBe(0);
+      });
+
+      it('does not step back either when the panel is being pulled home', async () => {
+        const onStepBack = jest.fn();
+        await release({
+          translationX: PAST_THRESHOLD,
+          velocityX: -2000,
+          canStepBack: true,
+          onStepBack,
+        });
+
+        expect(onStepBack).not.toHaveBeenCalled();
+      });
+
+      it('still steps back on a genuine completed swipe', async () => {
+        const onStepBack = jest.fn();
+        await release({
+          translationX: PAST_THRESHOLD,
+          velocityX: 0,
+          canStepBack: true,
+          onStepBack,
+        });
+
+        expect(onStepBack).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/__tests__/utils/motion.test.js
+++ b/__tests__/utils/motion.test.js
@@ -1,0 +1,162 @@
+// __tests__/utils/motion.test.js
+import {
+  rubberband,
+  clampWithRubberband,
+  RUBBERBAND_CONSTANT,
+  SPRING_SETTLE,
+  ANIMATED_SPRING_SETTLE,
+  PAN_VELOCITY_TO_PER_SECOND,
+} from '../../app/utils/motion';
+
+const DIMENSION = 400;
+
+describe('motion', () => {
+  describe('rubberband', () => {
+    it('returns zero at the boundary', () => {
+      expect(rubberband(0, DIMENSION)).toBe(0);
+    });
+
+    it('resists: the surface always moves less than the finger', () => {
+      for (const overshoot of [1, 10, 50, 200, 1000]) {
+        expect(rubberband(overshoot, DIMENSION)).toBeLessThan(overshoot);
+      }
+    });
+
+    it('is monotonic — more drag always means more movement', () => {
+      let previous = 0;
+      for (const overshoot of [1, 5, 20, 80, 300, 1200]) {
+        const moved = rubberband(overshoot, DIMENSION);
+        expect(moved).toBeGreaterThan(previous);
+        previous = moved;
+      }
+    });
+
+    it('resists progressively — the ratio of movement to drag keeps falling', () => {
+      const near = rubberband(20, DIMENSION) / 20;
+      const mid = rubberband(200, DIMENSION) / 200;
+      const far = rubberband(2000, DIMENSION) / 2000;
+      expect(near).toBeGreaterThan(mid);
+      expect(mid).toBeGreaterThan(far);
+    });
+
+    it('starts at roughly the resistance constant for tiny overshoots', () => {
+      // The point of a soft boundary: the very first pixel past the edge still
+      // moves, so the surface never reads as frozen.
+      expect(rubberband(0.5, DIMENSION) / 0.5).toBeCloseTo(RUBBERBAND_CONSTANT, 2);
+    });
+
+    it('approaches but never reaches the dimension as an asymptote', () => {
+      // Total give is bounded by the container size, whatever the constant —
+      // the surface can never be dragged arbitrarily far past its edge.
+      expect(rubberband(1e6, DIMENSION)).toBeLessThan(DIMENSION);
+      expect(rubberband(1e6, DIMENSION)).toBeGreaterThan(DIMENSION * 0.99);
+      expect(rubberband(1e9, DIMENSION, 0.2)).toBeLessThan(DIMENSION);
+    });
+
+    it('is sign-preserving so both edges behave the same', () => {
+      expect(rubberband(-120, DIMENSION)).toBeCloseTo(-rubberband(120, DIMENSION), 10);
+    });
+
+    it('a lower constant resists harder', () => {
+      expect(rubberband(100, DIMENSION, 0.3)).toBeLessThan(rubberband(100, DIMENSION, 0.55));
+    });
+
+    it('degrades safely on a zero or missing dimension', () => {
+      expect(rubberband(100, 0)).toBe(0);
+      expect(rubberband(100, undefined)).toBe(0);
+    });
+  });
+
+  describe('clampWithRubberband', () => {
+    const MIN = -1200;
+    const MAX = 0;
+
+    it('passes values inside the bounds through untouched', () => {
+      expect(clampWithRubberband(-600, MIN, MAX, DIMENSION)).toBe(-600);
+      expect(clampWithRubberband(MIN, MIN, MAX, DIMENSION)).toBe(MIN);
+      expect(clampWithRubberband(MAX, MIN, MAX, DIMENSION)).toBe(MAX);
+    });
+
+    it('lets the surface past the upper bound, with resistance', () => {
+      const result = clampWithRubberband(100, MIN, MAX, DIMENSION);
+      expect(result).toBeGreaterThan(MAX);
+      expect(result).toBeLessThan(100);
+    });
+
+    it('lets the surface past the lower bound, with resistance', () => {
+      const result = clampWithRubberband(MIN - 100, MIN, MAX, DIMENSION);
+      expect(result).toBeLessThan(MIN);
+      expect(result).toBeGreaterThan(MIN - 100);
+    });
+
+    it('is continuous at both bounds — no jump as the edge is crossed', () => {
+      // An epsilon past the edge may move the surface by at most that epsilon,
+      // so there is no discontinuity where free travel becomes resistance.
+      const eps = 1e-6;
+      expect(Math.abs(clampWithRubberband(MAX + eps, MIN, MAX, DIMENSION) - MAX))
+        .toBeLessThanOrEqual(eps);
+      expect(Math.abs(clampWithRubberband(MIN - eps, MIN, MAX, DIMENSION) - MIN))
+        .toBeLessThanOrEqual(eps);
+    });
+
+    it('regression: an edge over-drag never freezes (the old hard clamp did)', () => {
+      // Dragging right on the first tab used to pin translateX at 0 for the whole
+      // gesture, which reads as a broken touch. Every extra pixel must now yield
+      // at least some movement.
+      let previous = MAX;
+      for (const overshoot of [5, 25, 100, 400]) {
+        const moved = clampWithRubberband(MAX + overshoot, MIN, MAX, DIMENSION);
+        expect(moved).toBeGreaterThan(previous);
+        previous = moved;
+      }
+    });
+  });
+
+  describe('spring presets', () => {
+    it('SPRING_SETTLE is critically damped so full-bleed layers never oscillate', () => {
+      expect(SPRING_SETTLE.dampingRatio).toBe(1);
+      expect(SPRING_SETTLE.duration).toBeGreaterThan(0);
+    });
+
+    it('SPRING_SETTLE clamps overshoot — critical damping alone would not', () => {
+      // A hard flick hands the spring a large initial velocity, and a critically
+      // damped spring still crosses its target once at high v0. On a full-bleed
+      // layer that single crossing exposes empty background past the last tab /
+      // below a sheet, so it has to be clamped rather than merely non-oscillating.
+      expect(SPRING_SETTLE.overshootClamping).toBe(true);
+      expect(ANIMATED_SPRING_SETTLE.overshootClamping).toBe(true);
+    });
+
+    it('SPRING_SETTLE honours the OS reduce-motion setting', () => {
+      expect(SPRING_SETTLE.reduceMotion).toBe('system');
+    });
+
+    it('SPRING_SETTLE carries no baked-in velocity — call sites supply it', () => {
+      expect(SPRING_SETTLE.velocity).toBeUndefined();
+    });
+
+    it('ANIMATED_SPRING_SETTLE matches the critical-damping identity', () => {
+      const { stiffness, damping, mass } = ANIMATED_SPRING_SETTLE;
+      const critical = 2 * Math.sqrt(stiffness * mass);
+      // Within 5% of critical: no visible bounce, no sluggish overdamping.
+      expect(Math.abs(damping - critical) / critical).toBeLessThan(0.05);
+    });
+
+    it('ANIMATED_SPRING_SETTLE stays on the native driver', () => {
+      expect(ANIMATED_SPRING_SETTLE.useNativeDriver).toBe(true);
+    });
+
+    it('ANIMATED_SPRING_SETTLE mixes no legacy bounciness/speed config', () => {
+      // Animated.spring throws if bounciness/speed is combined with
+      // stiffness/damping.
+      expect(ANIMATED_SPRING_SETTLE.bounciness).toBeUndefined();
+      expect(ANIMATED_SPRING_SETTLE.speed).toBeUndefined();
+      expect(ANIMATED_SPRING_SETTLE.tension).toBeUndefined();
+      expect(ANIMATED_SPRING_SETTLE.friction).toBeUndefined();
+    });
+
+    it('converts PanResponder px/ms velocity to the px/s Animated.spring wants', () => {
+      expect(0.3 * PAN_VELOCITY_TO_PER_SECOND).toBe(300);
+    });
+  });
+});

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -21,9 +21,21 @@ import { useLocalization } from '../contexts/LocalizationContext';
 import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
 import { useBackShrink } from '../hooks/useBackShrink';
 import ModalBlurOverlay from './ModalBlurOverlay';
+import {
+  ANIMATED_SPRING_SETTLE,
+  PAN_VELOCITY_TO_PER_SECOND,
+  rubberband,
+} from '../utils/motion';
 
 // Pressable that can animate layout props (paddingBottom) for keyboard avoidance.
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+// How far the sheet may be lifted above its resting place, in px. The card is
+// glued to the bottom of the screen, so every pixel of lift opens a gap beneath
+// it — the give here is token by design: enough that an upward drag registers as
+// a boundary rather than a dead touch, not enough to show a visible strip of
+// background. (Downward has no such limit; that direction is the dismiss.)
+const UPWARD_GIVE = 32;
 
 /**
  * ModalShell — shared bottom-sheet wrapper for all modals.
@@ -108,6 +120,25 @@ export default function ModalShell({
   // Use a ref so the PanResponder closure always calls the latest onDismiss
   const onDismissRef = useRef(onDismiss);
   useEffect(() => { onDismissRef.current = onDismiss; }, [onDismiss]);
+  // Same reason: the PanResponder is built once, so it must not close over a
+  // screen height captured at mount (it would go stale on rotation).
+  const screenHeightRef = useRef(screenHeight);
+  useEffect(() => { screenHeightRef.current = screenHeight; }, [screenHeight]);
+
+  // Live copy of translateY. The open/close animations run on the native driver,
+  // where the JS-side value is never updated and `stopAnimation`'s callback comes
+  // back asynchronously over the bridge — too late for the first frames of a drag.
+  // A listener keeps a ~1-frame-fresh value the drag can rebase onto
+  // synchronously. Gated on `visible` because every ModalShell stays mounted for
+  // the whole session and an idle sheet has nothing worth subscribing to; it is
+  // declared before the open effect so the subscription is live for that first
+  // animation too.
+  const currentY = useRef(screenHeight);
+  useEffect(() => {
+    if (!visible) return undefined;
+    const id = translateY.addListener(({ value }) => { currentY.current = value; });
+    return () => translateY.removeListener(id);
+  }, [translateY, visible]);
 
   // Telegram-style predictive "back" shrink — played when the Android back
   // button/gesture closes the sheet (onRequestClose). The card keeps its
@@ -145,41 +176,74 @@ export default function ModalShell({
       useNativeDriver: true,
       // Leave translateY at screenHeight after close so the next open
       // renders offscreen immediately (no reset-to-0 flicker)
-    }).start(() => {
-      callback?.();
+    }).start(({ finished }) => {
+      // Only dismiss if the slide actually completed. A drag started while the
+      // sheet is sliding away cancels this animation (see onPanResponderGrant),
+      // and the sheet is now following the finger — closing it here would yank
+      // it out from under them.
+      if (finished) callback?.();
     });
   }, [translateY, screenHeight]);
+
+  // translateY at the instant the drag began. The sheet is grabbable while it is
+  // still animating (opening, or sliding away after an overlay tap), so the drag
+  // has to continue from wherever the card actually sits on screen — feeding the
+  // raw gesture `dy` would teleport it to `dy` measured from zero.
+  const dragStartY = useRef(0);
 
   const panResponder = useRef(
     PanResponder.create({
       onMoveShouldSetPanResponder: (_, gs) =>
-        gs.dy > 8 && Math.abs(gs.dy) > Math.abs(gs.dx),
+        Math.abs(gs.dy) > 8 && Math.abs(gs.dy) > Math.abs(gs.dx),
+      onPanResponderGrant: () => {
+        // Cancel whatever is in flight so it can't keep writing to translateY
+        // behind the finger, then rebase the drag onto where the card actually
+        // is right now (no callback — see the currentY listener above).
+        translateY.stopAnimation();
+        dragStartY.current = currentY.current;
+      },
       onPanResponderMove: (_, gs) => {
-        if (gs.dy > 0) translateY.setValue(gs.dy);
+        const next = dragStartY.current + gs.dy;
+        // Downward is free. Upward resists progressively instead of not moving
+        // at all — a sheet that ignores the finger reads as frozen, one that
+        // resists reads as "this is as far as it goes".
+        translateY.setValue(next >= 0 ? next : rubberband(next, UPWARD_GIVE));
       },
       onPanResponderRelease: (_, gs) => {
-        if (gs.dy > 80 || gs.vy > 0.3) {
-          Animated.timing(translateY, {
-            toValue: Dimensions.get('window').height,
-            duration: 200,
-            useNativeDriver: true,
-          }).start(() => {
+        const offset = dragStartY.current + gs.dy;
+        // PanResponder velocity is px/ms; Animated.spring wants px/s.
+        const velocity = gs.vy * PAN_VELOCITY_TO_PER_SECOND;
+        // Direction of travel outranks distance travelled: someone who has
+        // dragged the sheet well past the threshold but is now pulling it back
+        // up has changed their mind, and dismissing there fights the finger.
+        const pullingBack = gs.vy < -0.3;
+        if (!pullingBack && (offset > 80 || gs.vy > 0.3)) {
+          Animated.spring(translateY, {
+            ...ANIMATED_SPRING_SETTLE,
+            toValue: screenHeightRef.current,
+            // Carry the throw through: a hard flick now leaves fast and a gentle
+            // drag-past-threshold leaves gently, instead of both taking 200ms.
+            velocity,
+            // The card is out of sight long before the spring mathematically
+            // settles, so finish on "off-screen" rather than on the tail.
+            restDisplacementThreshold: 40,
+            restSpeedThreshold: 100,
+          }).start(({ finished }) => {
             // Leave translateY at screen height — no reset to avoid close flicker
-            onDismissRef.current?.();
+            if (finished) onDismissRef.current?.();
           });
         } else {
           Animated.spring(translateY, {
+            ...ANIMATED_SPRING_SETTLE,
             toValue: 0,
-            useNativeDriver: true,
-            bounciness: 0,
+            velocity,
           }).start();
         }
       },
       onPanResponderTerminate: () => {
         Animated.spring(translateY, {
+          ...ANIMATED_SPRING_SETTLE,
           toValue: 0,
-          useNativeDriver: true,
-          bounciness: 0,
         }).start();
       },
     }),

--- a/app/hooks/useSwipeDismiss.js
+++ b/app/hooks/useSwipeDismiss.js
@@ -5,14 +5,14 @@ import {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
+  withSpring,
   runOnJS,
   Easing,
 } from 'react-native-reanimated';
+import { SPRING_SETTLE } from '../utils/motion';
 
 const ENTER_DURATION = 260;
-const EXIT_DURATION = 220;
 const ENTER_EASING = Easing.out(Easing.cubic);
-const EXIT_EASING = Easing.in(Easing.cubic);
 const ACTIVE_OFFSET_X = 16;
 
 /**
@@ -80,12 +80,17 @@ export function useSwipeDismiss({ onDismiss, onStepBack, canStepBack = false, en
     translateX.value = withTiming(0, { duration: ENTER_DURATION, easing: ENTER_EASING });
   }, [translateX, dismissing, width]);
 
-  const dismiss = useCallback(() => {
+  // A worklet so the swipe can call it straight from the gesture's onEnd (on the
+  // UI thread, carrying the release velocity) while the back arrow / hardware
+  // back still calls it from JS with no velocity. Both paths then share the
+  // re-entrancy guard and the completion callback.
+  const dismiss = useCallback((velocity = 0) => {
+    'worklet';
     if (dismissing.value) return;
     dismissing.value = true;
-    translateX.value = withTiming(
+    translateX.value = withSpring(
       width,
-      { duration: EXIT_DURATION, easing: EXIT_EASING },
+      { ...SPRING_SETTLE, velocity },
       (finished) => {
         if (finished && onDismiss) {
           runOnJS(onDismiss)();
@@ -127,16 +132,25 @@ export function useSwipeDismiss({ onDismiss, onStepBack, canStepBack = false, en
         'worklet';
         if (!valid.value) return;
         const dx = event.translationX - dragStart.value;
-        const past = dx > DISTANCE_THRESHOLD || event.velocityX > VELOCITY_THRESHOLD;
+        // Direction of travel outranks distance travelled: a panel dragged past
+        // the threshold but released while heading back left has been recalled,
+        // and dismissing it there fights the finger.
+        const pullingBack = event.velocityX < -VELOCITY_THRESHOLD;
+        const past =
+          !pullingBack && (dx > DISTANCE_THRESHOLD || event.velocityX > VELOCITY_THRESHOLD);
         if (past && canStepBack) {
           // Go one level up within the panel; the overlay never moved, so there is
           // nothing to spring back — the inner level animates itself.
           if (onStepBack) runOnJS(onStepBack)();
         } else if (past) {
-          // Reuse dismiss() so the completion + re-entrancy guard live in one place.
-          runOnJS(dismiss)();
+          // Reuse dismiss() so the completion + re-entrancy guard live in one
+          // place. It's a worklet, so it runs here on the UI thread and the
+          // finger's speed carries straight into the slide-off — a panel flicked
+          // away leaves fast, and one dragged 90% of the way no longer brakes to
+          // spend a fixed 220ms on the last sliver.
+          dismiss(event.velocityX);
         } else {
-          translateX.value = withTiming(0, { duration: EXIT_DURATION, easing: ENTER_EASING });
+          translateX.value = withSpring(0, { ...SPRING_SETTLE, velocity: event.velocityX });
         }
       });
   }, [translateX, dragStart, valid, dismissing, enabledShared, width, edgeWidth, dismiss, canStepBack, onStepBack]);

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -8,12 +8,14 @@ import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
+  withSpring,
   withRepeat,
   cancelAnimation,
   Easing,
   runOnJS,
 } from 'react-native-reanimated';
 import { Svg, Circle } from 'react-native-svg';
+import { SPRING_SETTLE, clampWithRubberband } from '../utils/motion';
 
 const SCREEN_TIMING = { duration: 300, easing: Easing.out(Easing.cubic) };
 const PILL_TIMING = { duration: 200, easing: Easing.out(Easing.quad) };
@@ -454,8 +456,23 @@ export default function SimpleTabs() {
         const newTranslateX = startTranslateX.value + event.translationX;
         const maxTranslateX = 0;
         const minTranslateX = -(TABS.length - 1) * SCREEN_WIDTH;
-        translateX.value = Math.max(minTranslateX, Math.min(maxTranslateX, newTranslateX));
-        pillPosition.value = -translateX.value / SCREEN_WIDTH;
+        // Past the first / last tab the strip keeps following the finger with
+        // progressive resistance rather than freezing against the clamp — a hard
+        // stop at the edge reads as a broken touch, resistance reads as "this is
+        // the end". The spring in onEnd pulls it home either way.
+        translateX.value = clampWithRubberband(
+          newTranslateX,
+          minTranslateX,
+          maxTranslateX,
+          SCREEN_WIDTH,
+        );
+        // The pill has no rubber-band zone of its own (there is no tab slot past
+        // either end to slide into), so keep it pinned to the real index range
+        // while the strip overshoots.
+        pillPosition.value = Math.min(
+          TABS.length - 1,
+          Math.max(0, -translateX.value / SCREEN_WIDTH),
+        );
       })
       .onEnd((event) => {
         'worklet';
@@ -473,18 +490,26 @@ export default function SimpleTabs() {
           newIndex = Math.max(currentIndex - 1, 0);
         }
 
-        if (newIndex !== currentIndex) {
-          activeIndex.value = newIndex;
-          pillPosition.value = withTiming(newIndex, PILL_TIMING);
-          translateX.value = withTiming(-newIndex * SCREEN_WIDTH, SCREEN_TIMING, (isFinished) => {
-            if (isFinished) {
+        // Hand the finger's release speed to the spring so the strip keeps the
+        // momentum of the flick instead of restarting from a standstill on a
+        // fixed 300ms curve. The pill rides the same velocity, expressed in tab
+        // indices (it moves opposite to the strip), so the two stay in step.
+        // newIndex === currentIndex when the swipe fell short (or ran into a rubber-
+        // banded edge), so the same two springs cover both "commit" and "snap back".
+        activeIndex.value = newIndex;
+        pillPosition.value = withSpring(newIndex, {
+          ...SPRING_SETTLE,
+          velocity: -velocityX / SCREEN_WIDTH,
+        });
+        translateX.value = withSpring(
+          -newIndex * SCREEN_WIDTH,
+          { ...SPRING_SETTLE, velocity: velocityX },
+          (isFinished) => {
+            if (isFinished && newIndex !== currentIndex) {
               runOnJS(setActive)(TABS[newIndex].key);
             }
-          });
-        } else {
-          pillPosition.value = withTiming(currentIndex, PILL_TIMING);
-          translateX.value = withTiming(-currentIndex * SCREEN_WIDTH, SCREEN_TIMING);
-        }
+          },
+        );
       });
   }, [translateX, activeIndex, startTranslateX, TABS, setActive, subPanelActive, pillPosition, isTransitioningShared]);
 

--- a/app/utils/motion.js
+++ b/app/utils/motion.js
@@ -1,0 +1,120 @@
+// app/utils/motion.js
+/**
+ * Shared motion primitives for gesture-driven UI.
+ *
+ * Two ideas from Apple's "Designing Fluid Interfaces" that every draggable
+ * surface in the app needs, and that a fixed-duration timing curve cannot give:
+ *
+ *   1. Velocity handoff — when a gesture ends, the animation continues at the
+ *      finger's exact release speed, so there is no seam between dragging and
+ *      animating. A `withTiming(..., { duration })` release always starts from
+ *      zero speed, which is why a hard flick and a slow drag used to look
+ *      identical (and why a nearly-completed drag appeared to brake before the
+ *      finish).
+ *
+ *   2. Rubber-banding — at a boundary, resist progressively instead of stopping
+ *      dead. A hard clamp reads as "the touch broke"; resistance reads as
+ *      "responsive, but there is nothing more this way".
+ *
+ * Springs are used rather than easing curves because they are the only form
+ * that accepts an initial velocity and stays continuous when re-targeted
+ * mid-flight (i.e. when the user grabs a moving surface again).
+ */
+
+/**
+ * Critically damped spring for releasing a gesture (Reanimated).
+ *
+ * No bounce, deliberately: every draggable surface here is a full-bleed layer
+ * (the tab strip, a bottom sheet, a side panel), so travelling past the resting
+ * place would expose empty background behind it. The liveliness comes from the
+ * handed-off `velocity`, not from overshoot.
+ *
+ * `dampingRatio: 1` alone does not guarantee that. Critical damping rules out
+ * *oscillation*, but a spring launched at a high enough initial velocity still
+ * crosses its target once before easing back — exactly what a hard flick
+ * produces. `overshootClamping` is what actually pins the surface at rest.
+ *
+ * `duration` is Apple's "response", not a hard runtime — the spring settles when
+ * it settles, and a re-target mid-flight keeps its current velocity.
+ *
+ * `reduceMotion: 'system'` makes Reanimated honour the OS "Remove animations"
+ * accessibility setting for free (it jumps to the target instead of animating).
+ *
+ * Spread it and add `velocity` at the call site:
+ *   withSpring(target, { ...SPRING_SETTLE, velocity: event.velocityX })
+ */
+export const SPRING_SETTLE = {
+  duration: 350,
+  dampingRatio: 1,
+  overshootClamping: true,
+  reduceMotion: 'system',
+};
+
+/**
+ * The same spring expressed for the legacy `Animated` API (ModalShell), which
+ * has no duration/dampingRatio form. `damping = 2 * sqrt(stiffness * mass)` is
+ * the critical-damping identity, so this matches SPRING_SETTLE's character.
+ *
+ * NOTE: `Animated.spring` takes velocity in units **per second**, while
+ * `PanResponder`'s `gestureState.vy/vx` is in units per **millisecond** — remember
+ * to multiply by 1000. Reanimated's gesture `velocityY/velocityX` is already
+ * per second and needs no conversion.
+ */
+export const ANIMATED_SPRING_SETTLE = {
+  stiffness: 220,
+  damping: 30,
+  mass: 1,
+  overshootClamping: true,
+  useNativeDriver: true,
+};
+
+/** Milliseconds → seconds conversion for PanResponder velocities. */
+export const PAN_VELOCITY_TO_PER_SECOND = 1000;
+
+/**
+ * iOS's resistance constant. It sets how closely the surface follows the finger
+ * at the very start of the over-drag (movement/drag → `constant` as the
+ * overshoot approaches zero); lower is stiffer. The travel is bounded by
+ * `dimension` regardless of the constant.
+ */
+export const RUBBERBAND_CONSTANT = 0.55;
+
+/**
+ * Progressive resistance past a boundary.
+ *
+ * Returns how far a surface should actually move when the finger has travelled
+ * `overshoot` px beyond the edge. Starts at ~55% of the finger's movement and
+ * falls off from there, approaching (but never reaching) `dimension` — so the
+ * surface never quite runs away and never freezes either. Sign-preserving, so
+ * it works for both edges.
+ *
+ * @param {number} overshoot  Signed distance dragged past the boundary.
+ * @param {number} dimension  Size of the container the drag happens in.
+ * @param {number} [constant] Resistance constant; lower = stiffer.
+ * @returns {number} Signed distance the surface should move.
+ */
+export function rubberband(overshoot, dimension, constant = RUBBERBAND_CONSTANT) {
+  'worklet';
+  if (!dimension || dimension <= 0) return 0;
+  const magnitude = Math.abs(overshoot);
+  const resisted = (magnitude * dimension * constant) / (dimension + constant * magnitude);
+  return overshoot < 0 ? -resisted : resisted;
+}
+
+/**
+ * Clamp `value` into [min, max], but let it travel past either end with
+ * rubber-band resistance instead of stopping hard.
+ *
+ * @param {number} value      Raw (unclamped) position the finger asks for.
+ * @param {number} min        Lower bound.
+ * @param {number} max        Upper bound.
+ * @param {number} dimension  Size of the container (sets the resistance scale).
+ * @param {number} [constant] Resistance constant; lower = stiffer.
+ * @returns {number} Position to render.
+ */
+export function clampWithRubberband(value, min, max, dimension, constant = RUBBERBAND_CONSTANT) {
+  'worklet';
+  if (value > max) return max + rubberband(value - max, dimension, constant);
+  if (value < min) return min + rubberband(value - min, dimension, constant);
+  return value;
+}


### PR DESCRIPTION
## What

Every gesture in the app threw away the finger's speed at the moment of release and replayed a fixed-duration curve instead. A hard flick and a slow drag looked identical, and a drag taken 90% of the way still spent its full duration crawling through the last sliver. This wires release velocity into springs across the three gesture surfaces, and softens the two places that stopped dead against a hard clamp.

Follows Apple's *Designing Fluid Interfaces* guidance on velocity handoff, rubber-banding, and animating from the presentation value.

## New shared module — `app/utils/motion.js`

- `SPRING_SETTLE` / `ANIMATED_SPRING_SETTLE` — one critically damped, overshoot-clamped spring in both the Reanimated and legacy `Animated` dialects.
- `rubberband()` / `clampWithRubberband()` — the iOS progressive-resistance function.

`dampingRatio: 1` alone was not enough: critical damping rules out *oscillation*, but a spring launched at high initial velocity still crosses its target once — exactly what a flick produces. Every draggable surface here is a full-bleed layer where that crossing exposes empty background, hence `overshootClamping`.

## Tab strip — `SimpleTabs`

- Release springs to the resting tab at the finger's velocity. The pill rides the same velocity expressed in tab indices (it moves opposite to the strip), so the two stay in step instead of the strip flicking while the pill runs its own 200 ms curve.
- Past the first / last tab the strip rubber-bands instead of freezing against `Math.max(min, Math.min(max, x))`. A hard stop at the edge reads as a broken touch.

## Bottom sheets — `ModalShell`

- **Interrupt fix.** `onPanResponderMove` fed the raw gesture `dy` into `setValue`, so grabbing a sheet mid-animation teleported it to `dy` measured from zero. The drag now rebases onto the card's live position. Since the open/close animations run on the native driver — where the JS-side value is never updated and `stopAnimation`'s callback only comes back asynchronously over the bridge — a value listener supplies the presentation value synchronously.
- Dragging up gave nothing at all (`if (gs.dy > 0)`); it now yields a token 32 px of rubber-band. Deliberately small: the card is glued to the bottom, so every pixel of lift opens a gap beneath it.
- Release springs out at the throw's velocity, and an interrupted close no longer fires `onDismiss` out from under the finger.

## Side panels — `useSwipeDismiss`

- `dismiss()` became a worklet, so the swipe calls it on the UI thread carrying the release velocity while the back arrow / hardware back still calls it from JS. Both paths keep sharing the re-entrancy guard.
- A panel dragged past the threshold but released while heading back is now recalled rather than dismissed — direction of travel outranks distance travelled.

## Accessibility

These springs pass `reduceMotion: 'system'`, so they honour the OS "Remove animations" setting. The app had no reduce-motion support anywhere before this.

## Tests

- New `__tests__/utils/motion.test.js` (21 tests): resistance is monotonic, progressive, continuous at the boundary, sign-preserving, and bounded by the container; spring presets are critically damped, clamped, native-driver-safe, and free of the legacy `bounciness`/`speed` config that `Animated.spring` would throw on.
- New release-behaviour tests in `__tests__/hooks/useSwipeDismiss.test.js` drive the mocked Pan builder's real `onStart`/`onEnd` and assert the spring target and the handed-off velocity, including the commit-vs-reverse regression. These were verified to fail when the logic is reverted — mutation-checked, not decorative.
- Full suite: 4879 passed / 165 suites. `eslint --max-warnings 0` clean.

Not yet exercised on a device — the feel changes here deserve a spin on the emulator before merge.
