### PR TITLE
fix(budgets): stop the line and group editors juddering with the keyboard open

### DIFF
--- a/__tests__/hooks/useKeyboardOffset.test.js
+++ b/__tests__/hooks/useKeyboardOffset.test.js
@@ -1,0 +1,114 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { Keyboard } from 'react-native';
+import useKeyboardOffset from '../../app/hooks/useKeyboardOffset';
+
+// Regression cover for the bug this hook replaced: a `KeyboardAvoidingView`
+// with behavior="height" inside a Modal. With edge-to-edge enabled the Modal
+// window no longer resizes for the IME, so that component shrank its container
+// forever — the budget editors visibly juddered up and down and only a back
+// swipe got out of it. Lifting the card with an explicit inset is what fixes it,
+// so what matters here is that the inset tracks the keyboard and, critically,
+// always returns to 0.
+
+const listeners = new Map();
+
+const emit = (event, payload) => {
+  const handler = listeners.get(event);
+  if (handler) handler(payload);
+};
+
+describe('useKeyboardOffset', () => {
+  let removeSpies;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listeners.clear();
+    removeSpies = [];
+    jest.spyOn(Keyboard, 'addListener').mockImplementation((event, handler) => {
+      listeners.set(event, handler);
+      const remove = jest.fn(() => listeners.delete(event));
+      removeSpies.push(remove);
+      return { remove };
+    });
+    jest.spyOn(Keyboard, 'metrics').mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Subscription', () => {
+    it('subscribes only while the owning modal is visible', async () => {
+      const { rerender } = await renderHook(({ visible }) => useKeyboardOffset(visible), {
+        initialProps: { visible: false },
+      });
+      expect(Keyboard.addListener).not.toHaveBeenCalled();
+
+      await act(async () => { rerender({ visible: true }); });
+      expect(listeners.has('keyboardDidShow')).toBe(true);
+      expect(listeners.has('keyboardDidHide')).toBe(true);
+    });
+
+    it('unsubscribes when the modal closes', async () => {
+      const { rerender } = await renderHook(({ visible }) => useKeyboardOffset(visible), {
+        initialProps: { visible: true },
+      });
+      await act(async () => { rerender({ visible: false }); });
+
+      expect(removeSpies).toHaveLength(2);
+      removeSpies.forEach(remove => expect(remove).toHaveBeenCalled());
+      expect(listeners.size).toBe(0);
+    });
+
+    it('unsubscribes on unmount', async () => {
+      const { unmount } = await renderHook(() => useKeyboardOffset(true));
+      await act(async () => { unmount(); });
+      removeSpies.forEach(remove => expect(remove).toHaveBeenCalled());
+    });
+  });
+
+  describe('Offset', () => {
+    it('starts at zero', async () => {
+      const { result } = await renderHook(() => useKeyboardOffset(true));
+      expect(result.current.__getValue()).toBe(0);
+    });
+
+    it('seeds from a keyboard that is already open when the modal appears', async () => {
+      Keyboard.metrics.mockReturnValue({ height: 312 });
+      const { result } = await renderHook(() => useKeyboardOffset(true));
+      expect(result.current.__getValue()).toBe(312);
+    });
+
+    it('rises to the keyboard height on show', async () => {
+      const { result } = await renderHook(() => useKeyboardOffset(true));
+      await act(async () => {
+        emit('keyboardDidShow', { endCoordinates: { height: 280 } });
+      });
+      await waitFor(() => expect(result.current.__getValue()).toBe(280));
+    });
+
+    it('returns to zero on hide', async () => {
+      const { result } = await renderHook(() => useKeyboardOffset(true));
+      await act(async () => {
+        emit('keyboardDidShow', { endCoordinates: { height: 280 } });
+      });
+      await waitFor(() => expect(result.current.__getValue()).toBe(280));
+
+      await act(async () => { emit('keyboardDidHide', {}); });
+      await waitFor(() => expect(result.current.__getValue()).toBe(0));
+    });
+
+    it('clears a stale inset when the modal closes mid-typing', async () => {
+      const { result, rerender } = await renderHook(({ visible }) => useKeyboardOffset(visible), {
+        initialProps: { visible: true },
+      });
+      await act(async () => {
+        emit('keyboardDidShow', { endCoordinates: { height: 280 } });
+      });
+      await waitFor(() => expect(result.current.__getValue()).toBe(280));
+
+      await act(async () => { rerender({ visible: false }); });
+      expect(result.current.__getValue()).toBe(0);
+    });
+  });
+});

--- a/app/components/budgets/BudgetLineGroupModal.js
+++ b/app/components/budgets/BudgetLineGroupModal.js
@@ -6,8 +6,7 @@ import {
   Pressable,
   StyleSheet,
   ScrollView,
-  KeyboardAvoidingView,
-  Platform,
+  Animated,
   Keyboard,
 } from 'react-native';
 import PropTypes from 'prop-types';
@@ -15,10 +14,14 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../../contexts/ThemeColorsContext';
 import { useLocalization } from '../../contexts/LocalizationContext';
 import { useDialog } from '../../contexts/DialogContext';
+import useKeyboardOffset from '../../hooks/useKeyboardOffset';
 import FormInput from '../FormInput';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import ModalHeader from '../ModalHeader';
 import * as Currency from '../../services/currency';
+
+// The overlay carries the keyboard inset, so it has to be animatable.
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 /**
  * BudgetLineGroupModal — editor for a GROUP of budget lines (migration 0022).
@@ -48,6 +51,9 @@ export default function BudgetLineGroupModal({
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { showDialog } = useDialog();
+  // Lifts the card above the keyboard. NOT a KeyboardAvoidingView — see the
+  // hook's own note for what that one does inside a Modal under edge-to-edge.
+  const keyboardOffset = useKeyboardOffset(visible);
 
   const isEditing = group != null;
 
@@ -138,146 +144,144 @@ export default function BudgetLineGroupModal({
         onRequestClose={onClose}
         testID="plan-group-modal"
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={styles.flex1}
+        <AnimatedPressable
+          style={[styles.modalOverlay, { paddingBottom: keyboardOffset }]}
+          onPress={onClose}
         >
-          <Pressable style={styles.modalOverlay} onPress={onClose}>
-            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
-                <ModalHeader title={isEditing ? t('edit_group') : t('new_group')} />
+          <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
+            <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+              <ModalHeader title={isEditing ? t('edit_group') : t('new_group')} />
 
-                <View style={styles.field}>
-                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                    {t('group_name')}
-                  </Text>
-                  <FormInput
-                    value={label}
-                    onChangeText={(text) => { setLabel(text); setError(null); }}
-                    placeholder={t('group_name')}
-                    testID="plan-group-name"
-                  />
-                </View>
-
-                {/* Derived by default: the group is worth what its lines are
-                    worth, and that figure keeps itself up to date. The toggle is
-                    for the case where the envelope has a size of its own. */}
-                <Pressable
-                  style={[styles.toggleRow, { borderColor: colors.border }]}
-                  onPress={() => { setCustomBudget(v => !v); setError(null); }}
-                  accessibilityRole="switch"
-                  accessibilityState={{ checked: customBudget }}
-                  accessibilityLabel={t('custom_group_budget')}
-                  testID="plan-group-custom-toggle"
-                >
-                  <View style={styles.toggleLabel}>
-                    <Icon name="pencil-outline" size={20} color={colors.text} />
-                    <Text style={[styles.text16, { color: colors.text }]}>
-                      {t('custom_group_budget')}
-                    </Text>
-                  </View>
-                  <View style={[styles.switchTrack, { backgroundColor: customBudget ? colors.primary : colors.border }]}>
-                    <View style={[styles.switchThumb, { transform: [{ translateX: customBudget ? 18 : 2 }] }]} />
-                  </View>
-                </Pressable>
-
-                {!customBudget && (
-                  <Text style={[styles.fieldHint, { color: colors.mutedText }]} testID="plan-group-derived-hint">
-                    {t('group_budget_derived_hint')}
-                    {derivedTotal != null ? ` · ${Currency.formatAmount(derivedTotal, currency)} ${currency}` : ''}
-                  </Text>
-                )}
-
-                {customBudget && (
-                  <>
-                    {currencies.length > 0 && (
-                      <View style={styles.field}>
-                        <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>{t('currency')}</Text>
-                        <View style={styles.currencyRow}>
-                          {currencies.map((code) => (
-                            <Pressable
-                              key={code}
-                              style={[
-                                styles.currencyChip,
-                                { borderColor: colors.border },
-                                groupCurrency === code && { backgroundColor: colors.primary, borderColor: colors.primary },
-                              ]}
-                              onPress={() => setGroupCurrency(code)}
-                              accessibilityRole="button"
-                              accessibilityState={{ selected: groupCurrency === code }}
-                              accessibilityLabel={code}
-                              testID={`plan-group-currency-${code}`}
-                            >
-                              <Text style={[styles.currencyChipText, { color: colors.text }]}>{code}</Text>
-                            </Pressable>
-                          ))}
-                        </View>
-                      </View>
-                    )}
-                    <View style={styles.field}>
-                      <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                        {t('amount')}{groupCurrency ? ` · ${groupCurrency}` : ''}
-                      </Text>
-                      <FormInput
-                        value={amount}
-                        onChangeText={handleAmountChange}
-                        placeholder={derivedTotal != null ? String(derivedTotal) : '0'}
-                        keyboardType="decimal-pad"
-                        testID="plan-group-amount"
-                      />
-                      <Text style={[styles.fieldHint, { color: colors.mutedText }]}>
-                        {t('group_budget_override_hint')}
-                      </Text>
-                    </View>
-                  </>
-                )}
-
-                {error && (
-                  <Text style={[styles.error, { color: colors.danger }]} testID="plan-group-error">
-                    {error}
-                  </Text>
-                )}
-
-                {isEditing && (
-                  <Pressable
-                    style={[styles.deleteRow, { borderTopColor: colors.border }]}
-                    onPress={handleDelete}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('delete_group')}
-                    testID="plan-group-delete"
-                  >
-                    <Icon name="delete-outline" size={20} color={colors.delete || colors.danger} />
-                    <Text style={[styles.deleteText, { color: colors.delete || colors.danger }]}>
-                      {t('delete_group')}
-                    </Text>
-                  </Pressable>
-                )}
-              </ScrollView>
-
-              <View style={[styles.buttonRow, { backgroundColor: colors.card }]}>
-                <Pressable
-                  style={[styles.button, { backgroundColor: colors.secondary }]}
-                  onPress={onClose}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('cancel')}
-                >
-                  <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel')}</Text>
-                </Pressable>
-                <Pressable
-                  style={[styles.button, { backgroundColor: colors.primary }, saving && styles.buttonDisabled]}
-                  onPress={handleSave}
-                  disabled={saving}
-                  accessibilityRole="button"
-                  accessibilityLabel={t('save')}
-                  accessibilityState={{ disabled: saving, busy: saving }}
-                  testID="plan-group-save"
-                >
-                  <Text style={[styles.buttonText, { color: colors.text }]}>{t('save')}</Text>
-                </Pressable>
+              <View style={styles.field}>
+                <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                  {t('group_name')}
+                </Text>
+                <FormInput
+                  value={label}
+                  onChangeText={(text) => { setLabel(text); setError(null); }}
+                  placeholder={t('group_name')}
+                  testID="plan-group-name"
+                />
               </View>
-            </Pressable>
+
+              {/* Derived by default: the group is worth what its lines are
+                  worth, and that figure keeps itself up to date. The toggle is
+                  for the case where the envelope has a size of its own. */}
+              <Pressable
+                style={[styles.toggleRow, { borderColor: colors.border }]}
+                onPress={() => { setCustomBudget(v => !v); setError(null); }}
+                accessibilityRole="switch"
+                accessibilityState={{ checked: customBudget }}
+                accessibilityLabel={t('custom_group_budget')}
+                testID="plan-group-custom-toggle"
+              >
+                <View style={styles.toggleLabel}>
+                  <Icon name="pencil-outline" size={20} color={colors.text} />
+                  <Text style={[styles.text16, { color: colors.text }]}>
+                    {t('custom_group_budget')}
+                  </Text>
+                </View>
+                <View style={[styles.switchTrack, { backgroundColor: customBudget ? colors.primary : colors.border }]}>
+                  <View style={[styles.switchThumb, { transform: [{ translateX: customBudget ? 18 : 2 }] }]} />
+                </View>
+              </Pressable>
+
+              {!customBudget && (
+                <Text style={[styles.fieldHint, { color: colors.mutedText }]} testID="plan-group-derived-hint">
+                  {t('group_budget_derived_hint')}
+                  {derivedTotal != null ? ` · ${Currency.formatAmount(derivedTotal, currency)} ${currency}` : ''}
+                </Text>
+              )}
+
+              {customBudget && (
+                <>
+                  {currencies.length > 0 && (
+                    <View style={styles.field}>
+                      <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>{t('currency')}</Text>
+                      <View style={styles.currencyRow}>
+                        {currencies.map((code) => (
+                          <Pressable
+                            key={code}
+                            style={[
+                              styles.currencyChip,
+                              { borderColor: colors.border },
+                              groupCurrency === code && { backgroundColor: colors.primary, borderColor: colors.primary },
+                            ]}
+                            onPress={() => setGroupCurrency(code)}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: groupCurrency === code }}
+                            accessibilityLabel={code}
+                            testID={`plan-group-currency-${code}`}
+                          >
+                            <Text style={[styles.currencyChipText, { color: colors.text }]}>{code}</Text>
+                          </Pressable>
+                        ))}
+                      </View>
+                    </View>
+                  )}
+                  <View style={styles.field}>
+                    <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                      {t('amount')}{groupCurrency ? ` · ${groupCurrency}` : ''}
+                    </Text>
+                    <FormInput
+                      value={amount}
+                      onChangeText={handleAmountChange}
+                      placeholder={derivedTotal != null ? String(derivedTotal) : '0'}
+                      keyboardType="decimal-pad"
+                      testID="plan-group-amount"
+                    />
+                    <Text style={[styles.fieldHint, { color: colors.mutedText }]}>
+                      {t('group_budget_override_hint')}
+                    </Text>
+                  </View>
+                </>
+              )}
+
+              {error && (
+                <Text style={[styles.error, { color: colors.danger }]} testID="plan-group-error">
+                  {error}
+                </Text>
+              )}
+
+              {isEditing && (
+                <Pressable
+                  style={[styles.deleteRow, { borderTopColor: colors.border }]}
+                  onPress={handleDelete}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('delete_group')}
+                  testID="plan-group-delete"
+                >
+                  <Icon name="delete-outline" size={20} color={colors.delete || colors.danger} />
+                  <Text style={[styles.deleteText, { color: colors.delete || colors.danger }]}>
+                    {t('delete_group')}
+                  </Text>
+                </Pressable>
+              )}
+            </ScrollView>
+
+            <View style={[styles.buttonRow, { backgroundColor: colors.card }]}>
+              <Pressable
+                style={[styles.button, { backgroundColor: colors.secondary }]}
+                onPress={onClose}
+                accessibilityRole="button"
+                accessibilityLabel={t('cancel')}
+              >
+                <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel')}</Text>
+              </Pressable>
+              <Pressable
+                style={[styles.button, { backgroundColor: colors.primary }, saving && styles.buttonDisabled]}
+                onPress={handleSave}
+                disabled={saving}
+                accessibilityRole="button"
+                accessibilityLabel={t('save')}
+                accessibilityState={{ disabled: saving, busy: saving }}
+                testID="plan-group-save"
+              >
+                <Text style={[styles.buttonText, { color: colors.text }]}>{t('save')}</Text>
+              </Pressable>
+            </View>
           </Pressable>
-        </KeyboardAvoidingView>
+        </AnimatedPressable>
       </Modal>
     </>
   );
@@ -366,9 +370,6 @@ const styles = StyleSheet.create({
   fieldLabel: {
     fontSize: 12,
     marginBottom: 6,
-  },
-  flex1: {
-    flex: 1,
   },
   modalContent: {
     borderRadius: 12,

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -7,8 +7,6 @@ import {
   StyleSheet,
   FlatList,
   ScrollView,
-  KeyboardAvoidingView,
-  Platform,
   Keyboard,
   Animated,
   Easing,
@@ -21,10 +19,14 @@ import { useLocalization } from '../../contexts/LocalizationContext';
 import { DURATION_ENTER, DURATION_EXIT } from '../../utils/motion';
 import { motionDuration } from '../../utils/reducedMotion';
 import { useDialog } from '../../contexts/DialogContext';
+import useKeyboardOffset from '../../hooks/useKeyboardOffset';
 import FormInput from '../FormInput';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import ModalHeader from '../ModalHeader';
 import * as Currency from '../../services/currency';
+
+// The overlay carries the keyboard inset, so it has to be animatable.
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 const KINDS = ['income', 'expense', 'transfer'];
 
@@ -73,6 +75,9 @@ export default function BudgetPlanLineModal({
   const { colors } = useThemeColors();
   const { t } = useLocalization();
   const { showDialog } = useDialog();
+  // Lifts the card above the keyboard. NOT a KeyboardAvoidingView — see the
+  // hook's own note for what that one does inside a Modal under edge-to-edge.
+  const keyboardOffset = useKeyboardOffset(visible);
 
   const isEditingLine = line != null;
 
@@ -473,549 +478,547 @@ export default function BudgetPlanLineModal({
         onRequestClose={handleRequestClose}
         testID="plan-line-modal"
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={styles.flex1}
+        <AnimatedPressable
+          style={[styles.modalOverlay, { paddingBottom: keyboardOffset }]}
+          onPress={onClose}
         >
-          <Pressable style={styles.modalOverlay} onPress={onClose}>
-            <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-              <Animated.View
-                style={[styles.mainContent, { opacity: mainOpacity, transform: [{ translateX: mainTranslateX }] }]}
+          <Pressable style={[styles.modalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
+            <Animated.View
+              style={[styles.mainContent, { opacity: mainOpacity, transform: [{ translateX: mainTranslateX }] }]}
+            >
+              <ScrollView
+                contentContainerStyle={styles.scrollContent}
+                keyboardShouldPersistTaps="handled"
               >
-                <ScrollView
-                  contentContainerStyle={styles.scrollContent}
-                  keyboardShouldPersistTaps="handled"
-                >
-                  <ModalHeader title={title} />
+                <ModalHeader title={title} />
 
-                  {/* What this line is: income declares expected income, expense
-                      and transfer allocate it. */}
+                {/* What this line is: income declares expected income, expense
+                    and transfer allocate it. */}
+                <View style={styles.field}>
+                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                    {t('allocation_type')}
+                  </Text>
+                  <View style={styles.segment}>
+                    {KINDS.map((option) => (
+                      <Pressable
+                        key={option}
+                        style={[
+                          styles.segmentButton,
+                          { borderColor: colors.border },
+                          kind === option && { backgroundColor: colors.primary, borderColor: colors.primary },
+                        ]}
+                        onPress={() => handleSelectKind(option)}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: kind === option }}
+                        accessibilityLabel={t(option)}
+                        testID={`plan-line-kind-${option}`}
+                      >
+                        <Text style={[styles.segmentText, { color: kind === option ? colors.text : colors.mutedText }]}>
+                          {t(option)}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+
+                {/* Tracking target */}
+                <View style={styles.field}>
+                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                    {kind === 'income' ? `${t('income_target')} · ${t('optional')}` : t('tracking_target')}
+                  </Text>
+                  <Pressable
+                    style={[styles.targetButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                    onPress={openTargetPanel}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('select_target')}
+                    testID="plan-target-picker"
+                  >
+                    {targetSummary ? (
+                      <View style={styles.targetValue}>
+                        <Icon name={targetSummary.icon} size={20} color={colors.text} />
+                        <Text style={[styles.text16, { color: colors.text }]} numberOfLines={1}>
+                          {targetSummary.name}
+                        </Text>
+                      </View>
+                    ) : (
+                      <Text style={[styles.text16, { color: colors.mutedText }]}>
+                        {t('select_target')}
+                      </Text>
+                    )}
+                    <Icon name="chevron-right" size={20} color={colors.mutedText} />
+                  </Pressable>
+                </View>
+
+                {/* Execution account — set one and the line becomes a one-tap
+                    payable (the former planned operation). */}
+                <View style={styles.field}>
+                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                    {t('template_account')} · {t('optional')}
+                  </Text>
+                  <Pressable
+                    style={[styles.targetButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                    onPress={openAccountPanel}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('template_account')}
+                    testID="plan-account-picker"
+                  >
+                    {executionAccount ? (
+                      <View style={styles.targetValue}>
+                        <Icon name="wallet-outline" size={20} color={colors.text} />
+                        <Text style={[styles.text16, { color: colors.text }]} numberOfLines={1}>
+                          {executionAccount.name} · {executionAccount.currency}
+                        </Text>
+                      </View>
+                    ) : (
+                      <Text style={[styles.text16, { color: colors.mutedText }]}>
+                        {t('no_template_account')}
+                      </Text>
+                    )}
+                    <Icon name="chevron-right" size={20} color={colors.mutedText} />
+                  </Pressable>
+                  <Text style={[styles.fieldHint, { color: colors.mutedText }]}>
+                    {t('template_account_hint')}
+                  </Text>
+                </View>
+
+                {/* Group — an envelope this line shares with others (migration
+                    0022). Offered for allocations only: an income line declares
+                    expected income and has no spending for a group to total. */}
+                {kind !== 'income' && (
                   <View style={styles.field}>
                     <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                      {t('allocation_type')}
+                      {t('group')} · {t('optional')}
                     </Text>
-                    <View style={styles.segment}>
-                      {KINDS.map((option) => (
-                        <Pressable
-                          key={option}
-                          style={[
-                            styles.segmentButton,
-                            { borderColor: colors.border },
-                            kind === option && { backgroundColor: colors.primary, borderColor: colors.primary },
-                          ]}
-                          onPress={() => handleSelectKind(option)}
-                          accessibilityRole="button"
-                          accessibilityState={{ selected: kind === option }}
-                          accessibilityLabel={t(option)}
-                          testID={`plan-line-kind-${option}`}
-                        >
-                          <Text style={[styles.segmentText, { color: kind === option ? colors.text : colors.mutedText }]}>
-                            {t(option)}
+                    <Pressable
+                      style={[styles.targetButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
+                      onPress={openGroupPanel}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('group')}
+                      testID="plan-group-picker"
+                    >
+                      {selectedGroup ? (
+                        <View style={styles.targetValue}>
+                          <Icon name="folder-outline" size={20} color={colors.text} />
+                          <Text style={[styles.text16, { color: colors.text }]} numberOfLines={1}>
+                            {selectedGroup.label}
                           </Text>
+                        </View>
+                      ) : (
+                        <Text style={[styles.text16, { color: colors.mutedText }]}>
+                          {t('no_group')}
+                        </Text>
+                      )}
+                      <Icon name="chevron-right" size={20} color={colors.mutedText} />
+                    </Pressable>
+                  </View>
+                )}
+
+                {/* Recurring toggle: a recurring line is a global template that
+                    applies to every calendar month automatically, instead of
+                    being scoped to this one month. */}
+                <Pressable
+                  style={[styles.recurringRow, { borderColor: colors.border }]}
+                  onPress={() => setIsRecurring(v => !v)}
+                  accessibilityRole="switch"
+                  accessibilityState={{ checked: isRecurring }}
+                  accessibilityLabel={t('recurring_allocation')}
+                  testID="plan-line-recurring-toggle"
+                >
+                  <View style={styles.recurringLabel}>
+                    <Icon name="repeat" size={20} color={colors.text} />
+                    <Text style={[styles.text16, { color: colors.text }]}>
+                      {t('recurring_allocation')}
+                    </Text>
+                  </View>
+                  <View
+                    style={[
+                      styles.switchTrack,
+                      { backgroundColor: isRecurring ? colors.primary : colors.border },
+                    ]}
+                  >
+                    <View
+                      style={[
+                        styles.switchThumb,
+                        { transform: [{ translateX: isRecurring ? 18 : 2 }] },
+                      ]}
+                    />
+                  </View>
+                </Pressable>
+
+                {/* Currency picker — shown for any line without an execution
+                    account: with an account the amount is by definition in that
+                    account's currency and there is nothing to pick. A one-off
+                    line defaults to the plan's currency (and stores null, i.e.
+                    "inherit", while it stays on it). */}
+                {executionCurrency == null && currencyOptions.length > 0 && (
+                  <View style={styles.field}>
+                    <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                      {t('currency')}
+                    </Text>
+                    <View style={styles.currencyRow}>
+                      {currencyOptions.map((code) => (
+                        <Pressable
+                          key={code}
+                          style={[
+                            styles.currencyChip,
+                            { borderColor: colors.border },
+                            lineCurrency === code && { backgroundColor: colors.primary, borderColor: colors.primary },
+                          ]}
+                          onPress={() => setLineCurrency(code)}
+                          accessibilityRole="button"
+                          accessibilityState={{ selected: lineCurrency === code }}
+                          accessibilityLabel={code}
+                          testID={`plan-line-currency-${code}`}
+                        >
+                          <Text style={[styles.currencyChipText, { color: colors.text }]}>{code}</Text>
                         </Pressable>
                       ))}
                     </View>
                   </View>
+                )}
 
-                  {/* Tracking target */}
-                  <View style={styles.field}>
-                    <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                      {kind === 'income' ? `${t('income_target')} · ${t('optional')}` : t('tracking_target')}
-                    </Text>
-                    <Pressable
-                      style={[styles.targetButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                      onPress={openTargetPanel}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('select_target')}
-                      testID="plan-target-picker"
-                    >
-                      {targetSummary ? (
-                        <View style={styles.targetValue}>
-                          <Icon name={targetSummary.icon} size={20} color={colors.text} />
-                          <Text style={[styles.text16, { color: colors.text }]} numberOfLines={1}>
-                            {targetSummary.name}
-                          </Text>
-                        </View>
-                      ) : (
-                        <Text style={[styles.text16, { color: colors.mutedText }]}>
-                          {t('select_target')}
-                        </Text>
-                      )}
-                      <Icon name="chevron-right" size={20} color={colors.mutedText} />
-                    </Pressable>
-                  </View>
+                {/* Amount — a plain numeric field. A budget line is typed once
+                    and rarely edited, so the on-screen calculator cost half the
+                    modal's height (its bottom row sat under the button bar) and
+                    bought nothing the number pad doesn't already give. */}
+                <View style={styles.field}>
+                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                    {t('amount')}{displayCurrency ? ` · ${displayCurrency}` : ''}
+                  </Text>
+                  <FormInput
+                    value={amount}
+                    onChangeText={handleAmountChange}
+                    placeholder="0"
+                    keyboardType="decimal-pad"
+                    testID="plan-line-amount"
+                  />
+                </View>
 
-                  {/* Execution account — set one and the line becomes a one-tap
-                      payable (the former planned operation). */}
-                  <View style={styles.field}>
-                    <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                      {t('template_account')} · {t('optional')}
-                    </Text>
-                    <Pressable
-                      style={[styles.targetButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                      onPress={openAccountPanel}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('template_account')}
-                      testID="plan-account-picker"
-                    >
-                      {executionAccount ? (
-                        <View style={styles.targetValue}>
-                          <Icon name="wallet-outline" size={20} color={colors.text} />
-                          <Text style={[styles.text16, { color: colors.text }]} numberOfLines={1}>
-                            {executionAccount.name} · {executionAccount.currency}
-                          </Text>
-                        </View>
-                      ) : (
-                        <Text style={[styles.text16, { color: colors.mutedText }]}>
-                          {t('no_template_account')}
-                        </Text>
-                      )}
-                      <Icon name="chevron-right" size={20} color={colors.mutedText} />
-                    </Pressable>
-                    <Text style={[styles.fieldHint, { color: colors.mutedText }]}>
-                      {t('template_account_hint')}
-                    </Text>
-                  </View>
+                {/* Label + comment */}
+                <View style={styles.field}>
+                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                    {t('allocation_label')} · {t('optional')}
+                  </Text>
+                  <FormInput
+                    value={label}
+                    onChangeText={setLabel}
+                    placeholder={targetSummary?.name || t('allocation_label')}
+                    testID="plan-line-label"
+                  />
+                </View>
+                <View style={styles.field}>
+                  <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
+                    {t('allocation_comment')} · {t('optional')}
+                  </Text>
+                  <FormInput
+                    value={comment}
+                    onChangeText={setComment}
+                    placeholder={t('allocation_comment')}
+                    multiline
+                    numberOfLines={2}
+                    testID="plan-line-comment"
+                  />
+                </View>
 
-                  {/* Group — an envelope this line shares with others (migration
-                      0022). Offered for allocations only: an income line declares
-                      expected income and has no spending for a group to total. */}
-                  {kind !== 'income' && (
-                    <View style={styles.field}>
-                      <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                        {t('group')} · {t('optional')}
-                      </Text>
-                      <Pressable
-                        style={[styles.targetButton, { backgroundColor: colors.inputBackground, borderColor: colors.inputBorder }]}
-                        onPress={openGroupPanel}
-                        accessibilityRole="button"
-                        accessibilityLabel={t('group')}
-                        testID="plan-group-picker"
-                      >
-                        {selectedGroup ? (
-                          <View style={styles.targetValue}>
-                            <Icon name="folder-outline" size={20} color={colors.text} />
-                            <Text style={[styles.text16, { color: colors.text }]} numberOfLines={1}>
-                              {selectedGroup.label}
-                            </Text>
-                          </View>
-                        ) : (
-                          <Text style={[styles.text16, { color: colors.mutedText }]}>
-                            {t('no_group')}
-                          </Text>
-                        )}
-                        <Icon name="chevron-right" size={20} color={colors.mutedText} />
-                      </Pressable>
-                    </View>
-                  )}
+                {error && (
+                  <Text style={[styles.error, { color: colors.danger }]} testID="plan-line-error">
+                    {error}
+                  </Text>
+                )}
 
-                  {/* Recurring toggle: a recurring line is a global template that
-                      applies to every calendar month automatically, instead of
-                      being scoped to this one month. */}
+                {isEditingLine && (
                   <Pressable
-                    style={[styles.recurringRow, { borderColor: colors.border }]}
-                    onPress={() => setIsRecurring(v => !v)}
-                    accessibilityRole="switch"
-                    accessibilityState={{ checked: isRecurring }}
-                    accessibilityLabel={t('recurring_allocation')}
-                    testID="plan-line-recurring-toggle"
+                    style={[styles.deleteRow, { borderTopColor: colors.border }]}
+                    onPress={handleDelete}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('delete_allocation')}
+                    testID="plan-line-delete"
                   >
-                    <View style={styles.recurringLabel}>
-                      <Icon name="repeat" size={20} color={colors.text} />
-                      <Text style={[styles.text16, { color: colors.text }]}>
-                        {t('recurring_allocation')}
-                      </Text>
-                    </View>
-                    <View
-                      style={[
-                        styles.switchTrack,
-                        { backgroundColor: isRecurring ? colors.primary : colors.border },
-                      ]}
+                    <Icon name="delete-outline" size={20} color={colors.delete || colors.danger} />
+                    <Text style={[styles.deleteText, { color: colors.delete || colors.danger }]}>
+                      {t('delete_allocation')}
+                    </Text>
+                  </Pressable>
+                )}
+              </ScrollView>
+
+              <View style={[styles.buttonRow, { backgroundColor: colors.card }]}>
+                <Pressable
+                  style={[styles.button, { backgroundColor: colors.secondary }]}
+                  onPress={onClose}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('cancel')}
+                >
+                  <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel')}</Text>
+                </Pressable>
+                <Pressable
+                  style={[styles.button, { backgroundColor: colors.primary }, saving && styles.buttonDisabled]}
+                  onPress={handleSave}
+                  disabled={saving}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('save')}
+                  accessibilityState={{ disabled: saving, busy: saving }}
+                  testID="plan-line-save"
+                >
+                  <Text style={[styles.buttonText, { color: colors.text }]}>{t('save')}</Text>
+                </Pressable>
+              </View>
+            </Animated.View>
+
+            {/* Target picker subpanel (slides in over the form) */}
+            {activeSubPanel === 'target' && (
+              <Animated.View
+                testID="plan-target-subpanel"
+                style={[
+                  styles.subPanel,
+                  { backgroundColor: colors.card },
+                  { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
+                ]}
+              >
+                <View style={styles.subPanelHeader}>
+                  <Pressable
+                    onPress={closeSubPanel}
+                    style={styles.subPanelBack}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('back')}
+                    testID="plan-target-back"
+                  >
+                    <Icon name="arrow-left" size={24} color={colors.text} />
+                  </Pressable>
+                  <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('select_target')}</Text>
+                  {/* Categories toggle in place instead of closing the panel,
+                      so there has to be something that says "I'm finished
+                      picking". The account tab needs none — one tap there is
+                      the whole selection. */}
+                  {pickerKind === 'category' && (
+                    <Pressable
+                      onPress={closeSubPanel}
+                      style={styles.subPanelDone}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('done')}
+                      testID="plan-target-done"
                     >
-                      <View
-                        style={[
-                          styles.switchThumb,
-                          { transform: [{ translateX: isRecurring ? 18 : 2 }] },
-                        ]}
+                      <Text style={[styles.subPanelDoneText, { color: colors.primary }]}>{t('done')}</Text>
+                    </Pressable>
+                  )}
+                </View>
+
+                {/* Two-mode toggle: category OR destination account. An income
+                    line tracks no transfer target, so it skips the toggle. */}
+                {kind !== 'income' && (
+                  <View style={styles.segment}>
+                    <Pressable
+                      style={[
+                        styles.segmentButton,
+                        { borderColor: colors.border },
+                        pickerKind === 'category' && { backgroundColor: colors.primary },
+                      ]}
+                      onPress={() => setPickerKind('category')}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: pickerKind === 'category' }}
+                      accessibilityLabel={t('category_target')}
+                      testID="plan-target-tab-category"
+                    >
+                      <Text style={[styles.segmentText, { color: pickerKind === 'category' ? colors.text : colors.mutedText }]}>
+                        {t('category_target')}
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      style={[
+                        styles.segmentButton,
+                        { borderColor: colors.border },
+                        pickerKind === 'account' && { backgroundColor: colors.primary },
+                      ]}
+                      onPress={() => setPickerKind('account')}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: pickerKind === 'account' }}
+                      accessibilityLabel={t('transfer_target')}
+                      testID="plan-target-tab-account"
+                    >
+                      <Text style={[styles.segmentText, { color: pickerKind === 'account' ? colors.text : colors.mutedText }]}>
+                        {t('transfer_target')}
+                      </Text>
+                    </Pressable>
+                  </View>
+                )}
+
+                <FlatList
+                  data={kind !== 'income' && pickerKind === 'account' ? accounts : targetCategories}
+                  keyExtractor={(item) => String(item.id)}
+                  renderItem={renderTargetItem}
+                  keyboardShouldPersistTaps="handled"
+                  ListEmptyComponent={(
+                    <Text style={[styles.emptyText, { color: colors.mutedText }]}>
+                      {pickerKind === 'category' ? t('no_categories') : t('no_accounts')}
+                    </Text>
+                  )}
+                />
+              </Animated.View>
+            )}
+
+            {/* Group subpanel: pick an existing envelope, drop out of one, or
+                create one without leaving the half-filled form. */}
+            {activeSubPanel === 'group' && (
+              <Animated.View
+                testID="plan-group-subpanel"
+                style={[
+                  styles.subPanel,
+                  { backgroundColor: colors.card },
+                  { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
+                ]}
+              >
+                <View style={styles.subPanelHeader}>
+                  <Pressable
+                    onPress={closeSubPanel}
+                    style={styles.subPanelBack}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('back')}
+                    testID="plan-group-back"
+                  >
+                    <Icon name="arrow-left" size={24} color={colors.text} />
+                  </Pressable>
+                  <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('group')}</Text>
+                </View>
+
+                {onCreateGroup && (
+                  <View style={styles.newGroupRow}>
+                    <View style={styles.newGroupInput}>
+                      <FormInput
+                        value={newGroupName}
+                        onChangeText={setNewGroupName}
+                        placeholder={t('new_group')}
+                        testID="plan-group-new-name"
                       />
                     </View>
-                  </Pressable>
-
-                  {/* Currency picker — shown for any line without an execution
-                      account: with an account the amount is by definition in that
-                      account's currency and there is nothing to pick. A one-off
-                      line defaults to the plan's currency (and stores null, i.e.
-                      "inherit", while it stays on it). */}
-                  {executionCurrency == null && currencyOptions.length > 0 && (
-                    <View style={styles.field}>
-                      <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                        {t('currency')}
-                      </Text>
-                      <View style={styles.currencyRow}>
-                        {currencyOptions.map((code) => (
-                          <Pressable
-                            key={code}
-                            style={[
-                              styles.currencyChip,
-                              { borderColor: colors.border },
-                              lineCurrency === code && { backgroundColor: colors.primary, borderColor: colors.primary },
-                            ]}
-                            onPress={() => setLineCurrency(code)}
-                            accessibilityRole="button"
-                            accessibilityState={{ selected: lineCurrency === code }}
-                            accessibilityLabel={code}
-                            testID={`plan-line-currency-${code}`}
-                          >
-                            <Text style={[styles.currencyChipText, { color: colors.text }]}>{code}</Text>
-                          </Pressable>
-                        ))}
-                      </View>
-                    </View>
-                  )}
-
-                  {/* Amount — a plain numeric field. A budget line is typed once
-                      and rarely edited, so the on-screen calculator cost half the
-                      modal's height (its bottom row sat under the button bar) and
-                      bought nothing the number pad doesn't already give. */}
-                  <View style={styles.field}>
-                    <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                      {t('amount')}{displayCurrency ? ` · ${displayCurrency}` : ''}
-                    </Text>
-                    <FormInput
-                      value={amount}
-                      onChangeText={handleAmountChange}
-                      placeholder="0"
-                      keyboardType="decimal-pad"
-                      testID="plan-line-amount"
-                    />
-                  </View>
-
-                  {/* Label + comment */}
-                  <View style={styles.field}>
-                    <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                      {t('allocation_label')} · {t('optional')}
-                    </Text>
-                    <FormInput
-                      value={label}
-                      onChangeText={setLabel}
-                      placeholder={targetSummary?.name || t('allocation_label')}
-                      testID="plan-line-label"
-                    />
-                  </View>
-                  <View style={styles.field}>
-                    <Text style={[styles.fieldLabel, { color: colors.mutedText }]}>
-                      {t('allocation_comment')} · {t('optional')}
-                    </Text>
-                    <FormInput
-                      value={comment}
-                      onChangeText={setComment}
-                      placeholder={t('allocation_comment')}
-                      multiline
-                      numberOfLines={2}
-                      testID="plan-line-comment"
-                    />
-                  </View>
-
-                  {error && (
-                    <Text style={[styles.error, { color: colors.danger }]} testID="plan-line-error">
-                      {error}
-                    </Text>
-                  )}
-
-                  {isEditingLine && (
                     <Pressable
-                      style={[styles.deleteRow, { borderTopColor: colors.border }]}
-                      onPress={handleDelete}
+                      onPress={handleCreateGroup}
+                      disabled={!newGroupName.trim()}
+                      style={[
+                        styles.newGroupButton,
+                        { backgroundColor: colors.primary },
+                        !newGroupName.trim() && styles.buttonDisabled,
+                      ]}
                       accessibilityRole="button"
-                      accessibilityLabel={t('delete_allocation')}
-                      testID="plan-line-delete"
+                      accessibilityLabel={t('create_group')}
+                      accessibilityState={{ disabled: !newGroupName.trim() }}
+                      testID="plan-group-create"
                     >
-                      <Icon name="delete-outline" size={20} color={colors.delete || colors.danger} />
-                      <Text style={[styles.deleteText, { color: colors.delete || colors.danger }]}>
-                        {t('delete_allocation')}
+                      <Icon name="plus" size={20} color={colors.text} />
+                    </Pressable>
+                  </View>
+                )}
+
+                <Pressable
+                  onPress={() => handleSelectGroup(null)}
+                  style={({ pressed }) => [
+                    styles.pickerOption,
+                    { borderColor: colors.border },
+                    pressed && { backgroundColor: colors.selected },
+                    groupId == null && { backgroundColor: colors.selected },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('no_group')}
+                  testID="plan-group-option-none"
+                >
+                  <Icon name="close-circle-outline" size={22} color={colors.text} />
+                  <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
+                    {t('no_group')}
+                  </Text>
+                </Pressable>
+
+                <FlatList
+                  data={groups}
+                  keyExtractor={(item) => String(item.id)}
+                  keyboardShouldPersistTaps="handled"
+                  renderItem={({ item }) => (
+                    <Pressable
+                      onPress={() => handleSelectGroup(item.id)}
+                      style={({ pressed }) => [
+                        styles.pickerOption,
+                        { borderColor: colors.border },
+                        pressed && { backgroundColor: colors.selected },
+                        groupId === item.id && { backgroundColor: colors.selected },
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: groupId === item.id }}
+                      accessibilityLabel={item.label}
+                      testID={`plan-group-option-${item.id}`}
+                    >
+                      <Icon name="folder-outline" size={22} color={colors.text} />
+                      <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
+                        {item.label}
                       </Text>
                     </Pressable>
                   )}
-                </ScrollView>
-
-                <View style={[styles.buttonRow, { backgroundColor: colors.card }]}>
-                  <Pressable
-                    style={[styles.button, { backgroundColor: colors.secondary }]}
-                    onPress={onClose}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('cancel')}
-                  >
-                    <Text style={[styles.buttonText, { color: colors.text }]}>{t('cancel')}</Text>
-                  </Pressable>
-                  <Pressable
-                    style={[styles.button, { backgroundColor: colors.primary }, saving && styles.buttonDisabled]}
-                    onPress={handleSave}
-                    disabled={saving}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('save')}
-                    accessibilityState={{ disabled: saving, busy: saving }}
-                    testID="plan-line-save"
-                  >
-                    <Text style={[styles.buttonText, { color: colors.text }]}>{t('save')}</Text>
-                  </Pressable>
-                </View>
+                  ListEmptyComponent={(
+                    <Text style={[styles.emptyText, { color: colors.mutedText }]}>
+                      {t('no_groups_yet')}
+                    </Text>
+                  )}
+                />
               </Animated.View>
+            )}
 
-              {/* Target picker subpanel (slides in over the form) */}
-              {activeSubPanel === 'target' && (
-                <Animated.View
-                  testID="plan-target-subpanel"
-                  style={[
-                    styles.subPanel,
-                    { backgroundColor: colors.card },
-                    { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
-                  ]}
-                >
-                  <View style={styles.subPanelHeader}>
-                    <Pressable
-                      onPress={closeSubPanel}
-                      style={styles.subPanelBack}
-                      hitSlop={8}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('back')}
-                      testID="plan-target-back"
-                    >
-                      <Icon name="arrow-left" size={24} color={colors.text} />
-                    </Pressable>
-                    <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('select_target')}</Text>
-                    {/* Categories toggle in place instead of closing the panel,
-                        so there has to be something that says "I'm finished
-                        picking". The account tab needs none — one tap there is
-                        the whole selection. */}
-                    {pickerKind === 'category' && (
-                      <Pressable
-                        onPress={closeSubPanel}
-                        style={styles.subPanelDone}
-                        hitSlop={8}
-                        accessibilityRole="button"
-                        accessibilityLabel={t('done')}
-                        testID="plan-target-done"
-                      >
-                        <Text style={[styles.subPanelDoneText, { color: colors.primary }]}>{t('done')}</Text>
-                      </Pressable>
-                    )}
-                  </View>
-
-                  {/* Two-mode toggle: category OR destination account. An income
-                      line tracks no transfer target, so it skips the toggle. */}
-                  {kind !== 'income' && (
-                    <View style={styles.segment}>
-                      <Pressable
-                        style={[
-                          styles.segmentButton,
-                          { borderColor: colors.border },
-                          pickerKind === 'category' && { backgroundColor: colors.primary },
-                        ]}
-                        onPress={() => setPickerKind('category')}
-                        accessibilityRole="button"
-                        accessibilityState={{ selected: pickerKind === 'category' }}
-                        accessibilityLabel={t('category_target')}
-                        testID="plan-target-tab-category"
-                      >
-                        <Text style={[styles.segmentText, { color: pickerKind === 'category' ? colors.text : colors.mutedText }]}>
-                          {t('category_target')}
-                        </Text>
-                      </Pressable>
-                      <Pressable
-                        style={[
-                          styles.segmentButton,
-                          { borderColor: colors.border },
-                          pickerKind === 'account' && { backgroundColor: colors.primary },
-                        ]}
-                        onPress={() => setPickerKind('account')}
-                        accessibilityRole="button"
-                        accessibilityState={{ selected: pickerKind === 'account' }}
-                        accessibilityLabel={t('transfer_target')}
-                        testID="plan-target-tab-account"
-                      >
-                        <Text style={[styles.segmentText, { color: pickerKind === 'account' ? colors.text : colors.mutedText }]}>
-                          {t('transfer_target')}
-                        </Text>
-                      </Pressable>
-                    </View>
-                  )}
-
-                  <FlatList
-                    data={kind !== 'income' && pickerKind === 'account' ? accounts : targetCategories}
-                    keyExtractor={(item) => String(item.id)}
-                    renderItem={renderTargetItem}
-                    keyboardShouldPersistTaps="handled"
-                    ListEmptyComponent={(
-                      <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                        {pickerKind === 'category' ? t('no_categories') : t('no_accounts')}
-                      </Text>
-                    )}
-                  />
-                </Animated.View>
-              )}
-
-              {/* Group subpanel: pick an existing envelope, drop out of one, or
-                  create one without leaving the half-filled form. */}
-              {activeSubPanel === 'group' && (
-                <Animated.View
-                  testID="plan-group-subpanel"
-                  style={[
-                    styles.subPanel,
-                    { backgroundColor: colors.card },
-                    { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
-                  ]}
-                >
-                  <View style={styles.subPanelHeader}>
-                    <Pressable
-                      onPress={closeSubPanel}
-                      style={styles.subPanelBack}
-                      hitSlop={8}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('back')}
-                      testID="plan-group-back"
-                    >
-                      <Icon name="arrow-left" size={24} color={colors.text} />
-                    </Pressable>
-                    <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('group')}</Text>
-                  </View>
-
-                  {onCreateGroup && (
-                    <View style={styles.newGroupRow}>
-                      <View style={styles.newGroupInput}>
-                        <FormInput
-                          value={newGroupName}
-                          onChangeText={setNewGroupName}
-                          placeholder={t('new_group')}
-                          testID="plan-group-new-name"
-                        />
-                      </View>
-                      <Pressable
-                        onPress={handleCreateGroup}
-                        disabled={!newGroupName.trim()}
-                        style={[
-                          styles.newGroupButton,
-                          { backgroundColor: colors.primary },
-                          !newGroupName.trim() && styles.buttonDisabled,
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityLabel={t('create_group')}
-                        accessibilityState={{ disabled: !newGroupName.trim() }}
-                        testID="plan-group-create"
-                      >
-                        <Icon name="plus" size={20} color={colors.text} />
-                      </Pressable>
-                    </View>
-                  )}
-
+            {/* Execution account subpanel */}
+            {activeSubPanel === 'account' && (
+              <Animated.View
+                testID="plan-account-subpanel"
+                style={[
+                  styles.subPanel,
+                  { backgroundColor: colors.card },
+                  { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
+                ]}
+              >
+                <View style={styles.subPanelHeader}>
                   <Pressable
-                    onPress={() => handleSelectGroup(null)}
-                    style={({ pressed }) => [
-                      styles.pickerOption,
-                      { borderColor: colors.border },
-                      pressed && { backgroundColor: colors.selected },
-                      groupId == null && { backgroundColor: colors.selected },
-                    ]}
+                    onPress={closeSubPanel}
+                    style={styles.subPanelBack}
+                    hitSlop={8}
                     accessibilityRole="button"
-                    accessibilityLabel={t('no_group')}
-                    testID="plan-group-option-none"
+                    accessibilityLabel={t('back')}
+                    testID="plan-account-back"
                   >
-                    <Icon name="close-circle-outline" size={22} color={colors.text} />
-                    <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
-                      {t('no_group')}
-                    </Text>
+                    <Icon name="arrow-left" size={24} color={colors.text} />
                   </Pressable>
+                  <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('template_account')}</Text>
+                </View>
 
-                  <FlatList
-                    data={groups}
-                    keyExtractor={(item) => String(item.id)}
-                    keyboardShouldPersistTaps="handled"
-                    renderItem={({ item }) => (
-                      <Pressable
-                        onPress={() => handleSelectGroup(item.id)}
-                        style={({ pressed }) => [
-                          styles.pickerOption,
-                          { borderColor: colors.border },
-                          pressed && { backgroundColor: colors.selected },
-                          groupId === item.id && { backgroundColor: colors.selected },
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityState={{ selected: groupId === item.id }}
-                        accessibilityLabel={item.label}
-                        testID={`plan-group-option-${item.id}`}
-                      >
-                        <Icon name="folder-outline" size={22} color={colors.text} />
-                        <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
-                          {item.label}
-                        </Text>
-                      </Pressable>
-                    )}
-                    ListEmptyComponent={(
-                      <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                        {t('no_groups_yet')}
-                      </Text>
-                    )}
-                  />
-                </Animated.View>
-              )}
-
-              {/* Execution account subpanel */}
-              {activeSubPanel === 'account' && (
-                <Animated.View
-                  testID="plan-account-subpanel"
-                  style={[
-                    styles.subPanel,
-                    { backgroundColor: colors.card },
-                    { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
+                <Pressable
+                  onPress={() => handleSelectExecutionAccount(null)}
+                  style={({ pressed }) => [
+                    styles.pickerOption,
+                    { borderColor: colors.border },
+                    pressed && { backgroundColor: colors.selected },
+                    accountId == null && { backgroundColor: colors.selected },
                   ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('no_template_account')}
+                  testID="plan-account-option-none"
                 >
-                  <View style={styles.subPanelHeader}>
-                    <Pressable
-                      onPress={closeSubPanel}
-                      style={styles.subPanelBack}
-                      hitSlop={8}
-                      accessibilityRole="button"
-                      accessibilityLabel={t('back')}
-                      testID="plan-account-back"
-                    >
-                      <Icon name="arrow-left" size={24} color={colors.text} />
-                    </Pressable>
-                    <Text style={[styles.subPanelTitle, { color: colors.text }]}>{t('template_account')}</Text>
-                  </View>
+                  <Icon name="close-circle-outline" size={22} color={colors.text} />
+                  <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
+                    {t('no_template_account')}
+                  </Text>
+                </Pressable>
 
-                  <Pressable
-                    onPress={() => handleSelectExecutionAccount(null)}
-                    style={({ pressed }) => [
-                      styles.pickerOption,
-                      { borderColor: colors.border },
-                      pressed && { backgroundColor: colors.selected },
-                      accountId == null && { backgroundColor: colors.selected },
-                    ]}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('no_template_account')}
-                    testID="plan-account-option-none"
-                  >
-                    <Icon name="close-circle-outline" size={22} color={colors.text} />
-                    <Text style={[styles.optionText, { color: colors.text }]} numberOfLines={1}>
-                      {t('no_template_account')}
+                <FlatList
+                  data={accounts}
+                  keyExtractor={(item) => String(item.id)}
+                  renderItem={renderExecutionAccountItem}
+                  keyboardShouldPersistTaps="handled"
+                  ListEmptyComponent={(
+                    <Text style={[styles.emptyText, { color: colors.mutedText }]}>
+                      {t('no_accounts')}
                     </Text>
-                  </Pressable>
-
-                  <FlatList
-                    data={accounts}
-                    keyExtractor={(item) => String(item.id)}
-                    renderItem={renderExecutionAccountItem}
-                    keyboardShouldPersistTaps="handled"
-                    ListEmptyComponent={(
-                      <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                        {t('no_accounts')}
-                      </Text>
-                    )}
-                  />
-                </Animated.View>
-              )}
-            </Pressable>
+                  )}
+                />
+              </Animated.View>
+            )}
           </Pressable>
-        </KeyboardAvoidingView>
+        </AnimatedPressable>
       </Modal>
     </>
   );
@@ -1119,9 +1122,6 @@ const styles = StyleSheet.create({
   fieldLabel: {
     fontSize: 12,
     marginBottom: 6,
-  },
-  flex1: {
-    flex: 1,
   },
   mainContent: {
     flexShrink: 1,

--- a/app/components/operations/SplitOperationModal.js
+++ b/app/components/operations/SplitOperationModal.js
@@ -8,7 +8,6 @@ import {
   Pressable,
   StyleSheet,
   FlatList,
-  KeyboardAvoidingView,
   Animated,
   Easing,
   Dimensions,
@@ -19,6 +18,7 @@ import { SPACING, BORDER_RADIUS, HEIGHTS, FONT_SIZE } from '../../styles/designT
 import { DURATION_ENTER } from '../../utils/motion';
 import { motionDuration } from '../../utils/reducedMotion';
 import ModalBlurOverlay from '../ModalBlurOverlay';
+import useKeyboardOffset from '../../hooks/useKeyboardOffset';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -44,6 +44,7 @@ export default function SplitOperationModal({
   colors,
   t,
 }) {
+  const keyboardOffset = useKeyboardOffset(visible);
   const [splitAmount, setSplitAmount] = useState('');
   const [selectedCategoryId, setSelectedCategoryId] = useState('');
   const [showCategoryPicker, setShowCategoryPicker] = useState(false);
@@ -195,10 +196,10 @@ export default function SplitOperationModal({
         onRequestClose={onClose}
       >
         <SafeAreaView style={styles.fullFlex} edges={['top', 'bottom']}>
-          <KeyboardAvoidingView
-            behavior="height"
-            style={styles.fullFlex}
-          >
+          {/* Keyboard avoidance as an explicit inset — a KeyboardAvoidingView
+              here shrinks itself in a loop under edge-to-edge (see
+              useKeyboardOffset). */}
+          <Animated.View style={[styles.fullFlex, { paddingBottom: keyboardOffset }]}>
             <Pressable style={styles.modalOverlay} onPress={onClose}>
               <Pressable
                 style={[styles.modalContent, { backgroundColor: colors.card }]}
@@ -317,7 +318,7 @@ export default function SplitOperationModal({
                 </Animated.View>
               </Animated.View>
             )}
-          </KeyboardAvoidingView>
+          </Animated.View>
         </SafeAreaView>
       </Modal>
     </>

--- a/app/hooks/useKeyboardOffset.js
+++ b/app/hooks/useKeyboardOffset.js
@@ -1,0 +1,79 @@
+// app/hooks/useKeyboardOffset.js
+import { useRef, useEffect } from 'react';
+import { Animated, Keyboard } from 'react-native';
+
+/**
+ * Keyboard avoidance for content inside a `Modal`, as an animated bottom inset.
+ *
+ * `KeyboardAvoidingView` must not be used for this. With edge-to-edge enabled
+ * (SDK 54) the Modal's own window no longer resizes for the IME, so the
+ * `behavior="height"` variant keeps shrinking its container from JS while the
+ * window height it measures never changes: the shrink triggers a fresh
+ * `onLayout`, which triggers another shrink, and the modal visibly judders and
+ * can wedge the layout pass entirely — with nothing in the logs, since nothing
+ * throws. It only ever shows up once a keyboard is open, which is why it reads
+ * as "editing a text field breaks saving".
+ *
+ * Lifting the content ourselves is what {@link ModalShell} already does (see the
+ * note there); this hook is that logic, so the modals still on their own
+ * `Modal` + overlay markup can share it rather than each growing a copy.
+ *
+ * Apply the returned value as `paddingBottom` on the overlay that centres (or
+ * bottom-aligns) the card:
+ *
+ *   const keyboardOffset = useKeyboardOffset(visible);
+ *   <AnimatedPressable style={[styles.modalOverlay, { paddingBottom: keyboardOffset }]} />
+ *
+ * The card's own `maxHeight: '85%'` then resolves against the shortened overlay,
+ * so a tall form shrinks and scrolls instead of hiding behind the keyboard.
+ *
+ * @param {boolean} visible - Whether the owning modal is on screen. A closed
+ *   modal stays subscribed to nothing: these components stay mounted for the
+ *   session, and every one of them animating on every app-wide keyboard event
+ *   would be pure waste.
+ * @returns {Animated.Value} Current keyboard height, animated.
+ */
+export default function useKeyboardOffset(visible) {
+  const offset = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (!visible) {
+      // Back to zero for the next open, so a modal reopened after being closed
+      // mid-typing doesn't start with a stale inset.
+      offset.setValue(0);
+      return undefined;
+    }
+
+    // A keyboard may already be up when the modal appears (focus carried over
+    // from the screen behind it). `keyboardDidShow` has already fired by then
+    // and will not fire again for this subscription, so seed from the current
+    // metrics or the card sits under the keyboard until the user refocuses.
+    const metrics = Keyboard.metrics?.();
+    if (metrics?.height) offset.setValue(metrics.height);
+
+    const onShow = (e) => {
+      Animated.timing(offset, {
+        toValue: e?.endCoordinates?.height ?? 0,
+        duration: e?.duration || 220,
+        // paddingBottom is a layout prop — the native driver cannot animate it.
+        useNativeDriver: false,
+      }).start();
+    };
+    const onHide = (e) => {
+      Animated.timing(offset, {
+        toValue: 0,
+        duration: e?.duration || 180,
+        useNativeDriver: false,
+      }).start();
+    };
+
+    const showSub = Keyboard.addListener('keyboardDidShow', onShow);
+    const hideSub = Keyboard.addListener('keyboardDidHide', onHide);
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, [offset, visible]);
+
+  return offset;
+}


### PR DESCRIPTION
## The bug

Editing any text field of a budget line or group (name, comment, amount) and hitting save made the whole modal shake up and down endlessly. Nothing recovered it but a back swipe, and while it lasted every other action was dead — which is why deleting an allocation also "did nothing". No exception, nothing in the app log.

## Cause

`KeyboardAvoidingView behavior="height"` inside a `Modal`.

With `edgeToEdgeEnabled: true` (SDK 54) the Modal's own window no longer resizes for the IME. The component keeps shrinking its container from JS against a window height that never changes: the shrink triggers a fresh `onLayout`, which triggers another shrink, and the layout pass never settles. It can only trigger once a keyboard is up — hence "editing text breaks saving", and hence the vertical judder rather than a crash.

`ModalShell` already walked away from this in #976 and lifts its card with an explicit animated inset instead; the note it left behind ("the bug the old behavior=height KeyboardAvoidingView left behind") is exactly this failure. The budget editors were the last screens with text input still on the old component.

## Fix

- New `app/hooks/useKeyboardOffset.js` — ModalShell's approach extracted so modals still on their own `Modal` + overlay markup share it rather than each growing a copy. Returns an `Animated.Value` tracking the keyboard height; apply it as `paddingBottom` on the overlay.
- `BudgetPlanLineModal`, `BudgetLineGroupModal` and `SplitOperationModal` (the only three left on the old component) now use it.

The card's `maxHeight: '85%'` resolves against the shortened overlay, so a tall form shrinks and scrolls instead of hiding behind the keyboard. Overlay-tap-to-close, `onRequestClose` and the subpanel markup are unchanged.

## Tests

- `__tests__/hooks/useKeyboardOffset.test.js` — 8 cases: subscribes only while visible, unsubscribes on close/unmount, seeds from an already-open keyboard, tracks show, and always returns to 0 on hide and on close mid-typing (the residual-offset trap the old component left behind).
- Full suite: 169 suites / 4963 tests passing; `eslint --max-warnings 0` clean.

## Verification note

This is a layout loop that only reproduces on a real Android surface — Jest renders the editors, saves and deletes fine both before and after. Worth a quick manual pass on a build: open a budget line, type in a field with the keyboard up, save.
