### PR TITLE
feat(graphs): rework the category drill-down operations list

### DIFF
--- a/__tests__/components/graphs/CategoryOperationsList.test.js
+++ b/__tests__/components/graphs/CategoryOperationsList.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from 'react-native';
 import { render } from '@testing-library/react-native';
 import CategoryOperationsList from '../../../app/components/graphs/CategoryOperationsList';
 import { useDisplaySettings } from '../../../app/contexts/DisplaySettingsContext';
@@ -35,7 +36,7 @@ describe('CategoryOperationsList', () => {
     expect(getByText('nothing here')).toBeTruthy();
   });
 
-  it('shows the label as primary text and the date as secondary text', async () => {
+  it('shows the date, the label chip and the amount on one row', async () => {
     const ops = [{ id: '1', amount: '12.50', date: '2024-03-05', description: 'Coffee' }];
     const { getByText } = await render(
       <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
@@ -51,7 +52,7 @@ describe('CategoryOperationsList', () => {
       <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
     );
     expect(getByText('$10.00')).toBeTruthy();   // converted, selected currency
-    expect(getByText('֏4000')).toBeTruthy();    // original, account currency (AMD: 0 decimals)
+    expect(getByText('֏4,000')).toBeTruthy();   // original, account currency (AMD: 0 decimals)
   });
 
   it('does not show a separate original for a same-currency (convertedAmount null) op', async () => {
@@ -72,7 +73,7 @@ describe('CategoryOperationsList', () => {
     expect(getByText('5 июля')).toBeTruthy();
   });
 
-  it('falls back to the date as primary text when the operation has no label', async () => {
+  it('still shows date and amount when the operation has no label', async () => {
     const ops = [{ id: '2', amount: '100', date: '2024-03-05', description: '' }];
     const { getByText } = await render(
       <CategoryOperationsList operations={ops} currency="JPY" colors={colors} language="en" />,
@@ -103,5 +104,100 @@ describe('CategoryOperationsList', () => {
     expect(getByText('A')).toBeTruthy();
     expect(getByText('B')).toBeTruthy();
     expect(getByText('C')).toBeTruthy();
+  });
+
+  it('groups digits so a large amount stays readable', async () => {
+    const ops = [{ id: '1', amount: '100000', date: '2024-03-05', description: '' }];
+    const { getByText } = await render(
+      <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+    );
+    expect(getByText('$100,000.00')).toBeTruthy();
+  });
+
+  // Same-day operations read as one block: only the first of the day is dated.
+  describe('date grouping', () => {
+    const ops = [
+      { id: '1', amount: '10.00', date: '2024-03-05', description: 'A' },
+      { id: '2', amount: '20.00', date: '2024-03-05', description: 'B' },
+      { id: '3', amount: '30.00', date: '2024-03-04', description: 'C' },
+    ];
+
+    it('prints a date once per day, not once per operation', async () => {
+      const { queryAllByText } = await render(
+        <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+      );
+
+      expect(queryAllByText('March 5')).toHaveLength(1);
+      expect(queryAllByText('March 4')).toHaveLength(1);
+    });
+  });
+
+  describe('header', () => {
+    const ops = [
+      { id: '1', amount: '10.00', date: '2024-03-05', description: 'A' },
+      { id: '2', amount: '20.50', date: '2024-03-04', description: 'B' },
+    ];
+    const chip = <Text testID="chip">Groceries</Text>;
+
+    it('is not rendered when no chip is passed', async () => {
+      const { queryByText } = await render(
+        <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" />,
+      );
+
+      expect(queryByText('$30.50')).toBeNull();
+    });
+
+    it('pairs the chip with the total of the listed operations', async () => {
+      const { getByTestId, getByText } = await render(
+        <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" headerChip={chip} />,
+      );
+
+      expect(getByTestId('chip')).toBeTruthy();
+      expect(getByText('$30.50')).toBeTruthy();
+    });
+
+    // The rows show converted amounts, so the total has to agree with them —
+    // otherwise it would not match the pie slice the drill-down came from.
+    it('totals converted amounts, not the original foreign ones', async () => {
+      const foreign = [
+        { id: '1', amount: '4000', date: '2024-03-05', description: 'A', accountCurrency: 'AMD', convertedAmount: '10.00' },
+        { id: '2', amount: '5.00', date: '2024-03-04', description: 'B', accountCurrency: 'USD', convertedAmount: null },
+      ];
+      const { getByText } = await render(
+        <CategoryOperationsList operations={foreign} currency="USD" colors={colors} language="en" headerChip={chip} />,
+      );
+
+      expect(getByText('$15.00')).toBeTruthy();
+    });
+
+    it('masks the total when hideBalances is on', async () => {
+      useDisplaySettings.mockReturnValue({ hideBalances: true });
+      const { queryByText, getAllByText } = await render(
+        <CategoryOperationsList operations={ops} currency="USD" colors={colors} language="en" headerChip={chip} />,
+      );
+
+      expect(queryByText('$30.50')).toBeNull();
+      expect(getAllByText('••••').length).toBeGreaterThan(0);
+    });
+
+    // Losing the chip in these states would strand the user in the category:
+    // it is the only way back to the parent.
+    it('keeps the chip while loading', async () => {
+      const { getByTestId } = await render(
+        <CategoryOperationsList operations={[]} loading currency="USD" colors={colors} language="en" headerChip={chip} />,
+      );
+
+      expect(getByTestId('chip')).toBeTruthy();
+      expect(getByTestId('category-operations-loading')).toBeTruthy();
+    });
+
+    it('keeps the chip when the category has no operations', async () => {
+      const { getByTestId, getByText } = await render(
+        <CategoryOperationsList operations={[]} currency="USD" colors={colors} language="en" emptyText="nothing here" headerChip={chip} />,
+      );
+
+      expect(getByTestId('chip')).toBeTruthy();
+      expect(getByText('nothing here')).toBeTruthy();
+    });
   });
 });

--- a/__tests__/components/graphs/IncomePieChart.test.js
+++ b/__tests__/components/graphs/IncomePieChart.test.js
@@ -146,7 +146,7 @@ describe('IncomePieChart', () => {
       );
       expect(queryByTestId('donut-chart')).toBeNull();
       expect(getByText('Payday')).toBeTruthy();
-      expect(getByText('$3000.00')).toBeTruthy();
+      expect(getByText('$3,000.00')).toBeTruthy();
     });
 
     it('shows the empty state when the leaf has no operations', async () => {

--- a/app/components/graphs/CategoryOperationsList.js
+++ b/app/components/graphs/CategoryOperationsList.js
@@ -1,15 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+import { add as addAmounts } from '../../services/currency';
+import { SPACING, FONT_SIZE, FONT_WEIGHT } from '../../styles/designTokens';
 
-const formatOpAmount = (amount, currency) => {
+// Cap the chips per row so a heavily-labelled operation can't blow up the row
+// height inside the fixed-height chart panel; the remainder becomes "+N".
+const MAX_VISIBLE_LABELS = 3;
+
+// Group digits ("₽100 000", not "₽100000"). The amounts here are exact rather
+// than the compact "₽100.0K" the charts use — this is the one place in Graphs
+// that shows individual operations, so the figure has to be readable in full.
+const formatOpAmount = (amount, currency, language) => {
   const info = currencies[currency];
   const symbol = info?.symbol ?? currency;
   const decimals = info?.decimal_digits ?? 2;
-  return `${symbol}${parseFloat(amount).toFixed(decimals)}`;
+  const value = parseFloat(amount);
+  if (Number.isNaN(value)) return `${symbol}${amount}`;
+  try {
+    return `${symbol}${value.toLocaleString(language || undefined, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    })}`;
+  } catch {
+    return `${symbol}${value.toFixed(decimals)}`;
+  }
 };
 
 // Format "day month" in the app's language. Formatting day + month together lets
@@ -33,59 +51,127 @@ const formatOpDate = (dateStr, language) => {
  * donut once the pie-chart drill-down reaches a leaf category. Renders plain
  * Views (no inner ScrollView) so the parent chart ScrollView measures and
  * animates its height.
+ *
+ * Layout mirrors the Operations tab rather than inventing its own: the date
+ * leads the row in muted small caps, labels ride beside it as chips, and the
+ * amount closes the row in the type's colour. A date only prints on the first
+ * operation of its day, so same-day operations read as one block without
+ * needing a separator row of their own.
+ *
+ * `headerChip` is the drill-down back chip: with no donut to sit under, it
+ * heads the list instead, paired with the category's total for the period.
  */
-const CategoryOperationsList = ({ operations = [], loading = false, currency, colors, language, emptyText = '' }) => {
+const CategoryOperationsList = ({
+  operations = [],
+  loading = false,
+  currency,
+  colors,
+  language,
+  emptyText = '',
+  headerChip = null,
+}) => {
   const { hideBalances } = useDisplaySettings();
+
+  // Sum of exactly what the rows show — converted amounts where the operation
+  // was in a foreign currency, so the total matches the slice it came from.
+  const total = useMemo(
+    () => operations.reduce(
+      (sum, op) => addAmounts(sum, op.convertedAmount != null ? op.convertedAmount : op.amount),
+      '0',
+    ),
+    [operations],
+  );
+
+  const header = headerChip ? (
+    <View style={styles.header}>
+      <View style={styles.headerChip}>{headerChip}</View>
+      {operations.length > 0 && !loading ? (
+        <Text style={[styles.headerTotal, { color: colors.text }]} numberOfLines={1}>
+          {hideBalances ? '••••' : formatOpAmount(total, currency, language)}
+        </Text>
+      ) : null}
+    </View>
+  ) : null;
 
   if (loading) {
     return (
-      <View testID="category-operations-loading" style={styles.centerBox}>
-        <ActivityIndicator size="small" color={colors.primary} />
+      <View>
+        {header}
+        <View testID="category-operations-loading" style={styles.centerBox}>
+          <ActivityIndicator size="small" color={colors.primary} />
+        </View>
       </View>
     );
   }
 
   if (!operations || operations.length === 0) {
     return (
-      <Text style={[styles.empty, { color: colors.mutedText }]}>{emptyText}</Text>
+      <View>
+        {header}
+        <Text style={[styles.empty, { color: colors.mutedText }]}>{emptyText}</Text>
+      </View>
     );
   }
 
   return (
     <View style={styles.container}>
+      {header}
       {operations.map((op, index) => {
         const labels = visibleListLabels(parseLabels(op.description));
-        const dateText = formatOpDate(op.date, language);
-        const primary = labels.length ? labels.map(displayLabel).join(', ') : dateText;
-        const secondary = labels.length ? dateText : null;
-        const isLast = index === operations.length - 1;
+        const visibleLabels = labels.slice(0, MAX_VISIBLE_LABELS);
+        const overflowCount = labels.length - visibleLabels.length;
+        // Repeat the date only when the day changes — the list arrives sorted by
+        // date, so equal neighbours are the same day.
+        const startsDay = index === 0 || op.date !== operations[index - 1].date;
+        const amountColor = (op.type === 'income' ? colors.income : colors.expense) ?? colors.text;
 
         return (
           <View
             key={op.id}
             style={[
               styles.row,
-              !isLast && { borderBottomColor: colors.border, borderBottomWidth: StyleSheet.hairlineWidth },
+              startsDay && index > 0 && {
+                borderTopColor: colors.border,
+                borderTopWidth: StyleSheet.hairlineWidth,
+              },
             ]}
           >
-            <View style={styles.textCol}>
-              <Text style={[styles.primary, { color: colors.text }]} numberOfLines={1}>
-                {primary}
-              </Text>
-              {secondary ? (
-                <Text style={[styles.secondary, { color: colors.mutedText }]} numberOfLines={1}>
-                  {secondary}
+            <View style={styles.dateCol}>
+              {startsDay ? (
+                <Text style={[styles.date, { color: colors.mutedText }]} numberOfLines={1}>
+                  {formatOpDate(op.date, language)}
                 </Text>
               ) : null}
             </View>
+
+            <View style={styles.labelsCol}>
+              {visibleLabels.map((label) => (
+                <View
+                  key={label}
+                  style={[styles.labelChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}
+                >
+                  <Text style={[styles.labelChipText, { color: colors.mutedText }]} numberOfLines={1}>
+                    {displayLabel(label)}
+                  </Text>
+                </View>
+              ))}
+              {overflowCount > 0 ? (
+                <View style={[styles.labelChip, { backgroundColor: colors.altRow, borderColor: colors.border }]}>
+                  <Text style={[styles.labelChipText, { color: colors.mutedText }]}>{`+${overflowCount}`}</Text>
+                </View>
+              ) : null}
+            </View>
+
             <View style={styles.amountCol}>
-              <Text style={[styles.amount, { color: colors.text }]} numberOfLines={1}>
-                {hideBalances ? '••••' : formatOpAmount(op.convertedAmount != null ? op.convertedAmount : op.amount, currency)}
+              <Text style={[styles.amount, { color: amountColor }]} numberOfLines={1}>
+                {hideBalances
+                  ? '••••'
+                  : formatOpAmount(op.convertedAmount != null ? op.convertedAmount : op.amount, currency, language)}
               </Text>
               {/* For a converted foreign operation, show the original amount too */}
               {!hideBalances && op.convertedAmount != null && op.accountCurrency && op.accountCurrency !== currency ? (
                 <Text style={[styles.amountOriginal, { color: colors.mutedText }]} numberOfLines={1}>
-                  {formatOpAmount(op.amount, op.accountCurrency)}
+                  {formatOpAmount(op.amount, op.accountCurrency, language)}
                 </Text>
               ) : null}
             </View>
@@ -103,6 +189,7 @@ CategoryOperationsList.propTypes = {
       amount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       date: PropTypes.string,
       description: PropTypes.string,
+      type: PropTypes.string,
       accountCurrency: PropTypes.string,
       convertedAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     }),
@@ -112,20 +199,26 @@ CategoryOperationsList.propTypes = {
   colors: PropTypes.object.isRequired,
   language: PropTypes.string,
   emptyText: PropTypes.string,
+  // Drill-down back chip; heads the list when there is no donut to sit under.
+  headerChip: PropTypes.node,
 };
 
 const styles = StyleSheet.create({
   amount: {
-    fontSize: 13,
-    fontWeight: '600',
+    fontSize: FONT_SIZE.md,
+    fontWeight: FONT_WEIGHT.semibold,
+    includeFontPadding: false,
+    textAlign: 'right',
   },
   amountCol: {
     alignItems: 'flex-end',
-    marginLeft: 10,
+    marginLeft: SPACING.sm,
   },
   amountOriginal: {
-    fontSize: 11,
+    fontSize: FONT_SIZE.xs,
+    includeFontPadding: false,
     marginTop: 2,
+    textAlign: 'right',
   },
   centerBox: {
     alignItems: 'center',
@@ -133,31 +226,60 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    marginTop: 4,
+  },
+  date: {
+    fontSize: FONT_SIZE.sm,
+    includeFontPadding: false,
+  },
+  dateCol: {
+    justifyContent: 'center',
+    marginRight: SPACING.sm,
+    minWidth: 76,
   },
   empty: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     paddingVertical: 32,
     textAlign: 'center',
   },
-  primary: {
-    fontSize: 13,
-    fontWeight: '500',
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: SPACING.xs,
+    paddingBottom: SPACING.sm,
+  },
+  headerChip: {
+    flexShrink: 1,
+    marginRight: SPACING.sm,
+  },
+  headerTotal: {
+    fontSize: FONT_SIZE.base,
+    fontWeight: FONT_WEIGHT.semibold,
+    includeFontPadding: false,
+  },
+  labelChip: {
+    borderRadius: 10,
+    borderWidth: 1,
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: 1,
+  },
+  labelChipText: {
+    fontSize: FONT_SIZE.xs,
+    fontWeight: FONT_WEIGHT.medium,
+    maxWidth: 120,
+  },
+  labelsCol: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.xs,
+    minWidth: 0,
   },
   row: {
     alignItems: 'center',
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: 2,
-    paddingVertical: 10,
-  },
-  secondary: {
-    fontSize: 11,
-    marginTop: 2,
-  },
-  textCol: {
-    flex: 1,
-    minWidth: 0,
+    paddingVertical: SPACING.sm,
   },
 });
 

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -21,27 +21,26 @@ const ExpensePieChart = ({
   categoryChip = null,
 }) => {
   // The drill-down chip rides along with whatever this chart is showing: under
-  // the donut when there is one, above the body otherwise. Anywhere it can be
+  // the donut when there is one, heading the body otherwise. Anywhere it can be
   // reached, so a drilled-in category is never a dead end.
   const chipHeader = categoryChip ? (
     <View style={styles.chipHeader}>{categoryChip}</View>
   ) : null;
 
   // A leaf category has no sub-categories left to break down — show its actual
-  // operations for the period instead of a pointless single-slice donut.
+  // operations for the period instead of a pointless single-slice donut. The
+  // list heads itself with the chip so it can pair it with the category total.
   if (isLeafCategory) {
     return (
-      <View>
-        {chipHeader}
-        <CategoryOperationsList
-          operations={operations}
-          loading={loadingOperations}
-          currency={selectedCurrency}
-          colors={colors}
-          language={language}
-          emptyText={t('no_expense_data')}
-        />
-      </View>
+      <CategoryOperationsList
+        operations={operations}
+        loading={loadingOperations}
+        currency={selectedCurrency}
+        colors={colors}
+        language={language}
+        emptyText={t('no_expense_data')}
+        headerChip={categoryChip}
+      />
     );
   }
 

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -21,27 +21,26 @@ const IncomePieChart = ({
   categoryChip = null,
 }) => {
   // The drill-down chip rides along with whatever this chart is showing: under
-  // the donut when there is one, above the body otherwise. Anywhere it can be
+  // the donut when there is one, heading the body otherwise. Anywhere it can be
   // reached, so a drilled-in category is never a dead end.
   const chipHeader = categoryChip ? (
     <View style={styles.chipHeader}>{categoryChip}</View>
   ) : null;
 
   // A leaf category has no sub-categories left to break down — show its actual
-  // operations for the period instead of a pointless single-slice donut.
+  // operations for the period instead of a pointless single-slice donut. The
+  // list heads itself with the chip so it can pair it with the category total.
   if (isLeafCategory) {
     return (
-      <View>
-        {chipHeader}
-        <CategoryOperationsList
-          operations={operations}
-          loading={loadingOperations}
-          currency={selectedCurrency}
-          colors={colors}
-          language={language}
-          emptyText={t('no_income_data')}
-        />
-      </View>
+      <CategoryOperationsList
+        operations={operations}
+        loading={loadingOperations}
+        currency={selectedCurrency}
+        colors={colors}
+        language={language}
+        emptyText={t('no_income_data')}
+        headerChip={categoryChip}
+      />
     );
   }
 


### PR DESCRIPTION
Follow-up to #1464.

## Problem

Drilling into a leaf category shows the list of that category's operations. Two things were off:

1. **The back chip had nowhere to go.** #1464 put it under the donut, but a leaf category has no donut — it fell back to floating above the list, unattached to anything.
2. **The list itself read like a debug dump.** Every row was "date … amount" in one type size, with no total, no way to tell one day's operations from another's, and unseparated digits (`₽100000`).

## Change

**Header.** The chip now heads the list, paired with the category's total for the period. The total sums exactly what the rows show (converted amounts for foreign operations), so it agrees with the pie slice the drill-down came from, and it masks under `hideBalances`. The header survives the loading and empty states too — the chip is the only way back to the parent, so losing it would strand the user in an empty category.

**Rows.** Now speak the Operations tab's visual language rather than inventing one:

- date leads the row, muted and small;
- labels ride beside it as chips (same chip style as `OperationListItem`, capped at 3 + `+N`);
- the amount closes the row in the type's colour (`colors.expense` / `colors.income`), with the original foreign amount beneath it as before.

A date prints **once per day**, so same-day operations read as one block; a hairline separates day from day instead of row from row.

**Formatting.** Amounts group their digits via `toLocaleString(language)` — `$100,000.00`, `₽100 000` — instead of `$100000.00`. Exact, not the compact `₽100.0K` the charts use: this is the one place in Graphs showing individual operations, so the figure has to be readable in full. Hard-coded sizes and spacings moved onto design tokens.

## Tests

`CategoryOperationsList.test.js` gains a `header` group (chip + total, converted totals, `hideBalances` masking, chip kept in the loading and empty states), a date-grouping test (one date per day, not per operation), and a digit-grouping test. Existing expectations updated for the grouped digits.

Full suite: 4909 passed. Lint: clean (`--max-warnings 0`).

## Not verified on device

No dev-client build is available in this environment (the emulator only has release 0.210.1 installed), so this is verified by tests and code review, not by a screenshot of the real screen.
