### PR TITLE
fix(graphs): move the drill-down category chip under the donut

### DIFF
--- a/__tests__/components/graphs/CategoryBackChip.test.js
+++ b/__tests__/components/graphs/CategoryBackChip.test.js
@@ -2,9 +2,9 @@
  * CategoryBackChip Component Tests
  *
  * The chip shows which category a summary tab is drilled into and pops back to
- * its parent. It is rendered as an overlay above the tab strip rather than
- * inside a tab, so it must stay tappable without swallowing taps meant for the
- * tab underneath it.
+ * its parent. It renders inside the open chart (under the donut) rather than
+ * over the tab strip, where it used to cover the tab's own title — placement is
+ * the chart's job, so this component is just a self-sizing button.
  */
 
 import React from 'react';
@@ -22,7 +22,6 @@ describe('CategoryBackChip', () => {
     label: 'Food',
     backLabel: 'back',
     onPress: jest.fn(),
-    side: 'left',
   };
 
   beforeEach(() => {
@@ -58,34 +57,17 @@ describe('CategoryBackChip', () => {
     });
   });
 
-  describe('Overlay behaviour', () => {
-    // Without box-none the wrapper would blanket half the tab strip and eat
-    // every tap aimed at the tab beneath it.
-    it('lets taps that miss the chip fall through to the tab underneath', async () => {
+  describe('Sizing', () => {
+    // Under the donut the chip's slot is only as wide as the donut, so it has to
+    // cap itself there and ellipsise rather than stretch the row.
+    it('never grows past the slot it is placed in', async () => {
       const { getByTestId } = await render(
         <CategoryBackChip {...defaultProps} testID="chip" />,
       );
 
-      const wrapper = getByTestId('chip').parent;
+      const style = Object.assign({}, ...[].concat(getByTestId('chip').props.style));
 
-      expect(wrapper.props.pointerEvents).toBe('box-none');
-    });
-
-    it('sits over the half of the strip that owns it', async () => {
-      const { getByTestId, rerender } = await render(
-        <CategoryBackChip {...defaultProps} side="left" testID="chip" />,
-      );
-
-      const styleOf = () => {
-        const style = getByTestId('chip').parent.props.style;
-        return Object.assign({}, ...[].concat(style));
-      };
-
-      expect(styleOf()).toEqual(expect.objectContaining({ left: 0, width: '50%' }));
-
-      await rerender(<CategoryBackChip {...defaultProps} side="right" testID="chip" />);
-
-      expect(styleOf()).toEqual(expect.objectContaining({ right: 0, width: '50%' }));
+      expect(style.maxWidth).toBe('100%');
     });
   });
 

--- a/__tests__/components/graphs/ExpensePieChart.test.js
+++ b/__tests__/components/graphs/ExpensePieChart.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { render, within } from '@testing-library/react-native';
 import ExpensePieChart from '../../../app/components/graphs/ExpensePieChart';
+import { CHART_SIZE } from '../../../app/components/graphs/DonutChart';
 
 jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
   useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
@@ -63,7 +65,8 @@ describe('ExpensePieChart', () => {
   it('anchors the donut to the top of the row so it does not move with the legend', async () => {
     const { getByTestId } = await render(<ExpensePieChart {...defaultProps} />);
 
-    const row = getByTestId('donut-chart').parent;
+    // donut → its own column (which also holds the drill-down chip) → the row
+    const row = getByTestId('donut-chart').parent.parent;
     const rowStyle = Object.assign({}, ...[].concat(row.props.style));
 
     expect(rowStyle.alignItems).toBe('flex-start');
@@ -86,6 +89,50 @@ describe('ExpensePieChart', () => {
     // Other 4.5% — below 10%
     const { queryAllByTestId } = await render(<ExpensePieChart {...defaultProps} />);
     expect(queryAllByTestId('icon-dots-horizontal').length).toBe(0);
+  });
+
+  // The drill-down chip used to be an overlay on the tab strip, where it covered
+  // the tab's own title. It now travels with the chart body.
+  describe('drill-down chip', () => {
+    const chip = <Text testID="category-chip">Food</Text>;
+
+    it('places the chip under the donut rather than beside the legend', async () => {
+      const { getByTestId } = await render(
+        <ExpensePieChart {...defaultProps} categoryChip={chip} />,
+      );
+
+      const column = getByTestId('donut-chart').parent;
+      const columnStyle = Object.assign({}, ...[].concat(column.props.style));
+
+      // Same column as the donut, capped at the donut's width, and after it
+      expect(within(column).getByTestId('category-chip')).toBeTruthy();
+      expect(columnStyle.width).toBe(CHART_SIZE);
+      expect(column.children.indexOf(getByTestId('donut-chart'))).toBe(0);
+    });
+
+    it('keeps the chip reachable when the drill-down bottoms out in a list', async () => {
+      const { getByTestId } = await render(
+        <ExpensePieChart {...defaultProps} isLeafCategory={true} operations={[]} categoryChip={chip} />,
+      );
+
+      expect(getByTestId('category-chip')).toBeTruthy();
+    });
+
+    it('keeps the chip reachable while the category loads', async () => {
+      const { getByTestId } = await render(
+        <ExpensePieChart {...defaultProps} loading={true} categoryChip={chip} />,
+      );
+
+      expect(getByTestId('category-chip')).toBeTruthy();
+    });
+
+    it('keeps the chip reachable when the category has no data', async () => {
+      const { getByTestId } = await render(
+        <ExpensePieChart {...defaultProps} chartData={[]} categoryChip={chip} />,
+      );
+
+      expect(getByTestId('category-chip')).toBeTruthy();
+    });
   });
 
   describe('leaf category (operations list)', () => {

--- a/__tests__/components/graphs/ExpenseSummaryCard.test.js
+++ b/__tests__/components/graphs/ExpenseSummaryCard.test.js
@@ -244,8 +244,9 @@ describe('ExpenseSummaryCard', () => {
   });
 
   // The drill-down chip used to be an overlay inside this card. It now lives in
-  // CategoryBackChip, rendered by GraphsScreen above the tab strip, so that a
-  // button is never nested inside the tab button — see CategoryBackChip.test.js.
+  // CategoryBackChip, which GraphsScreen hands to the open chart to render under
+  // the donut, so a button is never nested inside the tab button — see
+  // CategoryBackChip.test.js.
   describe('nested controls', () => {
     it('renders no button other than the tab itself', async () => {
       const { getAllByRole } = await render(<ExpenseSummaryCard {...defaultProps} />);

--- a/__tests__/components/graphs/IncomePieChart.test.js
+++ b/__tests__/components/graphs/IncomePieChart.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { render, within } from '@testing-library/react-native';
 import IncomePieChart from '../../../app/components/graphs/IncomePieChart';
+import { CHART_SIZE } from '../../../app/components/graphs/DonutChart';
 
 jest.mock('../../../app/contexts/DisplaySettingsContext', () => ({
   useDisplaySettings: jest.fn(() => ({ hideBalances: false })),
@@ -63,7 +65,8 @@ describe('IncomePieChart', () => {
   it('anchors the donut to the top of the row so it does not move with the legend', async () => {
     const { getByTestId } = await render(<IncomePieChart {...defaultProps} />);
 
-    const row = getByTestId('donut-chart').parent;
+    // donut → its own column (which also holds the drill-down chip) → the row
+    const row = getByTestId('donut-chart').parent.parent;
     const rowStyle = Object.assign({}, ...[].concat(row.props.style));
 
     expect(rowStyle.alignItems).toBe('flex-start');
@@ -86,6 +89,50 @@ describe('IncomePieChart', () => {
     // Other 1.6% — below 10%
     const { queryAllByTestId } = await render(<IncomePieChart {...defaultProps} />);
     expect(queryAllByTestId('icon-dots-horizontal').length).toBe(0);
+  });
+
+  // The drill-down chip used to be an overlay on the tab strip, where it covered
+  // the tab's own title. It now travels with the chart body.
+  describe('drill-down chip', () => {
+    const chip = <Text testID="category-chip">Salary</Text>;
+
+    it('places the chip under the donut rather than beside the legend', async () => {
+      const { getByTestId } = await render(
+        <IncomePieChart {...defaultProps} categoryChip={chip} />,
+      );
+
+      const column = getByTestId('donut-chart').parent;
+      const columnStyle = Object.assign({}, ...[].concat(column.props.style));
+
+      // Same column as the donut, capped at the donut's width, and after it
+      expect(within(column).getByTestId('category-chip')).toBeTruthy();
+      expect(columnStyle.width).toBe(CHART_SIZE);
+      expect(column.children.indexOf(getByTestId('donut-chart'))).toBe(0);
+    });
+
+    it('keeps the chip reachable when the drill-down bottoms out in a list', async () => {
+      const { getByTestId } = await render(
+        <IncomePieChart {...defaultProps} isLeafCategory={true} operations={[]} categoryChip={chip} />,
+      );
+
+      expect(getByTestId('category-chip')).toBeTruthy();
+    });
+
+    it('keeps the chip reachable while the category loads', async () => {
+      const { getByTestId } = await render(
+        <IncomePieChart {...defaultProps} loadingIncome={true} categoryChip={chip} />,
+      );
+
+      expect(getByTestId('category-chip')).toBeTruthy();
+    });
+
+    it('keeps the chip reachable when the category has no data', async () => {
+      const { getByTestId } = await render(
+        <IncomePieChart {...defaultProps} incomeChartData={[]} categoryChip={chip} />,
+      );
+
+      expect(getByTestId('category-chip')).toBeTruthy();
+    });
   });
 
   describe('leaf category (operations list)', () => {

--- a/__tests__/components/graphs/IncomeSummaryCard.test.js
+++ b/__tests__/components/graphs/IncomeSummaryCard.test.js
@@ -236,8 +236,9 @@ describe('IncomeSummaryCard', () => {
   });
 
   // The drill-down chip used to be an overlay inside this card. It now lives in
-  // CategoryBackChip, rendered by GraphsScreen above the tab strip, so that a
-  // button is never nested inside the tab button — see CategoryBackChip.test.js.
+  // CategoryBackChip, which GraphsScreen hands to the open chart to render under
+  // the donut, so a button is never nested inside the tab button — see
+  // CategoryBackChip.test.js.
   describe('nested controls', () => {
     it('renders no button other than the tab itself', async () => {
       const { getAllByRole } = await render(<IncomeSummaryCard {...defaultProps} />);

--- a/app/components/graphs/CategoryBackChip.js
+++ b/app/components/graphs/CategoryBackChip.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 
@@ -7,30 +7,25 @@ import PropTypes from 'prop-types';
  * Shows the category a summary tab is currently drilled into, and pops back to
  * its parent when tapped.
  *
- * Rendered by GraphsScreen as an overlay above the tab strip rather than inside
- * the tab itself: the tab is already a button, and a button nested in a button
- * reads as two controls to a screen reader. `box-none` on the wrapper lets taps
- * that miss the chip fall through to the tab underneath.
+ * Rendered inside the open chart — under the donut, or above the operations list
+ * once the drill-down bottoms out — rather than over the tab strip: as an overlay
+ * it sat on top of the tab's own title. It stays outside the tab button either
+ * way, since a button nested in a button reads as two controls to a screen reader.
  */
-const CategoryBackChip = ({ colors, label, backLabel, onPress, side, testID }) => (
-  <View
-    style={[styles.overlay, side === 'left' ? styles.overlayLeft : styles.overlayRight]}
-    pointerEvents="box-none"
+const CategoryBackChip = ({ colors, label, backLabel, onPress, testID }) => (
+  <TouchableOpacity
+    testID={testID}
+    onPress={onPress}
+    style={[styles.chip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+    activeOpacity={0.7}
+    accessibilityRole="button"
+    accessibilityLabel={backLabel}
   >
-    <TouchableOpacity
-      testID={testID}
-      onPress={onPress}
-      style={[styles.chip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
-      activeOpacity={0.7}
-      accessibilityRole="button"
-      accessibilityLabel={backLabel}
-    >
-      <Text style={[styles.chipText, { color: colors.text }]} numberOfLines={1}>
-        {label}
-      </Text>
-      <Icon name="close-circle" size={14} color={colors.mutedText} />
-    </TouchableOpacity>
-  </View>
+    <Text style={[styles.chipText, { color: colors.text }]} numberOfLines={1}>
+      {label}
+    </Text>
+    <Icon name="close-circle" size={14} color={colors.mutedText} />
+  </TouchableOpacity>
 );
 
 CategoryBackChip.propTypes = {
@@ -38,7 +33,6 @@ CategoryBackChip.propTypes = {
   label: PropTypes.string.isRequired,
   backLabel: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
-  side: PropTypes.oneOf(['left', 'right']).isRequired,
   testID: PropTypes.string,
 };
 
@@ -49,7 +43,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     flexDirection: 'row',
     gap: 4,
-    maxWidth: '75%',
+    // Never wider than the slot it sits in — under the donut that slot is the
+    // donut's own width, so a long category name ellipsises instead of pushing
+    // the legend around.
+    maxWidth: '100%',
     paddingHorizontal: 10,
     paddingVertical: 4,
   },
@@ -57,21 +54,6 @@ const styles = StyleSheet.create({
     flexShrink: 1,
     fontSize: 13,
     fontWeight: '600',
-  },
-  overlay: {
-    alignItems: 'center',
-    bottom: 0,
-    justifyContent: 'center',
-    position: 'absolute',
-    top: 0,
-    // Each tab owns half the strip, so the chip is centred over its own half
-    width: '50%',
-  },
-  overlayLeft: {
-    left: 0,
-  },
-  overlayRight: {
-    right: 0,
   },
 });
 

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
-import DonutChart from './DonutChart';
+import DonutChart, { CHART_SIZE } from './DonutChart';
 import CustomLegend from './CustomLegend';
 import CategoryOperationsList from './CategoryOperationsList';
 
@@ -18,49 +18,71 @@ const ExpensePieChart = ({
   loadingOperations = false,
   introKey = 0,
   introDelay = 0,
+  categoryChip = null,
 }) => {
+  // The drill-down chip rides along with whatever this chart is showing: under
+  // the donut when there is one, above the body otherwise. Anywhere it can be
+  // reached, so a drilled-in category is never a dead end.
+  const chipHeader = categoryChip ? (
+    <View style={styles.chipHeader}>{categoryChip}</View>
+  ) : null;
+
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
   if (isLeafCategory) {
     return (
-      <CategoryOperationsList
-        operations={operations}
-        loading={loadingOperations}
-        currency={selectedCurrency}
-        colors={colors}
-        language={language}
-        emptyText={t('no_expense_data')}
-      />
+      <View>
+        {chipHeader}
+        <CategoryOperationsList
+          operations={operations}
+          loading={loadingOperations}
+          currency={selectedCurrency}
+          colors={colors}
+          language={language}
+          emptyText={t('no_expense_data')}
+        />
+      </View>
     );
   }
 
   if (loading) {
     return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={colors.primary} />
-        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
-          {t('loading_operations')}
-        </Text>
+      <View>
+        {chipHeader}
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.primary} />
+          <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+            {t('loading_operations')}
+          </Text>
+        </View>
       </View>
     );
   }
 
   if (chartData.length === 0) {
     return (
-      <Text style={[styles.noData, { color: colors.mutedText }]}>
-        {t('no_expense_data')}
-      </Text>
+      <View>
+        {chipHeader}
+        <Text style={[styles.noData, { color: colors.mutedText }]}>
+          {t('no_expense_data')}
+        </Text>
+      </View>
     );
   }
 
   return (
     <View style={styles.row}>
-      <DonutChart
-        data={chartData}
-        insetColor={colors.surface}
-        introKey={introKey}
-        introDelay={introDelay}
-      />
+      <View style={styles.donutColumn}>
+        <DonutChart
+          data={chartData}
+          insetColor={colors.surface}
+          introKey={introKey}
+          introDelay={introDelay}
+        />
+        {categoryChip ? (
+          <View style={styles.donutChip}>{categoryChip}</View>
+        ) : null}
+      </View>
       <View style={styles.legendWrapper}>
         <CustomLegend
           data={chartData}
@@ -89,9 +111,23 @@ ExpensePieChart.propTypes = {
   introKey: PropTypes.number,
   // Holds that replay back until the outgoing chart has faded out.
   introDelay: PropTypes.number,
+  // Drill-down chip owned by the screen; placed under the donut by this chart.
+  categoryChip: PropTypes.node,
 };
 
 const styles = StyleSheet.create({
+  chipHeader: {
+    alignItems: 'flex-start',
+    marginBottom: 10,
+  },
+  donutChip: {
+    marginTop: 10,
+    maxWidth: '100%',
+  },
+  donutColumn: {
+    alignItems: 'center',
+    width: CHART_SIZE,
+  },
   legendWrapper: {
     flex: 1,
   },

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
-import DonutChart from './DonutChart';
+import DonutChart, { CHART_SIZE } from './DonutChart';
 import CustomLegend from './CustomLegend';
 import CategoryOperationsList from './CategoryOperationsList';
 
@@ -18,49 +18,71 @@ const IncomePieChart = ({
   loadingOperations = false,
   introKey = 0,
   introDelay = 0,
+  categoryChip = null,
 }) => {
+  // The drill-down chip rides along with whatever this chart is showing: under
+  // the donut when there is one, above the body otherwise. Anywhere it can be
+  // reached, so a drilled-in category is never a dead end.
+  const chipHeader = categoryChip ? (
+    <View style={styles.chipHeader}>{categoryChip}</View>
+  ) : null;
+
   // A leaf category has no sub-categories left to break down — show its actual
   // operations for the period instead of a pointless single-slice donut.
   if (isLeafCategory) {
     return (
-      <CategoryOperationsList
-        operations={operations}
-        loading={loadingOperations}
-        currency={selectedCurrency}
-        colors={colors}
-        language={language}
-        emptyText={t('no_income_data')}
-      />
+      <View>
+        {chipHeader}
+        <CategoryOperationsList
+          operations={operations}
+          loading={loadingOperations}
+          currency={selectedCurrency}
+          colors={colors}
+          language={language}
+          emptyText={t('no_income_data')}
+        />
+      </View>
     );
   }
 
   if (loadingIncome) {
     return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={colors.primary} />
-        <Text style={[styles.loadingText, { color: colors.mutedText }]}>
-          {t('loading_operations')}
-        </Text>
+      <View>
+        {chipHeader}
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.primary} />
+          <Text style={[styles.loadingText, { color: colors.mutedText }]}>
+            {t('loading_operations')}
+          </Text>
+        </View>
       </View>
     );
   }
 
   if (incomeChartData.length === 0) {
     return (
-      <Text style={[styles.noData, { color: colors.mutedText }]}>
-        {t('no_income_data')}
-      </Text>
+      <View>
+        {chipHeader}
+        <Text style={[styles.noData, { color: colors.mutedText }]}>
+          {t('no_income_data')}
+        </Text>
+      </View>
     );
   }
 
   return (
     <View style={styles.row}>
-      <DonutChart
-        data={incomeChartData}
-        insetColor={colors.surface}
-        introKey={introKey}
-        introDelay={introDelay}
-      />
+      <View style={styles.donutColumn}>
+        <DonutChart
+          data={incomeChartData}
+          insetColor={colors.surface}
+          introKey={introKey}
+          introDelay={introDelay}
+        />
+        {categoryChip ? (
+          <View style={styles.donutChip}>{categoryChip}</View>
+        ) : null}
+      </View>
       <View style={styles.legendWrapper}>
         <CustomLegend
           data={incomeChartData}
@@ -89,9 +111,23 @@ IncomePieChart.propTypes = {
   introKey: PropTypes.number,
   // Holds that replay back until the outgoing chart has faded out.
   introDelay: PropTypes.number,
+  // Drill-down chip owned by the screen; placed under the donut by this chart.
+  categoryChip: PropTypes.node,
 };
 
 const styles = StyleSheet.create({
+  chipHeader: {
+    alignItems: 'flex-start',
+    marginBottom: 10,
+  },
+  donutChip: {
+    marginTop: 10,
+    maxWidth: '100%',
+  },
+  donutColumn: {
+    alignItems: 'center',
+    width: CHART_SIZE,
+  },
   legendWrapper: {
     flex: 1,
   },

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -622,6 +622,30 @@ const GraphsScreen = () => {
     }
   }, [expandedCard, panelHeight]);
 
+  // The drill-down chips live inside their chart (under the donut), not over the
+  // tab strip where they used to cover the tab's own title. They stay outside the
+  // tab button regardless — a button nested in a button reads as two controls to
+  // a screen reader. Each chart decides where to place the node it is handed.
+  const incomeCategoryChip = selectedIncomeCategoryName ? (
+    <CategoryBackChip
+      testID="income-category-chip"
+      colors={colors}
+      label={selectedIncomeCategoryName}
+      backLabel={t('back')}
+      onPress={handleBackToIncomeParent}
+    />
+  ) : null;
+
+  const expenseCategoryChip = selectedCategoryName ? (
+    <CategoryBackChip
+      testID="expense-category-chip"
+      colors={colors}
+      label={selectedCategoryName}
+      backLabel={t('back')}
+      onPress={handleBackToExpenseParent}
+    />
+  ) : null;
+
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
@@ -665,29 +689,6 @@ const GraphsScreen = () => {
                 onPress={handleToggleExpense}
                 expanded={expandedCard === 'expense'}
               />
-
-              {/* Drill-down chips sit above the strip, not inside a tab — a button
-                  nested in a button reads as two controls to a screen reader. */}
-              {selectedIncomeCategoryName && (
-                <CategoryBackChip
-                  testID="income-category-chip"
-                  colors={colors}
-                  side="left"
-                  label={selectedIncomeCategoryName}
-                  backLabel={t('back')}
-                  onPress={handleBackToIncomeParent}
-                />
-              )}
-              {selectedCategoryName && (
-                <CategoryBackChip
-                  testID="expense-category-chip"
-                  colors={colors}
-                  side="right"
-                  label={selectedCategoryName}
-                  backLabel={t('back')}
-                  onPress={handleBackToExpenseParent}
-                />
-              )}
             </View>
 
             {/* Both charts stay mounted and overlap, so they stay measured and
@@ -726,6 +727,7 @@ const GraphsScreen = () => {
                     loadingOperations={loadingIncomeOperations}
                     introKey={chartIntro.key}
                     introDelay={chartIntro.delay}
+                    categoryChip={incomeCategoryChip}
                   />
                 </Animated.View>
               </ScrollView>
@@ -763,6 +765,7 @@ const GraphsScreen = () => {
                     loadingOperations={loadingExpenseOperations}
                     introKey={chartIntro.key}
                     introDelay={chartIntro.delay}
+                    categoryChip={expenseCategoryChip}
                   />
                 </Animated.View>
               </ScrollView>


### PR DESCRIPTION
## Problem

Drilling into a parent category on the Graphs summary panel showed a chip with the category name as an absolute overlay on the tab strip, centred over the tab's own half. That put it right on top of the tab title — the "РАСХОД"/"EXPENSE" heading was covered by the chip (see the reported screenshot).

## Change

The chip now travels with the chart body instead of the tab strip:

- **Donut state** — the donut moves into its own column (capped at `CHART_SIZE`), with the chip centred underneath it.
- **Leaf / loading / empty states** — the chip renders above the body, left-aligned, so a drilled-in category is never a dead end when there is no donut to sit under.

`CategoryBackChip` drops its `box-none` overlay wrapper and `side` prop and is now a plain self-sizing button (`maxWidth: '100%'`, still single-line + ellipsis); placement is the chart's job. It still lives outside the tab button, so no button is nested in a button.

## Tests

- `CategoryBackChip.test.js` — overlay/side assertions replaced with a sizing assertion.
- `ExpensePieChart.test.js` / `IncomePieChart.test.js` — new `drill-down chip` group: the chip sits in the donut's column after the donut, and stays reachable in the leaf, loading and empty states. The donut-alignment regression test is re-anchored to the new column.

Full suite: 4901 passed. Lint: clean (`--max-warnings 0`).
