### PR TITLE
feat(graphs): default the yearly expense trend to all categories

### DIFF
--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -194,7 +194,7 @@ describe('CategorySpendingCard', () => {
       expect(onCategoryChange).toHaveBeenCalledWith('cat-transport');
     });
 
-    it('defaults to first parent category if none selected', async () => {
+    it('defaults to all categories if none selected', async () => {
       const { getByText } = await render(
         <CategorySpendingCard
           {...defaultProps}
@@ -202,8 +202,36 @@ describe('CategorySpendingCard', () => {
         />,
       );
 
-      // Should show Food as the default selection (first parent expense category)
-      expect(getByText('Food')).toBeTruthy();
+      // No pick means the whole expense trend, not the first parent category
+      expect(getByText('all_categories')).toBeTruthy();
+    });
+
+    it('offers an "all categories" row in the primary picker', async () => {
+      const onCategoryChange = jest.fn();
+
+      const { getByText, getAllByText } = await render(
+        <CategorySpendingCard
+          {...defaultProps}
+          onCategoryChange={onCategoryChange}
+        />,
+      );
+
+      await fireEvent.press(getByText('Food'));
+
+      const allRows = getAllByText('all_categories');
+      await fireEvent.press(allRows[allRows.length - 1]);
+
+      expect(onCategoryChange).toHaveBeenCalledWith('all');
+    });
+
+    it('does not offer "all categories" in the vs picker', async () => {
+      const { getByText, queryByText } = await render(
+        <CategorySpendingCard {...defaultProps} />,
+      );
+
+      await fireEvent.press(getByText('vs'));
+
+      expect(queryByText('all_categories')).toBeFalsy();
     });
 
     it('shows expand icon for categories with children', async () => {
@@ -391,7 +419,7 @@ describe('CategorySpendingCard', () => {
       );
     });
 
-    it('uses first category when selectedCategory is invalid', async () => {
+    it('falls back to all categories when selectedCategory is invalid', async () => {
       await render(
         <CategorySpendingCard
           {...defaultProps}
@@ -401,7 +429,7 @@ describe('CategorySpendingCard', () => {
 
       expect(useCategoryMonthlySpending).toHaveBeenCalledWith(
         'USD',
-        'cat-food', // Falls back to first parent expense category
+        'all', // Falls back to the whole expense trend
         defaultCategories,
         false,
       );

--- a/__tests__/hooks/useCategoryMonthlySpending.test.js
+++ b/__tests__/hooks/useCategoryMonthlySpending.test.js
@@ -1,5 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
-import useCategoryMonthlySpending from '../../app/hooks/useCategoryMonthlySpending';
+import useCategoryMonthlySpending, { ALL_EXPENSE_CATEGORIES } from '../../app/hooks/useCategoryMonthlySpending';
 import * as OperationsDB from '../../app/services/OperationsDB';
 import * as CategoriesDB from '../../app/services/CategoriesDB';
 import { appEvents, EVENTS } from '../../app/services/eventEmitter';
@@ -131,6 +131,26 @@ describe('useCategoryMonthlySpending', () => {
         [mockCategoryId, 'cat-groceries', 'cat-restaurants'],
         false,
       );
+    });
+
+    it('should query every expense without a category filter for ALL_EXPENSE_CATEGORIES', async () => {
+      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+
+      const { result } = await renderHook(() =>
+        useCategoryMonthlySpending(mockCurrency, ALL_EXPENSE_CATEGORIES, mockCategories),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // null = no category filter at all, so uncategorised expenses count too
+      expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+        mockCurrency,
+        null,
+        false,
+      );
+      expect(CategoriesDB.getAllDescendants).not.toHaveBeenCalled();
     });
 
     it('should filter by selected currency', async () => {

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -3514,4 +3514,50 @@ describe('OperationsDB Service', () => {
       expect(result).toHaveLength(3);
     });
   });
+
+  describe('getLast12MonthsSpendingByCategories', () => {
+    it('filters by the given category ids', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getLast12MonthsSpendingByCategories('USD', ['cat-food', 'cat-groceries']);
+
+      const [sql, params] = queryAll.mock.calls[0];
+      expect(sql).toContain('o.category_id IN (?,?)');
+      expect(params).toEqual(['USD', expect.any(String), expect.any(String), 'cat-food', 'cat-groceries']);
+    });
+
+    it('drops the category filter entirely when categoryIds is null', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getLast12MonthsSpendingByCategories('USD', null);
+
+      const [sql, params] = queryAll.mock.calls[0];
+      expect(sql).not.toContain('category_id');
+      expect(params).toEqual(['USD', expect.any(String), expect.any(String)]);
+    });
+
+    it('sums every expense, including uncategorised ones, when categoryIds is null', async () => {
+      queryAll.mockResolvedValue([
+        { year_month: '2026-07', amount: '10', currency: 'USD' },
+        { year_month: '2026-07', amount: '5.50', currency: 'USD' },
+        { year_month: '2026-06', amount: '3', currency: 'USD' },
+      ]);
+
+      const result = await OperationsDB.getLast12MonthsSpendingByCategories('USD', null);
+
+      expect(result).toEqual([
+        { yearMonth: '2026-06', total: '3' },
+        { yearMonth: '2026-07', total: '15.5' },
+      ]);
+    });
+
+    it('returns an empty result for an empty category list without querying', async () => {
+      queryAll.mockResolvedValue([]);
+
+      const result = await OperationsDB.getLast12MonthsSpendingByCategories('USD', []);
+
+      expect(result).toEqual([]);
+      expect(queryAll).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -6,7 +6,7 @@ import { matchFont, Paint, RoundedRect } from '@shopify/react-native-skia';
 import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
-import useCategoryMonthlySpending from '../../hooks/useCategoryMonthlySpending';
+import useCategoryMonthlySpending, { ALL_EXPENSE_CATEGORIES } from '../../hooks/useCategoryMonthlySpending';
 import { HORIZONTAL_PADDING } from '../../styles/layout';
 import { comparisonSeriesColor } from '../../styles/chartPalette';
 import ModalBlurOverlay from '../ModalBlurOverlay';
@@ -333,27 +333,33 @@ const CategorySpendingCard = ({
     return map;
   }, [parentExpenseCategories, allExpenseCategories]);
 
+  // No pick (or a stale one) means the whole expense trend, not an arbitrary
+  // first category — the default view should describe all spending.
   const effectiveCategory = useMemo(() => {
     if (selectedCategory && allExpenseCategories.some(c => c.id === selectedCategory)) {
       return selectedCategory;
     }
-    return parentExpenseCategories.length > 0 ? parentExpenseCategories[0].id : null;
-  }, [selectedCategory, allExpenseCategories, parentExpenseCategories]);
+    return ALL_EXPENSE_CATEGORIES;
+  }, [selectedCategory, allExpenseCategories]);
 
   const effectiveVsCategory = useMemo(() => {
     if (!vsCategory) return null;
     return allExpenseCategories.some(c => c.id === vsCategory) ? vsCategory : null;
   }, [vsCategory, allExpenseCategories]);
 
+  const isAllCategories = effectiveCategory === ALL_EXPENSE_CATEGORIES;
+
   const selectedCategoryName = useMemo(() => {
+    if (isAllCategories) return t('all_categories');
     const cat = allExpenseCategories.find(c => c.id === effectiveCategory);
     return cat ? cat.name : '';
-  }, [allExpenseCategories, effectiveCategory]);
+  }, [allExpenseCategories, effectiveCategory, isAllCategories, t]);
 
   const selectedCategoryIcon = useMemo(() => {
+    if (isAllCategories) return 'shape-outline';
     const cat = allExpenseCategories.find(c => c.id === effectiveCategory);
     return cat?.icon ?? null;
-  }, [allExpenseCategories, effectiveCategory]);
+  }, [allExpenseCategories, effectiveCategory, isAllCategories]);
 
   const vsCategoryName = useMemo(() => {
     if (!effectiveVsCategory) return '';
@@ -422,6 +428,24 @@ const CategorySpendingCard = ({
 
   const pickerContent = (
     <ScrollView>
+      {/* "All categories" is only offered for the primary series — comparing a
+          category against the total it is part of is not a meaningful vs. */}
+      {pickerMode === 'primary' && (
+        <View style={[styles.parentRow, { borderBottomColor: colors.border }]}>
+          <View style={styles.expandPlaceholder} />
+          <TouchableOpacity
+            style={[
+              styles.categoryItem,
+              isAllCategories && { backgroundColor: colors.selected },
+            ]}
+            onPress={() => handleSelectCategory(ALL_EXPENSE_CATEGORIES)}
+          >
+            <Text style={[styles.categoryText, { color: colors.text }]}>
+              {t('all_categories')}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
       {parentExpenseCategories.map(parent => {
         const children = childrenByParent.get(parent.id) || [];
         const hasChildren = children.length > 0;

--- a/app/hooks/useCategoryMonthlySpending.js
+++ b/app/hooks/useCategoryMonthlySpending.js
@@ -5,11 +5,19 @@ import { getAllDescendants } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 
 /**
+ * Sentinel category id meaning "every expense", not a single category.
+ * Kept distinct from `null` (which means "no series at all", used by the
+ * comparison series when nothing is picked to compare against).
+ */
+export const ALL_EXPENSE_CATEGORIES = 'all';
+
+/**
  * Custom hook for loading monthly spending data for a specific category
  * Shows the last 12 months (rolling window)
  * Includes all descendant categories in the totals
  * @param {string} selectedCurrency - Currency code
- * @param {string|null} selectedCategoryId - Category ID to show spending for
+ * @param {string|null} selectedCategoryId - Category ID to show spending for,
+ *   or ALL_EXPENSE_CATEGORIES for the total across every expense
  * @param {Array} categories - Array of all categories
  */
 const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, categories, convertAllCurrencies = false) => {
@@ -46,9 +54,14 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
     try {
       setLoading(true);
 
-      // Get all descendant category IDs including the selected category itself
-      const descendants = await getAllDescendants(selectedCategoryId);
-      const categoryIds = [selectedCategoryId, ...descendants.map(d => d.id)];
+      // Get all descendant category IDs including the selected category itself.
+      // `null` tells the DB layer to skip the category filter entirely, which
+      // also picks up expenses left uncategorised.
+      let categoryIds = null;
+      if (selectedCategoryId !== ALL_EXPENSE_CATEGORIES) {
+        const descendants = await getAllDescendants(selectedCategoryId);
+        categoryIds = [selectedCategoryId, ...descendants.map(d => d.id)];
+      }
 
       // Get last 12 months spending data
       const spending = await getLast12MonthsSpendingByCategories(

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -2140,7 +2140,9 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
 /**
  * Get spending by categories for the last 12 months (rolling)
  * @param {string} currency - Currency code
- * @param {Array<string>} categoryIds - Category IDs to include
+ * @param {Array<string>|null} categoryIds - Category IDs to include, or `null`
+ *   for every expense (uncategorised operations included). An empty array still
+ *   means "nothing to sum" and returns [].
  * @param {boolean} [convertAll=false] - When true, include operations from every
  *   currency and convert amounts to `currency` at the current exchange rate.
  *   Past months are converted at today's rate too (a single "current rate" view).
@@ -2148,11 +2150,13 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
  */
 export const getLast12MonthsSpendingByCategories = async (currency, categoryIds, convertAll = false) => {
   try {
-    if (!categoryIds || categoryIds.length === 0) {
+    const allCategories = categoryIds === null;
+
+    if (!allCategories && (!categoryIds || categoryIds.length === 0)) {
       return [];
     }
 
-    const placeholders = categoryIds.map(() => '?').join(',');
+    const placeholders = allCategories ? '' : categoryIds.map(() => '?').join(',');
 
     // Calculate date 12 months ago from today
     const now = new Date();
@@ -2163,9 +2167,11 @@ export const getLast12MonthsSpendingByCategories = async (currency, categoryIds,
     // When converting, keep the account currency per row so each amount can be
     // converted to the target currency before being summed into its month.
     const currencyFilter = convertAll ? '' : 'AND a.currency = ?';
+    const categoryFilter = allCategories ? '' : `AND o.category_id IN (${placeholders})`;
+    const categoryParams = allCategories ? [] : categoryIds;
     const params = convertAll
-      ? [startDateStr, endDateStr, ...categoryIds]
-      : [currency, startDateStr, endDateStr, ...categoryIds];
+      ? [startDateStr, endDateStr, ...categoryParams]
+      : [currency, startDateStr, endDateStr, ...categoryParams];
 
     const results = await queryAll(
       `SELECT
@@ -2178,7 +2184,7 @@ export const getLast12MonthsSpendingByCategories = async (currency, categoryIds,
          ${currencyFilter}
          AND o.date >= ?
          AND o.date <= ?
-         AND o.category_id IN (${placeholders})
+         ${categoryFilter}
        ORDER BY year_month ASC`,
       params,
     );


### PR DESCRIPTION
## What

The yearly (12-month) expense trend card no longer preselects a category. By default it shows **all expenses**, with an explicit "All categories" row at the top of the primary category picker so the total view is reachable again after drilling into a category.

## Why

The card used to fall back to the first parent expense category whenever nothing was selected, so the default view described an arbitrary slice of spending rather than the overall trend.

## How

- `useCategoryMonthlySpending` gains an exported `ALL_EXPENSE_CATEGORIES` sentinel. For it, the hook skips the descendant lookup and passes `null` to the DB layer.
- `getLast12MonthsSpendingByCategories` treats `categoryIds === null` as "no category filter" (uncategorised expenses count too). An empty array still means "nothing to sum" and returns `[]`, so existing callers are unaffected.
- `CategorySpendingCard` falls back to the sentinel instead of the first parent category, labels the selector `all_categories` (key already present in all 11 locales), and shows the "All categories" row only in the primary picker — comparing a category against the total it belongs to is not a meaningful vs. The comparison series keeps `null` as "no series", so the two states stay distinct.

## Tests

- New: hook queries with `null` and skips `getAllDescendants` for the sentinel; DB layer drops the `category_id IN (...)` clause and its params for `null`, sums every row, and still short-circuits on `[]`.
- Updated: card defaults to `all_categories`, falls back to `'all'` for a stale id, picks `'all'` from the picker, and hides the row in the vs picker.
- Full suite: 165 suites / 4864 tests green; eslint clean on touched files.
