### PR TITLE
feat(budgets): group several allocations under one envelope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ The app follows a feature-based organization under the `app/` directory:
   - Monitoring: `sentry.js` - Privacy-protective crash/error reporting (Sentry)
 
 - **db/** (1 file) - Database schema
-  - `schema.js` - Drizzle ORM schema (tables: accounts, categories, operations, budgets, budgetPlans, budgetPlanLines, plannedOperations, balanceHistory, appMetadata; `budgets` and `plannedOperations` are legacy/append-only since Budgets v3 — see docs/DATABASE.md)
+  - `schema.js` - Drizzle ORM schema (tables: accounts, categories, operations, budgets, budgetPlans, budgetPlanLines, budgetPlanLineCategories, budgetPlanLineGroups, plannedOperations, balanceHistory, appMetadata; `budgets` and `plannedOperations` are legacy/append-only since Budgets v3 — see docs/DATABASE.md)
 
 - **defaults/** (2 files) - Default/seed data
   - `defaultAccounts.js`, `defaultOperations.js`
@@ -152,7 +152,7 @@ Bottom tab bar height is set to 80px with 24px bottom padding.
 
 **Database Layer** (SQLite via Drizzle ORM):
 - SQLite database (`penny.db`)
-- Schema defined in `app/db/schema.js` - tables: accounts, categories, operations, budgets, budgetPlans, budgetPlanLines, plannedOperations, balanceHistory, appMetadata
+- Schema defined in `app/db/schema.js` - tables: accounts, categories, operations, budgets, budgetPlans, budgetPlanLines, budgetPlanLineCategories, budgetPlanLineGroups, plannedOperations, balanceHistory, appMetadata
 - Migrations managed by Drizzle Kit in `drizzle/` directory
 - DB modules: `AccountsDB.js`, `BudgetsDB.js`, `BudgetPlansDB.js`, `CategoriesDB.js`, `OperationsDB.js`, `BalanceHistoryDB.js`, `PreferencesDB.js`
 

--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -121,6 +121,16 @@ jest.mock('../../../app/components/budgets/BudgetPlanLineModal', () => {
           currency: 'USD',
         }),
       }, React.createElement(Text, {}, 'currency only')),
+      // Line groups (migration 0022): the group rides on the same save payload
+      // as every other field the editor collects.
+      React.createElement(Pressable, {
+        testID: 'mock-save-grouped-line',
+        onPress: () => props.onSaveLine({
+          amount: '250', label: 'New', comment: null, kind: 'expense',
+          categoryId: 'cat1', toAccountId: null, accountId: null,
+          isRecurring: false, currency: null, groupId: 'g1',
+        }),
+      }, React.createElement(Text, {}, 'save grouped')),
       React.createElement(Pressable, {
         testID: 'mock-delete-line',
         onPress: () => props.onDeleteLine(props.line?.id),
@@ -147,7 +157,7 @@ const ACCOUNTS = [
   { id: 2, name: 'Cash', currency: 'USD' },
 ];
 
-const setPlans = ({ plans = [], lines = [], planStatuses = new Map() } = {}) => {
+const setPlans = ({ plans = [], lines = [], planStatuses = new Map(), groups = [] } = {}) => {
   mockPlans = {
     plans,
     planStatuses,
@@ -165,6 +175,12 @@ const setPlans = ({ plans = [], lines = [], planStatuses = new Map() } = {}) => 
     // The section now loads its lines (recurring UNION this month's one-off
     // lines) via getLinesForMonth rather than getPlanLines directly.
     getLinesForMonth: jest.fn(async () => lines),
+    // Line groups (migration 0022) — global, loaded alongside the month's lines.
+    getLineGroups: jest.fn(async () => groups),
+    addLineGroup: jest.fn(async (group) => ({ id: 'g-new', isDerived: group.amount == null, ...group })),
+    updateLineGroup: jest.fn(async () => {}),
+    deleteLineGroup: jest.fn(async () => {}),
+    reorderLineGroups: jest.fn(async () => {}),
     // Executable templates (Budgets v3 phase 3)
     executeLine: jest.fn(async () => ({ id: 99 })),
     markLineExecuted: jest.fn(async () => {}),
@@ -1409,6 +1425,109 @@ describe('MonthlyPlanSection', () => {
       await waitFor(() => expect(getByTestId('plan-line-i1')).toBeTruthy());
       expect(queryByText('0 / 220')).toBeNull();
       expect(getByTestId('plan-income-total')).toHaveTextContent(/150 \/ 220 USD/);
+    });
+  });
+  describe('Line groups (migration 0022)', () => {
+    const GROUP = { id: 'g1', label: 'Car', amount: null, currency: null, sortOrder: 0, isDerived: true };
+    const groupedLines = () => ([
+      {
+        id: 'l-fuel', planId: 'p1', amount: '300', label: 'Fuel', comment: null, kind: 'expense',
+        categoryId: 'cat1', categoryIds: ['cat1'], toAccountId: null, sortOrder: 0, isBroken: false,
+        isRecurring: false, currency: null, groupId: 'g1',
+      },
+      {
+        id: 'l-parking', planId: 'p1', amount: '120', label: 'Parking', comment: null, kind: 'expense',
+        categoryId: 'cat2', categoryIds: ['cat2'], toAccountId: null, sortOrder: 1, isBroken: false,
+        isRecurring: false, currency: null, groupId: 'g1',
+      },
+      {
+        id: 'l-loose', planId: 'p1', amount: '50', label: 'Books', comment: null, kind: 'expense',
+        categoryId: 'cat1', categoryIds: ['cat1'], toAccountId: null, sortOrder: 2, isBroken: false,
+        isRecurring: false, currency: null, groupId: null,
+      },
+    ]);
+
+    it('renders a group header with the sum of its lines and indents its children', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [GROUP],
+      });
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+
+      // Derived budget: 300 + 120, formatted compactly like every other figure.
+      expect(getByTestId('plan-group-g1')).toHaveTextContent(/420/);
+      // Both children render, and both are indented; the ungrouped line is not.
+      const indent = (id) => StyleSheet.flatten(getByTestId(id).props.style)?.paddingLeft;
+      expect(indent('plan-line-l-fuel')).toBeGreaterThan(indent('plan-line-l-loose') ?? 0);
+      expect(indent('plan-line-l-parking')).toBe(indent('plan-line-l-fuel'));
+    });
+
+    it('counts a custom group budget in the month total instead of its children', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [{ ...GROUP, amount: '500', currency: 'USD', isDerived: false }],
+      });
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+
+      // 500 (the override) + 50 (the ungrouped line) — NOT 300 + 120 + 50.
+      expect(getByTestId('plan-totals')).toHaveTextContent(/550 USD/);
+      expect(getByTestId('plan-group-g1')).toHaveTextContent(/500/);
+    });
+
+    it('leaves the month total alone for a derived group', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [GROUP],
+      });
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+      expect(getByTestId('plan-totals')).toHaveTextContent(/470 USD/);
+    });
+
+    it('shows a group only in months where it has a line', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: [groupedLines()[2]],
+        groups: [GROUP],
+      });
+      const { queryByTestId, getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l-loose')).toBeTruthy());
+      expect(queryByTestId('plan-group-g1')).toBeNull();
+    });
+
+    it('opens the group editor when the group row is tapped', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [GROUP],
+      });
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+      await act(async () => { fireEvent.press(getByTestId('plan-group-g1')); });
+      await waitFor(() => expect(getByTestId('plan-group-modal')).toBeTruthy());
+      expect(getByTestId('plan-group-name').props.value).toBe('Car');
+    });
+
+    it('carries the picked group through to the saved line', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [GROUP],
+      });
+      const ref = React.createRef();
+      const { getByTestId } = await renderSection(ref);
+      await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+      // The stubbed editor is what a real pick would produce: the group travels
+      // on the same payload as every other field of the line.
+      await act(async () => { ref.current.openAddLine(); });
+      await waitFor(() => expect(getByTestId('mock-save-grouped-line')).toBeTruthy());
+      await act(async () => { fireEvent.press(getByTestId('mock-save-grouped-line')); });
+      expect(mockPlans.addLine).toHaveBeenCalledWith('p1', expect.objectContaining({ groupId: 'g1' }));
     });
   });
 });

--- a/__tests__/services/BackupRestore.test.js
+++ b/__tests__/services/BackupRestore.test.js
@@ -173,8 +173,8 @@ describe('BackupRestore', () => {
       expect(backup.timestamp).toBeDefined();
       // accounts, categories, operations, budgets, app_metadata, balance_history,
       // planned_operations, notification_merchant_rules, budget_plans,
-      // budget_plan_lines, budget_plan_line_categories
-      expect(mockDb.queryAll).toHaveBeenCalledTimes(11);
+      // budget_plan_lines, budget_plan_line_categories, budget_plan_line_groups
+      expect(mockDb.queryAll).toHaveBeenCalledTimes(12);
     });
 
     it('includes empty arrays when tables are empty', async () => {
@@ -566,10 +566,13 @@ describe('BackupRestore', () => {
       expect(deleteCalls[3]).toContain('budget_plan_line_categories');
       expect(deleteCalls[4]).toContain('budget_plan_lines');
       expect(deleteCalls[5]).toContain('budget_plans');
-      expect(deleteCalls[6]).toContain('accounts_balance_history');
-      expect(deleteCalls[7]).toContain('operations');
-      expect(deleteCalls[8]).toContain('categories');
-      expect(deleteCalls[9]).toContain('accounts');
+      // Groups (migration 0022) are referenced BY lines (ON DELETE SET NULL), so
+      // they clear after the lines that point at them.
+      expect(deleteCalls[6]).toContain('budget_plan_line_groups');
+      expect(deleteCalls[7]).toContain('accounts_balance_history');
+      expect(deleteCalls[8]).toContain('operations');
+      expect(deleteCalls[9]).toContain('categories');
+      expect(deleteCalls[10]).toContain('accounts');
     });
 
     it('preserves db_version metadata', async () => {
@@ -1676,14 +1679,14 @@ op-2,income,20,acc-1,cat-1`;
       const catCall = lineInserts.find(c => c[1][0] === 'line-cat');
       expect(catCall[1]).toEqual([
         'line-cat', 'plan-1', 'Groceries', '400.00', NON_ASCII_COMMENT,
-        'cat-1', null, 0, 0, null, null, null, null, 1, 'x', 'y',
+        'cat-1', null, 0, 0, null, null, null, null, 1, null, 'x', 'y',
       ]);
 
       // Transfer line: category_id null, to_account_id remapped 'acc-uuid' -> 42.
       const xferCall = lineInserts.find(c => c[1][0] === 'line-xfer');
       expect(xferCall[1]).toEqual([
         'line-xfer', 'plan-1', 'To savings', '500.00', null,
-        null, REMAPPED_ACCOUNT_ID, 1, 0, null, null, null, null, 1, 'x', 'y',
+        null, REMAPPED_ACCOUNT_ID, 1, 0, null, null, null, null, 1, null, 'x', 'y',
       ]);
 
       // A pre-0021 backup carries no junction, so the category line's link is
@@ -1764,7 +1767,7 @@ op-2,income,20,acc-1,cat-1`;
       expect(lineInserts).toHaveLength(1);
       expect(lineInserts[0][1]).toEqual([
         'line-rec', null, 'Rent', '65000', null,
-        'cat-1', null, 0, 1, 'USD', null, null, null, 1, 'x', 'y',
+        'cat-1', null, 0, 1, 'USD', null, null, null, 1, null, 'x', 'y',
       ]);
     });
 
@@ -1788,6 +1791,63 @@ op-2,income,20,acc-1,cat-1`;
       const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
       expect(lineInserts).toHaveLength(1);
       expect(lineInserts[0][1][0]).toBe('line-rec');
+    });
+
+    // Migration 0022: a group is restored before the lines that point at it, and
+    // a line whose group the backup doesn't carry comes back ungrouped rather
+    // than failing its foreign key and aborting the whole import.
+    describe('line groups (migration 0022)', () => {
+      const derivedGroup = {
+        id: 'grp-1', label: 'Car', amount: null, currency: null,
+        sort_order: 0, created_at: 'x', updated_at: 'y',
+      };
+
+      it('restores groups before the lines and keeps their membership', async () => {
+        const dbInstance = makeDbInstance();
+        mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+        const backup = backupWithPlan();
+        backup.data.budget_plan_line_groups = [derivedGroup];
+        backup.data.budget_plan_lines = [{ ...categoryLine, group_id: 'grp-1' }];
+
+        await BackupRestore.restoreBackup(backup);
+
+        const groupInserts = findInsert(dbInstance, 'budget_plan_line_groups');
+        expect(groupInserts).toHaveLength(1);
+        expect(groupInserts[0][1].slice(0, 4)).toEqual(['grp-1', 'Car', null, null]);
+
+        const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
+        // ..., include_children, group_id, created_at, updated_at
+        expect(lineInserts[0][1][lineInserts[0][1].length - 3]).toBe('grp-1');
+      });
+
+      it('ungroups a line whose group is not in the backup', async () => {
+        const dbInstance = makeDbInstance();
+        mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+        const backup = backupWithPlan();
+        backup.data.budget_plan_lines = [{ ...categoryLine, group_id: 'grp-gone' }];
+
+        await BackupRestore.restoreBackup(backup);
+
+        const lineInserts = findInsert(dbInstance, 'budget_plan_lines');
+        expect(lineInserts[0][1][lineInserts[0][1].length - 3]).toBeNull();
+      });
+
+      it('reads a CSV-blanked amount back as a derived group, not as an empty string', async () => {
+        const dbInstance = makeDbInstance();
+        mockDb.executeTransaction.mockImplementation(async (cb) => { await cb(dbInstance); });
+
+        const backup = backupWithPlan();
+        // What a CSV round trip produces for a group with no override.
+        backup.data.budget_plan_line_groups = [{ ...derivedGroup, amount: '', currency: '' }];
+        backup.data.budget_plan_lines = [];
+
+        await BackupRestore.restoreBackup(backup);
+
+        const groupInserts = findInsert(dbInstance, 'budget_plan_line_groups');
+        expect(groupInserts[0][1].slice(2, 4)).toEqual([null, null]);
+      });
     });
 
     describe('legacy budgets -> recurring lines bridge (Budgets v3 phase 2)', () => {

--- a/__tests__/services/BudgetPlansDB.groups.test.js
+++ b/__tests__/services/BudgetPlansDB.groups.test.js
@@ -1,0 +1,339 @@
+/**
+ * Tests for budget line GROUPS (migration 0022): the envelope several plan lines
+ * can share. Covers group validation and CRUD, the derived-vs-override budget
+ * rule, group membership on lines, and what calculatePlanStatus does with both —
+ * in particular that an override REPLACES its children's sum in the month's
+ * allocated total while a derived group leaves it untouched.
+ */
+
+import * as BudgetPlansDB from '../../app/services/BudgetPlansDB';
+import { calculateSpendingForCategories } from '../../app/services/BudgetsDB';
+import { executeQuery, queryAll, queryFirst, executeTransaction } from '../../app/services/db';
+import {
+  fetchRatesToTarget,
+  convertWithRateMap,
+  getTransferTotals,
+  getUnconvertibleCurrencies,
+} from '../../app/services/OperationsDB';
+
+jest.mock('../../app/services/db');
+jest.mock('../../app/services/CategoriesDB');
+// Keep the real deriveSpendingStatus (the group's bands go through it) and stub
+// only the spending engine, exactly as BudgetPlansDB.status.test.js does.
+jest.mock('../../app/services/BudgetsDB', () => ({
+  ...jest.requireActual('../../app/services/BudgetsDB'),
+  calculateSpendingForCategories: jest.fn(),
+}));
+jest.mock('../../app/services/OperationsDB', () => ({
+  fetchRatesToTarget: jest.fn(),
+  convertWithRateMap: jest.fn(),
+  getTransferTotals: jest.fn(),
+  getUnconvertibleCurrencies: jest.fn(),
+  createOperationInTx: jest.fn(),
+}));
+
+let mockUuidCounter = 0;
+jest.mock('react-native-uuid', () => ({
+  v4: jest.fn(() => `uuid-${++mockUuidCounter}`),
+}));
+
+// Same deterministic rate stand-in the other BudgetPlansDB suites use: a fixed
+// map and a plain multiply; an unmapped currency converts to null (no rate).
+const stubRates = (rates) => {
+  const rateMap = new Map(Object.entries(rates));
+  fetchRatesToTarget.mockResolvedValue(rateMap);
+  convertWithRateMap.mockImplementation((amount, from, target, map) => {
+    if (from === target) return amount;
+    const rate = map.get(from);
+    if (!rate) return null;
+    return String(parseFloat(amount) * parseFloat(rate));
+  });
+};
+
+const PLAN_ROW = {
+  id: 'p1', month: '2026-07', currency: 'USD', expected_income: '1000',
+  created_at: 't', updated_at: 't',
+};
+
+const lineRow = (id, amount, { groupId = null, categoryId = 'cat1', sortOrder = 0 } = {}) => ({
+  id, plan_id: 'p1', label: null, amount, comment: null,
+  category_id: categoryId, category_ids: categoryId, to_account_id: null,
+  sort_order: sortOrder, is_recurring: 0, currency: null, group_id: groupId,
+  created_at: 't', updated_at: 't',
+});
+
+const groupRow = (id, label, { amount = null, currency = null, sortOrder = 0 } = {}) => ({
+  id, label, amount, currency, sort_order: sortOrder, created_at: 't', updated_at: 't',
+});
+
+// Dispatch the db mocks by SQL shape, like the status suite. Note the group
+// table's name is NOT a substring of the line table's, so the two never collide.
+const setupDb = ({ lines = [], groups = [], spending = '0' }) => {
+  queryFirst.mockImplementation(async (sql) => {
+    if (sql.includes('FROM budget_plans WHERE id')) return PLAN_ROW;
+    if (sql.includes("o.type = 'income'")) return { total: 0 };
+    return null;
+  });
+  queryAll.mockImplementation(async (sql) => {
+    if (sql.includes('FROM budget_plan_line_groups')) return groups;
+    if (sql.includes('is_recurring = 1') && !sql.includes('WHERE l.plan_id')) return [];
+    if (sql.includes('FROM budget_plan_lines')) return lines;
+    return [];
+  });
+  calculateSpendingForCategories.mockResolvedValue(spending);
+};
+
+describe('BudgetPlansDB line groups', () => {
+  let mockRunAsync;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUuidCounter = 0;
+    executeQuery.mockResolvedValue(undefined);
+    queryAll.mockResolvedValue([]);
+    queryFirst.mockResolvedValue(null);
+    calculateSpendingForCategories.mockResolvedValue('0');
+    getTransferTotals.mockResolvedValue({ incoming: '0', outgoing: '0' });
+    getUnconvertibleCurrencies.mockResolvedValue([]);
+    stubRates({});
+    mockRunAsync = jest.fn().mockResolvedValue(undefined);
+    executeTransaction.mockImplementation(async (cb) => cb({ runAsync: mockRunAsync }));
+  });
+
+  describe('validateLineGroup', () => {
+    it('accepts a group with just a name (its budget is derived)', () => {
+      expect(BudgetPlansDB.validateLineGroup({ label: 'Car' })).toBeNull();
+    });
+
+    it('rejects a missing or blank name', () => {
+      expect(BudgetPlansDB.validateLineGroup({})).toBe('A group name is required');
+      expect(BudgetPlansDB.validateLineGroup({ label: '   ' })).toBe('A group name is required');
+    });
+
+    it('rejects a non-positive or unparseable override amount', () => {
+      expect(BudgetPlansDB.validateLineGroup({ label: 'Car', amount: '0', currency: 'USD' }))
+        .toBe('Amount must be greater than zero');
+      expect(BudgetPlansDB.validateLineGroup({ label: 'Car', amount: 'x', currency: 'USD' }))
+        .toBe('Amount must be greater than zero');
+    });
+
+    it('requires a currency alongside an override amount', () => {
+      expect(BudgetPlansDB.validateLineGroup({ label: 'Car', amount: '500' }))
+        .toBe('Currency is required for a custom group budget');
+    });
+  });
+
+  describe('createLineGroup', () => {
+    it('stores a derived group with null amount AND null currency', async () => {
+      const created = await BudgetPlansDB.createLineGroup({ label: '  Car  ', currency: 'USD' });
+
+      expect(created).toMatchObject({ label: 'Car', amount: null, currency: null, isDerived: true });
+      const [, params] = executeQuery.mock.calls[0];
+      expect(params.slice(0, 4)).toEqual(['uuid-1', 'Car', null, null]);
+    });
+
+    it('stores an override amount with its currency', async () => {
+      const created = await BudgetPlansDB.createLineGroup({ label: 'Car', amount: '500', currency: 'EUR' });
+
+      expect(created).toMatchObject({ amount: '500', currency: 'EUR', isDerived: false });
+    });
+
+    it('rejects an invalid group before touching the database', async () => {
+      await expect(BudgetPlansDB.createLineGroup({ label: '' })).rejects.toThrow('A group name is required');
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateLineGroup', () => {
+    it('clears the stored currency when the override is removed', async () => {
+      await BudgetPlansDB.updateLineGroup('g1', { amount: null });
+
+      const [sql, params] = executeQuery.mock.calls[0];
+      expect(sql).toContain('amount = ?');
+      expect(sql).toContain('currency = ?');
+      expect(params.slice(0, 2)).toEqual([null, null]);
+    });
+
+    it('falls back to the stored currency when an amount is set without one', async () => {
+      queryFirst.mockResolvedValue({ currency: 'EUR' });
+
+      await BudgetPlansDB.updateLineGroup('g1', { amount: '500' });
+
+      const [, params] = executeQuery.mock.calls[0];
+      expect(params.slice(0, 2)).toEqual(['500', 'EUR']);
+    });
+
+    it('rejects an override with no currency anywhere to express it in', async () => {
+      queryFirst.mockResolvedValue({ currency: null });
+
+      await expect(BudgetPlansDB.updateLineGroup('g1', { amount: '500' }))
+        .rejects.toThrow('Currency is required for a custom group budget');
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+
+    it('rejects a blank name', async () => {
+      await expect(BudgetPlansDB.updateLineGroup('g1', { label: '  ' }))
+        .rejects.toThrow('A group name is required');
+    });
+
+    it('ignores a currency edit on a group that has no override to describe', async () => {
+      queryFirst.mockResolvedValue({ amount: null });
+
+      await BudgetPlansDB.updateLineGroup('g1', { currency: 'EUR' });
+
+      expect(executeQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteLineGroup', () => {
+    it('deletes only the group row — its lines are ungrouped by the FK, not deleted', async () => {
+      await BudgetPlansDB.deleteLineGroup('g1');
+
+      expect(executeQuery).toHaveBeenCalledTimes(1);
+      expect(executeQuery.mock.calls[0][0]).toContain('DELETE FROM budget_plan_line_groups');
+      expect(executeQuery.mock.calls[0][0]).not.toContain('budget_plan_lines');
+    });
+  });
+
+  describe('reorderLineGroups', () => {
+    it('writes each group\'s index as its sort order', async () => {
+      await BudgetPlansDB.reorderLineGroups(['g2', 'g1']);
+
+      expect(mockRunAsync).toHaveBeenNthCalledWith(1, expect.stringContaining('sort_order = ?'), [0, expect.any(String), 'g2']);
+      expect(mockRunAsync).toHaveBeenNthCalledWith(2, expect.any(String), [1, expect.any(String), 'g1']);
+    });
+
+    it('rejects a duplicate id rather than half-applying an order', async () => {
+      await expect(BudgetPlansDB.reorderLineGroups(['g1', 'g1'])).rejects.toThrow('Duplicate group ID');
+    });
+  });
+
+  describe('membership on a line', () => {
+    it('maps group_id onto the line', () => {
+      expect(BudgetPlansDB.mapLineFields(lineRow('l1', '100', { groupId: 'g1' })).groupId).toBe('g1');
+    });
+
+    it('never reports an income line as grouped', () => {
+      const row = { ...lineRow('i1', '100'), kind: 'income', group_id: 'g1' };
+      expect(BudgetPlansDB.mapLineFields(row).groupId).toBeNull();
+    });
+
+    it('persists the group on insert', async () => {
+      await BudgetPlansDB.addLine('p1', { amount: '100', categoryIds: ['cat1'], groupId: 'g1' });
+
+      const [sql, params] = mockRunAsync.mock.calls[0];
+      expect(sql).toContain('group_id');
+      expect(params).toContain('g1');
+    });
+
+    it('drops the group when a line is turned into an income line', async () => {
+      await BudgetPlansDB.updateLine('l1', { kind: 'income' });
+
+      const [sql, params] = executeQuery.mock.calls[0];
+      expect(sql).toContain('group_id = ?');
+      // kind, group_id, updated_at, id — the group is nulled without being asked.
+      expect(params[1]).toBeNull();
+    });
+  });
+
+  describe('calculatePlanStatus', () => {
+    it('totals a derived group from its children and leaves `allocated` alone', async () => {
+      setupDb({
+        lines: [
+          lineRow('l-fuel', '300', { groupId: 'g1' }),
+          lineRow('l-parking', '120', { groupId: 'g1', sortOrder: 1 }),
+          lineRow('l-loose', '50', { sortOrder: 2 }),
+        ],
+        groups: [groupRow('g1', 'Car')],
+        spending: '60',
+      });
+
+      const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
+
+      expect(status.groups).toHaveLength(1);
+      expect(status.groups[0]).toMatchObject({
+        groupId: 'g1', overrideApplied: false, lineCount: 2,
+      });
+      expect(parseFloat(status.groups[0].amount)).toBe(420);
+      // Each of the three lines "spent" 60 — the group counts only its own two.
+      expect(parseFloat(status.groups[0].actual)).toBe(120);
+      expect(parseFloat(status.totals.allocated)).toBe(470);
+    });
+
+    it('swaps an override into `allocated` in place of its children', async () => {
+      setupDb({
+        lines: [
+          lineRow('l-fuel', '300', { groupId: 'g1' }),
+          lineRow('l-parking', '120', { groupId: 'g1', sortOrder: 1 }),
+          lineRow('l-loose', '50', { sortOrder: 2 }),
+        ],
+        groups: [groupRow('g1', 'Car', { amount: '500', currency: 'USD' })],
+      });
+
+      const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
+
+      expect(status.groups[0]).toMatchObject({ overrideApplied: true });
+      expect(parseFloat(status.groups[0].amount)).toBe(500);
+      expect(parseFloat(status.groups[0].childAmount)).toBe(420);
+      // 500 (override) + 50 (ungrouped) — the children's 420 is replaced, not added.
+      expect(parseFloat(status.totals.allocated)).toBe(550);
+    });
+
+    it('converts an override priced in another currency', async () => {
+      stubRates({ EUR: '2' });
+      setupDb({
+        lines: [lineRow('l-fuel', '300', { groupId: 'g1' })],
+        groups: [groupRow('g1', 'Car', { amount: '250', currency: 'EUR' })],
+      });
+
+      const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
+
+      expect(parseFloat(status.groups[0].amount)).toBe(500);
+      expect(parseFloat(status.totals.allocated)).toBe(500);
+    });
+
+    it('falls back to the children\'s sum when the override has no rate', async () => {
+      stubRates({}); // no EUR rate at all
+      setupDb({
+        lines: [lineRow('l-fuel', '300', { groupId: 'g1' })],
+        groups: [groupRow('g1', 'Car', { amount: '250', currency: 'EUR' })],
+      });
+
+      const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
+
+      expect(status.groups[0]).toMatchObject({ status: 'unconvertible', overrideApplied: false });
+      expect(parseFloat(status.groups[0].amount)).toBe(300);
+      // The month's total keeps counting the children, which ARE in the display
+      // currency — an unconvertible override must not silently drop them.
+      expect(parseFloat(status.totals.allocated)).toBe(300);
+      expect(getUnconvertibleCurrencies).toHaveBeenCalledWith(
+        expect.objectContaining({ has: expect.any(Function) }),
+        'USD',
+      );
+    });
+
+    it('omits a group with no line in the month', async () => {
+      setupDb({
+        lines: [lineRow('l-loose', '50')],
+        groups: [groupRow('g1', 'Car'), groupRow('g2', 'Holiday')],
+      });
+
+      const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
+
+      expect(status.groups).toEqual([]);
+    });
+
+    it('bands a group the same way a line is banded', async () => {
+      setupDb({
+        lines: [lineRow('l-fuel', '100', { groupId: 'g1' })],
+        groups: [groupRow('g1', 'Car')],
+        spending: '150',
+      });
+
+      const status = await BudgetPlansDB.calculatePlanStatus('p1', 'USD', false);
+
+      expect(status.groups[0]).toMatchObject({ status: 'exceeded', percentage: 150, isExceeded: true });
+      expect(parseFloat(status.groups[0].remaining)).toBe(-50);
+    });
+  });
+});

--- a/__tests__/services/BudgetPlansDB.test.js
+++ b/__tests__/services/BudgetPlansDB.test.js
@@ -394,8 +394,8 @@ describe('BudgetPlansDB', () => {
       await BudgetPlansDB.addLine('p1', { amount: '10', categoryId: 'c1', includeChildren: false });
       const [sql, params] = mockRunAsync.mock.calls.find(([s]) => s.includes('INSERT INTO budget_plan_lines'));
       expect(sql).toContain('include_children');
-      // Column order: ..., last_executed_month, include_children, created_at, updated_at
-      expect(params[params.length - 3]).toBe(1);
+      // Column order: ..., last_executed_month, include_children, group_id, created_at, updated_at
+      expect(params[params.length - 4]).toBe(1);
     });
 
     // Bug 10 (adversarial review): addLine/addRecurringLine share one insertPlanLine

--- a/__tests__/services/GoogleSheetsService.test.js
+++ b/__tests__/services/GoogleSheetsService.test.js
@@ -143,12 +143,12 @@ describe('GoogleSheetsService', () => {
 
     // The "Planned Operations" tab is gone as of Budgets v3 phase 3 — planned
     // operations are plan lines with a template now, exported in Budget Plan Lines.
-    it('returns 7 sheets with correct titles', async () => {
+    it('returns 8 sheets with correct titles', async () => {
       const sheets = buildSheetsData(mockBackup);
       const titles = sheets.map(s => s.range.split('!')[0]);
       expect(titles).toEqual([
         'Accounts', 'Operations', 'Categories', 'Budgets', 'Balance History',
-        'Budget Plans', 'Budget Plan Lines',
+        'Budget Plans', 'Budget Plan Lines', 'Budget Line Groups',
       ]);
     });
 
@@ -300,14 +300,20 @@ describe('GoogleSheetsService', () => {
       },
     };
 
+    // Every tab today's export writes. The metadata read happens FIRST now (it
+    // both spots the tabs a spreadsheet is missing and supplies the IDs the
+    // filters hang off), so a spreadsheet described here as complete makes the
+    // export exactly four calls: metadata, clear, write, filters.
     const mockMetadata = {
       sheets: [
         { properties: { title: 'Accounts', sheetId: 0 } },
         { properties: { title: 'Operations', sheetId: 1 } },
         { properties: { title: 'Categories', sheetId: 2 } },
         { properties: { title: 'Budgets', sheetId: 3 } },
-        { properties: { title: 'Planned Operations', sheetId: 4 } },
-        { properties: { title: 'Balance History', sheetId: 5 } },
+        { properties: { title: 'Balance History', sheetId: 4 } },
+        { properties: { title: 'Budget Plans', sheetId: 5 } },
+        { properties: { title: 'Budget Plan Lines', sheetId: 6 } },
+        { properties: { title: 'Budget Line Groups', sheetId: 7 } },
       ],
     };
 
@@ -318,10 +324,10 @@ describe('GoogleSheetsService', () => {
         ok: true,
         json: async () => ({ spreadsheetId: 'new-sheet-id' }),
       });
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata });
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIdsByTitle
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // clearSheets
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // writeSheets
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // applyFilters
 
       const url = await exportToSheets('access-token', mockBackup);
 
@@ -331,10 +337,10 @@ describe('GoogleSheetsService', () => {
 
     it('updates existing spreadsheet without creating a new one on re-export', async () => {
       getPreference.mockResolvedValue('existing-sheet-id');
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata });
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIdsByTitle
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // clearSheets
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // writeSheets
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // applyFilters
 
       const url = await exportToSheets('access-token', mockBackup);
 
@@ -345,24 +351,25 @@ describe('GoogleSheetsService', () => {
 
     it('applies basic filters to every exported sheet after writing data', async () => {
       getPreference.mockResolvedValue('sheet-id');
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIdsByTitle
       mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // clearSheets
       mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // writeSheets
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIds
       mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // applyFilters
 
       await exportToSheets('access-token', mockBackup);
 
       const applyFiltersCall = mockFetch.mock.calls[3];
       const body = JSON.parse(applyFiltersCall[1].body);
-      expect(body.requests).toHaveLength(5);
+      expect(body.requests).toHaveLength(8);
       expect(body.requests[0].setBasicFilter.filter.range.sheetId).toBe(0);
-      expect(body.requests[4].setBasicFilter.filter.range.sheetId).toBe(5);
+      expect(body.requests[7].setBasicFilter.filter.range.sheetId).toBe(7);
     });
 
     it('throws refresh_failed and signs out when clearSheets returns 401', async () => {
       getPreference.mockResolvedValue('sheet-id');
       GoogleSignin.revokeAccess.mockResolvedValue(undefined);
       GoogleSignin.signOut.mockResolvedValue(undefined);
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIdsByTitle
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
@@ -377,7 +384,8 @@ describe('GoogleSheetsService', () => {
       getPreference.mockResolvedValue('sheet-id');
       GoogleSignin.revokeAccess.mockResolvedValue(undefined);
       GoogleSignin.signOut.mockResolvedValue(undefined);
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIdsByTitle
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // clearSheets
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
@@ -390,7 +398,8 @@ describe('GoogleSheetsService', () => {
 
     it('throws quota_exceeded when batchUpdate returns 429', async () => {
       getPreference.mockResolvedValue('sheet-id');
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => mockMetadata }); // getSheetIdsByTitle
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) }); // clearSheets
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 429,
@@ -636,7 +645,7 @@ describe('GoogleSheetsService', () => {
       const sheets = buildSheetsData(mockBackup);
       const lines = sheets.find(s => s.range === 'Budget Plan Lines!A1');
       const header = lines.values[0];
-      expect(header).toEqual(['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month', 'categories', 'category_ids', 'include_children']);
+      expect(header).toEqual(['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month', 'categories', 'category_ids', 'include_children', 'group', 'group_id']);
 
       const catRow = lines.values.find(r => r[0] === 'line-cat');
       expect(catRow[header.indexOf('category')]).toBe('Food');
@@ -844,6 +853,90 @@ describe('GoogleSheetsService', () => {
       const backup = await importFromSheets('token');
       expect(backup.data.budget_plans).toEqual([]);
       expect(backup.data.budget_plan_lines).toEqual([]);
+    });
+  });
+
+  // Migration 0022: an envelope over several lines, exported on its own tab with
+  // the line's membership carried as a name/ID pair like every other reference.
+  describe('Budget line groups (migration 0022)', () => {
+    const { getPreference } = require('../../app/services/PreferencesDB');
+
+    const groupBackup = {
+      data: {
+        accounts: [{ id: 1, name: 'Savings', balance: '0', currency: 'USD' }],
+        categories: [{ id: 'cat-1', name: 'Food', type: 'entry', category_type: 'expense' }],
+        operations: [],
+        budgets: [],
+        planned_operations: [],
+        balance_history: [],
+        budget_plans: [{ id: 'plan-1', month: '2026-07', currency: 'USD', expected_income: '0' }],
+        budget_plan_lines: [
+          { id: 'line-a', plan_id: 'plan-1', label: 'Fuel', amount: '300', comment: null, category_id: 'cat-1', to_account_id: null, sort_order: 0, is_recurring: 0, currency: null, group_id: 'grp-1' },
+          { id: 'line-b', plan_id: 'plan-1', label: 'Books', amount: '50', comment: null, category_id: 'cat-1', to_account_id: null, sort_order: 1, is_recurring: 0, currency: null, group_id: null },
+        ],
+        budget_plan_line_groups: [
+          { id: 'grp-1', label: 'Car', amount: null, currency: null, sort_order: 0 },
+          { id: 'grp-2', label: 'Holiday', amount: '1200', currency: 'EUR', sort_order: 1 },
+        ],
+      },
+    };
+
+    it('writes a Budget Line Groups sheet and the membership of each line', () => {
+      const sheets = buildSheetsData(groupBackup);
+      const groups = sheets.find(s => s.range === 'Budget Line Groups!A1');
+      expect(groups.values[0]).toEqual(['id', 'label', 'amount', 'currency', 'sort_order']);
+      // A derived group writes blanks, not zeros: its budget is its lines' sum.
+      expect(groups.values[1]).toEqual(['grp-1', 'Car', '', '', 0]);
+      expect(groups.values[2]).toEqual(['grp-2', 'Holiday', '1200', 'EUR', 1]);
+
+      const lines = sheets.find(s => s.range === 'Budget Plan Lines!A1');
+      const header = lines.values[0];
+      const grouped = lines.values.find(r => r[0] === 'line-a');
+      const loose = lines.values.find(r => r[0] === 'line-b');
+      expect(grouped[header.indexOf('group')]).toBe('Car');
+      expect(grouped[header.indexOf('group_id')]).toBe('grp-1');
+      expect(loose[header.indexOf('group')]).toBe('');
+    });
+
+    it('reads groups back and resolves a line\'s group by ID or by name', async () => {
+      getPreference.mockResolvedValue('sheet-id-123');
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          valueRanges: [
+            { range: 'Accounts!A1:D2', values: [['id', 'name', 'balance', 'currency'], ['1', 'Savings', '0', 'USD']] },
+            { range: 'Categories!A1:B2', values: [['id', 'name', 'type', 'category_type'], ['cat-1', 'Food', 'entry', 'expense']] },
+            {
+              range: 'Budget Plan Lines!A1:U3',
+              values: [
+                ['id', 'plan_id', 'label', 'amount', 'category_id', 'group', 'group_id'],
+                ['line-a', 'plan-1', 'Fuel', '300', 'cat-1', '', 'grp-1'],
+                // Someone editing by hand reaches for the name column, not the ID.
+                ['line-b', 'plan-1', 'Parking', '120', 'cat-1', 'Car', ''],
+                ['line-c', 'plan-1', 'Books', '50', 'cat-1', 'Nowhere', 'grp-missing'],
+              ],
+            },
+            {
+              range: 'Budget Line Groups!A1:E2',
+              values: [
+                ['id', 'label', 'amount', 'currency', 'sort_order'],
+                ['grp-1', 'Car', '', '', '0'],
+              ],
+            },
+          ],
+        }),
+      });
+
+      const backup = await importFromSheets('token');
+
+      expect(backup.data.budget_plan_line_groups).toEqual([
+        expect.objectContaining({ id: 'grp-1', label: 'Car', amount: null, currency: null, sort_order: 0 }),
+      ]);
+      const byId = new Map(backup.data.budget_plan_lines.map(l => [l.id, l]));
+      expect(byId.get('line-a').group_id).toBe('grp-1');
+      expect(byId.get('line-b').group_id).toBe('grp-1');
+      // A group the sheet doesn't list drops to null rather than dangling.
+      expect(byId.get('line-c').group_id).toBeNull();
     });
   });
 });

--- a/__tests__/services/db.fastpath.test.js
+++ b/__tests__/services/db.fastpath.test.js
@@ -53,6 +53,7 @@ const COMPLETE_TABLES = [
   'accounts_balance_history', 'planned_operations',
   'notification_merchant_rules', 'pending_notifications',
   'budget_plans', 'budget_plan_lines', 'budget_plan_line_categories',
+  'budget_plan_line_groups',
 ];
 const mockSchemaComplete = (db, storedUserVersion) => {
   db.getFirstAsync.mockImplementation((q) => {
@@ -96,6 +97,7 @@ const mockSchemaComplete = (db, storedUserVersion) => {
         { name: 'kind', type: 'TEXT' }, { name: 'account_id', type: 'INTEGER' },
         { name: 'last_executed_month', type: 'TEXT' },
         { name: 'include_children', type: 'INTEGER' },
+        { name: 'group_id', type: 'TEXT' },
       ]);
     }
     return Promise.resolve([]);

--- a/app/components/budgets/BudgetLineGroupModal.js
+++ b/app/components/budgets/BudgetLineGroupModal.js
@@ -1,0 +1,422 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  Pressable,
+  StyleSheet,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  Keyboard,
+} from 'react-native';
+import PropTypes from 'prop-types';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import { useThemeColors } from '../../contexts/ThemeColorsContext';
+import { useLocalization } from '../../contexts/LocalizationContext';
+import { useDialog } from '../../contexts/DialogContext';
+import FormInput from '../FormInput';
+import ModalBlurOverlay from '../ModalBlurOverlay';
+import ModalHeader from '../ModalHeader';
+import * as Currency from '../../services/currency';
+
+/**
+ * BudgetLineGroupModal — editor for a GROUP of budget lines (migration 0022).
+ *
+ * A group has two properties worth editing and nothing else: its name, and
+ * whether its budget is DERIVED (the sum of the lines inside it, which is the
+ * default and needs no input at all) or an explicit figure the user sets. The
+ * derived sum is printed next to the toggle so the override is typed with the
+ * number it replaces in view.
+ *
+ * Membership is not edited here — a line joins a group from the line's own
+ * editor, where the rest of what that line is already lives. Deleting the group
+ * therefore only dissolves the envelope: every line inside it survives, ungrouped,
+ * which is what the confirmation says.
+ */
+export default function BudgetLineGroupModal({
+  visible = false,
+  group = null,
+  currency = 'USD',
+  currencyOptions = [],
+  derivedTotal = null,
+  saving = false,
+  onSave = () => {},
+  onDelete = () => {},
+  onClose = () => {},
+}) {
+  const { colors } = useThemeColors();
+  const { t } = useLocalization();
+  const { showDialog } = useDialog();
+
+  const isEditing = group != null;
+
+  const [label, setLabel] = useState('');
+  const [customBudget, setCustomBudget] = useState(false);
+  const [amount, setAmount] = useState('');
+  const [groupCurrency, setGroupCurrency] = useState(currency);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    setError(null);
+    if (group) {
+      setLabel(group.label || '');
+      setCustomBudget(!group.isDerived);
+      setAmount(group.amount != null ? String(group.amount) : '');
+      setGroupCurrency(group.currency || currency);
+    } else {
+      setLabel('');
+      setCustomBudget(false);
+      setAmount('');
+      setGroupCurrency(currency);
+    }
+  }, [visible, group, currency]);
+
+  // The plan's own currency is always offered even when no account uses it, and
+  // an existing group keeps its own in the list — the same rule the line editor
+  // follows, for the same reason (an account may since have been closed).
+  const currencies = useMemo(() => {
+    const set = new Set(currencyOptions);
+    if (currency) set.add(currency);
+    if (group?.currency) set.add(group.currency);
+    return [...set];
+  }, [currencyOptions, currency, group]);
+
+  const handleAmountChange = useCallback((text) => {
+    // Android decimal-pad keyboards emit "," in most locales; every amount field
+    // in the app normalizes it the same way.
+    setAmount(text.replace(/,/g, '.'));
+    setError(null);
+  }, []);
+
+  const handleSave = useCallback(() => {
+    if (saving) return;
+    Keyboard.dismiss();
+    if (!label.trim()) {
+      setError(t('group_name_required'));
+      return;
+    }
+    if (customBudget) {
+      if (!Currency.isValid(amount)) {
+        setError(t('valid_amount_required'));
+        return;
+      }
+      if (Currency.compare(amount, '0') <= 0) {
+        setError(t('amount_must_be_greater_than_zero'));
+        return;
+      }
+    }
+    onSave({
+      label: label.trim(),
+      // null puts the group back on its derived total — and clears the stored
+      // currency with it (see BudgetPlansDB.updateLineGroup).
+      amount: customBudget ? String(amount) : null,
+      currency: customBudget ? groupCurrency : null,
+    });
+  }, [saving, label, customBudget, amount, groupCurrency, onSave, t]);
+
+  const handleDelete = useCallback(() => {
+    if (!isEditing) return;
+    showDialog(
+      t('delete_group'),
+      t('delete_group_confirm'),
+      [
+        { text: t('cancel'), style: 'cancel' },
+        { text: t('delete'), style: 'destructive', onPress: () => onDelete(group.id) },
+      ],
+    );
+  }, [isEditing, showDialog, t, onDelete, group]);
+
+  return (
+    <>
+      {visible && <ModalBlurOverlay />}
+      <Modal
+        visible={visible}
+        animationType="slide"
+        transparent
+        onRequestClose={onClose}
+        testID="plan-group-modal"
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.flex1}
+        >
+          <Pressable style={styles.modalOverlay} onPress={onClose}>
+            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
+              <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+                <ModalHeader title={isEditing ? t('edit_group') : t('new_group')} />
+
+                <View style={styles.field}>
+                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                    {t('group_name')}
+                  </Text>
+                  <FormInput
+                    value={label}
+                    onChangeText={(text) => { setLabel(text); setError(null); }}
+                    placeholder={t('group_name')}
+                    testID="plan-group-name"
+                  />
+                </View>
+
+                {/* Derived by default: the group is worth what its lines are
+                    worth, and that figure keeps itself up to date. The toggle is
+                    for the case where the envelope has a size of its own. */}
+                <Pressable
+                  style={[styles.toggleRow, { borderColor: colors.border }]}
+                  onPress={() => { setCustomBudget(v => !v); setError(null); }}
+                  accessibilityRole="switch"
+                  accessibilityState={{ checked: customBudget }}
+                  accessibilityLabel={t('custom_group_budget')}
+                  testID="plan-group-custom-toggle"
+                >
+                  <View style={styles.toggleLabel}>
+                    <Icon name="pencil-outline" size={20} color={colors.text} />
+                    <Text style={[styles.text16, { color: colors.text }]}>
+                      {t('custom_group_budget')}
+                    </Text>
+                  </View>
+                  <View style={[styles.switchTrack, { backgroundColor: customBudget ? colors.primary : colors.border }]}>
+                    <View style={[styles.switchThumb, { transform: [{ translateX: customBudget ? 18 : 2 }] }]} />
+                  </View>
+                </Pressable>
+
+                {!customBudget && (
+                  <Text style={[styles.fieldHint, { color: colors.mutedText }]} testID="plan-group-derived-hint">
+                    {t('group_budget_derived_hint')}
+                    {derivedTotal != null ? ` · ${Currency.formatAmount(derivedTotal, currency)} ${currency}` : ''}
+                  </Text>
+                )}
+
+                {customBudget && (
+                  <>
+                    {currencies.length > 0 && (
+                      <View style={styles.field}>
+                        <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>{t('currency')}</Text>
+                        <View style={styles.currencyRow}>
+                          {currencies.map((code) => (
+                            <Pressable
+                              key={code}
+                              style={[
+                                styles.currencyChip,
+                                { borderColor: colors.border },
+                                groupCurrency === code && { backgroundColor: colors.primary, borderColor: colors.primary },
+                              ]}
+                              onPress={() => setGroupCurrency(code)}
+                              accessibilityRole="button"
+                              accessibilityState={{ selected: groupCurrency === code }}
+                              accessibilityLabel={code}
+                              testID={`plan-group-currency-${code}`}
+                            >
+                              <Text style={[styles.currencyChipText, { color: colors.text }]}>{code}</Text>
+                            </Pressable>
+                          ))}
+                        </View>
+                      </View>
+                    )}
+                    <View style={styles.field}>
+                      <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                        {t('amount')}{groupCurrency ? ` · ${groupCurrency}` : ''}
+                      </Text>
+                      <FormInput
+                        value={amount}
+                        onChangeText={handleAmountChange}
+                        placeholder={derivedTotal != null ? String(derivedTotal) : '0'}
+                        keyboardType="decimal-pad"
+                        testID="plan-group-amount"
+                      />
+                      <Text style={[styles.fieldHint, { color: colors.mutedText }]}>
+                        {t('group_budget_override_hint')}
+                      </Text>
+                    </View>
+                  </>
+                )}
+
+                {error && (
+                  <Text style={[styles.error, { color: colors.danger }]} testID="plan-group-error">
+                    {error}
+                  </Text>
+                )}
+
+                {isEditing && (
+                  <Pressable
+                    style={[styles.deleteRow, { borderTopColor: colors.border }]}
+                    onPress={handleDelete}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('delete_group')}
+                    testID="plan-group-delete"
+                  >
+                    <Icon name="delete-outline" size={20} color={colors.delete || colors.danger} />
+                    <Text style={[styles.deleteText, { color: colors.delete || colors.danger }]}>
+                      {t('delete_group')}
+                    </Text>
+                  </Pressable>
+                )}
+              </ScrollView>
+
+              <View style={[styles.buttonRow, { backgroundColor: colors.card }]}>
+                <Pressable
+                  style={[styles.button, { backgroundColor: colors.secondary }]}
+                  onPress={onClose}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('cancel')}
+                >
+                  <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel')}</Text>
+                </Pressable>
+                <Pressable
+                  style={[styles.button, { backgroundColor: colors.primary }, saving && styles.buttonDisabled]}
+                  onPress={handleSave}
+                  disabled={saving}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('save')}
+                  accessibilityState={{ disabled: saving, busy: saving }}
+                  testID="plan-group-save"
+                >
+                  <Text style={[styles.buttonText, { color: colors.text }]}>{t('save')}</Text>
+                </Pressable>
+              </View>
+            </Pressable>
+          </Pressable>
+        </KeyboardAvoidingView>
+      </Modal>
+    </>
+  );
+}
+
+BudgetLineGroupModal.propTypes = {
+  visible: PropTypes.bool,
+  group: PropTypes.shape({
+    id: PropTypes.string,
+    label: PropTypes.string,
+    amount: PropTypes.string,
+    currency: PropTypes.string,
+    isDerived: PropTypes.bool,
+  }),
+  currency: PropTypes.string,
+  currencyOptions: PropTypes.arrayOf(PropTypes.string),
+  derivedTotal: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  saving: PropTypes.bool,
+  onSave: PropTypes.func,
+  onDelete: PropTypes.func,
+  onClose: PropTypes.func,
+};
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    borderRadius: 6,
+    flex: 1,
+    marginHorizontal: 8,
+    paddingVertical: 12,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingBottom: 20,
+    paddingHorizontal: 12,
+    paddingTop: 12,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  currencyChip: {
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  currencyChipText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  currencyRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  deleteRow: {
+    alignItems: 'center',
+    borderTopWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 16,
+    paddingVertical: 12,
+  },
+  deleteText: {
+    fontSize: 16,
+    fontWeight: '500',
+    marginLeft: 8,
+  },
+  error: {
+    fontSize: 13,
+    marginTop: 8,
+  },
+  field: {
+    marginBottom: 16,
+  },
+  fieldHint: {
+    fontSize: 11,
+    marginBottom: 12,
+    marginTop: 4,
+  },
+  fieldLabel: {
+    fontSize: 12,
+    marginBottom: 6,
+  },
+  flex1: {
+    flex: 1,
+  },
+  modalContent: {
+    borderRadius: 12,
+    elevation: 5,
+    maxHeight: '85%',
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    width: '90%',
+  },
+  modalOverlay: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 12,
+  },
+  switchThumb: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    height: 16,
+    width: 16,
+  },
+  switchTrack: {
+    borderRadius: 10,
+    height: 20,
+    justifyContent: 'center',
+    width: 36,
+  },
+  text16: {
+    fontSize: 16,
+  },
+  toggleLabel: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 10,
+  },
+  toggleRow: {
+    alignItems: 'center',
+    borderRadius: 4,
+    borderWidth: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+    padding: 12,
+  },
+});

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -63,9 +63,11 @@ export default function BudgetPlanLineModal({
   expenseCategories = [],
   incomeCategories = [],
   accounts = [],
+  groups = [],
   saving = false,
   onSaveLine = () => {},
   onDeleteLine = () => {},
+  onCreateGroup = null,
   onClose = () => {},
 }) {
   const { colors } = useThemeColors();
@@ -87,6 +89,10 @@ export default function BudgetPlanLineModal({
   const [accountId, setAccountId] = useState(null);
   const [isRecurring, setIsRecurring] = useState(false);
   const [lineCurrency, setLineCurrency] = useState(currency);
+  // The envelope this line belongs to (migration 0022), or null for a line that
+  // stands on its own — which is what every line is until it is put in one.
+  const [groupId, setGroupId] = useState(null);
+  const [newGroupName, setNewGroupName] = useState('');
   const [error, setError] = useState(null);
 
   const accountsById = useMemo(
@@ -128,7 +134,7 @@ export default function BudgetPlanLineModal({
   }, [accounts, currency, line]);
 
   // Subpanel navigation for the pickers.
-  const [activeSubPanel, setActiveSubPanel] = useState(null); // null | 'target' | 'account'
+  const [activeSubPanel, setActiveSubPanel] = useState(null); // null | 'target' | 'account' | 'group'
   // Which kind of target the target picker is currently showing.
   const [pickerKind, setPickerKind] = useState('category'); // 'category' | 'account'
   const mainAnim = useRef(new Animated.Value(0)).current;
@@ -149,6 +155,7 @@ export default function BudgetPlanLineModal({
       setAccountId(line.accountId ?? null);
       setIsRecurring(!!line.isRecurring);
       setLineCurrency(line.currency || currency);
+      setGroupId(line.groupId ?? null);
     } else {
       setKind(initialKind);
       setAmount('');
@@ -159,7 +166,9 @@ export default function BudgetPlanLineModal({
       setAccountId(null);
       setIsRecurring(false);
       setLineCurrency(currency);
+      setGroupId(null);
     }
+    setNewGroupName('');
   }, [visible, line, initialKind, currency]);
 
   // Reset subpanel + animations whenever the modal is hidden.
@@ -213,6 +222,33 @@ export default function BudgetPlanLineModal({
   }, [kind, toAccountId, openSubPanel]);
 
   const openAccountPanel = useCallback(() => openSubPanel('account'), [openSubPanel]);
+  const openGroupPanel = useCallback(() => openSubPanel('group'), [openSubPanel]);
+
+  const handleSelectGroup = useCallback((id) => {
+    setGroupId(id);
+    setError(null);
+    closeSubPanel();
+  }, [closeSubPanel]);
+
+  // Creating the envelope from inside the line that is joining it: the
+  // alternative is making the user leave a half-filled form, go create a group
+  // somewhere else, and come back to it.
+  const handleCreateGroup = useCallback(async () => {
+    const name = newGroupName.trim();
+    if (!name || !onCreateGroup) return;
+    try {
+      const created = await onCreateGroup(name);
+      if (created?.id) {
+        setGroupId(created.id);
+        setNewGroupName('');
+        closeSubPanel();
+      }
+    } catch (createError) {
+      // Already surfaced by the host's error dialog; keep the panel open so the
+      // typed name isn't lost.
+      console.error('Failed to create budget line group:', createError);
+    }
+  }, [newGroupName, onCreateGroup, closeSubPanel]);
 
   // Switching kind drops a target that no longer applies, so the line can never
   // be saved as e.g. a transfer that still carries a category.
@@ -319,9 +355,12 @@ export default function BudgetPlanLineModal({
       // An executable line is priced in its account's currency; a template-less
       // one-off line inherits the plan's (null).
       currency: effectiveCurrency,
+      // An income line is never grouped — groups aggregate allocations, and the
+      // group row is not offered for one (see the picker below).
+      groupId: kind === 'income' ? null : groupId,
     });
   }, [saving, kind, amount, amountIsParseable, amountIsPositive, label, comment, categoryIds, toAccountId, accountId,
-    isRecurring, effectiveCurrency, onSaveLine, t]);
+    isRecurring, effectiveCurrency, groupId, onSaveLine, t]);
 
   const handleDelete = useCallback(() => {
     if (!isEditingLine) return;
@@ -367,6 +406,7 @@ export default function BudgetPlanLineModal({
   }, [kind, categoryIds, toAccountId, categoriesById, accountsById, t]);
 
   const executionAccount = accountId != null ? accountsById.get(accountId) : null;
+  const selectedGroup = groupId != null ? groups.find(g => g.id === groupId) : null;
 
   const panelWidth = Dimensions.get('window').width;
   const subPanelTranslateX = subPanelAnim.interpolate({ inputRange: [0, 1], outputRange: [panelWidth, 0] });
@@ -536,6 +576,38 @@ export default function BudgetPlanLineModal({
                       {t('template_account_hint')}
                     </Text>
                   </View>
+
+                  {/* Group — an envelope this line shares with others (migration
+                      0022). Offered for allocations only: an income line declares
+                      expected income and has no spending for a group to total. */}
+                  {kind !== 'income' && (
+                    <View style={styles.field}>
+                      <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                        {t('group')} · {t('optional')}
+                      </Text>
+                      <Pressable
+                        style={[styles.targetButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                        onPress={openGroupPanel}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('group')}
+                        testID="plan-group-picker"
+                      >
+                        {selectedGroup ? (
+                          <View style={styles.targetValue}>
+                            <Icon name="folder-outline" size={20} color={colors.text} />
+                            <Text style={[styles.text16, { color: colors.text }]} numberOfLines={1}>
+                              {selectedGroup.label}
+                            </Text>
+                          </View>
+                        ) : (
+                          <Text style={[styles.text16, { color: colors.mutedText }]}>
+                            {t('no_group')}
+                          </Text>
+                        )}
+                        <Icon name="chevron-right" size={20} color={colors.mutedText} />
+                      </Pressable>
+                    </View>
+                  )}
 
                   {/* Recurring toggle: a recurring line is a global template that
                       applies to every calendar month automatically, instead of
@@ -782,6 +854,110 @@ export default function BudgetPlanLineModal({
                 </Animated.View>
               )}
 
+              {/* Group subpanel: pick an existing envelope, drop out of one, or
+                  create one without leaving the half-filled form. */}
+              {activeSubPanel === 'group' && (
+                <Animated.View
+                  testID="plan-group-subpanel"
+                  style={[
+                    styles.subPanel,
+                    { backgroundColor: colors.card },
+                    { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
+                  ]}
+                >
+                  <View style={styles.subPanelHeader}>
+                    <Pressable
+                      onPress={closeSubPanel}
+                      style={styles.subPanelBack}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('back')}
+                      testID="plan-group-back"
+                    >
+                      <Icon name="arrow-left" size={24} color={colors.text} />
+                    </Pressable>
+                    <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('group')}</Text>
+                  </View>
+
+                  {onCreateGroup && (
+                    <View style={styles.newGroupRow}>
+                      <View style={styles.newGroupInput}>
+                        <FormInput
+                          value={newGroupName}
+                          onChangeText={setNewGroupName}
+                          placeholder={t('new_group')}
+                          testID="plan-group-new-name"
+                        />
+                      </View>
+                      <Pressable
+                        onPress={handleCreateGroup}
+                        disabled={!newGroupName.trim()}
+                        style={[
+                          styles.newGroupButton,
+                          { backgroundColor: colors.primary },
+                          !newGroupName.trim() && styles.buttonDisabled,
+                        ]}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('create_group')}
+                        accessibilityState={{ disabled: !newGroupName.trim() }}
+                        testID="plan-group-create"
+                      >
+                        <Icon name="plus" size={20} color={colors.text} />
+                      </Pressable>
+                    </View>
+                  )}
+
+                  <Pressable
+                    onPress={() => handleSelectGroup(null)}
+                    style={({ pressed }) => [
+                      styles.pickerOption,
+                      { borderColor: colors.border },
+                      pressed && { backgroundColor: colors.selected },
+                      groupId == null && { backgroundColor: colors.selected },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('no_group')}
+                    testID="plan-group-option-none"
+                  >
+                    <Icon name="close-circle-outline" size={22} color={colors.text} />
+                    <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
+                      {t('no_group')}
+                    </Text>
+                  </Pressable>
+
+                  <FlatList
+                    data={groups}
+                    keyExtractor={(item) => String(item.id)}
+                    keyboardShouldPersistTaps="handled"
+                    renderItem={({ item }) => (
+                      <Pressable
+                        onPress={() => handleSelectGroup(item.id)}
+                        style={({ pressed }) => [
+                          styles.pickerOption,
+                          { borderColor: colors.border },
+                          pressed && { backgroundColor: colors.selected },
+                          groupId === item.id && { backgroundColor: colors.selected },
+                        ]}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: groupId === item.id }}
+                        accessibilityLabel={item.label}
+                        testID={`plan-group-option-${item.id}`}
+                      >
+                        <Icon name="folder-outline" size={22} color={colors.text} />
+                        <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
+                          {item.label}
+                        </Text>
+                      </Pressable>
+                    )}
+                    ListEmptyComponent={(
+                      <Text style={[styles.emptyText, { color: colors.mutedText }]}>
+                        {t('no_groups_yet')}
+                      </Text>
+                    )}
+                  />
+                </Animated.View>
+              )}
+
               {/* Execution account subpanel */}
               {activeSubPanel === 'account' && (
                 <Animated.View
@@ -859,15 +1035,21 @@ BudgetPlanLineModal.propTypes = {
     kind: PropTypes.oneOf(KINDS),
     isRecurring: PropTypes.bool,
     currency: PropTypes.string,
+    groupId: PropTypes.string,
   }),
   initialKind: PropTypes.oneOf(KINDS),
   currency: PropTypes.string,
   expenseCategories: PropTypes.array,
   incomeCategories: PropTypes.array,
   accounts: PropTypes.array,
+  groups: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+  })),
   saving: PropTypes.bool,
   onSaveLine: PropTypes.func,
   onDeleteLine: PropTypes.func,
+  onCreateGroup: PropTypes.func,
   onClose: PropTypes.func,
 };
 
@@ -962,6 +1144,22 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     justifyContent: 'center',
+  },
+  newGroupButton: {
+    alignItems: 'center',
+    borderRadius: 8,
+    justifyContent: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  newGroupInput: {
+    flex: 1,
+  },
+  newGroupRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
   },
   optionText: {
     flex: 1,

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -12,11 +12,19 @@ import * as Currency from '../../services/currency';
 import usePlanLineAmounts from '../../hooks/usePlanLineAmounts';
 import { SPACING } from '../../styles/layout';
 import BudgetPlanLineModal from './BudgetPlanLineModal';
+import BudgetLineGroupModal from './BudgetLineGroupModal';
 import PlanLineRow from './PlanLineRow';
+import PlanGroupRow from './PlanGroupRow';
 import PlanTemplateSummary from './PlanTemplateSummary';
 import { currentMonthKey, addMonths, formatMonthLabel, monthProgressFraction } from '../../utils/monthUtils';
 
 const CLOSED_MODAL = { visible: false, line: null, kind: 'expense' };
+const CLOSED_GROUP_MODAL = { visible: false, group: null };
+
+// Key under which a group's own (override) amount rides along in the shared
+// conversion map — see the `amountSources` memo. Groups and lines have separate
+// ID spaces, so the prefix is what keeps a group from ever shadowing a line.
+const groupAmountKey = (groupId) => `group:${groupId}`;
 
 /**
  * MonthlyPlanSection — the unified Budgets list: one month-scoped envelope view
@@ -70,6 +78,11 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     reorderLines,
     reorderRecurringLines,
     getLinesForMonth,
+    getLineGroups,
+    addLineGroup,
+    updateLineGroup,
+    deleteLineGroup,
+    reorderLineGroups,
     executeLine,
     markLineExecuted,
     unmarkLineExecuted,
@@ -81,7 +94,13 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   const [internalMonth, setInternalMonth] = useState(currentMonthKey);
   const month = controlledMonth ? monthProp : internalMonth;
   const [lines, setLines] = useState([]);
+  // Groups are global (not month-scoped), but they are loaded alongside the
+  // month's lines: the two are read together on every render below, and fetching
+  // them from separate effects would let the list render a group's children under
+  // a header that has not arrived yet.
+  const [groups, setGroups] = useState([]);
   const [modal, setModal] = useState(CLOSED_MODAL);
+  const [groupModal, setGroupModal] = useState(CLOSED_GROUP_MODAL);
   const [busy, setBusy] = useState(false);
   // Synchronous double-tap guard (Fix 3, adversarial review round 2): `busy`
   // (React state) only reflects reality AFTER a re-render commits, so two taps
@@ -171,6 +190,16 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     return map;
   }, [planStatus]);
 
+  // Group statuses arrive on the same object and go stale the same way, so they
+  // read off `planStatus` exactly as the line ones do.
+  const groupStatusById = useMemo(() => {
+    const map = new Map();
+    for (const groupStatus of planStatus?.groups || []) {
+      map.set(groupStatus.groupId, groupStatus);
+    }
+    return map;
+  }, [planStatus]);
+
   const categoriesById = useMemo(
     () => new Map([...expenseCategories, ...incomeCategories].map(c => [c.id, c])),
     [expenseCategories, incomeCategories],
@@ -185,28 +214,36 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   // no plan created yet (see BudgetPlansDB.getLinesForMonth).
   const reloadLines = useCallback(async () => {
     try {
-      const data = await getLinesForMonth(month);
+      const [data, groupData] = await Promise.all([getLinesForMonth(month), getLineGroups()]);
       setLines(data);
+      setGroups(groupData);
     } catch (error) {
       console.error('Failed to load plan lines:', error);
       setLines([]);
+      setGroups([]);
     }
-  }, [getLinesForMonth, month]);
+  }, [getLinesForMonth, getLineGroups, month]);
 
   // Load lines whenever the shown month changes (navigation, plan create/copy).
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const data = await getLinesForMonth(month);
-        if (!cancelled) setLines(data);
+        const [data, groupData] = await Promise.all([getLinesForMonth(month), getLineGroups()]);
+        if (!cancelled) {
+          setLines(data);
+          setGroups(groupData);
+        }
       } catch (error) {
         console.error('Failed to load plan lines:', error);
-        if (!cancelled) setLines([]);
+        if (!cancelled) {
+          setLines([]);
+          setGroups([]);
+        }
       }
     })();
     return () => { cancelled = true; };
-  }, [month, getLinesForMonth]);
+  }, [month, getLinesForMonth, getLineGroups]);
 
   // Income lines declare the expected income; the rest allocate it. Recurring
   // (global template) lines and this month's one-off lines are edited and
@@ -214,13 +251,37 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   // layer (see BudgetPlansDB) — so allocations are split for move actions.
   const incomeLines = useMemo(() => lines.filter(l => l.kind === 'income'), [lines]);
   const allocationLines = useMemo(() => lines.filter(l => l.kind !== 'income'), [lines]);
-  const recurringLines = useMemo(() => allocationLines.filter(l => l.isRecurring), [allocationLines]);
-  const oneOffLines = useMemo(() => allocationLines.filter(l => !l.isRecurring), [allocationLines]);
 
-  // Every line's target amount expressed in the screen's single currency. Rows,
-  // the live totals below and the template summary strip all read from this one
-  // map, so no two of them can print the same line in different units.
-  const { amountById, converting } = usePlanLineAmounts(lines, planCurrency);
+  // Group membership (migration 0022). A line pointing at a group this screen
+  // doesn't know about is treated as ungrouped rather than vanishing into a
+  // header that never renders.
+  const groupIdSet = useMemo(() => new Set(groups.map(g => g.id)), [groups]);
+  const isGrouped = useCallback(
+    (line) => line.groupId != null && groupIdSet.has(line.groupId),
+    [groupIdSet],
+  );
+  const recurringLines = useMemo(
+    () => allocationLines.filter(l => l.isRecurring && !isGrouped(l)),
+    [allocationLines, isGrouped],
+  );
+  const oneOffLines = useMemo(
+    () => allocationLines.filter(l => !l.isRecurring && !isGrouped(l)),
+    [allocationLines, isGrouped],
+  );
+
+  // Every line's target amount expressed in the screen's single currency — plus
+  // each OVERRIDE group's own figure, which is priced in a currency of its own
+  // for the same reason a recurring line is (a group belongs to no plan). Sharing
+  // one conversion pass is what keeps a group's row and its children in the same
+  // units. The array keeps `lines`' identity when no group overrides exist, so
+  // the common case adds no work and no extra render.
+  const amountSources = useMemo(() => {
+    const overrides = groups
+      .filter(g => !g.isDerived && g.amount != null)
+      .map(g => ({ id: groupAmountKey(g.id), amount: g.amount, currency: g.currency }));
+    return overrides.length > 0 ? [...lines, ...overrides] : lines;
+  }, [lines, groups]);
+  const { amountById, converting } = usePlanLineAmounts(amountSources, planCurrency);
 
   // Live totals: allocated = Σ allocation amounts, expected = Σ income lines,
   // remainder = expected − allocated. Same precise decimal math as
@@ -233,6 +294,9 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     let allocated = '0';
     let income = '0';
     let hasIncomeLine = false;
+    // Per-group child sums, so an override group can swap its own figure in for
+    // them below — the same correction calculatePlanStatus makes server-side.
+    const childSumByGroup = new Map();
     for (const line of lines) {
       const amount = amountById.get(line.id);
       if (amount == null) continue;
@@ -242,6 +306,26 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         continue;
       }
       allocated = Currency.add(allocated, amount, planCurrency);
+      if (line.groupId != null) {
+        childSumByGroup.set(
+          line.groupId,
+          Currency.add(childSumByGroup.get(line.groupId) ?? '0', amount, planCurrency),
+        );
+      }
+    }
+    // An override REPLACES its children's sum: the user said the envelope is
+    // worth this much whatever its parts add up to (see the migration's note).
+    // A group with no line in this month contributes nothing either way.
+    for (const group of groups) {
+      if (group.isDerived) continue;
+      const childSum = childSumByGroup.get(group.id);
+      const groupAmount = amountById.get(groupAmountKey(group.id));
+      if (childSum == null || groupAmount == null) continue;
+      allocated = Currency.add(
+        Currency.subtract(allocated, childSum, planCurrency),
+        groupAmount,
+        planCurrency,
+      );
     }
     // Fallback for a plan whose expected income was never bridged into lines
     // (migration 0020 only skips that when income templates already exist).
@@ -250,7 +334,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     }
     const remainder = Currency.subtract(income, allocated, planCurrency);
     return { income, allocated, remainder };
-  }, [plan, lines, amountById, planCurrency]);
+  }, [plan, lines, groups, amountById, planCurrency]);
 
   // Once the plan status has resolved (and is not stale — see freshPlanStatus
   // above), prefer its totals: those are computed with correct cross-currency
@@ -594,6 +678,156 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     [moveInBlock, oneOffLines],
   );
 
+  /* ── Groups (migration 0022) ─────────────────────────────────────────────── */
+
+  // The groups that have something to show THIS month, each with its children
+  // split by scope — recurring and one-off lines keep separate sort_order
+  // sequences at the DB layer, so they also move within separate blocks here.
+  const groupViews = useMemo(() => {
+    const childrenByGroup = new Map();
+    for (const line of allocationLines) {
+      if (!isGrouped(line)) continue;
+      const current = childrenByGroup.get(line.groupId);
+      if (current) current.push(line);
+      else childrenByGroup.set(line.groupId, [line]);
+    }
+    return groups
+      .filter(group => childrenByGroup.has(group.id))
+      .map((group) => {
+        const children = childrenByGroup.get(group.id);
+        // The derived figure the group shows until (and unless) the async status
+        // lands: the same sum, from the same converted amounts the rows print.
+        let derived = '0';
+        for (const child of children) {
+          const amount = amountById.get(child.id);
+          if (amount != null) derived = Currency.add(derived, amount, planCurrency);
+        }
+        const override = amountById.get(groupAmountKey(group.id));
+        return {
+          group,
+          children,
+          recurring: children.filter(l => l.isRecurring),
+          oneOff: children.filter(l => !l.isRecurring),
+          displayAmount: group.isDerived ? derived : (override ?? null),
+          derived,
+        };
+      });
+  }, [groups, allocationLines, isGrouped, amountById, planCurrency]);
+
+  // One stable pair of movers per group, rebuilt only when the blocks themselves
+  // change — building them inline in the render would hand every child row a new
+  // `onMove` on each pass and defeat PlanLineRow's memo.
+  const groupMovers = useMemo(() => {
+    const map = new Map();
+    for (const view of groupViews) {
+      map.set(`${view.group.id}|r`, (index, direction) => moveInBlock(view.recurring, index, direction, true));
+      map.set(`${view.group.id}|o`, (index, direction) => moveInBlock(view.oneOff, index, direction, false));
+    }
+    return map;
+  }, [groupViews, moveInBlock]);
+
+  const moveGroup = useCallback(async (index, direction) => {
+    if (moveGuardRef.current) return;
+    const target = index + direction;
+    const ordered = groupViews.map(v => v.group);
+    if (target < 0 || target >= ordered.length) return;
+    moveGuardRef.current = true;
+    const reordered = ordered.slice();
+    const [moved] = reordered.splice(index, 1);
+    reordered.splice(target, 0, moved);
+    // Optimistic, then reconciled from the DB either way — same contract as
+    // moveInBlock. Groups not shown this month keep their stored order: only the
+    // visible ones are renumbered, and their relative order is all that shows.
+    const movedIds = new Set(reordered.map(g => g.id));
+    setGroups(prev => [...reordered, ...prev.filter(g => !movedIds.has(g.id))]);
+    try {
+      await reorderLineGroups(reordered.map(g => g.id));
+      await reloadLines();
+    } catch (error) {
+      console.error('Failed to reorder budget line groups:', error);
+      await reloadLines();
+    } finally {
+      moveGuardRef.current = false;
+    }
+  }, [groupViews, reorderLineGroups, reloadLines]);
+
+  const openEditGroup = useCallback((group) => setGroupModal({ visible: true, group }), []);
+  const closeGroupModal = useCallback(() => setGroupModal(CLOSED_GROUP_MODAL), []);
+
+  const handleSaveGroup = useCallback(async (groupData) => {
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    try {
+      if (groupModal.group) {
+        await updateLineGroup(groupModal.group.id, groupData);
+      } else {
+        await addLineGroup(groupData);
+      }
+      await reloadLines();
+      setStatusStale(true);
+      refreshPlanStatuses?.();
+      closeGroupModal();
+    } catch (error) {
+      // Error dialog already shown by the context.
+      console.error('Failed to save budget line group:', error);
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [groupModal.group, updateLineGroup, addLineGroup, reloadLines, refreshPlanStatuses, closeGroupModal]);
+
+  const handleDeleteGroup = useCallback(async (groupId) => {
+    try {
+      await deleteLineGroup(groupId);
+      // The lines inside are ungrouped, not deleted (ON DELETE SET NULL), so they
+      // reappear in the ungrouped blocks after this reload.
+      await reloadLines();
+      setStatusStale(true);
+      refreshPlanStatuses?.();
+      closeGroupModal();
+    } catch (error) {
+      console.error('Failed to delete budget line group:', error);
+    }
+  }, [deleteLineGroup, reloadLines, refreshPlanStatuses, closeGroupModal]);
+
+  // Creating a group from inside the line editor, so a line can join an envelope
+  // that doesn't exist yet without the form being abandoned.
+  const handleCreateGroupInline = useCallback(async (label) => {
+    const created = await addLineGroup({ label, sortOrder: groups.length });
+    if (created) setGroups(prev => [...prev, created]);
+    return created;
+  }, [addLineGroup, groups.length]);
+
+  const handleLongPressGroup = useCallback((group, index, listLength, onMove) => {
+    const moveActions = [];
+    if (onMove) {
+      if (index > 0) moveActions.push({ text: t('move_up'), onPress: () => onMove(index, -1) });
+      if (index < listLength - 1) moveActions.push({ text: t('move_down'), onPress: () => onMove(index, 1) });
+    }
+    showDialog(
+      t('select_action'),
+      group.label,
+      [
+        { text: t('edit_group'), onPress: () => openEditGroup(group) },
+        ...moveActions,
+        {
+          text: t('delete_group'),
+          style: 'destructive',
+          onPress: () => showDialog(
+            t('delete_group'),
+            t('delete_group_confirm'),
+            [
+              { text: t('cancel'), style: 'cancel' },
+              { text: t('delete'), style: 'destructive', onPress: () => handleDeleteGroup(group.id) },
+            ],
+          ),
+        },
+        { text: t('cancel'), style: 'cancel' },
+      ],
+    );
+  }, [t, showDialog, openEditGroup, handleDeleteGroup]);
+
   /* ── Rendering ───────────────────────────────────────────────────────────── */
 
   const lineIcon = useCallback((line) => {
@@ -606,13 +840,14 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
 
   // Shared row renderer for every block — each list moves independently (own
   // sort_order sequence), so `list` and `onMove` are passed in per block.
-  const renderLine = useCallback((line, index, list, onMove) => {
+  const renderLine = useCallback((line, index, list, onMove, indented = false) => {
     const executed = line.lastExecutedMonth === month;
     return (
       <PlanLineRow
         key={line.id}
         line={line}
         index={index}
+        indented={indented}
         name={lineDisplayName(line)}
         icon={lineIcon(line)}
         status={lineStatusById.get(line.id) || null}
@@ -640,6 +875,22 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     handleMarkExecuted, handleUndoExecuted]);
 
   const hasAnyLines = lines.length > 0;
+
+  // Currencies the group editor may price an override in: the same set the line
+  // editor offers, for the same reason (a group belongs to no plan, so it needs
+  // to name its own).
+  const currencyOptions = useMemo(() => {
+    const set = new Set(accounts.map(a => a.currency));
+    if (planCurrency) set.add(planCurrency);
+    return [...set];
+  }, [accounts, planCurrency]);
+
+  // What the group being edited adds up to right now, shown next to the
+  // custom-budget toggle so an override is typed with the number it replaces in
+  // view.
+  const editedGroupDerivedTotal = groupModal.group
+    ? (groupViews.find(v => v.group.id === groupModal.group.id)?.derived ?? null)
+    : null;
 
   return (
     <>
@@ -712,6 +963,37 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
             <Text style={[styles.sectionTitle, { color: colors.text }]}>{t('allocations')}</Text>
           </View>
         </View>
+
+        {/* Groups first, each followed by its own lines one indent deeper. A
+            group is an envelope over allocations that need share nothing
+            structurally — categories from unrelated trees, a transfer target, a
+            recurring line next to a one-off one — so it sits above the loose
+            ones rather than among them. */}
+        {groupViews.map((view, groupIndex) => (
+          <React.Fragment key={view.group.id}>
+            <PlanGroupRow
+              group={view.group}
+              index={groupIndex}
+              listLength={groupViews.length}
+              status={groupStatusById.get(view.group.id) || null}
+              displayAmount={view.displayAmount}
+              converting={converting}
+              childCount={view.children.length}
+              colors={colors}
+              t={t}
+              pace={pace}
+              onMove={moveGroup}
+              onPress={openEditGroup}
+              onLongPress={handleLongPressGroup}
+            />
+            {view.recurring.map((line, index) => renderLine(
+              line, index, view.recurring, groupMovers.get(`${view.group.id}|r`), true,
+            ))}
+            {view.oneOff.map((line, index) => renderLine(
+              line, index, view.oneOff, groupMovers.get(`${view.group.id}|o`), true,
+            ))}
+          </React.Fragment>
+        ))}
 
         {recurringLines.map((line, index) => renderLine(line, index, recurringLines, handleMoveRecurring))}
         {oneOffLines.map((line, index) => renderLine(line, index, oneOffLines, handleMoveOneOff))}
@@ -829,10 +1111,24 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
           expenseCategories={expenseCategories}
           incomeCategories={incomeCategories}
           accounts={accounts}
+          groups={groups}
           saving={busy}
           onSaveLine={handleSaveLine}
           onDeleteLine={handleDeleteLine}
+          onCreateGroup={handleCreateGroupInline}
           onClose={closeModal}
+        />
+
+        <BudgetLineGroupModal
+          visible={groupModal.visible}
+          group={groupModal.group}
+          currency={planCurrency}
+          currencyOptions={currencyOptions}
+          derivedTotal={editedGroupDerivedTotal}
+          saving={busy}
+          onSave={handleSaveGroup}
+          onDelete={handleDeleteGroup}
+          onClose={closeGroupModal}
         />
       </View>
     </>

--- a/app/components/budgets/PlanGroupRow.js
+++ b/app/components/budgets/PlanGroupRow.js
@@ -1,0 +1,210 @@
+import React, { memo } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import * as Currency from '../../services/currency';
+import EnvelopeFill from './EnvelopeFill';
+import { SPACING } from '../../styles/layout';
+
+// Stands in for a figure whose exchange rate is still resolving — same em dash
+// PlanLineRow uses, for the same reason.
+const CONVERTING_PLACEHOLDER = '—';
+
+/**
+ * The header row of a GROUP of allocations (migration 0022).
+ *
+ * A group is an envelope over several lines that need not have anything in
+ * common structurally — categories from unrelated trees, transfer targets, a
+ * recurring line beside a one-off one. Its budget is the sum of its children by
+ * default, or a figure the user set explicitly; its actual is always the sum of
+ * theirs.
+ *
+ * The row deliberately looks like a heavier PlanLineRow rather than like a
+ * section title: it carries the same amount pair, the same progress wash and the
+ * same tone rules, because it IS a budget — the thing the person actually tracks
+ * when they say "we spend 50k on the car". Its children sit indented beneath it
+ * and read as its parts.
+ */
+const PlanGroupRow = memo(function PlanGroupRow({
+  group,
+  index,
+  status = null,
+  displayAmount = null,
+  converting = false,
+  childCount,
+  colors,
+  t,
+  pace = null,
+  listLength,
+  onMove = null,
+  onPress,
+  onLongPress,
+}) {
+  const isUnconvertible = status?.status === 'unconvertible';
+  // A group is "tracked" once its actual is known — which only the async plan
+  // status can supply (per-line actuals are not computed on the client). Until
+  // then the row prints its target alone, exactly like a line does.
+  const tracked = !!status && !isUnconvertible && status.actual != null;
+  const spentFraction = tracked ? status.percentage / 100 : 0;
+
+  let tone = null;
+  if (tracked && status.isExceeded) {
+    tone = colors.overspend;
+  } else if (tracked && pace != null && spentFraction > pace) {
+    tone = colors.warning;
+  }
+
+  const target = status?.amount ?? displayAmount;
+  let amountText;
+  if (target == null) {
+    amountText = CONVERTING_PLACEHOLDER;
+  } else if (tracked) {
+    amountText = `${Currency.formatCompact(status.actual)} / ${Currency.formatCompact(target)}`;
+  } else {
+    amountText = Currency.formatCompact(target);
+  }
+
+  // What the children add up to, shown ONLY when the group's own budget says
+  // something different — that disagreement is the entire content of an
+  // override, and hiding it would leave the user to do the subtraction. A
+  // derived group's children sum IS its budget, so repeating it would be noise.
+  const childSum = status?.overrideApplied
+    && status.childAmount != null
+    && Currency.compare(status.childAmount, status.amount) !== 0
+    ? Currency.formatCompact(status.childAmount)
+    : null;
+
+  return (
+    <Pressable
+      style={[styles.groupRow, { borderColor: colors.border }]}
+      onPress={() => onPress(group)}
+      onLongPress={() => onLongPress(group, index, listLength, onMove)}
+      accessibilityRole="button"
+      accessibilityLabel={`${t('edit_group')}: ${group.label}, ${amountText}, ${childCount} ${t('allocations')}`}
+      testID={`plan-group-${group.id}`}
+    >
+      {tracked && (
+        <EnvelopeFill
+          fraction={spentFraction}
+          tone={tone}
+          mutedColor={colors.mutedText}
+          testID={`plan-group-fill-${group.id}`}
+        />
+      )}
+      <View style={styles.groupTop}>
+        <Icon name="folder-outline" size={20} color={colors.text} />
+        <View style={styles.groupBody}>
+          <Text style={[styles.groupName, { color: colors.text }]} numberOfLines={1}>
+            {group.label}
+          </Text>
+          <View style={styles.groupMetaRow}>
+            {/* A glyph and a number rather than "3 allocations": the phrase
+                needs plural agreement in most of the eleven shipped locales,
+                and the row has no space for the longest of them. The screen
+                reader gets the words (see accessibilityLabel above). */}
+            <Icon name="format-list-bulleted" size={11} color={colors.mutedText} />
+            <Text style={[styles.groupMeta, { color: colors.mutedText }]} numberOfLines={1}>
+              {childCount}
+            </Text>
+            {childSum && (
+              <Text
+                style={[styles.groupMeta, { color: colors.mutedText }]}
+                numberOfLines={1}
+                testID={`plan-group-childsum-${group.id}`}
+              >
+                · Σ {childSum}
+              </Text>
+            )}
+          </View>
+        </View>
+        <Text style={[styles.groupAmount, { color: colors.text }]}>
+          {converting && target == null ? CONVERTING_PLACEHOLDER : amountText}
+        </Text>
+      </View>
+      {isUnconvertible && (
+        // The group's own budget is in a currency with no rate to the screen's,
+        // so the figure above fell back to its children's sum — say why rather
+        // than quietly printing a different number than the user typed.
+        <View style={styles.noteRow} testID={`plan-group-unconvertible-${group.id}`}>
+          <Icon name="alert-circle-outline" size={14} color={colors.mutedText} />
+          <Text style={[styles.noteText, { color: colors.mutedText }]} numberOfLines={1}>
+            {t('graphs_currencies_not_converted')}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+});
+
+PlanGroupRow.propTypes = {
+  group: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    amount: PropTypes.string,
+    currency: PropTypes.string,
+    isDerived: PropTypes.bool,
+  }).isRequired,
+  index: PropTypes.number.isRequired,
+  listLength: PropTypes.number.isRequired,
+  status: PropTypes.object,
+  displayAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  converting: PropTypes.bool,
+  childCount: PropTypes.number.isRequired,
+  colors: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired,
+  pace: PropTypes.number,
+  onMove: PropTypes.func,
+  onPress: PropTypes.func.isRequired,
+  onLongPress: PropTypes.func.isRequired,
+};
+
+export default PlanGroupRow;
+
+const styles = StyleSheet.create({
+  groupAmount: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginLeft: 8,
+  },
+  groupBody: {
+    flex: 1,
+    marginLeft: 10,
+  },
+  groupMeta: {
+    fontSize: 11,
+  },
+  groupMetaRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 4,
+    marginTop: 1,
+  },
+  groupName: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  groupRow: {
+    // A hairline under the header instead of a filled bar: the children below it
+    // are already indented, and two devices for one relationship is one too many.
+    borderBottomWidth: 1,
+    borderRadius: 8,
+    marginTop: SPACING.xs,
+    overflow: 'hidden',
+    paddingHorizontal: SPACING.sm,
+    paddingVertical: SPACING.sm,
+  },
+  groupTop: {
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  noteRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 6,
+    marginTop: 4,
+  },
+  noteText: {
+    flex: 1,
+    fontSize: 12,
+  },
+});

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -51,6 +51,7 @@ const PlanLineRow = memo(function PlanLineRow({
   canExecute = false,
   canUndo = false,
   showProgress = true,
+  indented = false,
   pace = null,
   listLength,
   onMove = null,
@@ -169,7 +170,15 @@ const PlanLineRow = memo(function PlanLineRow({
 
   const content = (
     <Pressable
-      style={[styles.lineRow, index % 2 === 1 && { backgroundColor: colors.altRow }]}
+      style={[
+        styles.lineRow,
+        index % 2 === 1 && { backgroundColor: colors.altRow },
+        // A line inside a group is one of that group's parts, and the indent is
+        // the only thing that says so — the group header above it carries the
+        // name and the total, and repeating either on every child would make the
+        // group's own row the least readable thing on the screen.
+        indented && styles.lineRowIndented,
+      ]}
       onPress={() => onPress(line)}
       // The row renders nothing from `listLength`/`onMove` — it forwards them so
       // the host can build the move actions. Keeping them as props (rather than
@@ -364,6 +373,7 @@ PlanLineRow.propTypes = {
   canExecute: PropTypes.bool,
   canUndo: PropTypes.bool,
   showProgress: PropTypes.bool,
+  indented: PropTypes.bool,
   pace: PropTypes.number,
   onMove: PropTypes.func,
   onPress: PropTypes.func.isRequired,
@@ -425,6 +435,12 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     paddingHorizontal: SPACING.sm,
     paddingVertical: SPACING.sm,
+  },
+  lineRowIndented: {
+    // Deep enough to read as a level of nesting at a glance, shallow enough that
+    // the child's own icon still lines up under the group's text rather than
+    // drifting into the middle of the row.
+    paddingLeft: SPACING.md + SPACING.sm,
   },
   lineTop: {
     alignItems: 'center',

--- a/app/contexts/BudgetPlansActionsContext.js
+++ b/app/contexts/BudgetPlansActionsContext.js
@@ -127,6 +127,39 @@ export const BudgetPlansActionsProvider = ({ children }) => {
   // month's one-off lines (if a plan exists yet) — see BudgetPlansDB.getLinesForMonth.
   const getLinesForMonth = useCallback((month) => BudgetPlansDB.getLinesForMonth(month), []);
   const getBrokenLines = useCallback((planId) => BudgetPlansDB.getBrokenLines(planId), []);
+
+  // Line groups (migration 0022): the envelopes several lines can share. Global,
+  // so they are fetched once per screen rather than per month — like lines, they
+  // are not held in context state.
+  const getLineGroups = useCallback(() => BudgetPlansDB.getLineGroups(), []);
+  const addLineGroup = useCallback(async (group) => {
+    try {
+      return await BudgetPlansDB.createLineGroup(group);
+    } catch (error) {
+      console.error('Failed to create budget line group:', error);
+      reportError(error);
+      throw error;
+    }
+  }, [reportError]);
+  const updateLineGroup = useCallback(async (id, updates) => {
+    try {
+      await BudgetPlansDB.updateLineGroup(id, updates);
+    } catch (error) {
+      console.error('Failed to update budget line group:', error);
+      reportError(error);
+      throw error;
+    }
+  }, [reportError]);
+  const deleteLineGroup = useCallback(async (id) => {
+    try {
+      await BudgetPlansDB.deleteLineGroup(id);
+    } catch (error) {
+      console.error('Failed to delete budget line group:', error);
+      reportError(error);
+      throw error;
+    }
+  }, [reportError]);
+  const reorderLineGroups = useCallback((orderedIds) => BudgetPlansDB.reorderLineGroups(orderedIds), []);
   const getPlanTotals = useCallback((planId) => BudgetPlansDB.getPlanTotals(planId), []);
   const getPlanByMonth = useCallback((month) => BudgetPlansDB.getPlanByMonth(month), []);
 
@@ -182,6 +215,11 @@ export const BudgetPlansActionsProvider = ({ children }) => {
     getRecurringLines,
     getLinesForMonth,
     getBrokenLines,
+    getLineGroups,
+    addLineGroup,
+    updateLineGroup,
+    deleteLineGroup,
+    reorderLineGroups,
     getPlanTotals,
     getPlanByMonth,
     executeLine,
@@ -203,6 +241,11 @@ export const BudgetPlansActionsProvider = ({ children }) => {
     getRecurringLines,
     getLinesForMonth,
     getBrokenLines,
+    getLineGroups,
+    addLineGroup,
+    updateLineGroup,
+    deleteLineGroup,
+    reorderLineGroups,
     getPlanTotals,
     getPlanByMonth,
     executeLine,

--- a/app/db/schema.js
+++ b/app/db/schema.js
@@ -346,13 +346,53 @@ export const budgetPlanLines = sqliteTable('budget_plan_lines', {
   // subtree; a leaf has no subtree), so the app writes 1 and ignores a stored 0.
   // The column stays for the backup/Sheets shape — see BudgetPlansDB.mapLineFields.
   includeChildren: integer('include_children').notNull().default(1),
+  // Migration 0022. The envelope this line belongs to, or NULL for a line that
+  // stands on its own. ON DELETE SET NULL: dropping a group ungroups its lines,
+  // it never deletes the budgets inside it.
+  groupId: text('group_id').references(() => budgetPlanLineGroups.id, { onDelete: 'set null' }),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
 }, (table) => ({
   planIdx: index('idx_budget_plan_lines_plan').on(table.planId),
   recurringIdx: index('idx_budget_plan_lines_recurring').on(table.isRecurring),
   kindIdx: index('idx_budget_plan_lines_kind').on(table.kind),
+  groupIdx: index('idx_budget_plan_lines_group').on(table.groupId),
 }));
+
+/**
+ * Budget Plan Line Groups table (migration 0022)
+ *
+ * An envelope over several lines. A group's members may mix category targets from
+ * unrelated trees with transfer targets, and recurring lines with one-off ones —
+ * membership is the only thing a group asserts.
+ *
+ * GLOBAL, like recurring lines: no `plan_id`, so a group outlives any single
+ * month and shows up in every month where at least one of its lines does. That is
+ * what lets one group hold a recurring line (which belongs to no plan) and a
+ * one-off line (which belongs to exactly one) at the same time.
+ *
+ * `amount` NULL — the default — means the group's budget is DERIVED: the sum of
+ * its children's targets, in whatever currency the screen is read in. A non-null
+ * amount overrides that and, being an override the user typed deliberately,
+ * replaces the children's sum in the month's allocated total (see
+ * BudgetPlansDB.calculatePlanStatus). `currency` accompanies an override amount
+ * (a group has no plan to inherit one from) and is NULL for a derived group.
+ *
+ * A group's ACTUAL is always the sum of its children's actuals — an override
+ * changes the target, never what was really spent.
+ */
+export const budgetPlanLineGroups = sqliteTable('budget_plan_line_groups', {
+  id: text('id').primaryKey(),
+  // Required: a group has no target to borrow a name from, unlike a line.
+  label: text('label').notNull(),
+  // NULL = derived (sum of the group's lines). Non-null = explicit override.
+  amount: text('amount'),
+  // Set only alongside an override `amount`.
+  currency: text('currency'),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+});
 
 /**
  * Budget Plan Line ↔ Categories junction (migration 0021)

--- a/app/services/BackupRestore.js
+++ b/app/services/BackupRestore.js
@@ -30,7 +30,7 @@ export const createBackup = async () => {
     console.log('Creating database backup...');
 
     // Fetch all data from all tables
-    const [accounts, categories, operations, budgets, appMetadata, balanceHistory, plannedOperations, merchantRules, budgetPlans, budgetPlanLines, budgetPlanLineCategories] = await Promise.all([
+    const [accounts, categories, operations, budgets, appMetadata, balanceHistory, plannedOperations, merchantRules, budgetPlans, budgetPlanLines, budgetPlanLineCategories, budgetPlanLineGroups] = await Promise.all([
       queryAll('SELECT * FROM accounts ORDER BY created_at ASC'),
       queryAll('SELECT * FROM categories ORDER BY created_at ASC'),
       queryAll('SELECT * FROM operations ORDER BY created_at ASC'),
@@ -48,6 +48,9 @@ export const createBackup = async () => {
       // so a backup of a pre-0021 database still succeeds — restore rebuilds the
       // links from each line's category_id when this section is absent.
       queryAll('SELECT * FROM budget_plan_line_categories ORDER BY line_id ASC, category_id ASC').catch(() => []),
+      // Line groups (migration 0022). Guarded the same way; a pre-0022 backup has
+      // no groups and every line restores ungrouped.
+      queryAll('SELECT * FROM budget_plan_line_groups ORDER BY sort_order ASC, created_at ASC').catch(() => []),
     ]);
 
     // Create backup object
@@ -70,6 +73,7 @@ export const createBackup = async () => {
         budget_plans: budgetPlans || [],
         budget_plan_lines: budgetPlanLines || [],
         budget_plan_line_categories: budgetPlanLineCategories || [],
+        budget_plan_line_groups: budgetPlanLineGroups || [],
       },
     };
 
@@ -83,6 +87,7 @@ export const createBackup = async () => {
       budget_plans: backup.data.budget_plans.length,
       budget_plan_lines: backup.data.budget_plan_lines.length,
       budget_plan_line_categories: backup.data.budget_plan_line_categories.length,
+      budget_plan_line_groups: backup.data.budget_plan_line_groups.length,
     });
 
     return backup;
@@ -108,10 +113,14 @@ const TABLE_FIELDS = {
   // `is_recurring` / `currency` were added by that same migration.
   // `include_children` (migration 0021) says whether descendants of the linked
   // categories roll up into the line's actual.
-  budget_plan_lines: ['id', 'plan_id', 'label', 'amount', 'comment', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'account_id', 'last_executed_month', 'include_children', 'created_at', 'updated_at'],
+  // `group_id` (migration 0022) is the envelope the line belongs to, or null.
+  budget_plan_lines: ['id', 'plan_id', 'label', 'amount', 'comment', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'account_id', 'last_executed_month', 'include_children', 'group_id', 'created_at', 'updated_at'],
   // The full category set of each line (migration 0021); `category_id` above is
   // only its primary entry.
   budget_plan_line_categories: ['line_id', 'category_id'],
+  // Line groups (migration 0022). `amount`/`currency` are null for a group whose
+  // budget is derived from its lines.
+  budget_plan_line_groups: ['id', 'label', 'amount', 'currency', 'sort_order', 'created_at', 'updated_at'],
 };
 
 /**
@@ -171,6 +180,7 @@ export const exportBackupCSV = async () => {
       'budget_plans.csv': convertToCSV(backup.data.budget_plans, TABLE_FIELDS.budget_plans),
       'budget_plan_lines.csv': convertToCSV(backup.data.budget_plan_lines, TABLE_FIELDS.budget_plan_lines),
       'budget_plan_line_categories.csv': convertToCSV(backup.data.budget_plan_line_categories, TABLE_FIELDS.budget_plan_line_categories),
+      'budget_plan_line_groups.csv': convertToCSV(backup.data.budget_plan_line_groups, TABLE_FIELDS.budget_plan_line_groups),
       'backup_info.csv': `version,timestamp,platform\n${backup.version},${backup.timestamp},${backup.platform}`,
     };
 
@@ -188,7 +198,8 @@ export const exportBackupCSV = async () => {
     combinedCSV += `[PLANNED_OPERATIONS]\n${csvFiles['planned_operations.csv']}\n\n`;
     combinedCSV += `[BUDGET_PLANS]\n${csvFiles['budget_plans.csv']}\n\n`;
     combinedCSV += `[BUDGET_PLAN_LINES]\n${csvFiles['budget_plan_lines.csv']}\n\n`;
-    combinedCSV += `[BUDGET_PLAN_LINE_CATEGORIES]\n${csvFiles['budget_plan_line_categories.csv']}\n`;
+    combinedCSV += `[BUDGET_PLAN_LINE_CATEGORIES]\n${csvFiles['budget_plan_line_categories.csv']}\n\n`;
+    combinedCSV += `[BUDGET_PLAN_LINE_GROUPS]\n${csvFiles['budget_plan_line_groups.csv']}\n`;
 
     const filename = `money_tracker_backup_${timestamp}.csv`;
     const fileUri = `${FileSystem.documentDirectory}${filename}`;
@@ -522,6 +533,9 @@ export const restoreBackup = async (backup, cancelToken) => {
       await db.runAsync('DELETE FROM budget_plan_line_categories').catch(() => {});
       await db.runAsync('DELETE FROM budget_plan_lines').catch(() => {});
       await db.runAsync('DELETE FROM budget_plans').catch(() => {});
+      // Groups (migration 0022) reference nothing and are referenced by lines
+      // (ON DELETE SET NULL), so they clear after the lines that point at them.
+      await db.runAsync('DELETE FROM budget_plan_line_groups').catch(() => {});
       await db.runAsync('DELETE FROM accounts_balance_history');
       await db.runAsync('DELETE FROM operations');
       await db.runAsync('DELETE FROM categories');
@@ -839,11 +853,40 @@ export const restoreBackup = async (backup, cancelToken) => {
       {
         const plans = backup.data.budget_plans || [];
         const lines = backup.data.budget_plan_lines || [];
+        const groups = backup.data.budget_plan_line_groups || [];
         appEvents.emit(IMPORT_PROGRESS_EVENT, {
           stepId: 'budget_plans',
           status: 'in_progress',
           data: plans.length,
         });
+
+        // Groups first: a line's group_id references them. Only the ones that
+        // really landed may be assigned below, for the same reason plans are
+        // tracked — a dangling FK would abort the entire restore.
+        const restoredGroupIds = new Set();
+        for (const group of groups) {
+          if (!group.id || !group.label) {
+            console.warn('Skipping budget line group with missing required fields:', group);
+            continue;
+          }
+          // A CSV round trip turns a null amount into '', which must restore as a
+          // DERIVED group (null), not as the string '' sitting in a numeric column.
+          const amount = group.amount === '' || group.amount == null ? null : String(group.amount);
+          await db.runAsync(
+            'INSERT INTO budget_plan_line_groups (id, label, amount, currency, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [
+              group.id,
+              group.label,
+              amount,
+              // The currency only means anything alongside an override amount.
+              amount === null ? null : (group.currency || null),
+              Number.isInteger(group.sort_order) ? group.sort_order : Number(group.sort_order) || 0,
+              group.created_at || new Date().toISOString(),
+              group.updated_at || new Date().toISOString(),
+            ],
+          );
+          restoredGroupIds.add(group.id);
+        }
 
         // Track the plans actually inserted (not merely present in the backup):
         // a plan skipped for missing fields must NOT let its lines through, or
@@ -910,7 +953,7 @@ export const restoreBackup = async (backup, cancelToken) => {
             mappedAccountId = accountIdMapping.get(String(line.account_id)) ?? null;
           }
           await db.runAsync(
-            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, group_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
               line.id,
               isRecurring ? null : line.plan_id,
@@ -935,6 +978,11 @@ export const restoreBackup = async (backup, cancelToken) => {
               (line.include_children === '' || line.include_children == null)
                 ? 1
                 : (Number(line.include_children) === 0 ? 0 : 1),
+              // Group membership (migration 0022). A group the backup doesn't
+              // contain drops to NULL — the line restores ungrouped rather than
+              // failing its FK and taking the whole import down with it. Absent
+              // on every pre-0022 backup, where '' likewise means "no group".
+              (line.group_id && restoredGroupIds.has(line.group_id)) ? line.group_id : null,
               line.created_at || new Date().toISOString(),
               line.updated_at || new Date().toISOString(),
             ],
@@ -1319,9 +1367,10 @@ const importBackupCSV = async (fileUri, cancelToken) => {
     budget_plans: [],
     budget_plan_lines: [],
     budget_plan_line_categories: [],
+    budget_plan_line_groups: [],
   };
 
-  // Split by section markers. The three [BUDGET_PLAN*] markers don't collide:
+  // Split by section markers. The four [BUDGET_PLAN*] markers don't collide:
   // each marker + newline (`[BUDGET_PLANS]\n`, `[BUDGET_PLAN_LINES]\n`) is not a
   // substring of any of the others.
   const accountsMatch = fileContent.match(/\[ACCOUNTS\]\n([\s\S]*?)(?=\n\[|$)/);
@@ -1334,6 +1383,7 @@ const importBackupCSV = async (fileUri, cancelToken) => {
   const budgetPlansMatch = fileContent.match(/\[BUDGET_PLANS\]\n([\s\S]*?)(?=\n\[|$)/);
   const budgetPlanLinesMatch = fileContent.match(/\[BUDGET_PLAN_LINES\]\n([\s\S]*?)(?=\n\[|$)/);
   const budgetPlanLineCategoriesMatch = fileContent.match(/\[BUDGET_PLAN_LINE_CATEGORIES\]\n([\s\S]*?)(?=\n\[|$)/);
+  const budgetPlanLineGroupsMatch = fileContent.match(/\[BUDGET_PLAN_LINE_GROUPS\]\n([\s\S]*?)(?=\n\[|$)/);
 
   if (accountsMatch) sections.accounts = parseCSV(accountsMatch[1]);
   if (categoriesMatch) sections.categories = parseCSV(categoriesMatch[1]);
@@ -1345,6 +1395,7 @@ const importBackupCSV = async (fileUri, cancelToken) => {
   if (budgetPlansMatch) sections.budget_plans = parseCSV(budgetPlansMatch[1]);
   if (budgetPlanLinesMatch) sections.budget_plan_lines = parseCSV(budgetPlanLinesMatch[1]);
   if (budgetPlanLineCategoriesMatch) sections.budget_plan_line_categories = parseCSV(budgetPlanLineCategoriesMatch[1]);
+  if (budgetPlanLineGroupsMatch) sections.budget_plan_line_groups = parseCSV(budgetPlanLineGroupsMatch[1]);
 
   // Extract version from header
   const versionMatch = fileContent.match(/# Version: (\d+)/);
@@ -1481,6 +1532,17 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
       console.warn('No budget_plan_line_categories table in imported database (older format)');
     }
 
+    // Line groups (migration 0022), newer still — its own guard for the same
+    // reason: a pre-0022 database has no groups and every line imports ungrouped.
+    let budgetPlanLineGroups = [];
+    try {
+      budgetPlanLineGroups = await tempDb.getAllAsync(
+        'SELECT * FROM budget_plan_line_groups ORDER BY sort_order ASC, created_at ASC',
+      );
+    } catch (e) {
+      console.warn('No budget_plan_line_groups table in imported database (older format)');
+    }
+
     // Create backup object
     const backup = {
       version: BACKUP_VERSION,
@@ -1498,6 +1560,7 @@ const importBackupSQLite = async (fileUri, cancelToken) => {
         budget_plans: budgetPlans || [],
         budget_plan_lines: budgetPlanLines || [],
         budget_plan_line_categories: budgetPlanLineCategories || [],
+        budget_plan_line_groups: budgetPlanLineGroups || [],
       },
     };
 

--- a/app/services/BudgetPlansDB.js
+++ b/app/services/BudgetPlansDB.js
@@ -128,6 +128,10 @@ export const mapLineFields = (row) => {
     // a stored 0 no longer changes how a line counts.
     toAccountId,
     sortOrder: row.sort_order ?? 0,
+    // The envelope this line belongs to (migration 0022), or null when it stands
+    // on its own. An income line is never grouped — groups sit in the allocations
+    // section and aggregate spending, which income lines have none of.
+    groupId: kind === 'income' ? null : (row.group_id ?? null),
     isBroken: kind !== 'income' && categoryIds.length === 0 && toAccountId === null,
     isRecurring: row.is_recurring === 1,
     currency: row.currency ?? null,
@@ -541,6 +545,9 @@ const insertPlanLine = async (planId, line) => {
       // Always 1: descendant spending always rolls up (see mapLineFields). The
       // column is kept written so the backup/Sheets shape stays stable.
       include_children: 1,
+      // An income line is never grouped (see mapLineFields), so the column is
+      // written NULL for one however the caller asked.
+      group_id: (line.kind !== 'income' && isSet(line.groupId)) ? line.groupId : null,
       created_at: now,
       updated_at: now,
     };
@@ -550,12 +557,12 @@ const insertPlanLine = async (planId, line) => {
     // silently stop tracking anything.
     await executeTransaction(async (db) => {
       await db.runAsync(
-        'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, group_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
         [
           row.id, row.plan_id, row.label, row.amount, row.comment, row.category_id,
           row.to_account_id, row.sort_order, row.is_recurring, row.currency,
           row.kind, row.account_id, row.last_executed_month, row.include_children,
-          row.created_at, row.updated_at,
+          row.group_id, row.created_at, row.updated_at,
         ],
       );
       await writeLineCategoriesInTx(db, row.id, categoryIds);
@@ -776,6 +783,17 @@ export const updateLine = async (id, updates) => {
       fields.push('last_executed_month = ?');
       values.push(updates.lastExecutedMonth ?? null);
     }
+    // Group membership (migration 0022). Turning a line into an income line drops
+    // it out of its group even when the caller said nothing about groups: income
+    // lines are not part of the allocations the groups aggregate (see
+    // mapLineFields), and a stale group_id there would make the group's derived
+    // total count a figure its own children's sum cannot explain.
+    if (updates.groupId !== undefined || updates.kind === 'income') {
+      fields.push('group_id = ?');
+      values.push(
+        updates.kind === 'income' || !isSet(updates.groupId) ? null : updates.groupId,
+      );
+    }
 
     // Amount, possibly re-derived below when the effective currency changes.
     let amount = updates.amount;
@@ -933,6 +951,258 @@ export const reorderLines = async (planId, orderedIds) => reorderPlanLines(planI
 export const reorderRecurringLines = async (orderedIds) => reorderPlanLines(null, orderedIds);
 
 /* -------------------------------------------------------------------------- */
+/* Groups (migration 0022)                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Map a budget_plan_line_groups row to camelCase. `isDerived` is the computed
+ * "this group has no override" flag every consumer keys off — a null `amount`
+ * means the group's budget is the sum of its lines, recomputed as they change.
+ * @param {Object|null} row
+ * @returns {Object|null}
+ */
+export const mapGroupFields = (row) => {
+  if (!row) return null;
+  const amount = isSet(row.amount) ? String(row.amount) : null;
+  return {
+    id: row.id,
+    label: row.label,
+    amount,
+    // Only meaningful alongside an override amount; a derived group's total is
+    // expressed in whatever currency the screen is being read in.
+    currency: amount === null ? null : (row.currency ?? null),
+    sortOrder: row.sort_order ?? 0,
+    isDerived: amount === null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
+
+/**
+ * Validate a group. An override amount must be a positive number AND name its
+ * currency — a bare number would be read in whichever currency the screen
+ * happened to be showing when it was typed.
+ * @param {Object} group
+ * @returns {string|null} Error message or null if valid.
+ */
+export const validateLineGroup = (group) => {
+  if (!group || !isSet(group.label) || !String(group.label).trim()) {
+    return 'A group name is required';
+  }
+  if (isSet(group.amount)) {
+    if (!Currency.isValid(group.amount) || Currency.compare(group.amount, '0') <= 0) {
+      return 'Amount must be greater than zero';
+    }
+    if (!isSet(group.currency)) {
+      return 'Currency is required for a custom group budget';
+    }
+  }
+  return null;
+};
+
+/**
+ * Create a group.
+ * @param {Object} group - { id?, label, amount?, currency?, sortOrder? }
+ * @returns {Promise<Object>} The created group (camelCase).
+ */
+export const createLineGroup = async (group) => {
+  try {
+    const validationError = validateLineGroup(group);
+    if (validationError) {
+      throw new Error(validationError);
+    }
+    const now = new Date().toISOString();
+    const hasAmount = isSet(group.amount);
+    const row = {
+      id: group.id || uuid.v4(),
+      // Trimmed, NOT sanitizeNewLabel'd: that strips the system-label prefixes
+      // that mark a protected imported operation, and a group's name never
+      // becomes an operation description — running it through would silently
+      // empty a group a user legitimately called "Category: fun".
+      label: String(group.label).trim(),
+      amount: hasAmount ? String(group.amount) : null,
+      // Currency is stored only with an override; a derived group carrying one
+      // would suggest its computed total is fixed to that currency, which it is not.
+      currency: hasAmount ? group.currency : null,
+      sort_order: Number.isInteger(group.sortOrder) ? group.sortOrder : 0,
+      created_at: now,
+      updated_at: now,
+    };
+    await executeQuery(
+      'INSERT INTO budget_plan_line_groups (id, label, amount, currency, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [row.id, row.label, row.amount, row.currency, row.sort_order, row.created_at, row.updated_at],
+    );
+    return mapGroupFields(row);
+  } catch (error) {
+    console.error('Failed to create budget line group:', error);
+    throw error;
+  }
+};
+
+/**
+ * Every group, in display order. Groups are global (not month-scoped), so this is
+ * the whole list — the UI shows the ones that have a line in the month it renders.
+ * @returns {Promise<Array>}
+ */
+export const getLineGroups = async () => {
+  try {
+    const rows = await queryAll(
+      'SELECT * FROM budget_plan_line_groups ORDER BY sort_order ASC, created_at ASC',
+    );
+    return (rows || []).map(mapGroupFields);
+  } catch (error) {
+    console.error('Failed to get budget line groups:', error);
+    throw error;
+  }
+};
+
+/**
+ * A single group by ID.
+ * @param {string} id
+ * @returns {Promise<Object|null>}
+ */
+export const getLineGroupById = async (id) => {
+  try {
+    const row = await queryFirst('SELECT * FROM budget_plan_line_groups WHERE id = ?', [id]);
+    return mapGroupFields(row);
+  } catch (error) {
+    console.error('Failed to get budget line group:', error);
+    throw error;
+  }
+};
+
+/**
+ * Update a group. Partial updates.
+ *
+ * Passing `amount: null` clears the override and returns the group to a DERIVED
+ * total — and clears the stored currency with it, so a later override cannot
+ * inherit a currency the user last picked months ago. Passing an amount requires
+ * a currency (either in this call or already stored), for the reason
+ * {@link validateLineGroup} gives.
+ * @param {string} id
+ * @param {Object} updates - Partial { label, amount, currency, sortOrder }
+ * @returns {Promise<void>}
+ */
+export const updateLineGroup = async (id, updates) => {
+  try {
+    const fields = [];
+    const values = [];
+
+    if (updates.label !== undefined) {
+      if (!isSet(updates.label) || !String(updates.label).trim()) {
+        throw new Error('A group name is required');
+      }
+      fields.push('label = ?');
+      values.push(String(updates.label).trim());
+    }
+
+    if (updates.amount !== undefined) {
+      if (isSet(updates.amount)) {
+        if (!Currency.isValid(updates.amount) || Currency.compare(updates.amount, '0') <= 0) {
+          throw new Error('Amount must be greater than zero');
+        }
+        // The currency may come with this update or already be on the row; one of
+        // the two must hold, or the stored number means nothing.
+        let currency = updates.currency;
+        if (!isSet(currency)) {
+          const existing = await queryFirst('SELECT currency FROM budget_plan_line_groups WHERE id = ?', [id]);
+          currency = existing?.currency;
+        }
+        if (!isSet(currency)) {
+          throw new Error('Currency is required for a custom group budget');
+        }
+        fields.push('amount = ?', 'currency = ?');
+        values.push(String(updates.amount), currency);
+      } else {
+        // Back to a derived total: the currency goes with the amount it described.
+        fields.push('amount = ?', 'currency = ?');
+        values.push(null, null);
+      }
+    } else if (updates.currency !== undefined) {
+      // A currency edit on its own only makes sense for a group that HAS an
+      // override; for a derived one there is no amount for it to describe.
+      const existing = await queryFirst('SELECT amount FROM budget_plan_line_groups WHERE id = ?', [id]);
+      if (isSet(existing?.amount)) {
+        if (!isSet(updates.currency)) {
+          throw new Error('Currency is required for a custom group budget');
+        }
+        fields.push('currency = ?');
+        values.push(updates.currency);
+      }
+    }
+
+    if (updates.sortOrder !== undefined) {
+      fields.push('sort_order = ?');
+      values.push(Number.isInteger(updates.sortOrder) ? updates.sortOrder : 0);
+    }
+
+    if (fields.length === 0) {
+      return; // Nothing to update
+    }
+
+    fields.push('updated_at = ?');
+    values.push(new Date().toISOString());
+    values.push(id);
+
+    await executeQuery(
+      `UPDATE budget_plan_line_groups SET ${fields.join(', ')} WHERE id = ?`,
+      values,
+    );
+  } catch (error) {
+    console.error('Failed to update budget line group:', error);
+    throw error;
+  }
+};
+
+/**
+ * Delete a group. Its lines are UNGROUPED, not deleted (group_id is ON DELETE SET
+ * NULL) — the budgets inside an envelope outlive the envelope.
+ * @param {string} id
+ * @returns {Promise<void>}
+ */
+export const deleteLineGroup = async (id) => {
+  try {
+    await executeQuery('DELETE FROM budget_plan_line_groups WHERE id = ?', [id]);
+  } catch (error) {
+    console.error('Failed to delete budget line group:', error);
+    throw error;
+  }
+};
+
+/**
+ * Persist a new group order. `orderedIds` is the full list of group IDs in the
+ * desired order; each group's sort_order is set to its index.
+ * @param {Array<string>} orderedIds
+ * @returns {Promise<void>}
+ */
+export const reorderLineGroups = async (orderedIds) => {
+  try {
+    const seen = new Set();
+    for (const id of orderedIds) {
+      if (!id) {
+        throw new Error('Invalid group data: missing id');
+      }
+      if (seen.has(id)) {
+        throw new Error(`Duplicate group ID in reorder: ${id}`);
+      }
+      seen.add(id);
+    }
+    const now = new Date().toISOString();
+    await executeTransaction(async (db) => {
+      for (let i = 0; i < orderedIds.length; i++) {
+        await db.runAsync(
+          'UPDATE budget_plan_line_groups SET sort_order = ?, updated_at = ? WHERE id = ?',
+          [i, now, orderedIds[i]],
+        );
+      }
+    });
+  } catch (error) {
+    console.error('Failed to reorder budget line groups:', error);
+    throw error;
+  }
+};
+
+/* -------------------------------------------------------------------------- */
 /* Derived                                                                     */
 /* -------------------------------------------------------------------------- */
 
@@ -945,6 +1215,10 @@ export const reorderRecurringLines = async (orderedIds) => reorderPlanLines(null
  * column is bridged into lines by migration 0020 and only survives as a fallback
  * for a plan that has no income line at all. Income lines are, of course, not
  * part of `allocated`.
+ *
+ * A raw same-currency sum of THIS plan's own lines: it counts no recurring line
+ * (those hang off no plan) and applies no group override (migration 0022). The
+ * screen's figures come from {@link calculatePlanStatus}, which does both.
  * @param {string} planId
  * @returns {Promise<{ expectedIncome: string, allocated: string, remainder: string }>}
  */
@@ -1029,12 +1303,16 @@ export const copyPlan = async (fromMonth, toMonth) => {
           // month pending too, exactly like a recurring line does when the month
           // rolls over.
           await db.runAsync(
-            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, ?, ?, ?)',
+            'INSERT INTO budget_plan_lines (id, plan_id, label, amount, comment, category_id, to_account_id, sort_order, is_recurring, currency, kind, account_id, last_executed_month, include_children, group_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, ?, ?, ?, ?)',
             [
               clonedId, newPlanId, line.label, line.amount, line.comment,
               line.categoryId, line.toAccountId, line.sortOrder ?? i,
               line.currency, line.kind, line.accountId,
-              1, now, now, // include_children: always on, see mapLineFields
+              1, // include_children: always on, see mapLineFields
+              // Groups are global, so the clone joins the very same envelope its
+              // source belongs to — copying a month must not scatter its groups.
+              line.groupId ?? null,
+              now, now,
             ],
           );
           // The clone must track the same SET of categories, not just the primary
@@ -1299,6 +1577,10 @@ const collectPlanSourceCurrencies = async (lines, startDate, endDate, convertAll
  * @returns {Promise<Object>} {
  *   planId, month, currency, convertAll,
  *   lines: Array<{ lineId, broken, amount, actual, remaining, percentage, isExceeded, status }>,
+ *   groups: Array<{ groupId, amount, childAmount, actual, remaining, percentage, isExceeded,
+ *     status, overrideApplied, lineCount }> — one per group with at least one line in
+ *     this month (migration 0022). `amount` is the group's override when it has one
+ *     (and it is convertible), else its children's sum; `overrideApplied` says which.
  *   totals: { expectedIncome, actualIncome, allocated, totalActual, plannedRemainder, actualRemainder },
  *   unconvertible: string[],
  * }
@@ -1310,9 +1592,25 @@ export const calculatePlanStatus = async (planId, displayCurrency = null, conver
       throw new Error(`Budget plan ${planId} not found`);
     }
     const target = displayCurrency || plan.currency;
-    const [oneOffLines, recurringLines] = await Promise.all([getPlanLines(planId), getRecurringLines()]);
+    const [oneOffLines, recurringLines, allGroups] = await Promise.all([
+      getPlanLines(planId), getRecurringLines(), getLineGroups(),
+    ]);
     const lines = [...recurringLines, ...oneOffLines];
     const { startDate, endDate } = getMonthDateRange(plan.month);
+
+    const groupsById = new Map(allGroups.map(g => [g.id, g]));
+    // What each group's own children contribute, accumulated as the lines are
+    // walked below. Only lines that actually reached `allocated` are counted, so
+    // a derived group's total can never claim a figure the month's own does not hold.
+    const groupTallies = new Map();
+    const tallyFor = (groupId) => {
+      let tally = groupTallies.get(groupId);
+      if (!tally) {
+        tally = { childAmount: '0', actual: '0', lineCount: 0 };
+        groupTallies.set(groupId, tally);
+      }
+      return tally;
+    };
 
     const lineStatuses = [];
     const transferCurrencies = new Set();
@@ -1328,8 +1626,14 @@ export const calculatePlanStatus = async (planId, displayCurrency = null, conver
     // pattern as calculateActualIncome below) instead of a per-line fetch inside
     // the loop — with N recurring lines in foreign currencies, that used to mean
     // N sequential network/offline-table round trips instead of one.
+    // Group override amounts carry their own currency too (a group is global, so
+    // it has no plan to inherit one from) — collected here so they share the one
+    // lookup rather than adding a round trip per group.
     const distinctLineCurrencies = [...new Set(
-      lines.map(line => line.currency || target).filter(c => c !== target),
+      [
+        ...lines.map(line => line.currency || target),
+        ...allGroups.map(group => group.currency || target),
+      ].filter(c => c !== target),
     )];
     const lineRateByCurrency = distinctLineCurrencies.length > 0
       ? await fetchRatesToTarget(distinctLineCurrencies, target)
@@ -1382,6 +1686,15 @@ export const calculatePlanStatus = async (planId, displayCurrency = null, conver
       }
 
       allocated = Currency.add(allocated, amount, target);
+      // A line only counts toward its group once its amount is known in the
+      // target currency — which is exactly the point it counts toward `allocated`.
+      const groupTally = isSet(line.groupId) && groupsById.has(line.groupId)
+        ? tallyFor(line.groupId)
+        : null;
+      if (groupTally) {
+        groupTally.childAmount = Currency.add(groupTally.childAmount, amount, target);
+        groupTally.lineCount += 1;
+      }
       const { broken, actual, sourceCurrency } = await calculateLineActual(line, plan.month, target, convertAll);
 
       if (broken) {
@@ -1402,6 +1715,9 @@ export const calculatePlanStatus = async (planId, displayCurrency = null, conver
         transferCurrencies.add(sourceCurrency);
       }
       totalActual = Currency.add(totalActual, actual, target);
+      if (groupTally) {
+        groupTally.actual = Currency.add(groupTally.actual, actual, target);
+      }
       const remaining = Currency.subtract(amount, actual, target);
       const { isExceeded, percentage, status } = deriveSpendingStatus(actual, amount);
       lineStatuses.push({
@@ -1413,6 +1729,66 @@ export const calculatePlanStatus = async (planId, displayCurrency = null, conver
         percentage,
         isExceeded,
         status,
+      });
+    }
+
+    // Group statuses, and the correction an OVERRIDE group makes to `allocated`.
+    //
+    // A derived group (the default) is pure presentation: its target is the sum
+    // of the very lines already counted, so the month's total is untouched. An
+    // override is the opposite — the user said the envelope is worth X whatever
+    // its parts add up to, so X REPLACES the children's sum in `allocated`
+    // (otherwise the number in the group's own row would disagree with the total
+    // printed under it, and the override would be decorative).
+    //
+    // Only groups with at least one line in this month appear: a group whose
+    // members are all one-off lines of another month is not part of this one.
+    const groupStatuses = [];
+    for (const group of allGroups) {
+      const tally = groupTallies.get(group.id);
+      if (!tally || tally.lineCount === 0) continue;
+
+      let amount = tally.childAmount;
+      let overrideApplied = false;
+      let unconvertibleOverride = false;
+      if (!group.isDerived) {
+        const groupCurrency = group.currency || target;
+        const converted = groupCurrency === target
+          ? group.amount
+          : convertWithRateMap(group.amount, groupCurrency, target, lineRateByCurrency);
+        if (converted === null) {
+          // No rate for the override's currency. Falling back to the derived sum
+          // keeps the row and the totals in one currency and honest about it;
+          // the currency is flagged through the same unconvertible plumbing a
+          // line uses.
+          transferCurrencies.add(groupCurrency);
+          unconvertibleOverride = true;
+        } else {
+          amount = converted;
+          overrideApplied = true;
+          allocated = Currency.add(
+            Currency.subtract(allocated, tally.childAmount, target),
+            amount,
+            target,
+          );
+        }
+      }
+
+      const { isExceeded, percentage, status } = deriveSpendingStatus(tally.actual, amount);
+      groupStatuses.push({
+        groupId: group.id,
+        amount,
+        childAmount: tally.childAmount,
+        actual: tally.actual,
+        remaining: Currency.subtract(amount, tally.actual, target),
+        percentage,
+        isExceeded,
+        status: unconvertibleOverride ? 'unconvertible' : status,
+        // True when the printed target is the group's own figure rather than its
+        // children's sum — the row says so, since the two disagreeing is the
+        // whole point of an override.
+        overrideApplied,
+        lineCount: tally.lineCount,
       });
     }
 
@@ -1436,6 +1812,7 @@ export const calculatePlanStatus = async (planId, displayCurrency = null, conver
       currency: target,
       convertAll,
       lines: lineStatuses,
+      groups: groupStatuses,
       totals: { expectedIncome, actualIncome, allocated, totalActual, plannedRemainder, actualRemainder },
       unconvertible,
     };

--- a/app/services/GoogleSheetsService.js
+++ b/app/services/GoogleSheetsService.js
@@ -66,7 +66,7 @@ export const signOut = async () => {
 };
 
 /**
- * Build the 7-sheet data structure from a backup object.
+ * Build the 8-sheet data structure from a backup object.
  *
  * The "Planned Operations" sheet is gone as of Budgets v3 phase 3: planned
  * operations are now plan lines carrying an executable template, exported in
@@ -79,10 +79,14 @@ export const buildSheetsData = (backup) => {
   const {
     accounts, categories, operations, budgets, balance_history,
     budget_plans, budget_plan_lines, budget_plan_line_categories,
+    budget_plan_line_groups,
   } = backup.data;
 
   const accountNames = new Map(accounts.map(a => [a.id, a.name]));
   const categoryNames = new Map(categories.map(c => [c.id, c.name]));
+  // Line groups (migration 0022) — the name is for the reader, the ID is what
+  // makes the round trip; a line carries both, like every other reference here.
+  const groupNames = new Map((budget_plan_line_groups || []).map(g => [g.id, g.label]));
 
   // A line's full category set (migration 0021), keyed by line. Semicolon-joined
   // rather than comma-joined because a category NAME may well contain a comma —
@@ -176,7 +180,7 @@ export const buildSheetsData = (backup) => {
     {
       range: 'Budget Plan Lines!A1',
       values: [
-        ['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month', 'categories', 'category_ids', 'include_children'],
+        ['id', 'plan_id', 'label', 'amount', 'comment', 'category', 'account', 'category_id', 'to_account_id', 'sort_order', 'is_recurring', 'currency', 'kind', 'execution_account', 'account_id', 'last_executed_month', 'categories', 'category_ids', 'include_children', 'group', 'group_id'],
         ...(budget_plan_lines || []).map(l => {
           const ids = lineCategoryIds(l);
           return [
@@ -198,8 +202,22 @@ export const buildSheetsData = (backup) => {
             ids.map(id => categoryNames.get(id) || '').join(';'),
             ids.join(';'),
             l.include_children === 0 ? 0 : 1,
+            l.group_id ? (groupNames.get(l.group_id) || '') : '',
+            l.group_id || '',
           ];
         }),
+      ],
+    },
+    {
+      // Line groups (migration 0022). A blank `amount` is the normal state: the
+      // group's budget is then the sum of the lines pointing at it, so there is
+      // nothing to write down — and `currency` only accompanies an override.
+      range: 'Budget Line Groups!A1',
+      values: [
+        ['id', 'label', 'amount', 'currency', 'sort_order'],
+        ...(budget_plan_line_groups || []).map(g => [
+          g.id, g.label, g.amount ?? '', g.currency ?? '', g.sort_order ?? 0,
+        ]),
       ],
     },
   ];
@@ -224,7 +242,7 @@ const parseSheet = (valueRange) => {
 
 /**
  * Import all app data from the saved Google Sheets spreadsheet.
- * Fetches all 7 sheets in one batchGet call, resolves foreign keys
+ * Fetches all 8 sheets in one batchGet call, resolves foreign keys
  * (ID-first, name fallback), and returns a backup object compatible
  * with restoreBackup(). Does NOT call restoreBackup itself.
  *
@@ -244,15 +262,34 @@ export const importFromSheets = async (accessToken, onProgress) => {
     throw new Error('no_spreadsheet_configured');
   }
 
-  const sheetNames = ['Accounts', 'Operations', 'Categories', 'Budgets', 'Balance History', 'Budget Plans', 'Budget Plan Lines'];
-  const rangesParam = sheetNames.map(n => `ranges=${encodeURIComponent(n)}`).join('&');
-  const response = await fetch(
-    `${SHEETS_API}/${spreadsheetId}/values:batchGet?${rangesParam}`,
+  const sheetNames = ['Accounts', 'Operations', 'Categories', 'Budgets', 'Balance History', 'Budget Plans', 'Budget Plan Lines', 'Budget Line Groups'];
+  const batchGet = (names) => fetch(
+    `${SHEETS_API}/${spreadsheetId}/values:batchGet?${names.map(n => `ranges=${encodeURIComponent(n)}`).join('&')}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   );
 
+  let response = await batchGet(sheetNames);
+
+  // A range naming a tab the spreadsheet doesn't have fails the WHOLE call with
+  // a 400 — which is what every spreadsheet written by an older build would do
+  // the moment a tab is added to the list above. Rather than paying for a
+  // metadata read on every import, ask for the titles only once that happens and
+  // retry with the ones that are actually there; the absent ones then parse as
+  // empty (see findSheet below).
+  if (!response.ok && response.status === 400) {
+    const existingTitles = await getSheetTitles(accessToken, spreadsheetId);
+    const presentSheetNames = sheetNames.filter(name => existingTitles.has(name));
+    if (presentSheetNames.length === 0) {
+      // Not one recognizable tab — this is some other spreadsheet, not a Penny
+      // export. Say so instead of "successfully importing" nothing over the
+      // user's whole database.
+      throw new Error('fetch_sheets_failed');
+    }
+    response = await batchGet(presentSheetNames);
+  }
+
   if (!response.ok) {
-    const data = await response.json();
+    const data = await response.json().catch(() => ({}));
     if (response.status === 401) {
       await signOut();
       throw new Error('refresh_failed');
@@ -280,6 +317,9 @@ export const importFromSheets = async (accessToken, onProgress) => {
   const historyRows = findSheet('Balance History');
   const budgetPlanRows = findSheet('Budget Plans');
   const budgetPlanLineRows = findSheet('Budget Plan Lines');
+  // Absent from any spreadsheet written before migration 0022 — findSheet then
+  // yields [], and every line imports ungrouped.
+  const budgetLineGroupRows = findSheet('Budget Line Groups');
 
   // Build lookup maps: id->id (direct) and name->id (fallback)
   const accountIdMap = new Map();
@@ -391,6 +431,28 @@ export const importFromSheets = async (accessToken, onProgress) => {
     updated_at: now,
   }));
 
+  // Groups first: a line's group reference resolves against them. Same ID-first,
+  // name-fallback shape as every other reference on this sheet, so a group the
+  // user renamed by hand still lands on the right row.
+  const budget_plan_line_groups = budgetLineGroupRows
+    .filter(g => g.id && g.label)
+    .map(g => ({
+      id: g.id,
+      label: g.label,
+      // A blank amount is a DERIVED group; its currency goes with it.
+      amount: g.amount === '' || g.amount == null ? null : String(g.amount),
+      currency: (g.amount === '' || g.amount == null) ? null : (g.currency || null),
+      sort_order: (g.sort_order !== '' && g.sort_order != null) ? Number(g.sort_order) : 0,
+      created_at: now,
+      updated_at: now,
+    }));
+
+  const groupIdMap = new Map();
+  budget_plan_line_groups.forEach(g => {
+    groupIdMap.set(String(g.id), String(g.id));
+    if (g.label) groupIdMap.set(g.label, String(g.id));
+  });
+
   const budget_plan_lines = budgetPlanLineRows.map(l => {
     const isRecurring = l.is_recurring !== '' && l.is_recurring != null ? Number(l.is_recurring) : 0;
     return {
@@ -420,6 +482,11 @@ export const importFromSheets = async (accessToken, onProgress) => {
       // which is the default ON; `Number('')` is 0, so this cannot go through
       // a plain numeric comparison.
       include_children: readIncludeChildren(l.include_children),
+      // Group membership. A reference to a group the sheet doesn't list drops to
+      // null (the line imports ungrouped) rather than dangling into a failed FK.
+      group_id: (l.group_id || l.group)
+        ? (groupIdMap.get(String(l.group_id)) ?? groupIdMap.get(String(l.group)) ?? null)
+        : null,
       created_at: now,
       updated_at: now,
     };
@@ -478,6 +545,7 @@ export const importFromSheets = async (accessToken, onProgress) => {
       budget_plans,
       budget_plan_lines,
       budget_plan_line_categories,
+      budget_plan_line_groups,
     },
   };
 };
@@ -499,6 +567,7 @@ const createSpreadsheet = async (accessToken) => {
         { properties: { title: 'Balance History' } },
         { properties: { title: 'Budget Plans' } },
         { properties: { title: 'Budget Plan Lines' } },
+        { properties: { title: 'Budget Line Groups' } },
       ],
     }),
   });
@@ -509,18 +578,100 @@ const createSpreadsheet = async (accessToken) => {
   return data.spreadsheetId;
 };
 
-const getSheetIds = async (accessToken, spreadsheetId, sheetNames) => {
+/**
+ * Titles of the tabs a spreadsheet actually has.
+ *
+ * Both the export and the import name their tabs by hand, and the Sheets API
+ * rejects the WHOLE request (400, "Unable to parse range") when any range names
+ * a tab that doesn't exist. A spreadsheet created by an older build of the app
+ * has fewer tabs than today's list — so every call that spans them has to ask
+ * first, or one added tab breaks every existing user's export.
+ * @param {string} accessToken
+ * @param {string} spreadsheetId
+ * @returns {Promise<Set<string>>}
+ */
+const getSheetTitles = async (accessToken, spreadsheetId) => {
+  const response = await fetch(
+    `${SHEETS_API}/${spreadsheetId}?fields=sheets.properties.title`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    if (response.status === 401) {
+      await signOut();
+      throw new Error('refresh_failed');
+    }
+    if (response.status === 404) throw new Error('spreadsheet_not_found');
+    throw new Error(data.error?.message || 'get_sheet_ids_failed');
+  }
+  const data = await response.json();
+  return new Set((data.sheets || []).map(s => s.properties?.title).filter(Boolean));
+};
+
+/**
+ * Every tab's title → sheetId. One metadata read serves both jobs the export
+ * needs it for: knowing which tabs are missing, and knowing the IDs to hang the
+ * basic filters on.
+ * @param {string} accessToken
+ * @param {string} spreadsheetId
+ * @returns {Promise<Map<string, number>>}
+ */
+const getSheetIdsByTitle = async (accessToken, spreadsheetId) => {
   const response = await fetch(
     `${SHEETS_API}/${spreadsheetId}?fields=sheets.properties`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   );
   if (!response.ok) {
-    const data = await response.json();
+    const data = await response.json().catch(() => ({}));
+    if (response.status === 401) {
+      await signOut();
+      throw new Error('refresh_failed');
+    }
     throw new Error(data.error?.message || 'get_sheet_ids_failed');
   }
   const data = await response.json();
-  const nameToId = new Map(data.sheets.map(s => [s.properties.title, s.properties.sheetId]));
-  return sheetNames.map(name => nameToId.get(name)).filter(id => id !== undefined);
+  return new Map((data.sheets || []).map(s => [s.properties?.title, s.properties?.sheetId]));
+};
+
+/**
+ * Create any of `sheetNames` the spreadsheet is missing, returning the IDs of the
+ * ones created. A no-op when it already has them all, which is the usual case —
+ * this exists for the spreadsheet a user has been exporting into since before the
+ * newest tab was added, where naming an absent tab in a batchClear range fails
+ * the whole call with a 400.
+ * @param {string} accessToken
+ * @param {string} spreadsheetId
+ * @param {Array<string>} missing
+ * @returns {Promise<Map<string, number>>}
+ */
+const addSheets = async (accessToken, spreadsheetId, missing) => {
+  const response = await fetch(`${SHEETS_API}/${spreadsheetId}:batchUpdate`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      requests: missing.map(title => ({ addSheet: { properties: { title } } })),
+    }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    if (response.status === 401) {
+      await signOut();
+      throw new Error('refresh_failed');
+    }
+    throw new Error(data.error?.message || 'create_spreadsheet_failed');
+  }
+  // Each addSheet reply carries the new tab's properties, so the filters below
+  // can be applied to a tab created moments ago without a second metadata read.
+  const data = await response.json().catch(() => ({}));
+  const added = new Map();
+  for (const reply of data.replies || []) {
+    const properties = reply.addSheet?.properties;
+    if (properties?.title != null) added.set(properties.title, properties.sheetId);
+  }
+  return added;
 };
 
 const applyFilters = async (accessToken, spreadsheetId, sheetIds) => {
@@ -615,12 +766,25 @@ export const exportToSheets = async (accessToken, backup, onProgress) => {
   const sheetNames = sheets.map(s => s.range.split('!')[0]);
 
   report('clear', 'in_progress');
+  // One metadata read up front, before anything names a range: a spreadsheet
+  // from an older build lacks the newest tabs, and naming an absent one in a
+  // batchClear range fails the entire call. The same read supplies the sheet IDs
+  // the filters need at the end, so this costs no extra request in the common
+  // case — it just moved from after the write to before the clear.
+  const sheetIdByTitle = await getSheetIdsByTitle(accessToken, spreadsheetId);
+  const missing = sheetNames.filter(name => !sheetIdByTitle.has(name));
+  if (missing.length > 0) {
+    const added = await addSheets(accessToken, spreadsheetId, missing);
+    for (const [title, id] of added) sheetIdByTitle.set(title, id);
+  }
   await clearSheets(accessToken, spreadsheetId, sheetNames);
   report('clear', 'completed');
 
   report('write', 'in_progress');
   await writeSheets(accessToken, spreadsheetId, sheets);
-  const sheetIds = await getSheetIds(accessToken, spreadsheetId, sheetNames);
+  const sheetIds = sheetNames
+    .map(name => sheetIdByTitle.get(name))
+    .filter(id => id !== undefined);
   await applyFilters(accessToken, spreadsheetId, sheetIds);
   report('write', 'completed');
 

--- a/app/services/db.js
+++ b/app/services/db.js
@@ -171,6 +171,7 @@ const isSchemaComplete = async (rawDb) => {
       'app_metadata', 'accounts_balance_history', 'planned_operations',
       'notification_merchant_rules', 'pending_notifications',
       'budget_plans', 'budget_plan_lines', 'budget_plan_line_categories',
+      'budget_plan_line_groups',
     ];
     const existingTables = await rawDb.getAllAsync(
       "SELECT name FROM sqlite_master WHERE type='table'",
@@ -294,6 +295,14 @@ const isSchemaComplete = async (rawDb) => {
     // created the table and failed the ALTER must not read as complete, or every
     // line query would throw `no such column: include_children`.
     if (!planLineCols.some(c => c.name === 'include_children')) return false;
+
+    // Check budget_plan_lines has group_id (migration 0022). The accompanying
+    // budget_plan_line_groups table is covered by the expectedTables check above,
+    // but the column is a separate ADD COLUMN statement and
+    // applyPendingMigrations continues on failure — so a 0022 that created the
+    // table and failed the ALTER must not read as complete, or every line query
+    // would throw `no such column: group_id`.
+    if (!planLineCols.some(c => c.name === 'group_id')) return false;
 
     return true;
   } catch (error) {
@@ -625,6 +634,16 @@ const detectAppliedMigrations = async (rawDb) => {
     if ((await tableExists('budget_plan_line_categories'))
       && planLineCols.some(c => c.name === 'include_children')) {
       applied.push(21);
+    }
+
+    // Migration 0022: creates budget_plan_line_groups AND adds
+    // budget_plan_lines.group_id. Require both — a half-applied 0022 must re-run.
+    // Re-running is safe: the CREATE and the index are IF NOT EXISTS, and the
+    // ALTER only fails (harmlessly, applyPendingMigrations continues) when the
+    // column is already there.
+    if ((await tableExists('budget_plan_line_groups'))
+      && planLineCols.some(c => c.name === 'group_id')) {
+      applied.push(22);
     }
   }
 

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -568,5 +568,18 @@
   "relink_target": "Ziel gelöscht — zum erneuten Verknüpfen tippen",
   "previous_month": "Voriger Monat",
   "next_month": "Nächster Monat",
-  "recurring_allocation": "Wiederkehrend"
+  "recurring_allocation": "Wiederkehrend",
+  "group": "Gruppe",
+  "no_group": "Keine Gruppe",
+  "new_group": "Neue Gruppe",
+  "create_group": "Gruppe erstellen",
+  "no_groups_yet": "Noch keine Gruppen",
+  "group_name": "Gruppenname",
+  "group_name_required": "Ein Gruppenname ist erforderlich",
+  "edit_group": "Gruppe bearbeiten",
+  "delete_group": "Gruppe löschen",
+  "delete_group_confirm": "Diese Gruppe löschen? Ihre Posten bleiben erhalten und sind danach einfach ohne Gruppe.",
+  "custom_group_budget": "Eigenes Budget",
+  "group_budget_derived_hint": "Das Budget der Gruppe ist die Summe ihrer Posten",
+  "group_budget_override_hint": "Zählt im Monatstotal anstelle der Summe der Posten"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -571,5 +571,18 @@
   "relink_target": "Target deleted — tap to re-link",
   "previous_month": "Previous month",
   "next_month": "Next month",
-  "recurring_allocation": "Recurring"
+  "recurring_allocation": "Recurring",
+  "group": "Group",
+  "no_group": "No group",
+  "new_group": "New group",
+  "create_group": "Create group",
+  "no_groups_yet": "No groups yet",
+  "group_name": "Group name",
+  "group_name_required": "A group name is required",
+  "edit_group": "Edit group",
+  "delete_group": "Delete group",
+  "delete_group_confirm": "Delete this group? Its allocations are kept — they simply become ungrouped.",
+  "custom_group_budget": "Custom budget",
+  "group_budget_derived_hint": "The group's budget is the sum of its allocations",
+  "group_budget_override_hint": "Counts toward the month's total instead of the sum of its allocations"
 }

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -568,5 +568,18 @@
   "relink_target": "Objetivo eliminado — toca para volver a vincular",
   "previous_month": "Mes anterior",
   "next_month": "Mes siguiente",
-  "recurring_allocation": "Recurrente"
+  "recurring_allocation": "Recurrente",
+  "group": "Grupo",
+  "no_group": "Sin grupo",
+  "new_group": "Nuevo grupo",
+  "create_group": "Crear grupo",
+  "no_groups_yet": "Aún no hay grupos",
+  "group_name": "Nombre del grupo",
+  "group_name_required": "El nombre del grupo es obligatorio",
+  "edit_group": "Editar grupo",
+  "delete_group": "Eliminar grupo",
+  "delete_group_confirm": "¿Eliminar este grupo? Sus asignaciones se conservan y quedan sin grupo.",
+  "custom_group_budget": "Presupuesto propio",
+  "group_budget_derived_hint": "El presupuesto del grupo es la suma de sus asignaciones",
+  "group_budget_override_hint": "Cuenta en el total del mes en lugar de la suma de las asignaciones"
 }

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -568,5 +568,18 @@
   "relink_target": "Cible supprimée — appuyez pour relier à nouveau",
   "previous_month": "Mois précédent",
   "next_month": "Mois suivant",
-  "recurring_allocation": "Récurrent"
+  "recurring_allocation": "Récurrent",
+  "group": "Groupe",
+  "no_group": "Aucun groupe",
+  "new_group": "Nouveau groupe",
+  "create_group": "Créer le groupe",
+  "no_groups_yet": "Aucun groupe pour l'instant",
+  "group_name": "Nom du groupe",
+  "group_name_required": "Le nom du groupe est obligatoire",
+  "edit_group": "Modifier le groupe",
+  "delete_group": "Supprimer le groupe",
+  "delete_group_confirm": "Supprimer ce groupe ? Ses lignes sont conservées et se retrouvent simplement sans groupe.",
+  "custom_group_budget": "Budget personnalisé",
+  "group_budget_derived_hint": "Le budget du groupe est la somme de ses lignes",
+  "group_budget_override_hint": "Compte dans le total du mois à la place de la somme des lignes"
 }

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -568,5 +568,18 @@
   "relink_target": "Թիրախը ջնջված է — հպեք՝ նորից կապելու համար",
   "previous_month": "Նախորդ ամիս",
   "next_month": "Հաջորդ ամիս",
-  "recurring_allocation": "Կրկնվող"
+  "recurring_allocation": "Կրկնվող",
+  "group": "Խումբ",
+  "no_group": "Առանց խմբի",
+  "new_group": "Նոր խումբ",
+  "create_group": "Ստեղծել խումբ",
+  "no_groups_yet": "Դեռ խմբեր չկան",
+  "group_name": "Խմբի անվանումը",
+  "group_name_required": "Խմբի անվանումը պարտադիր է",
+  "edit_group": "Խմբագրել խումբը",
+  "delete_group": "Ջնջել խումբը",
+  "delete_group_confirm": "Ջնջե՞լ այս խումբը։ Դրա հոդվածները կմնան և պարզապես դուրս կգան խմբից։",
+  "custom_group_budget": "Սեփական բյուջե",
+  "group_budget_derived_hint": "Խմբի բյուջեն նրա հոդվածների գումարն է",
+  "group_budget_override_hint": "Ամսվա հաշվարկում կգնա այս գումարը, ոչ թե հոդվածների գումարը"
 }

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -568,5 +568,18 @@
   "relink_target": "Destinazione eliminata — tocca per ricollegare",
   "previous_month": "Mese precedente",
   "next_month": "Mese successivo",
-  "recurring_allocation": "Ricorrente"
+  "recurring_allocation": "Ricorrente",
+  "group": "Gruppo",
+  "no_group": "Nessun gruppo",
+  "new_group": "Nuovo gruppo",
+  "create_group": "Crea gruppo",
+  "no_groups_yet": "Ancora nessun gruppo",
+  "group_name": "Nome del gruppo",
+  "group_name_required": "Il nome del gruppo è obbligatorio",
+  "edit_group": "Modifica gruppo",
+  "delete_group": "Elimina gruppo",
+  "delete_group_confirm": "Eliminare questo gruppo? Le sue voci restano e tornano semplicemente senza gruppo.",
+  "custom_group_budget": "Budget personalizzato",
+  "group_budget_derived_hint": "Il budget del gruppo è la somma delle sue voci",
+  "group_budget_override_hint": "Viene conteggiato nel totale del mese al posto della somma delle voci"
 }

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -568,5 +568,18 @@
   "relink_target": "対象が削除されました — タップして再リンク",
   "previous_month": "前の月",
   "next_month": "次の月",
-  "recurring_allocation": "繰り返し"
+  "recurring_allocation": "繰り返し",
+  "group": "グループ",
+  "no_group": "グループなし",
+  "new_group": "新しいグループ",
+  "create_group": "グループを作成",
+  "no_groups_yet": "グループはまだありません",
+  "group_name": "グループ名",
+  "group_name_required": "グループ名を入力してください",
+  "edit_group": "グループを編集",
+  "delete_group": "グループを削除",
+  "delete_group_confirm": "このグループを削除しますか？中の項目は残り、グループなしになります。",
+  "custom_group_budget": "予算を手動で設定",
+  "group_budget_derived_hint": "グループの予算は各項目の合計です",
+  "group_budget_override_hint": "月の合計には各項目の合計ではなくこの金額が使われます"
 }

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -568,5 +568,18 @@
   "relink_target": "대상이 삭제됨 — 눌러서 다시 연결",
   "previous_month": "이전 달",
   "next_month": "다음 달",
-  "recurring_allocation": "반복"
+  "recurring_allocation": "반복",
+  "group": "그룹",
+  "no_group": "그룹 없음",
+  "new_group": "새 그룹",
+  "create_group": "그룹 만들기",
+  "no_groups_yet": "아직 그룹이 없습니다",
+  "group_name": "그룹 이름",
+  "group_name_required": "그룹 이름을 입력하세요",
+  "edit_group": "그룹 편집",
+  "delete_group": "그룹 삭제",
+  "delete_group_confirm": "이 그룹을 삭제할까요? 안의 항목은 유지되며 그룹만 해제됩니다.",
+  "custom_group_budget": "예산 직접 설정",
+  "group_budget_derived_hint": "그룹 예산은 항목 합계입니다",
+  "group_budget_override_hint": "이 금액이 항목 합계 대신 월 합계에 반영됩니다"
 }

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -568,5 +568,18 @@
   "relink_target": "Destino excluído — toque para revincular",
   "previous_month": "Mês anterior",
   "next_month": "Próximo mês",
-  "recurring_allocation": "Recorrente"
+  "recurring_allocation": "Recorrente",
+  "group": "Grupo",
+  "no_group": "Sem grupo",
+  "new_group": "Novo grupo",
+  "create_group": "Criar grupo",
+  "no_groups_yet": "Ainda não há grupos",
+  "group_name": "Nome do grupo",
+  "group_name_required": "O nome do grupo é obrigatório",
+  "edit_group": "Editar grupo",
+  "delete_group": "Excluir grupo",
+  "delete_group_confirm": "Excluir este grupo? As alocações são mantidas e apenas ficam sem grupo.",
+  "custom_group_budget": "Orçamento personalizado",
+  "group_budget_derived_hint": "O orçamento do grupo é a soma das suas alocações",
+  "group_budget_override_hint": "Entra no total do mês no lugar da soma das alocações"
 }

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -571,5 +571,18 @@
   "relink_target": "Цель удалена — привязать заново",
   "previous_month": "Предыдущий месяц",
   "next_month": "Следующий месяц",
-  "recurring_allocation": "Повторять каждый месяц"
+  "recurring_allocation": "Повторять каждый месяц",
+  "group": "Группа",
+  "no_group": "Без группы",
+  "new_group": "Новая группа",
+  "create_group": "Создать группу",
+  "no_groups_yet": "Групп пока нет",
+  "group_name": "Название группы",
+  "group_name_required": "Укажите название группы",
+  "edit_group": "Изменить группу",
+  "delete_group": "Удалить группу",
+  "delete_group_confirm": "Удалить эту группу? Её статьи останутся и просто выйдут из группы.",
+  "custom_group_budget": "Свой бюджет группы",
+  "group_budget_derived_hint": "Бюджет группы — сумма её статей",
+  "group_budget_override_hint": "В итог месяца пойдёт эта сумма, а не сумма статей"
 }

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -568,5 +568,18 @@
   "relink_target": "目标已删除 — 点击重新关联",
   "previous_month": "上个月",
   "next_month": "下个月",
-  "recurring_allocation": "重复"
+  "recurring_allocation": "重复",
+  "group": "分组",
+  "no_group": "不分组",
+  "new_group": "新建分组",
+  "create_group": "创建分组",
+  "no_groups_yet": "还没有分组",
+  "group_name": "分组名称",
+  "group_name_required": "请填写分组名称",
+  "edit_group": "编辑分组",
+  "delete_group": "删除分组",
+  "delete_group_confirm": "删除该分组？其中的预算条目会保留，只是不再属于任何分组。",
+  "custom_group_budget": "自定义预算",
+  "group_budget_derived_hint": "分组预算等于其条目之和",
+  "group_budget_override_hint": "月度合计将按此金额计算，而不是条目之和"
 }

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -260,12 +260,56 @@ tracking target.
   kind: TEXT,                       // 'income' | 'expense' | 'transfer' (NULL = legacy)
   account_id: INTEGER REFERENCES accounts(id) ON DELETE SET NULL,  // set = executable
   last_executed_month: TEXT,        // YYYY-MM of the last execution
+  include_children: INTEGER NOT NULL DEFAULT 1,  // migration 0021, always 1 now
+  group_id: TEXT REFERENCES budget_plan_line_groups(id) ON DELETE SET NULL,
   created_at: TEXT NOT NULL,
   updated_at: TEXT NOT NULL
 }
 ```
 
-**Indexes**: `plan_id`, `is_recurring`, `kind`
+**Indexes**: `plan_id`, `is_recurring`, `kind`, `group_id`
+
+Since **migration 0021** a line tracks a SET of categories via the
+`budget_plan_line_categories` junction (line_id, category_id), which is the
+source of truth; `category_id` above is the denormalized primary entry, kept for
+the backup/Sheets shape. `include_children` survives from that migration but no
+longer expresses a choice — descendant spending always rolls up.
+
+### 10. budget_plan_line_groups (migration 0022)
+
+An envelope over several `budget_plan_lines`. Members may mix category targets
+from unrelated trees with transfer targets, and recurring lines with one-off
+ones — membership is the only thing a group asserts.
+
+Groups are **global**, like recurring lines: no `plan_id`, so a group outlives
+any single month and renders in every month where at least one of its lines
+does. That is what lets one group hold a recurring line (which belongs to no
+plan) beside a one-off line (which belongs to exactly one).
+
+- `amount` NULL — the default — means the group's budget is **derived**: the sum
+  of its lines' targets, in whatever currency the screen is read in.
+- A non-null `amount` is an explicit override and **replaces** the children's sum
+  in the month's `allocated` total (`BudgetPlansDB.calculatePlanStatus`), so the
+  figure on the group's row and the totals printed under it always agree.
+  `currency` accompanies it (a group has no plan to inherit one from) and is
+  cleared whenever the override is.
+- A group's ACTUAL is always the sum of its children's actuals — an override
+  changes the target, never what was really spent.
+
+`budget_plan_lines.group_id` is ON DELETE SET NULL: deleting a group ungroups its
+lines, it never deletes the budgets inside it.
+
+```javascript
+{
+  id: TEXT PRIMARY KEY,
+  label: TEXT NOT NULL,        // required: a group has no target to borrow a name from
+  amount: TEXT,                // NULL = derived from the group's lines
+  currency: TEXT,              // set only alongside an override amount
+  sort_order: INTEGER NOT NULL DEFAULT 0,
+  created_at: TEXT NOT NULL,
+  updated_at: TEXT NOT NULL
+}
+```
 
 ## Design Principles
 

--- a/drizzle/0022_plan_line_groups.js
+++ b/drizzle/0022_plan_line_groups.js
@@ -1,0 +1,58 @@
+/**
+ * Migration 0022: Group several budget lines under one envelope
+ *
+ * A `budget_plan_lines` row is one tracking target — a set of categories, or a
+ * destination account. Several of them routinely belong to one real-world
+ * envelope that spans category trees and transfer targets alike ("Car" = Fuel +
+ * Parking + the monthly transfer into the repairs account), and until now there
+ * was no way to say so: the screen showed six unrelated rows and no figure for
+ * the thing the user actually budgets.
+ *
+ * `budget_plan_line_groups` is that envelope. Deliberately NOT a line: a group
+ * has no tracking target of its own (its actual is the sum of its children's,
+ * which are already computed) and no executable template, so folding it into
+ * budget_plan_lines would have meant a row that fails almost every invariant
+ * that table enforces.
+ *
+ * - `amount` is NULLABLE and that is the DEFAULT state: null means "the group's
+ *   budget is the sum of its children", recomputed as lines are added, edited or
+ *   removed. A non-null amount is an explicit override and REPLACES the
+ *   children's sum in the month's allocated total (see
+ *   BudgetPlansDB.calculatePlanStatus) — otherwise the override would be
+ *   decorative, agreeing with the group's own progress bar while the totals
+ *   under it kept counting something else.
+ * - `currency` travels with an override amount for the same reason a recurring
+ *   line carries one: a group is global (below), so there is no plan to inherit
+ *   a currency from. Null alongside a null amount — a derived total is expressed
+ *   in whatever currency the screen is being read in.
+ *
+ * GROUPS ARE GLOBAL, like recurring lines: they are not scoped to a month's plan
+ * (there is no `plan_id`), so a group may hold recurring and one-off lines at the
+ * same time, and it survives month navigation, copyPlan and a backup round trip
+ * without its membership being rebuilt. A group renders in any month where at
+ * least one of its children does.
+ *
+ * `budget_plan_lines.group_id` is ON DELETE SET NULL, not CASCADE: deleting a
+ * group must ungroup its lines, never destroy the budgets inside it. (SQLite
+ * allows a REFERENCES clause on ADD COLUMN only when the default is NULL, which
+ * is exactly what this is.)
+ *
+ * Append-only: never edit or revert an existing migration. This migration is also
+ * registered in app/services/db.js (isSchemaComplete + detectAppliedMigrations),
+ * otherwise existing installs would skip migrate() and crash with
+ * `no such table: budget_plan_line_groups`.
+ */
+
+const sql = `CREATE TABLE IF NOT EXISTS \`budget_plan_line_groups\` (
+	\`id\` text PRIMARY KEY NOT NULL,
+	\`label\` text NOT NULL,
+	\`amount\` text,
+	\`currency\` text,
+	\`sort_order\` integer DEFAULT 0 NOT NULL,
+	\`created_at\` text NOT NULL,
+	\`updated_at\` text NOT NULL
+);--> statement-breakpoint
+ALTER TABLE \`budget_plan_lines\` ADD COLUMN \`group_id\` text REFERENCES \`budget_plan_line_groups\`(\`id\`) ON UPDATE no action ON DELETE set null;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS \`idx_budget_plan_lines_group\` ON \`budget_plan_lines\` (\`group_id\`)`;
+
+export default sql;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1767600000000,
       "tag": "0021_plan_line_categories",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1767700000000,
+      "tag": "0022_plan_line_groups",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -23,6 +23,7 @@ import m0018 from './0018_budget_plans.js';
 import m0019, { postMigration as m0019PostMigration } from './0019_recurring_plan_lines.js';
 import m0020, { postMigration as m0020PostMigration } from './0020_plan_line_templates.js';
 import m0021 from './0021_plan_line_categories.js';
+import m0022 from './0022_plan_line_groups.js';
 
 export default {
   journal,
@@ -49,6 +50,7 @@ export default {
     m0019,
     m0020,
     m0021,
+    m0022,
   },
   postMigrationHandlers: {
     m0003: m0003PostMigration,


### PR DESCRIPTION
## Why

A budget line tracks one thing: a set of categories, or a transfer target. Several of them routinely belong to one real-world envelope that spans category trees and transfer targets alike — "Car" is Fuel + Parking + the monthly transfer into the repairs account — and there was no way to say so. The screen showed six unrelated rows and no figure for the thing the user actually budgets.

## What

Migration **0022** adds `budget_plan_line_groups` and `budget_plan_lines.group_id`.

- **Global, like a recurring line.** A group has no `plan_id`, so it outlives any single month, may hold recurring and one-off lines at the same time, and survives `copyPlan` and a backup round trip with its membership intact. It renders in every month where at least one of its lines does.
- **Derived budget by default** — the sum of its lines, recomputed as they change. A stored `amount` is an explicit override and **replaces** the children's sum in the month's `allocated` total; otherwise the figure on the group's row would disagree with the totals printed right under it. `currency` travels with the override (a group has no plan to inherit one from) and is cleared with it.
- **The actual is always the sum of the children's actuals.** An override changes the target, never what was really spent.
- `group_id` is `ON DELETE SET NULL`: deleting a group ungroups its lines, it never deletes the budgets inside it.
- An income line is never grouped — groups aggregate allocations, and income has no per-line spending to total.

### UI

The group row is a heavier `PlanLineRow` rather than a section title, because it *is* a budget: same amount pair, same progress wash, same tone rules, with its children indented beneath it. It prints the children's sum next to its own figure only when the two disagree — that disagreement is the whole content of an override.

A line joins a group from the line editor (the subpanel pattern from CLAUDE.md), where the rest of what that line is already lives, and a group can be created there without abandoning a half-filled form. Tapping a group row edits it; long press offers edit / move / delete.

### Incidental fix: Google Sheets tab list

Both export and import named a fixed list of tabs, and a range naming a tab the spreadsheet lacks fails the **whole** call with a 400 — so adding any tab (as this PR does) would have broken every spreadsheet written by an older build. Export now reads the tab metadata first — the same read that already supplied the filter sheet IDs, so no extra request — and creates whatever is missing. Import retries against the tabs that exist, but only after a 400, so the happy path still costs one call.

## Compatibility

- Migration 0022 is registered in `app/services/db.js` (`isSchemaComplete` + `detectAppliedMigrations`), so existing installs don't take the fast path and crash with `no such column: group_id`.
- Groups round-trip through JSON, CSV and SQLite backups and through Google Sheets. A pre-0022 backup restores every line ungrouped; a group the backup doesn't carry drops a line's `group_id` to NULL rather than failing its FK and aborting the import.

## Tests

`__tests__/services/BudgetPlansDB.groups.test.js` (group validation/CRUD, derived vs override, the `allocated` swap, unconvertible-override fallback, membership on lines), plus group cases in the section, backup and Sheets suites. Full suite: 168 suites / 4955 tests green locally.
