### PR TITLE
fix(notifications): route the review alert to quick add, not settings

### DIFF
--- a/__tests__/hooks/useNotificationResponseRouter.test.js
+++ b/__tests__/hooks/useNotificationResponseRouter.test.js
@@ -1,6 +1,6 @@
 /**
  * Tests for the notification deep-link router hook: it emits
- * OPEN_NOTIFICATION_PROCESSING for a matching tapped notification (cold start and
+ * OPEN_PENDING_OPERATIONS for a matching tapped notification (cold start and
  * while running), ignores unrelated responses, and cleans up its subscription.
  */
 
@@ -37,7 +37,7 @@ describe('useNotificationResponseRouter', () => {
     const { unmount } = await renderHook(() => useNotificationResponseRouter());
 
     await waitFor(() =>
-      expect(emitSpy).toHaveBeenCalledWith(EVENTS.OPEN_NOTIFICATION_PROCESSING),
+      expect(emitSpy).toHaveBeenCalledWith(EVENTS.OPEN_PENDING_OPERATIONS),
     );
     await unmount();
   });
@@ -54,7 +54,7 @@ describe('useNotificationResponseRouter', () => {
     // (no React state update), so it needs no act() wrapper.
     listener(matchResponse);
 
-    expect(emitSpy).toHaveBeenCalledWith(EVENTS.OPEN_NOTIFICATION_PROCESSING);
+    expect(emitSpy).toHaveBeenCalledWith(EVENTS.OPEN_PENDING_OPERATIONS);
     await unmount();
   });
 

--- a/__tests__/screens/OperationsScreen.test.js
+++ b/__tests__/screens/OperationsScreen.test.js
@@ -2515,4 +2515,83 @@ describe('OperationsScreen', () => {
       expect(mockShowDialog).toHaveBeenCalled();
     });
   });
+
+  // A tapped "transactions to review" notification routes to this screen (not to
+  // settings): SimpleTabs switches tabs, and the screen brings the suggestion deck
+  // over the quick-add form into view.
+  describe('Pending-operations deep link', () => {
+    const { act } = require('@testing-library/react-native');
+    const { appEvents, EVENTS } = require('../../app/services/eventEmitter');
+
+    const mockSuggestionsHook = (overrides = {}) => {
+      const usePendingOperationSuggestions =
+        require('../../app/hooks/usePendingOperationSuggestions').default;
+      const hookValue = {
+        suggestions: [],
+        committingIds: {},
+        saveErrors: {},
+        choices: {},
+        setChoice: jest.fn(),
+        reload: jest.fn(),
+        refresh: jest.fn(),
+        accept: jest.fn(),
+        dismiss: jest.fn(),
+        ...overrides,
+      };
+      usePendingOperationSuggestions.mockReturnValue(hookValue);
+      return hookValue;
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('refreshes the suggestion queue on the deep-link event', async () => {
+      const OperationsScreen = require('../../app/screens/OperationsScreen').default;
+      const { refresh } = mockSuggestionsHook();
+
+      await render(<OperationsScreen />);
+      await act(async () => {
+        appEvents.emit(EVENTS.OPEN_PENDING_OPERATIONS);
+      });
+
+      expect(refresh).toHaveBeenCalled();
+    });
+
+    it('closes search first — the deck is collapsed with the quick-add block while search is open', async () => {
+      const OperationsScreen = require('../../app/screens/OperationsScreen').default;
+      const { useSearch } = require('../../app/contexts/SearchContext');
+      const closeSearch = jest.fn();
+      useSearch.mockReturnValue({
+        searchMode: 'open',
+        filtersExpanded: false,
+        openSearch: jest.fn(),
+        closeSearch,
+        reopenSearch: jest.fn(),
+        toggleFilters: jest.fn(),
+        registerSearchHandler: jest.fn(),
+      });
+      mockSuggestionsHook();
+
+      await render(<OperationsScreen />);
+      await act(async () => {
+        appEvents.emit(EVENTS.OPEN_PENDING_OPERATIONS);
+      });
+
+      expect(closeSearch).toHaveBeenCalled();
+    });
+
+    it('drops its subscription on unmount', async () => {
+      const OperationsScreen = require('../../app/screens/OperationsScreen').default;
+      const { refresh } = mockSuggestionsHook();
+
+      const { unmount } = await render(<OperationsScreen />);
+      await unmount();
+      await act(async () => {
+        appEvents.emit(EVENTS.OPEN_PENDING_OPERATIONS);
+      });
+
+      expect(refresh).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/__tests__/screens/SettingsScreen.test.js
+++ b/__tests__/screens/SettingsScreen.test.js
@@ -483,6 +483,24 @@ describe('SettingsScreen', () => {
 
       expect(mockSetSubPanelActive).toHaveBeenCalledWith(true);
     });
+
+    // A tapped "transactions to review" notification navigates to the Operations
+    // tab, so an open subpanel here must not stay active behind the user's back
+    // (it would keep swipe navigation disabled and hijack hardware back).
+    it('closes an open subpanel when the pending-operations deep link fires', async () => {
+      const { appEvents, EVENTS } = require('../../app/services/eventEmitter');
+      const { getByTestId } = await render(
+        <SettingsScreen setSubPanelActive={mockSetSubPanelActive} />,
+      );
+      await fireEvent.press(getByTestId('settings-language-row'));
+      mockSetSubPanelActive.mockClear();
+
+      await act(async () => {
+        appEvents.emit(EVENTS.OPEN_PENDING_OPERATIONS);
+      });
+
+      expect(mockSetSubPanelActive).toHaveBeenCalledWith(false);
+    });
   });
 
   describe('Language Selection', () => {

--- a/__tests__/services/notifications/localNotifications.test.js
+++ b/__tests__/services/notifications/localNotifications.test.js
@@ -32,24 +32,24 @@ describe('localNotifications', () => {
     expect(handlerInstalledAtLoad).toBeGreaterThan(0);
   });
 
-  describe('isNotificationProcessingResponse', () => {
+  describe('isPendingOperationsResponse', () => {
     it('matches a review-queue deep-link response', () => {
       const response = {
         notification: { request: { content: { data: { route: 'notificationProcessing' } } } },
       };
-      expect(localNotifications.isNotificationProcessingResponse(response)).toBe(true);
+      expect(localNotifications.isPendingOperationsResponse(response)).toBe(true);
     });
 
     it('rejects null / unrelated responses', () => {
-      expect(localNotifications.isNotificationProcessingResponse(null)).toBe(false);
-      expect(localNotifications.isNotificationProcessingResponse({})).toBe(false);
+      expect(localNotifications.isPendingOperationsResponse(null)).toBe(false);
+      expect(localNotifications.isPendingOperationsResponse({})).toBe(false);
       expect(
-        localNotifications.isNotificationProcessingResponse({
+        localNotifications.isPendingOperationsResponse({
           notification: { request: { content: { data: { route: 'somethingElse' } } } },
         }),
       ).toBe(false);
       expect(
-        localNotifications.isNotificationProcessingResponse({
+        localNotifications.isPendingOperationsResponse({
           notification: { request: { content: { data: {} } } },
         }),
       ).toBe(false);

--- a/app/hooks/useNotificationResponseRouter.js
+++ b/app/hooks/useNotificationResponseRouter.js
@@ -1,21 +1,24 @@
 import { useEffect } from 'react';
 import * as Notifications from 'expo-notifications';
 import { appEvents, EVENTS } from '../services/eventEmitter';
-import { isNotificationProcessingResponse } from '../services/notifications/localNotifications';
+import { isPendingOperationsResponse } from '../services/notifications/localNotifications';
 
 /**
- * Routes a tapped "transactions to review" notification to the notification-
- * processing screen.
+ * Routes a tapped "transactions to review" notification to the quick-add surface
+ * on the operations page, where the queued suggestions are stacked as binding
+ * cards over the form — reviewing them is an operations task, not a settings one.
  *
  * Handles both cases:
  *   - Warm: the app is already running when the notification is tapped
  *     (addNotificationResponseReceivedListener).
  *   - Cold: the app was launched by the tap (getLastNotificationResponseAsync).
  *
- * On a match it emits OPEN_NOTIFICATION_PROCESSING, which SimpleTabs (switch to
- * the Settings tab) and SettingsScreen (open the review subpanel) listen for.
- * All tab screens are pre-mounted, so both listeners are already subscribed by
- * the time the async cold-start lookup resolves.
+ * On a match it emits OPEN_PENDING_OPERATIONS, which SimpleTabs (switch to the
+ * Operations tab) and OperationsScreen (close search, scroll the deck into view,
+ * refresh the queue) listen for. All tab screens are pre-mounted, so both
+ * listeners are already subscribed by the time the async cold-start lookup
+ * resolves — and Operations is the default tab anyway, so a missed cold-start
+ * emit still lands the user on the right screen.
  *
  * Mount this once, near the app root.
  */
@@ -24,8 +27,8 @@ export default function useNotificationResponseRouter() {
     let active = true;
 
     const route = (response) => {
-      if (isNotificationProcessingResponse(response)) {
-        appEvents.emit(EVENTS.OPEN_NOTIFICATION_PROCESSING);
+      if (isPendingOperationsResponse(response)) {
+        appEvents.emit(EVENTS.OPEN_PENDING_OPERATIONS);
       }
     };
 

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -427,11 +427,11 @@ export default function SimpleTabs() {
   }, [showAccountsTab, showBudgetTab]);
 
   // A tapped "transactions to review" notification routes here: jump to the
-  // Settings tab. SettingsScreen listens for the same event and opens the
-  // notification-processing subpanel, so the two land together.
+  // Operations tab. OperationsScreen listens for the same event and surfaces the
+  // suggestion deck over the quick-add form, so the two land together.
   React.useEffect(() => {
-    const unsubscribe = appEvents.on(EVENTS.OPEN_NOTIFICATION_PROCESSING, () => {
-      handleTabPress('Settings');
+    const unsubscribe = appEvents.on(EVENTS.OPEN_PENDING_OPERATIONS, () => {
+      handleTabPress('Operations');
     });
     return unsubscribe;
   }, [handleTabPress]);

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -13,6 +13,7 @@ import { useOperationsActions } from '../contexts/OperationsActionsContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
 import { useCategories } from '../contexts/CategoriesContext';
 import { setLastAccessedAccount } from '../services/LastAccount';
+import { appEvents, EVENTS } from '../services/eventEmitter';
 import { formatDate as toDateString } from '../services/BalanceHistoryDB';
 import { getDistinctLabels } from '../services/OperationsDB';
 import { parseLabels, serializeLabels, addLabel, hasLabel } from '../utils/labelUtils';
@@ -1154,6 +1155,24 @@ const OperationsScreen = () => {
   const scrollToTop = useCallback(() => {
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
   }, []);
+
+  // A tapped "transactions to review" notification lands here (SimpleTabs switches
+  // to this tab on the same event): put the suggestion deck in front of the user
+  // instead of sending them to settings. Search is closed first — the quick-add
+  // block, and the deck laid over it, is collapsed while search is open — and its
+  // close effect already scrolls the list to the top, so only the non-search case
+  // scrolls here. The queue is refreshed so a notification that arrived while the
+  // app was backgrounded is ingested rather than showing a stale (or empty) deck.
+  const handleOpenPendingSuggestions = useCallback(() => {
+    if (isSearchOpen) handleCloseSearch();
+    else scrollToTop();
+    refreshSuggestions();
+  }, [isSearchOpen, handleCloseSearch, scrollToTop, refreshSuggestions]);
+
+  useEffect(
+    () => appEvents.on(EVENTS.OPEN_PENDING_OPERATIONS, handleOpenPendingSuggestions),
+    [handleOpenPendingSuggestions],
+  );
 
   // Safety net for scrollToIndex failures. The list now provides getItemLayout,
   // so scrollToLocation resolves offsets directly and this should not fire in

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -379,16 +379,6 @@ export default function SettingsScreen({ setSubPanelActive }) {
     setSubPanelActive(activeSubPanel !== null);
   }, [activeSubPanel, setSubPanelActive]);
 
-  // A tapped "transactions to review" notification opens the notification-
-  // processing subpanel directly. SimpleTabs handles switching to the Settings
-  // tab on the same event; this screen is pre-mounted, so the listener is live.
-  useEffect(() => {
-    const unsubscribe = appEvents.on(EVENTS.OPEN_NOTIFICATION_PROCESSING, () => {
-      openSubPanel('notificationProcessing');
-    });
-    return unsubscribe;
-  }, [openSubPanel]);
-
   // Android hardware back: step one level up when possible (nested step / embedded
   // screen), otherwise close the panel — mirroring the swipe and the back arrow.
   useEffect(() => {
@@ -418,6 +408,19 @@ export default function SettingsScreen({ setSubPanelActive }) {
       closeSubPanelRef.current();
     });
     return () => subscription.remove();
+  }, []);
+
+  // A tapped "transactions to review" notification now routes to the operations
+  // page, so a subpanel left open here would stay "active" behind the user's back:
+  // it keeps swipe navigation disabled and its hardware-back handler mounted while
+  // they are on another tab. Close it on the same event (with the in-flight-async
+  // guard the backgrounding reset uses), leaving Settings on its root list.
+  useEffect(() => {
+    const unsubscribe = appEvents.on(EVENTS.OPEN_PENDING_OPERATIONS, () => {
+      if (!activeSubPanelRef.current || isBackDisabledRef.current) return;
+      closeSubPanelRef.current();
+    });
+    return unsubscribe;
   }, []);
 
   const handleLanguageSelect = useCallback((lng) => {

--- a/app/services/eventEmitter.js
+++ b/app/services/eventEmitter.js
@@ -52,7 +52,7 @@ export const EVENTS = {
   BUDGETS_NEED_REFRESH: 'budgets:refresh',
   ACCOUNTS_INITIALIZED: 'accounts:initialized',
   // Emitted when the user taps a background "transactions to review" notification.
-  // Handled by SimpleTabs (switch to the Settings tab) and SettingsScreen (open
-  // the notification-processing subpanel).
-  OPEN_NOTIFICATION_PROCESSING: 'navigate:notificationProcessing',
+  // Handled by SimpleTabs (switch to the Operations tab) and OperationsScreen
+  // (surface the suggestion deck over the quick-add form).
+  OPEN_PENDING_OPERATIONS: 'navigate:pendingOperations',
 };

--- a/app/services/notifications/localNotifications.js
+++ b/app/services/notifications/localNotifications.js
@@ -3,8 +3,9 @@
  *
  * Only local, immediately-presented notifications are used — no push tokens and
  * no FCM setup. The single alert this app posts tells the user that new bank
- * transactions have landed in the review queue; tapping it deep-links into the
- * notification-processing screen (see useNotificationResponseRouter).
+ * transactions have landed in the review queue; tapping it deep-links to the
+ * quick-add surface on the operations page, where the queue is stacked as
+ * binding cards over the form (see useNotificationResponseRouter).
  */
 
 import { Platform } from 'react-native';
@@ -13,9 +14,14 @@ import * as Notifications from 'expo-notifications';
 /** Android channel the pending-operations alert is posted on. */
 export const BANK_ALERTS_CHANNEL_ID = 'bank-operations';
 
-/** Data key + value used to route a tapped notification to the review screen. */
+/**
+ * Data key + value used to route a tapped notification to the review surface.
+ * The value keeps its original 'notificationProcessing' wording so an alert
+ * posted by an older build (still sitting in the tray across an update) keeps
+ * routing after the destination moved to the operations page.
+ */
 export const NOTIFICATION_ROUTE_KEY = 'route';
-export const ROUTE_NOTIFICATION_PROCESSING = 'notificationProcessing';
+export const ROUTE_PENDING_OPERATIONS = 'notificationProcessing';
 
 // A fixed identifier so a fresh alert replaces the previous one instead of
 // stacking a new row every background run.
@@ -97,7 +103,7 @@ export const presentPendingOperationsAlert = async ({ title, body, channelName }
       content: {
         title,
         body,
-        data: { [NOTIFICATION_ROUTE_KEY]: ROUTE_NOTIFICATION_PROCESSING },
+        data: { [NOTIFICATION_ROUTE_KEY]: ROUTE_PENDING_OPERATIONS },
       },
       // `null` presents the notification immediately, but assigns it to the
       // Android channel above (channelId is read from the content on 8.0+).
@@ -115,7 +121,7 @@ export const presentPendingOperationsAlert = async ({ title, body, channelName }
  * @param {object|null} response - a Notifications.NotificationResponse
  * @returns {boolean}
  */
-export const isNotificationProcessingResponse = (response) => {
+export const isPendingOperationsResponse = (response) => {
   const data = response?.notification?.request?.content?.data;
-  return !!data && data[NOTIFICATION_ROUTE_KEY] === ROUTE_NOTIFICATION_PROCESSING;
+  return !!data && data[NOTIFICATION_ROUTE_KEY] === ROUTE_PENDING_OPERATIONS;
 };


### PR DESCRIPTION
## What

Tapping the **"transactions to review"** notification used to land the user in **Settings → Notification processing**. It now lands on the **Operations** tab, on the suggestion deck stacked over the quick-add form — the same queue, one tap from booking, where the user actually adds operations.

## How

- `EVENTS.OPEN_NOTIFICATION_PROCESSING` → `EVENTS.OPEN_PENDING_OPERATIONS`; `isNotificationProcessingResponse` → `isPendingOperationsResponse`.
- `SimpleTabs` switches to `Operations` instead of `Settings`.
- `OperationsScreen` listens for the event: closes search (the quick-add block, and the deck laid over it, is collapsed while search is open — its close effect also scrolls to the top), scrolls the list to the top otherwise, and refreshes the pending queue so a notification that arrived while the app was backgrounded is ingested rather than showing a stale deck.
- `SettingsScreen` no longer opens the subpanel on the event, but **closes an already-open one** — otherwise it would stay `subPanelActive` behind the user's back on another tab, keeping swipe navigation disabled and hijacking hardware back. Guarded by the same in-flight-async check the backgrounding reset uses.
- The notification `data.route` value stays `'notificationProcessing'` so an alert posted by an older build, still in the tray across an update, keeps routing.

The review queue remains reachable from Settings as before — only the deep link moved.

## Tests

- Router + matcher tests updated to the new names.
- New `OperationsScreen` tests: the event refreshes the queue, closes search first, and the subscription is dropped on unmount.
- New `SettingsScreen` test: an open subpanel closes on the event.
- Full suite: 4959 passing, `eslint --max-warnings 0` clean.
