### PR TITLE
feat(motion): unify tab, sheet and panel motion and honour reduced motion

### DIFF
--- a/__tests__/utils/reducedMotion.test.js
+++ b/__tests__/utils/reducedMotion.test.js
@@ -1,0 +1,117 @@
+import { AccessibilityInfo } from 'react-native';
+
+// Each test re-imports the module so the lazy subscription runs against that
+// test's mocks — the cache is module-level by design, so a shared instance would
+// carry the first test's answer into every later one.
+const loadModule = () => {
+  let mod;
+  jest.isolateModules(() => {
+    mod = require('../../app/utils/reducedMotion');
+  });
+  return mod;
+};
+
+describe('reducedMotion', () => {
+  let listeners;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listeners = {};
+    AccessibilityInfo.isReduceMotionEnabled = jest.fn(() => Promise.resolve(false));
+    AccessibilityInfo.addEventListener = jest.fn((event, handler) => {
+      listeners[event] = handler;
+      return { remove: jest.fn() };
+    });
+  });
+
+  describe('Initialization', () => {
+    it('reports motion as allowed before the async read resolves', () => {
+      const { isReduceMotionEnabled } = loadModule();
+      // Synchronous first call: the OS answer has not arrived yet, and the
+      // honest default is to animate rather than to freeze the whole UI.
+      expect(isReduceMotionEnabled()).toBe(false);
+    });
+
+    it('does not touch AccessibilityInfo until something asks', () => {
+      loadModule();
+      expect(AccessibilityInfo.isReduceMotionEnabled).not.toHaveBeenCalled();
+      expect(AccessibilityInfo.addEventListener).not.toHaveBeenCalled();
+    });
+
+    it('subscribes exactly once across repeated queries', () => {
+      const { isReduceMotionEnabled } = loadModule();
+      isReduceMotionEnabled();
+      isReduceMotionEnabled();
+      isReduceMotionEnabled();
+      expect(AccessibilityInfo.addEventListener).toHaveBeenCalledTimes(1);
+      expect(AccessibilityInfo.addEventListener).toHaveBeenCalledWith(
+        'reduceMotionChanged',
+        expect.any(Function),
+      );
+    });
+
+    it('picks up the value the OS reports', async () => {
+      AccessibilityInfo.isReduceMotionEnabled = jest.fn(() => Promise.resolve(true));
+      const { isReduceMotionEnabled } = loadModule();
+      isReduceMotionEnabled();
+      await Promise.resolve();
+      expect(isReduceMotionEnabled()).toBe(true);
+    });
+  });
+
+  describe('motionDuration', () => {
+    it('passes the duration through when motion is allowed', () => {
+      const { motionDuration } = loadModule();
+      expect(motionDuration(260)).toBe(260);
+      expect(motionDuration(0)).toBe(0);
+    });
+
+    it('collapses the duration to zero under reduced motion', () => {
+      const { motionDuration, __setReduceMotionForTests } = loadModule();
+      __setReduceMotionForTests(true);
+      expect(motionDuration(260)).toBe(0);
+      expect(motionDuration(1500)).toBe(0);
+    });
+  });
+
+  describe('Live changes', () => {
+    it('follows the setting being turned on and off while running', async () => {
+      const { isReduceMotionEnabled, motionDuration } = loadModule();
+      isReduceMotionEnabled();
+      await Promise.resolve();
+
+      listeners.reduceMotionChanged(true);
+      expect(isReduceMotionEnabled()).toBe(true);
+      expect(motionDuration(200)).toBe(0);
+
+      listeners.reduceMotionChanged(false);
+      expect(isReduceMotionEnabled()).toBe(false);
+      expect(motionDuration(200)).toBe(200);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('animates normally when the platform has no accessibility module', () => {
+      AccessibilityInfo.isReduceMotionEnabled = undefined;
+      AccessibilityInfo.addEventListener = undefined;
+      const { isReduceMotionEnabled, motionDuration } = loadModule();
+      expect(isReduceMotionEnabled()).toBe(false);
+      expect(motionDuration(260)).toBe(260);
+    });
+
+    it('animates normally when the OS query rejects', async () => {
+      AccessibilityInfo.isReduceMotionEnabled = jest.fn(() => Promise.reject(new Error('nope')));
+      const { isReduceMotionEnabled, motionDuration } = loadModule();
+      expect(isReduceMotionEnabled()).toBe(false);
+      await Promise.resolve();
+      expect(motionDuration(260)).toBe(260);
+    });
+
+    it('survives a query that returns something other than a promise', () => {
+      AccessibilityInfo.isReduceMotionEnabled = jest.fn(() => undefined);
+      const { isReduceMotionEnabled } = loadModule();
+      expect(() => isReduceMotionEnabled()).not.toThrow();
+      expect(isReduceMotionEnabled()).toBe(false);
+    });
+  });
+});

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -26,6 +26,7 @@ import {
   PAN_VELOCITY_TO_PER_SECOND,
   rubberband,
 } from '../utils/motion';
+import { isReduceMotionEnabled } from '../utils/reducedMotion';
 
 // Pressable that can animate layout props (paddingBottom) for keyboard avoidance.
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -154,11 +155,24 @@ export default function ModalShell({
       translateY.setValue(screenHeight);
       keyboardOffset.setValue(0);
       resetShrink();
+      // A sheet rising from the bottom edge is travel, which is what the OS
+      // "Remove animations" setting is about — so under it the sheet is simply
+      // there. `Animated` has no reduceMotion of its own (Reanimated does, which
+      // is why the shrink above needs no equivalent branch).
+      if (isReduceMotionEnabled()) {
+        translateY.setValue(0);
+        return;
+      }
+      // The same spring the drag release and the snap-back use. It used to be a
+      // `bounciness: 2 / speed: 14` spring of its own, which put two problems in
+      // one line: the sheet arrived on a different physics than the one that
+      // takes it away (so opening and dismissing read as different objects), and
+      // the bounce overshot a card pinned to `justifyContent: 'flex-end'` — the
+      // overshoot travels the card past the bottom edge and briefly opens a strip
+      // of the screen behind it. ANIMATED_SPRING_SETTLE clamps exactly that.
       Animated.spring(translateY, {
+        ...ANIMATED_SPRING_SETTLE,
         toValue: 0,
-        useNativeDriver: true,
-        bounciness: 2,
-        speed: 14,
       }).start();
     }
   }, [visible, translateY, screenHeight, resetShrink, keyboardOffset]);
@@ -170,10 +184,23 @@ export default function ModalShell({
 
   // Animate out then call callback — used for overlay tap and cancel button
   const animateOut = useCallback((callback) => {
-    Animated.timing(translateY, {
+    if (isReduceMotionEnabled()) {
+      translateY.setValue(screenHeight);
+      callback?.();
+      return;
+    }
+    // A spring, not a 200ms timing with React Native's default `inOut(ease)`.
+    // Tapping the overlay and flicking the sheet down are the same act — getting
+    // rid of this sheet — and they were leaving on visibly different curves. The
+    // tap simply has no velocity to hand over, so it starts from rest.
+    Animated.spring(translateY, {
+      ...ANIMATED_SPRING_SETTLE,
       toValue: screenHeight,
-      duration: 200,
-      useNativeDriver: true,
+      // The card is out of sight long before the spring mathematically settles,
+      // so finish on "off-screen" rather than on the tail — same thresholds the
+      // drag dismissal uses.
+      restDisplacementThreshold: 40,
+      restSpeedThreshold: 100,
       // Leave translateY at screenHeight after close so the next open
       // renders offscreen immediately (no reset-to-0 flicker)
     }).start(({ finished }) => {

--- a/app/components/NotificationsContentPanel.js
+++ b/app/components/NotificationsContentPanel.js
@@ -7,6 +7,7 @@ import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { parseBankNotification } from '../services/notifications/parseBankNotification';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { motionDuration } from '../utils/reducedMotion';
 
 // Renders the "date · time" label for a notification's post time. Mirrors the
 // update panel's timestamp treatment so the two subpanels read alike.
@@ -38,7 +39,7 @@ export function NotificationCard({ notification, colors, t, onReAdd = null, reAd
     if (!animateIn) return;
     Animated.timing(enterAnim, {
       toValue: 1,
-      duration: 320,
+      duration: motionDuration(320),
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
@@ -156,7 +157,7 @@ export default function NotificationsContentPanel({ isLoading = false, notificat
     }
     Animated.timing(contentAnim, {
       toValue: 1,
-      duration: 280,
+      duration: motionDuration(280),
       easing: Easing.out(Easing.quad),
       useNativeDriver: true,
     }).start();

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -6,6 +6,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { motionDuration } from '../utils/reducedMotion';
 
 const DATE_RE = /(\d{4}-\d{2}-\d{2})/;
 const PR_RE = /#(\d+)/g;
@@ -385,7 +386,7 @@ export default function UpdateContentPanel({ isChecking = false, updateResult = 
     if (!isChecking && updateResult) {
       Animated.timing(contentAnim, {
         toValue: 1,
-        duration: 280,
+        duration: motionDuration(280),
         easing: Easing.out(Easing.quad),
         useNativeDriver: true,
       }).start();

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -18,6 +18,8 @@ import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../../contexts/ThemeColorsContext';
 import { useLocalization } from '../../contexts/LocalizationContext';
+import { DURATION_ENTER, DURATION_EXIT } from '../../utils/motion';
+import { motionDuration } from '../../utils/reducedMotion';
 import { useDialog } from '../../contexts/DialogContext';
 import FormInput from '../FormInput';
 import ModalBlurOverlay from '../ModalBlurOverlay';
@@ -181,10 +183,10 @@ export default function BudgetPlanLineModal({
     setActiveSubPanel(panel);
     Animated.parallel([
       Animated.timing(mainAnim, {
-        toValue: 1, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true,
+        toValue: 1, duration: motionDuration(DURATION_EXIT), easing: Easing.in(Easing.quad), useNativeDriver: true,
       }),
       Animated.timing(subPanelAnim, {
-        toValue: 1, duration: 260, easing: Easing.out(Easing.cubic), useNativeDriver: true,
+        toValue: 1, duration: motionDuration(DURATION_ENTER), easing: Easing.out(Easing.cubic), useNativeDriver: true,
       }),
     ]).start();
   }, [mainAnim, subPanelAnim]);
@@ -193,10 +195,10 @@ export default function BudgetPlanLineModal({
     const token = ++subPanelTokenRef.current;
     Animated.parallel([
       Animated.timing(subPanelAnim, {
-        toValue: 0, duration: 180, easing: Easing.in(Easing.quad), useNativeDriver: true,
+        toValue: 0, duration: motionDuration(180), easing: Easing.in(Easing.quad), useNativeDriver: true,
       }),
       Animated.timing(mainAnim, {
-        toValue: 0, duration: 240, easing: Easing.out(Easing.cubic), useNativeDriver: true,
+        toValue: 0, duration: motionDuration(240), easing: Easing.out(Easing.cubic), useNativeDriver: true,
       }),
     ]).start(() => {
       if (subPanelTokenRef.current === token) setActiveSubPanel(null);

--- a/app/components/operations/DescriptionSuggestionRow.js
+++ b/app/components/operations/DescriptionSuggestionRow.js
@@ -5,6 +5,7 @@ import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 import { SPACING, FONT_SIZE, BORDER_RADIUS, DURATION } from '../../styles/designTokens';
 import { useSwipeNavigationGesture } from '../../contexts/SwipeNavigationContext';
 import { displayLabel } from '../../utils/labelUtils';
+import { motionDuration } from '../../utils/reducedMotion';
 
 const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
   // Entry polish only (rise into place). Like UndoSnackbar, this row is
@@ -25,7 +26,7 @@ const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
   useEffect(() => {
     Animated.timing(entryAnim, {
       toValue: 1,
-      duration: DURATION.fast,
+      duration: motionDuration(DURATION.fast),
       useNativeDriver: true,
     }).start();
   }, []);

--- a/app/components/operations/NotificationBindingStack.js
+++ b/app/components/operations/NotificationBindingStack.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { View, Text, StyleSheet, Animated, Easing } from 'react-native';
 import NotificationBindingCard from './NotificationBindingCard';
 import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
+import { motionDuration } from '../../utils/reducedMotion';
 
 // At most this many cards render as deck layers; the rest are summed up in the
 // "+N" badge and surface as the front cards drain.
@@ -48,7 +49,7 @@ const DeckSlot = memo(function DeckSlot({
   useEffect(() => {
     Animated.timing(enterAnim, {
       toValue: 1,
-      duration: 320,
+      duration: motionDuration(320),
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -5,6 +5,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';
+import { isReduceMotionEnabled } from '../../utils/reducedMotion';
 
 // Height reserved for the floating action bar; used to decide whether it fits
 // above the pressed row or has to sit below it.
@@ -30,6 +31,13 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
 
   useEffect(() => {
     if (menu) {
+      // Under the OS "Remove animations" setting the menu is simply present: the
+      // lift is what carries the meaning here, and there is no fade left to keep
+      // once it is gone (`progress` drives the backdrop and the clone together).
+      if (isReduceMotionEnabled()) {
+        progress.setValue(1);
+        return;
+      }
       progress.setValue(0);
       Animated.spring(progress, {
         toValue: 1,

--- a/app/components/operations/SplitOperationModal.js
+++ b/app/components/operations/SplitOperationModal.js
@@ -16,6 +16,8 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { SPACING, BORDER_RADIUS, HEIGHTS, FONT_SIZE } from '../../styles/designTokens';
+import { DURATION_ENTER } from '../../utils/motion';
+import { motionDuration } from '../../utils/reducedMotion';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -110,7 +112,7 @@ export default function SplitOperationModal({
     setShowCategoryPicker(true);
     Animated.timing(pickerAnim, {
       toValue: 1,
-      duration: 260,
+      duration: motionDuration(DURATION_ENTER),
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
@@ -120,7 +122,7 @@ export default function SplitOperationModal({
   const closeCategoryPicker = useCallback(() => {
     Animated.timing(pickerAnim, {
       toValue: 0,
-      duration: 180,
+      duration: motionDuration(180),
       easing: Easing.in(Easing.quad),
       useNativeDriver: true,
     }).start(() => setShowCategoryPicker(false));

--- a/app/components/operations/UndoSnackbar.js
+++ b/app/components/operations/UndoSnackbar.js
@@ -9,6 +9,7 @@ import {
   ICON_SIZE,
   BORDER_RADIUS,
 } from '../../styles/designTokens';
+import { motionDuration } from '../../utils/reducedMotion';
 
 /**
  * UndoSnackbar
@@ -75,10 +76,13 @@ const UndoSnackbar = ({
   }, [exitAnim, onClosed, operationId]);
 
   useEffect(() => {
-    // Entry: gentle rise into the row's reserved slot.
+    // Entry: gentle rise into the row's reserved slot. The rise is the only part
+    // the OS "Remove animations" setting silences — the countdown below it keeps
+    // running, because a depleting bar is information about how long the undo
+    // stays available, not decoration.
     Animated.timing(entryAnim, {
       toValue: 1,
-      duration: DURATION.normal,
+      duration: motionDuration(DURATION.normal),
       useNativeDriver: true,
     }).start();
 

--- a/app/modals/CategoryModal.js
+++ b/app/modals/CategoryModal.js
@@ -8,8 +8,11 @@ import {
   TouchableOpacity,
   Keyboard,
   Animated,
+  Easing,
   Dimensions,
 } from 'react-native';
+import { DURATION_ENTER, DURATION_EXIT } from '../utils/motion';
+import { motionDuration } from '../utils/reducedMotion';
 import { TextInput as PaperTextInput, TouchableRipple } from 'react-native-paper';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
@@ -105,15 +108,29 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
     );
   }, [category, deleteCategory, onClose, t, showDialog]);
 
+  // Both directions state their easing. An `Animated.timing` without one gets
+  // React Native's `Easing.inOut(Easing.ease)` default — symmetric, slow off the
+  // mark in both directions — which is why this picker used to feel heavier than
+  // the identical picker in SplitOperationModal. Decelerate in, accelerate out,
+  // per the subpanel convention in CLAUDE.md.
   const handleOpenPicker = useCallback((pickerKey) => {
     pickerSlideAnim.setValue(Dimensions.get('window').width);
     setActivePicker(pickerKey);
-    Animated.timing(pickerSlideAnim, { toValue: 0, duration: 260, useNativeDriver: true }).start();
+    Animated.timing(pickerSlideAnim, {
+      toValue: 0,
+      duration: motionDuration(DURATION_ENTER),
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
   }, [pickerSlideAnim]);
 
   const handleClosePicker = useCallback(() => {
-    Animated.timing(pickerSlideAnim, { toValue: Dimensions.get('window').width, duration: 260, useNativeDriver: true })
-      .start(() => setActivePicker(null));
+    Animated.timing(pickerSlideAnim, {
+      toValue: Dimensions.get('window').width,
+      duration: motionDuration(DURATION_EXIT),
+      easing: Easing.in(Easing.quad),
+      useNativeDriver: true,
+    }).start(() => setActivePicker(null));
   }, [pickerSlideAnim]);
 
   const potentialParents = useMemo(() => {

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -17,8 +17,20 @@ import Animated, {
 import { Svg, Circle } from 'react-native-svg';
 import { SPRING_SETTLE, clampWithRubberband } from '../utils/motion';
 
-const SCREEN_TIMING = { duration: 300, easing: Easing.out(Easing.cubic) };
-const PILL_TIMING = { duration: 200, easing: Easing.out(Easing.quad) };
+// One physics for a tab change, whichever way it was asked for.
+//
+// A tap used to animate the strip on a 300ms timing curve and the pill on a
+// 200ms one, while a swipe released both into SPRING_SETTLE with the finger's
+// velocity. Three consequences, all of them visible: the pill arrived a tenth of
+// a second before the screen it belongs to, the same journey felt different
+// depending on how it was started, and a tap landing on a still-settling swipe
+// switched curves mid-flight. A spring is also the only form that re-targets
+// cleanly when that happens — a timing restarts from its own zero.
+//
+// The response is shortened from SPRING_SETTLE's 350ms because switching tabs is
+// something a user does dozens of times a day, and the ceiling for motion at
+// that frequency is lower than for a sheet they open occasionally.
+const TAB_SPRING = { ...SPRING_SETTLE, duration: 280 };
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import OperationsScreen from '../screens/OperationsScreen';
 import AccountsScreen from '../screens/AccountsScreen';
@@ -344,10 +356,10 @@ export default function SimpleTabs() {
     // UI thread and does not depend on a React render, so it starts on the very
     // next frame instead of waiting for React to commit the tab-highlight change.
     activeIndex.value = newIndex;
-    pillPosition.value = withTiming(newIndex, PILL_TIMING);
+    pillPosition.value = withSpring(newIndex, TAB_SPRING);
 
     if (distance === 1) {
-      translateX.value = withTiming(-newIndex * SCREEN_WIDTH, SCREEN_TIMING);
+      translateX.value = withSpring(-newIndex * SCREEN_WIDTH, TAB_SPRING);
     } else {
       // ---- Non-adjacent tab ----
       // Reposition the target screen to sit immediately adjacent to the source
@@ -372,7 +384,7 @@ export default function SimpleTabs() {
       }
 
       targetAdjust.value = adjacentOffset; // instant reposition on worklet thread
-      translateX.value = withTiming(-(oldIndex + direction) * SCREEN_WIDTH, SCREEN_TIMING, (finished) => {
+      translateX.value = withSpring(-(oldIndex + direction) * SCREEN_WIDTH, TAB_SPRING, (finished) => {
         'worklet';
         if (!finished) return;
         // Snap strip, zero offset, restore opacities — all on worklet thread, no flash.
@@ -498,12 +510,12 @@ export default function SimpleTabs() {
         // banded edge), so the same two springs cover both "commit" and "snap back".
         activeIndex.value = newIndex;
         pillPosition.value = withSpring(newIndex, {
-          ...SPRING_SETTLE,
+          ...TAB_SPRING,
           velocity: -velocityX / SCREEN_WIDTH,
         });
         translateX.value = withSpring(
           -newIndex * SCREEN_WIDTH,
-          { ...SPRING_SETTLE, velocity: velocityX },
+          { ...TAB_SPRING, velocity: velocityX },
           (isFinished) => {
             if (isFinished && newIndex !== currentIndex) {
               runOnJS(setActive)(TABS[newIndex].key);

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -18,6 +18,8 @@ import { useAccountsData } from '../contexts/AccountsDataContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { getDefaultAccountId, setDefaultAccountId } from '../services/PreferencesDB';
+import { DURATION_ENTER, DURATION_EXIT } from '../utils/motion';
+import { motionDuration } from '../utils/reducedMotion';
 import { computeNetWorthSummary, getOperationsByDateRange } from '../services/OperationsDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { parseCardMasks, serializeCardMasks, cardMaskLast4 } from '../utils/cardMask';
@@ -565,7 +567,7 @@ export default function AccountsScreen({ onBackStateChange }) {
     setNewCardMask('');
     Animated.timing(formPanelAnim, {
       toValue: 1,
-      duration: 260,
+      duration: motionDuration(DURATION_ENTER),
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
@@ -574,7 +576,7 @@ export default function AccountsScreen({ onBackStateChange }) {
   const closeFormPanel = useCallback(() => {
     Animated.timing(formPanelAnim, {
       toValue: 0,
-      duration: 200,
+      duration: motionDuration(DURATION_EXIT),
       easing: Easing.in(Easing.quad),
       useNativeDriver: true,
     }).start(() => {
@@ -675,16 +677,21 @@ export default function AccountsScreen({ onBackStateChange }) {
     setCurrencyPanelVisible(true);
     Animated.timing(currencySlideAnim, {
       toValue: 0,
-      duration: 260,
+      duration: motionDuration(DURATION_ENTER),
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
   }, [currencySlideAnim]);
 
   const handleClosePicker = useCallback(() => {
+    // Accelerating and shorter than the entry, like closeFormPanel above it and
+    // every other subpanel in the app. Left without an `easing` this inherited
+    // React Native's symmetric `inOut(ease)` default, so the currency picker was
+    // the one panel that took as long to leave as it did to arrive.
     Animated.timing(currencySlideAnim, {
       toValue: Dimensions.get('window').width,
-      duration: 260,
+      duration: motionDuration(DURATION_EXIT),
+      easing: Easing.in(Easing.quad),
       useNativeDriver: true,
     }).start(() => setCurrencyPanelVisible(false));
   }, [currencySlideAnim]);

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -17,6 +17,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import { DURATION_ENTER, DURATION_EXIT } from '../utils/motion';
+import { motionDuration } from '../utils/reducedMotion';
 import AddFAB from '../components/AddFAB';
 import EmptyState from '../components/EmptyState';
 import LoadingView from '../components/LoadingView';
@@ -102,16 +104,16 @@ const CategoriesScreen = ({ onBackStateChange }) => {
     setFormErrors({});
     setActivePanel('form');
     Animated.parallel([
-      Animated.timing(listAnim, { toValue: 1, duration: 200, easing: Easing.in(Easing.quad), useNativeDriver: true }),
-      Animated.timing(formAnim, { toValue: 1, duration: 260, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+      Animated.timing(listAnim, { toValue: 1, duration: motionDuration(DURATION_EXIT), easing: Easing.in(Easing.quad), useNativeDriver: true }),
+      Animated.timing(formAnim, { toValue: 1, duration: motionDuration(DURATION_ENTER), easing: Easing.out(Easing.cubic), useNativeDriver: true }),
     ]).start();
   }, [listAnim, formAnim, gridParentId, categories]);
 
   const closeForm = useCallback(() => {
     Keyboard.dismiss();
     Animated.parallel([
-      Animated.timing(formAnim, { toValue: 0, duration: 180, easing: Easing.in(Easing.quad), useNativeDriver: true }),
-      Animated.timing(listAnim, { toValue: 0, duration: 240, easing: Easing.out(Easing.cubic), useNativeDriver: true }),
+      Animated.timing(formAnim, { toValue: 0, duration: motionDuration(180), easing: Easing.in(Easing.quad), useNativeDriver: true }),
+      Animated.timing(listAnim, { toValue: 0, duration: motionDuration(240), easing: Easing.out(Easing.cubic), useNativeDriver: true }),
     ]).start(() => {
       setActivePanel(null);
       setFormErrors({});
@@ -158,7 +160,7 @@ const CategoriesScreen = ({ onBackStateChange }) => {
     setActivePicker(pickerKey);
     Animated.timing(pickerSlideAnim, {
       toValue: 0,
-      duration: 220,
+      duration: motionDuration(220),
       easing: Easing.out(Easing.cubic),
       useNativeDriver: true,
     }).start();
@@ -167,7 +169,7 @@ const CategoriesScreen = ({ onBackStateChange }) => {
   const handleClosePicker = useCallback(() => {
     Animated.timing(pickerSlideAnim, {
       toValue: Dimensions.get('window').width,
-      duration: 180,
+      duration: motionDuration(180),
       easing: Easing.in(Easing.quad),
       useNativeDriver: true,
     }).start(() => setActivePicker(null));

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { View, StyleSheet, FlatList, TouchableOpacity, TextInput, Pressable, Modal, Keyboard, BackHandler } from 'react-native';
-import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -38,8 +38,16 @@ import useQuickAddLocation from '../hooks/useQuickAddLocation';
 import usePendingOperationSuggestions from '../hooks/usePendingOperationSuggestions';
 import { useSearch } from '../contexts/SearchContext';
 import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
+import { TIMING_ENTER, TIMING_EXIT, DURATION_ENTER, DURATION_EXIT } from '../utils/motion';
 
 // Note: dynamic createStyles removed to keep linting stable.
+
+// Ceiling for the quick-add clip, not a size: at rest the clip must not
+// constrain the form, because the form's height changes underneath it (transfer
+// fields appear, a suggestion deck stacks over it) and pinning it to whatever it
+// measured last would slice those off. The collapse animation never travels from
+// here — it starts at the block's measured height (see the searchMode effect).
+const QUICK_ADD_UNCLIPPED = 1000;
 
 // Map a QuickAdd validation failure to the form field that should flash red,
 // so single-field omissions get the same lightweight inline treatment the
@@ -123,20 +131,44 @@ const OperationsScreen = () => {
   const scrollOffsetRef = useRef(0);
   const prevFiltersExpandedRef = useRef(false);
   const prevSearchModeRef = useRef(searchMode);
-  const quickAddMaxHeight = useSharedValue(1000); // Large enough to not clip
+  const quickAddMaxHeight = useSharedValue(QUICK_ADD_UNCLIPPED);
   const quickAddTranslateY = useSharedValue(0);
+  // Live height of the block being clipped, measured on the slide container.
+  // A ref, not state: nothing renders from it, and onLayout fires often enough
+  // that a state write here would re-render the whole screen for nothing.
+  const quickAddClipHeightRef = useRef(0);
+  const handleQuickAddClipLayout = useCallback((event) => {
+    quickAddClipHeightRef.current = Math.round(event.nativeEvent.layout.height);
+  }, []);
 
   // Animate when searchMode changes
   useEffect(() => {
+    // Collapse from the block's REAL height rather than from the 1000 ceiling.
+    // Animating 1000 → 0 spends ~93% of its time above the form's ~200dp, where
+    // the clip touches nothing: the list below sat still for 300ms and then
+    // jumped as the last 20ms cut through the actual content. Starting at the
+    // measured height makes every frame of the collapse a frame the eye can see.
+    const measured = quickAddClipHeightRef.current || QUICK_ADD_UNCLIPPED;
     if (searchMode === 'open') {
-      // Outer clip collapses (easeIn so it accelerates into zero),
-      // inner content slides upward within the fixed clip boundary.
-      quickAddMaxHeight.value = withTiming(0, { duration: 320, easing: Easing.in(Easing.cubic) });
-      quickAddTranslateY.value = withTiming(-120, { duration: 320, easing: Easing.in(Easing.cubic) });
+      // Outer clip collapses; inner content slides upward within it, travelling
+      // exactly its own height so it clears the boundary as the boundary closes.
+      quickAddMaxHeight.value = measured;
+      quickAddMaxHeight.value = withTiming(0, { ...TIMING_EXIT, duration: DURATION_EXIT });
+      quickAddTranslateY.value = withTiming(-measured, { ...TIMING_EXIT, duration: DURATION_EXIT });
     } else {
-      // Slide back down — content descends into view as height expands.
-      quickAddTranslateY.value = withTiming(0, { duration: 300, easing: Easing.out(Easing.cubic) });
-      quickAddMaxHeight.value = withTiming(1000, { duration: 300, easing: Easing.out(Easing.cubic) });
+      // Slide back down — content descends into view as the clip opens.
+      quickAddTranslateY.value = withTiming(0, { ...TIMING_ENTER, duration: DURATION_ENTER });
+      quickAddMaxHeight.value = withTiming(
+        measured,
+        { ...TIMING_ENTER, duration: DURATION_ENTER },
+        (finished) => {
+          'worklet';
+          // Hand the ceiling back once the form is fully open, so it can grow
+          // (transfer fields, suggestion deck) without being clipped at the
+          // height it happened to have when search closed.
+          if (finished) quickAddMaxHeight.value = QUICK_ADD_UNCLIPPED;
+        },
+      );
     }
   }, [searchMode]);
 
@@ -1007,7 +1039,7 @@ const OperationsScreen = () => {
   const quickAddFormComponent = useMemo(() => (
     <>
       <Animated.View style={animatedQuickAddClipStyle}>
-        <Animated.View style={animatedQuickAddSlideStyle}>
+        <Animated.View style={animatedQuickAddSlideStyle} onLayout={handleQuickAddClipLayout}>
           {/* Deck container: the binding cards overlay the quick-add form
               (absolute, sized to the measured wrapper below), with top padding
               for the peeking edges of the cards behind the front one. The
@@ -1075,7 +1107,7 @@ const OperationsScreen = () => {
       </Animated.View>
       {filtersExpanded && filterPanelHeight > 0 && <View style={{ height: filterPanelHeight }} />}
     </>
-  ), [animatedQuickAddClipStyle, animatedQuickAddSlideStyle, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, handleOperationCurrencyChange, foreignRateSource, foreignExchangeRate, filterPanelHeight, filtersExpanded, quickAddFlash, operationSuggestions, hasSuggestions, quickAddHeight, handleQuickAddLayout, accounts, categories, suggestionSaveErrors, suggestionChoices, setSuggestionChoice, acceptSuggestion, dismissSuggestion]);
+  ), [animatedQuickAddClipStyle, animatedQuickAddSlideStyle, handleQuickAddClipLayout, colors, t, quickAddValues, visibleAccounts, filteredCategories, topCategoriesForType, getCategoryInfo, getAccountName, getAccountBalance, getCategoryName, openPicker, handleQuickAdd, handleAmountChange, handleExchangeRateChange, handleDestinationAmountChange, handleAutoAddWithCategory, topTransferAccountsForForm, handleAutoAddWithAccount, TYPES, rateSource, handleOperationCurrencyChange, foreignRateSource, foreignExchangeRate, filterPanelHeight, filtersExpanded, quickAddFlash, operationSuggestions, hasSuggestions, quickAddHeight, handleQuickAddLayout, accounts, categories, suggestionSaveErrors, suggestionChoices, setSuggestionChoice, acceptSuggestion, dismissSuggestion]);
 
   // Auto-scroll to top when filter panel closes, but only if the user is still
   // near the top (hasn't scrolled into past dates). The threshold is filterPanelHeight:

--- a/app/utils/motion.js
+++ b/app/utils/motion.js
@@ -60,16 +60,46 @@ export const SPRING_SETTLE = {
  * plan), so each caller states its own and spreads this in for the rest:
  *   withTiming(1, { ...TIMING_ENTER, duration: 280 })
  *
- * `reduceMotion` is the point of having this at all. It is the one property that
- * is easy to leave off and impossible to see missing, and omitting it means the
- * surface ignores the OS "Remove animations" setting. Spreading this makes the
- * accessible behaviour the default rather than something each call site
- * remembers.
+ * `reduceMotion: 'system'` is Reanimated's own default, so spreading this does
+ * not switch the behaviour on. What it does is state it: a call site that opts
+ * out (`reduceMotion: 'never'`) then reads as a deliberate exception rather than
+ * as the norm. The legacy `Animated` API has no equivalent at all — surfaces on
+ * that API need the `useReducedMotion` hook to honour the OS setting.
  */
 export const TIMING_ENTER = {
   easing: Easing.out(Easing.cubic),
   reduceMotion: 'system',
 };
+
+/**
+ * The mirror of TIMING_ENTER, for a surface leaving on a timing.
+ *
+ * Accelerating, not decelerating: a thing on its way out has nothing to settle
+ * into, and easing *into* the exit gets it off the screen while the eye is still
+ * on it. This is the curve CLAUDE.md's subpanel convention already names; having
+ * it here is what stops the next panel from silently inheriting React Native's
+ * `Easing.inOut(Easing.ease)` default, which is what an `Animated.timing` with no
+ * `easing` key gets — a symmetric curve that reads as slow at both ends.
+ */
+export const TIMING_EXIT = {
+  easing: Easing.in(Easing.quad),
+  reduceMotion: 'system',
+};
+
+/**
+ * The two durations the app's panels travel on.
+ *
+ * Asymmetric on purpose: arriving is the part the user waits for and watches, so
+ * it gets room to decelerate; leaving is a thing they have already decided on, so
+ * it gets out of the way. Both sit inside the 300ms budget UI motion has before
+ * it starts reading as latency.
+ *
+ * Surfaces with their own travel distance (a full-screen sheet, a dialog that
+ * barely moves) still state their own duration — these are the default for the
+ * ordinary case of a panel sliding over another panel.
+ */
+export const DURATION_ENTER = 260;
+export const DURATION_EXIT = 200;
 
 /**
  * Spring for a small badge or glyph confirming that an action landed.

--- a/app/utils/reducedMotion.js
+++ b/app/utils/reducedMotion.js
@@ -1,0 +1,73 @@
+// app/utils/reducedMotion.js
+/**
+ * OS "Remove animations" support for the surfaces still on React Native's
+ * `Animated` API.
+ *
+ * Reanimated reads the accessibility setting itself — every `withTiming` /
+ * `withSpring` in the app defaults to `ReduceMotion.System` and jumps straight to
+ * the target when the user has asked for less movement. The legacy `Animated`
+ * API has no such notion, so roughly half of this app's motion (every modal
+ * subpanel, the bottom sheet, the currency pickers) ignored the setting
+ * entirely. This module is that half's version of the same behaviour.
+ *
+ * It is a module-level cache rather than a hook on purpose. The call sites are
+ * `Animated.timing` configs inside `useCallback`s, not render bodies — a hook
+ * would mean threading a value through every one of them and re-creating the
+ * callbacks whenever it changed, to animate the exact same way. A synchronous
+ * getter reads correctly at the moment the animation is built, which is the only
+ * moment that matters.
+ *
+ * What "reduced" means here follows the accessibility guidance rather than the
+ * blunt reading of it: movement is dropped, feedback is not. A panel that slides
+ * in arrives instantly (duration 0); a thing that only fades keeps fading, and a
+ * progress bar keeps depleting — those carry information, not decoration. So
+ * `motionDuration` is applied to travel, and deliberately not to every timing in
+ * the codebase.
+ */
+
+import { AccessibilityInfo } from 'react-native';
+
+let enabled = false;
+let subscribed = false;
+
+// Subscribe lazily, on the first query, rather than at import time: this module
+// is imported by screens that unit tests render with AccessibilityInfo mocked to
+// a bare object, and an import-time listener would throw there before any test
+// body runs.
+function ensureSubscribed() {
+  if (subscribed) return;
+  subscribed = true;
+  try {
+    AccessibilityInfo.isReduceMotionEnabled?.()
+      ?.then((value) => { enabled = !!value; })
+      ?.catch(() => {});
+    AccessibilityInfo.addEventListener?.('reduceMotionChanged', (value) => {
+      enabled = !!value;
+    });
+  } catch {
+    // An environment without the accessibility module animates normally.
+    enabled = false;
+  }
+}
+
+/** Whether the OS has asked for reduced motion. Synchronous; safe before init. */
+export function isReduceMotionEnabled() {
+  ensureSubscribed();
+  return enabled;
+}
+
+/**
+ * A duration for an animation that moves something.
+ *
+ * @param {number} ms  The duration to use normally.
+ * @returns {number} `ms`, or 0 when the OS asked for reduced motion.
+ */
+export function motionDuration(ms) {
+  return isReduceMotionEnabled() ? 0 : ms;
+}
+
+/** Test seam: force the cached value (and skip the async read). */
+export function __setReduceMotionForTests(value) {
+  subscribed = true;
+  enabled = !!value;
+}


### PR DESCRIPTION
A motion audit of the whole app, and the seven fixes it produced. The gesture layer added in #1459 / #1463 was already right — this is the rest of the app catching up to the tokens that work introduced.

## What was wrong

**Quick-add collapse felt like a jump, not a collapse.** `OperationsScreen` animated the clip's `maxHeight` from a hardcoded `1000` to `0`. The form is ~200dp tall, so ~93% of the 320ms happened above the content where the clip touches nothing — the list below sat still — and then the last ~20ms cut through the entire form at once. Now it collapses from the block's measured height, and hands the ceiling back once open so the form can still grow (transfer fields, suggestion deck).

**One tab change, three physics.** A tap moved the strip on a 300ms timing and the pill on a 200ms one, so the pill arrived a tenth of a second before the screen it belongs to; a swipe released both into `SPRING_SETTLE` with the finger's velocity. All four call sites now share one spring — with a 280ms response, because switching tabs is a dozens-of-times-a-day action and the ceiling for motion at that frequency is lower than for a sheet.

**The bottom sheet arrived and left as different objects.** Opening used a `bounciness: 2` spring of its own, whose overshoot travels a card pinned to `justifyContent: 'flex-end'` past the bottom edge and briefly opens a strip of screen below it — exactly what `ANIMATED_SPRING_SETTLE` clamps. Tapping the overlay left on a 200ms timing while dragging left on a velocity-carrying spring. Both now use the same spring.

**Half the app ignored "Remove animations".** Reanimated honours the OS setting by default (`ReduceMotion.System`), so the newer surfaces were covered; every surface still on React Native's `Animated` had no equivalent and ignored it entirely — `AccessibilityInfo` appeared nowhere in the codebase. Adds `app/utils/reducedMotion.js`, a lazily-subscribed cache with a synchronous getter, and applies it to **travel only**: panels arrive instantly, while fades, the undo countdown and the update spinner keep running. Reduced motion means gentler, not none.

**Two panels inherited React Native's default easing.** `CategoryModal`'s picker and `AccountsScreen`'s currency picker passed no `easing` key, so they got `Easing.inOut(Easing.ease)` — symmetric, slow off the mark both ways. That is why they felt heavier than the identical picker in `SplitOperationModal`, which states the convention. Both now follow CLAUDE.md's subpanel curves.

**Nine hand-typed durations across 15+ files.** Adds `TIMING_EXIT`, `DURATION_ENTER` and `DURATION_EXIT` beside the existing `TIMING_ENTER`. Also corrects the `TIMING_ENTER` comment, which claimed that omitting `reduceMotion` makes a surface ignore the OS setting — it is Reanimated's default; the token states the intent rather than switching it on.

## Deliberately not changed

- `Easing.in(...)` on subpanel exits — the convention CLAUDE.md documents.
- `height` animation in `GraphsScreen:587` — the panel has to actually grow; there is no transform equivalent that doesn't distort the chart.
- `OperationActionMenu`'s instant unmount on close — documented as the intended feel for a context menu.
- The `isTransitioningRef` lock during a non-adjacent tab tap. It still blocks input for the length of the transition, but lifting it means reworking the off-screen repositioning that makes non-adjacent switches look adjacent — a separate change with real regression risk in the most-used part of the app.

## Verification

- 4911 tests passing (167 suites), including 10 new ones for the reduced-motion cache.
- `eslint --max-warnings 0` clean.
- Feel checks worth doing on device: open/close search and watch the list below the quick-add move throughout the collapse rather than at the end; tap a non-adjacent tab and confirm pill and screen arrive together; flick the bottom sheet up and confirm no strip of background appears under it; enable Settings → Accessibility → Remove animations and confirm panels appear instantly while the undo countdown still depletes.
