### PR TITLE
feat(motion): give the budgets month, plan rows and dialogs a spatial story

### DIFF
--- a/app/components/MaterialDialog.js
+++ b/app/components/MaterialDialog.js
@@ -1,9 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, View, Text, StyleSheet, Pressable } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { HORIZONTAL_PADDING } from '../styles/layout';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import ModalBlurOverlay from './ModalBlurOverlay';
+import { TIMING_ENTER } from '../utils/motion';
+
+// The card grows a hair as it fades in. 4%, not 10%: this dialog interrupts,
+// which is a reason to arrive quickly and stop, not to make an entrance.
+const OPEN_SCALE_FROM = 0.96;
+const OPEN_DURATION = 200;
+
+// The card is a Pressable (it swallows taps so they don't reach the dismissing
+// overlay behind it) AND the thing that scales. Animating the Pressable itself
+// rather than wrapping it in an Animated.View keeps `styles.dialog` — which sizes
+// the card at 80% of the overlay — on a single node; a bare wrapper would have
+// had to size itself from its own child's percentage width.
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 /**
  * Material Design Dialog Component
@@ -24,6 +38,27 @@ export default function MaterialDialog({
   onDismiss,
 }) {
   const { colors } = useThemeColors();
+
+  // Every other surface in the app arrives from somewhere — panels slide, sheets
+  // rise, the graph panel grows out of its header. This dialog was the one that
+  // simply existed at full size the moment it was there.
+  //
+  // Only the entry is scripted. The exit stays with `animationType="fade"`,
+  // which unmounts the children as it runs: a scripted exit would need the card
+  // to outlive `visible`, and buying a 150ms shrink with a second copy of the
+  // dialog's visibility state is the wrong trade for the app's most-used modal.
+  //
+  // Scale only. The Modal's own fade already carries the opacity, and animating
+  // it here too would double it into a slower-looking arrival — so the shared
+  // value is the scale itself rather than a 0..1 progress to interpolate off.
+  const scale = useSharedValue(1);
+  useEffect(() => {
+    if (!visible) return;
+    scale.value = OPEN_SCALE_FROM;
+    scale.value = withTiming(1, { ...TIMING_ENTER, duration: OPEN_DURATION });
+  }, [visible, scale]);
+
+  const dialogStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
 
   const handleButtonPress = (button) => {
     if (button.onPress) {
@@ -59,9 +94,9 @@ export default function MaterialDialog({
           style={styles.overlay}
           onPress={onDismiss}
         >
-          <Pressable
+          <AnimatedPressable
             testID="material-dialog-content"
-            style={[styles.dialog, { backgroundColor: colors.card }]}
+            style={[styles.dialog, { backgroundColor: colors.card }, dialogStyle]}
             onPress={() => {}}
           >
             {/* Title */}
@@ -101,7 +136,7 @@ export default function MaterialDialog({
                 </Pressable>
               ))}
             </View>
-          </Pressable>
+          </AnimatedPressable>
         </Pressable>
       </Modal>
     </>

--- a/app/components/budgets/EnvelopeFill.js
+++ b/app/components/budgets/EnvelopeFill.js
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import PropTypes from 'prop-types';
+import { TIMING_ENTER } from '../../utils/motion';
 
 // Tint strength as a hex alpha channel appended to a 6-digit colour.
 //
@@ -12,6 +14,11 @@ import PropTypes from 'prop-types';
 // spent only where there is something to say.
 const CALM_ALPHA = '14'; // ~8%, neutral grey
 const SIGNAL_ALPHA = '2E'; // ~18%, warning / overspend
+
+// How long the wash takes to travel to a new fraction. The curve comes from
+// TIMING_ENTER, so a row settling reads as the same material as the graph panel
+// opening or the quick-add sliding back.
+const FILL_DURATION = 300;
 
 /**
  * A plan row's progress, drawn as the row's own background rather than as a
@@ -33,17 +40,30 @@ const SIGNAL_ALPHA = '2E'; // ~18%, warning / overspend
  *   nothing to flag, which is washed in neutral grey instead
  */
 const EnvelopeFill = ({ fraction, tone = null, mutedColor, testID }) => {
-  const fillPercent = Math.min(Math.max(fraction, 0), 1) * 100;
+  const clamped = Math.min(Math.max(fraction, 0), 1);
   const fillColor = tone ? `${tone}${SIGNAL_ALPHA}` : `${mutedColor}${CALM_ALPHA}`;
+
+  // Drawn as a full-width bar scaled from its left edge rather than as a
+  // percentage width, for two reasons. A `width` in percent is a layout prop, so
+  // animating it re-lays-out the row on the JS thread every frame; `scaleX` is a
+  // transform and runs on the UI thread. And the row is what changes when the
+  // user executes a line right above it — the wash sliding to its new length is
+  // the visible result of that action, where a jump is just a different picture.
+  const fill = useSharedValue(clamped);
+  useEffect(() => {
+    // Seeded with `clamped`, so a row that mounts already at 60% renders there:
+    // this only animates a fraction that changes while the row is on screen.
+    fill.value = withTiming(clamped, { ...TIMING_ENTER, duration: FILL_DURATION });
+  }, [clamped, fill]);
+
+  const fillStyle = useAnimatedStyle(() => ({ transform: [{ scaleX: fill.value }] }));
 
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="none" testID={testID}>
-      {fillPercent > 0 && (
-        <View
-          testID={testID ? `${testID}-bar` : undefined}
-          style={[styles.fill, { width: `${fillPercent}%`, backgroundColor: fillColor }]}
-        />
-      )}
+      <Animated.View
+        testID={testID ? `${testID}-bar` : undefined}
+        style={[styles.fill, { backgroundColor: fillColor }, fillStyle]}
+      />
     </View>
   );
 };
@@ -64,6 +84,10 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     position: 'absolute',
+    right: 0,
     top: 0,
+    // Without this the bar would grow from its centre and the wash would detach
+    // from the row's left edge.
+    transformOrigin: 'left',
   },
 });

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -1,11 +1,18 @@
-import React, { memo, useRef } from 'react';
+import React, { memo, useRef, useEffect } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { Swipeable } from 'react-native-gesture-handler';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import EnvelopeFill from './EnvelopeFill';
 import { SPACING } from '../../styles/layout';
+import { SPRING_BADGE_POP } from '../../utils/motion';
+
+// Where the badge springs from when its state flips. Not 0: a glyph growing out
+// of nothing reads as an element arriving, and this one was already there — it
+// changed what it says.
+const BADGE_POP_FROM = 0.4;
 
 // Stands in for a foreign-currency amount while its exchange rate resolves — an
 // em dash rather than the stored figure, which would read as a number in the
@@ -130,6 +137,27 @@ const PlanLineRow = memo(function PlanLineRow({
     handler?.(line);
   };
 
+  // Executing a line is a swipe, a row that slides back, and then a 13dp glyph
+  // that silently becomes a different glyph — the only evidence on the row that
+  // anything happened at all (the amount pair moves too, but by an amount the
+  // user cannot predict, so it does not read as a confirmation). The pop is that
+  // confirmation.
+  //
+  // Skipped on the first render: rows arrive already done or already pending
+  // when the month loads, and a card full of popping badges on every mount would
+  // announce nothing.
+  const badgeScale = useSharedValue(1);
+  const badgeSettled = useRef(false);
+  useEffect(() => {
+    if (!badgeSettled.current) {
+      badgeSettled.current = true;
+      return;
+    }
+    badgeScale.value = BADGE_POP_FROM;
+    badgeScale.value = withSpring(1, SPRING_BADGE_POP);
+  }, [executed, badgeScale]);
+  const badgeStyle = useAnimatedStyle(() => ({ transform: [{ scale: badgeScale.value }] }));
+
   // The scope and template state moved from a text line into a glyph and an icon
   // badge, which a screen reader cannot announce — so they are spelled out here
   // instead. Sighted density and non-visual completeness are not the same
@@ -169,19 +197,19 @@ const PlanLineRow = memo(function PlanLineRow({
               occupy the same 13dp corner, so the row height doesn't move
               between states. */}
           {executed ? (
-            <View
+            <Animated.View
               testID={`plan-line-check-${line.id}`}
-              style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.income }]}
+              style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.income }, badgeStyle]}
             >
               <Icon name="check" size={7} color="white" />
-            </View>
+            </Animated.View>
           ) : line.hasTemplate ? (
-            <View
+            <Animated.View
               testID={`plan-line-pending-${line.id}`}
-              style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.primary }]}
+              style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.primary }, badgeStyle]}
             >
               <Icon name="play" size={7} color="white" />
-            </View>
+            </Animated.View>
           ) : null}
         </View>
         <View style={styles.lineBody}>

--- a/app/screens/BudgetScreen.js
+++ b/app/screens/BudgetScreen.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { View, StyleSheet, FlatList, Pressable } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { Text, Snackbar } from 'react-native-paper';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -14,6 +15,7 @@ import LoadingView from '../components/LoadingView';
 import * as Currency from '../services/currency';
 import { SPACING } from '../styles/layout';
 import { currentMonthKey, addMonths, formatMonthLabel } from '../utils/monthUtils';
+import { TIMING_ENTER } from '../utils/motion';
 
 // The Budgets screen is a single month-scoped list rendered by
 // MonthlyPlanSection (Budgets v3: the per-category budgets list, the monthly plan
@@ -26,6 +28,20 @@ const renderNothing = () => null;
 // Stands in for the header's remainder until the plan section has computed and
 // reported one.
 const PENDING_PLACEHOLDER = '—';
+
+// How far the plan travels when the month changes, and for how long.
+//
+// 20dp, not a screen width. The tab strip already owns full-bleed horizontal
+// travel (SimpleTabs swipes between tabs), so a plan that slid the whole way
+// would claim to be a second pager on the same axis. This is a directional hint:
+// enough to say "later" or "earlier", not enough to be mistaken for navigation.
+//
+// Nothing animates out. The two months would have to be mounted at once for
+// that, and they stack vertically inside the FlatList header — the exiting copy
+// would push the incoming one down the screen. The graph panel resolved the same
+// problem the same way (chartTransitions.js): a fade through, not a cross-fade.
+const MONTH_SHIFT = 20;
+const MONTH_TRANSITION_DURATION = 280;
 
 const BudgetScreen = () => {
   const { colors } = useThemeColors();
@@ -48,7 +64,14 @@ const BudgetScreen = () => {
 
   // The whole screen is scoped to one month via a single shared ‹ Month › header;
   // MonthlyPlanSection is controlled from here.
-  const [month, setMonth] = useState(currentMonthKey);
+  //
+  // The direction of travel rides along with the key rather than living in its
+  // own state: it is only ever meaningful for the render that the new month
+  // causes, and two separate setState calls could be batched into an order where
+  // the plan animates the wrong way. `dir` is null on the first render, which is
+  // what keeps the screen from animating on mount.
+  const [monthState, setMonthState] = useState(() => ({ key: currentMonthKey(), dir: null }));
+  const month = monthState.key;
   const isCurrentMonth = month === currentMonthKey();
 
   const [snackbarVisible, setSnackbarVisible] = useState(false);
@@ -83,15 +106,49 @@ const BudgetScreen = () => {
     ));
   }, []);
 
-  const handlePrevMonth = useCallback(() => setMonth(m => addMonths(m, -1)), []);
-  const handleNextMonth = useCallback(() => setMonth(m => addMonths(m, 1)), []);
+  const handlePrevMonth = useCallback(() => setMonthState(s => ({ key: addMonths(s.key, -1), dir: -1 })), []);
+  const handleNextMonth = useCallback(() => setMonthState(s => ({ key: addMonths(s.key, 1), dir: 1 })), []);
   // Explicit affordance for Fix 4: the screen stays mounted across tab
   // switches, so a user who navigates away from the current month and comes
   // back later would otherwise land on a stale month with the executable
   // templates non-executable (isCurrentMonth === false) and no obvious way
   // back. Surface a visible "jump to current month" control instead of
   // silently auto-resetting the month on focus.
-  const handleJumpToCurrentMonth = useCallback(() => setMonth(currentMonthKey()), []);
+  //
+  // The jump can go either way, so the direction is read off the keys. They are
+  // 'YYYY-MM', so a plain string compare orders them. Returning the same object
+  // when the user is already on the current month keeps the plan from re-rendering
+  // (and from animating) for a tap that changes nothing.
+  const handleJumpToCurrentMonth = useCallback(() => setMonthState(s => {
+    const key = currentMonthKey();
+    return key === s.key ? s : { key, dir: key > s.key ? 1 : -1 };
+  }), []);
+
+  // Month navigation is the Budgets tab's primary axis, and it was the only
+  // navigation in the app with no spatial story: the sticky header said a new
+  // month and the entire plan under it was simply replaced, mid-scroll, with no
+  // indication of which way through the year the user had moved.
+  //
+  // Driven by a shared value rather than by Reanimated's `entering` on a keyed
+  // view, because remounting the FlatList's header on every month would reset the
+  // scroll position — the plan would jump to the top as well as change.
+  // One value drives both the fade and the travel: they are the same 0→1
+  // arrival, so a second animation with an identical config would only be a
+  // second thing that can fall out of sync. `monthDir` is set, never animated —
+  // it is which way this particular arrival comes from.
+  const monthProgress = useSharedValue(1);
+  const monthDir = useSharedValue(0);
+  useEffect(() => {
+    if (monthState.dir === null) return;
+    monthDir.value = monthState.dir;
+    monthProgress.value = 0;
+    monthProgress.value = withTiming(1, { ...TIMING_ENTER, duration: MONTH_TRANSITION_DURATION });
+  }, [monthState, monthProgress, monthDir]);
+
+  const monthTransitionStyle = useAnimatedStyle(() => ({
+    opacity: monthProgress.value,
+    transform: [{ translateX: (1 - monthProgress.value) * monthDir.value * MONTH_SHIFT }],
+  }));
 
   // Memoize unique currencies from accounts
   const currencies = useMemo(() =>
@@ -285,13 +342,20 @@ const BudgetScreen = () => {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]} testID="budget-screen">
       {monthHeader}
-      <FlatList
-        data={EMPTY_LIST}
-        keyExtractor={(item) => item.id}
-        renderItem={renderNothing}
-        ListHeaderComponent={listHeader}
-        contentContainerStyle={styles.listContent}
-      />
+      {/* The scrolling layer as a whole is what belongs to the month, so it is
+          what moves — wrapping the memoized header instead would have put an
+          animated style into that memo's dependencies, and a style object that
+          ever stopped being referentially stable would rebuild the entire plan
+          on every render of this screen. */}
+      <Animated.View style={[styles.planLayer, monthTransitionStyle]} testID="budget-plan-transition">
+        <FlatList
+          data={EMPTY_LIST}
+          keyExtractor={(item) => item.id}
+          renderItem={renderNothing}
+          ListHeaderComponent={listHeader}
+          contentContainerStyle={styles.listContent}
+        />
+      </Animated.View>
 
       <AddFAB
         onPress={handleOpenAddAllocation}
@@ -395,6 +459,11 @@ const styles = StyleSheet.create({
   },
   navButton: {
     padding: 4,
+  },
+  // The animated wrapper sits between the screen's column and the FlatList, so
+  // it has to pass the remaining height through or the list collapses to nothing.
+  planLayer: {
+    flex: 1,
   },
   snackbar: {
     marginBottom: 100,

--- a/app/screens/LanguageSelectionScreen.js
+++ b/app/screens/LanguageSelectionScreen.js
@@ -8,6 +8,7 @@ import {
   StatusBar,
   Platform,
 } from 'react-native';
+import Animated, { FadeInDown, Easing, ReduceMotion } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import enTranslations from '../../assets/i18n/en.json';
 import itTranslations from '../../assets/i18n/it.json';
@@ -18,6 +19,27 @@ import zhTranslations from '../../assets/i18n/zh.json';
 import deTranslations from '../../assets/i18n/de.json';
 import hyTranslations from '../../assets/i18n/hy.json';
 import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING } from '../styles/layout';
+
+// This is the only screen in the app a user sees exactly once, and it is where
+// the whole motion budget for first-run lives: everywhere else in Penny is a
+// screen people open every day, which argues for less movement, not more.
+//
+// The gap between cards. Seven of them at 45ms trails ~570ms behind the title,
+// which is longer than anything else in the app is allowed to take — permissible
+// only because nothing waits on it: the buttons are laid out and pressable from
+// the first frame, the animation is purely how they arrive.
+const ENTRY_STAGGER = 45;
+const ENTRY_DURATION = 260;
+// Rise distance. Small enough that a card never starts outside its own row, so
+// the stagger reads as one list settling rather than as seven things flying in.
+const ENTRY_RISE = 12;
+
+const entry = (index) => FadeInDown
+  .delay(index * ENTRY_STAGGER)
+  .duration(ENTRY_DURATION)
+  .easing(Easing.out(Easing.cubic))
+  .withInitialValues({ transform: [{ translateY: ENTRY_RISE }] })
+  .reduceMotion(ReduceMotion.System);
 
 // Map language codes to their translation data
 const i18nData = {
@@ -65,47 +87,50 @@ const LanguageSelectionScreen = ({ onLanguageSelected }) => {
       <StatusBar barStyle="dark-content" backgroundColor="#ffffff" />
       <View style={styles.container}>
         <View style={styles.content}>
-          <Text style={styles.title}>{t('welcome_title')}</Text>
-          <Text style={styles.subtitle}>{t('welcome_subtitle')}</Text>
+          {/* Title and subtitle lead the stagger at slots 0 and 1, so the cards
+              below them read as continuing a movement rather than starting one. */}
+          <Animated.Text entering={entry(0)} style={styles.title}>{t('welcome_title')}</Animated.Text>
+          <Animated.Text entering={entry(1)} style={styles.subtitle}>{t('welcome_subtitle')}</Animated.Text>
 
           <View style={styles.languagesContainer}>
-            {languages.map((language) => (
-              <TouchableOpacity
-                key={language.code}
-                style={[
-                  styles.languageButton,
-                  selectedLanguage === language.code && styles.languageButtonSelected,
-                ]}
-                onPress={() => handleLanguageSelect(language.code)}
-                accessibilityRole="button"
-                accessibilityLabel={`Select ${language.name}`}
-                accessibilityState={{ selected: selectedLanguage === language.code }}
-              >
-                <Text style={styles.flag}>{language.flag}</Text>
-                <View style={styles.languageTextContainer}>
-                  <Text
-                    style={[
-                      styles.languageName,
-                      selectedLanguage === language.code && styles.languageNameSelected,
-                    ]}
-                  >
-                    {language.nativeName}
-                  </Text>
-                  <Text
-                    style={[
-                      styles.languageEnglishName,
-                      selectedLanguage === language.code && styles.languageEnglishNameSelected,
-                    ]}
-                  >
-                    {language.name}
-                  </Text>
-                </View>
-                {selectedLanguage === language.code && (
-                  <View style={styles.checkmark}>
-                    <Text style={styles.checkmarkText}>✓</Text>
+            {languages.map((language, index) => (
+              <Animated.View key={language.code} entering={entry(index + 2)}>
+                <TouchableOpacity
+                  style={[
+                    styles.languageButton,
+                    selectedLanguage === language.code && styles.languageButtonSelected,
+                  ]}
+                  onPress={() => handleLanguageSelect(language.code)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Select ${language.name}`}
+                  accessibilityState={{ selected: selectedLanguage === language.code }}
+                >
+                  <Text style={styles.flag}>{language.flag}</Text>
+                  <View style={styles.languageTextContainer}>
+                    <Text
+                      style={[
+                        styles.languageName,
+                        selectedLanguage === language.code && styles.languageNameSelected,
+                      ]}
+                    >
+                      {language.nativeName}
+                    </Text>
+                    <Text
+                      style={[
+                        styles.languageEnglishName,
+                        selectedLanguage === language.code && styles.languageEnglishNameSelected,
+                      ]}
+                    >
+                      {language.name}
+                    </Text>
                   </View>
-                )}
-              </TouchableOpacity>
+                  {selectedLanguage === language.code && (
+                    <View style={styles.checkmark}>
+                      <Text style={styles.checkmarkText}>✓</Text>
+                    </View>
+                  )}
+                </TouchableOpacity>
+              </Animated.View>
             ))}
           </View>
         </View>

--- a/app/utils/motion.js
+++ b/app/utils/motion.js
@@ -21,6 +21,8 @@
  * mid-flight (i.e. when the user grabs a moving surface again).
  */
 
+import { Easing } from 'react-native-reanimated';
+
 /**
  * Critically damped spring for releasing a gesture (Reanimated).
  *
@@ -47,6 +49,44 @@ export const SPRING_SETTLE = {
   duration: 350,
   dampingRatio: 1,
   overshootClamping: true,
+  reduceMotion: 'system',
+};
+
+/**
+ * The app's entry curve, for the surfaces that arrive on a timing rather than
+ * off a gesture: decelerating, so a thing slows into place instead of stopping.
+ *
+ * Carries no duration — arrival distances differ (a dialog is not a month of
+ * plan), so each caller states its own and spreads this in for the rest:
+ *   withTiming(1, { ...TIMING_ENTER, duration: 280 })
+ *
+ * `reduceMotion` is the point of having this at all. It is the one property that
+ * is easy to leave off and impossible to see missing, and omitting it means the
+ * surface ignores the OS "Remove animations" setting. Spreading this makes the
+ * accessible behaviour the default rather than something each call site
+ * remembers.
+ */
+export const TIMING_ENTER = {
+  easing: Easing.out(Easing.cubic),
+  reduceMotion: 'system',
+};
+
+/**
+ * Spring for a small badge or glyph confirming that an action landed.
+ *
+ * The deliberate opposite of SPRING_SETTLE on the one point that matters:
+ * overshoot is welcome here. SPRING_SETTLE clamps it because every surface it
+ * drives is a full-bleed layer, and travelling past the resting place would
+ * expose empty background behind it. A 13dp badge sitting on top of a row has
+ * nothing behind it to expose, and the small bounce is what makes the moment
+ * read as "done" rather than as a re-render.
+ *
+ * `dampingRatio: 0.55` is under-damped enough to see once and not enough to
+ * wobble; `duration` is the response, as in SPRING_SETTLE.
+ */
+export const SPRING_BADGE_POP = {
+  duration: 320,
+  dampingRatio: 0.55,
   reduceMotion: 'system',
 };
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -918,6 +918,16 @@ jest.mock('react-native-reanimated', () => {
   const React = require('react');
   const { View, Text, Image, ScrollView } = require('react-native');
 
+  // Layout animation builders are chainable and every method returns the
+  // builder, so one self-returning object stands in for the whole family.
+  const layoutAnimationMock = () => {
+    const o = {};
+    for (const method of ['duration', 'easing', 'delay', 'springify', 'withInitialValues', 'reduceMotion', 'withCallback']) {
+      o[method] = jest.fn(() => o);
+    }
+    return o;
+  };
+
   return {
     __esModule: true,
     default: {
@@ -967,15 +977,25 @@ jest.mock('react-native-reanimated', () => {
       delay(ms) { return this; }
       withCallback(callback) { return this; }
     },
-    FadeIn: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    FadeOut: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    FadeInRight: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    FadeInLeft: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    SlideInRight: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    SlideInLeft: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    SlideOutLeft: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    SlideOutRight: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); return o; })(),
-    LinearTransition: (() => { const o = {}; o.duration = jest.fn(() => o); o.easing = jest.fn(() => o); o.springify = jest.fn(() => o); return o; })(),
+    FadeIn: layoutAnimationMock(),
+    FadeOut: layoutAnimationMock(),
+    FadeInDown: layoutAnimationMock(),
+    FadeInUp: layoutAnimationMock(),
+    FadeInRight: layoutAnimationMock(),
+    FadeInLeft: layoutAnimationMock(),
+    SlideInRight: layoutAnimationMock(),
+    SlideInLeft: layoutAnimationMock(),
+    SlideOutLeft: layoutAnimationMock(),
+    SlideOutRight: layoutAnimationMock(),
+    LinearTransition: layoutAnimationMock(),
+    // Reanimated resolves 'system' against the OS accessibility setting at
+    // runtime; under test there is no such setting, so the enum just needs to
+    // carry stable values for the components that pass it through.
+    ReduceMotion: {
+      System: 'system',
+      Always: 'always',
+      Never: 'never',
+    },
     SharedValue: class SharedValue {
       constructor(value) { this.value = value; }
     },


### PR DESCRIPTION
Five surfaces that changed state instantly now say what happened. Found by sweeping the app for animation gaps and rejecting most candidates — the app is already motion-mature (velocity handoff, rubber-banding, the graph panel's fade-through, the subpanel pattern), so this is about the places that were left flat, not about adding movement.

## What changed

**1. Budgets month navigation** — `app/screens/BudgetScreen.js`

The Budgets tab's primary axis is time, and it was the only navigation in the app with no spatial story: the sticky header named a new month and the entire plan under it was replaced, mid-scroll, with no indication of which way through the year the user had moved. Every other axis (tabs, subpanels, category drill-down, charts) is carefully animated.

Now a fade-through with a 20dp directional shift. Notes on the shape:

- **20dp, not a screen width.** `SimpleTabs` already owns full-bleed horizontal travel; a plan that slid the whole way would claim to be a second pager on the same axis. This is a directional hint, not navigation.
- **No exit animation.** Both months would have to be mounted at once, and they stack vertically inside the `FlatList` header — the exiting copy would push the incoming one down the screen. `chartTransitions.js` resolved the identical problem the identical way.
- **Direction rides inside the month state** (`{key, dir}`), not in its own `useState`. Two separate setState calls could batch into an order where the plan animates the wrong way.
- **Driven by a shared value, not `entering` on a keyed view** — remounting the header would reset scroll position, so the plan would jump to the top as well as change.
- The animated wrapper is around the `FlatList`, not around the memoized header: putting an animated style into that memo's dependencies means any loss of referential stability rebuilds the whole plan on every render.

**2. Plan line badges** — `app/components/budgets/PlanLineRow.js`

Executing a line is a swipe, a row sliding back, and then a 13dp glyph silently becoming a different glyph. The badge is the only evidence on the row that anything happened (the amount pair moves too, but by an amount the user can't predict, so it doesn't read as confirmation). It springs now. First render is skipped — rows arrive already done or already pending when a month loads, and a card full of popping badges on mount announces nothing.

**3. `EnvelopeFill`** — `app/components/budgets/EnvelopeFill.js`

The wash travels to its new fraction instead of jumping. Drawn as `scaleX` off a full-width bar with `transformOrigin: 'left'` rather than a percentage width: a percent width is a layout prop, so animating it re-lays-out the row on the JS thread every frame. The shared value is seeded with the current fraction, so only a change while the row is on screen animates — mounting at 60% renders at 60%.

**4. First-run language screen** — `app/screens/LanguageSelectionScreen.js`

The one screen a user sees exactly once, and where the motion budget for first-run belongs — everywhere else in Penny is a screen people open every day, which argues for less movement, not more. Title and subtitle lead the stagger at slots 0 and 1 so the cards read as continuing a movement rather than starting one. Nothing waits on it: the buttons are laid out and pressable from the first frame.

**5. `MaterialDialog`** — `app/components/MaterialDialog.js`

Scales up 4% as it fades in — the same arrival every other surface in the app already had. Only the entry is scripted; the exit stays with `animationType="fade"`, since a scripted exit would need the card to outlive `visible`, and a second copy of the dialog's visibility state is the wrong trade for the app's most-used modal. `createAnimatedComponent(Pressable)` rather than a wrapper view, so `styles.dialog`'s `width: '80%'` stays on one node.

## Shared vocabulary

`TIMING_ENTER` and `SPRING_BADGE_POP` join `SPRING_SETTLE` in `app/utils/motion.js` rather than five local copies of the same config.

`TIMING_ENTER` carries `reduceMotion` deliberately: it's the one property that's easy to leave off and impossible to see missing, and omitting it means the surface ignores the OS "Remove animations" setting. Spreading it makes the accessible behaviour the default instead of something each call site remembers.

`SPRING_BADGE_POP` is the deliberate opposite of `SPRING_SETTLE` on overshoot. `SPRING_SETTLE` clamps it because every surface it drives is a full-bleed layer where travelling past rest exposes empty background; a 13dp badge on top of a row has nothing behind it, and the small bounce is what makes the moment read as "done" rather than as a re-render.

## Test mock

`jest.setup.js` gained `ReduceMotion` and `FadeInDown`, and its nine copy-pasted layout-animation builder IIFEs collapsed into one factory that also covers `delay` / `withInitialValues` / `reduceMotion`.

## Verification

- `npx jest --silent` — 166 suites, 4894 tests, all passing
- `npx eslint app jest.setup.js --ext .js,.jsx --max-warnings 0` — clean
- `FadeInDown.withInitialValues` override shape checked against the installed Reanimated source (`initialValues: { opacity: 0, transform: [{ translateY: 25 }], ...initialValues }`), and `useAnimatedStyle`'s referential stability confirmed the same way (returns `useRef.current`) before relying on it in a `useMemo` dependency list.

Not verified on a device — the motion values are reasoned from the repo's existing timings rather than watched. Worth a look on the emulator before merge, particularly the Budgets month transition.
