### PR TITLE
fix(operations): keep the long-pressed row in place in the action menu

### DIFF
--- a/__tests__/components/operations/OperationActionMenu.test.js
+++ b/__tests__/components/operations/OperationActionMenu.test.js
@@ -76,4 +76,19 @@ describe('OperationActionMenu', () => {
     fireEvent.press(getByTestId('operation-action-menu-backdrop'));
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
+
+  describe('Regression Tests', () => {
+    // The app runs edge-to-edge, so measureInWindow reports the pressed row's
+    // position relative to the top of the screen. A Modal window that stops at
+    // the status bar would render the lifted clone one status-bar height too
+    // low, making the row visibly jump on long press.
+    it('spans under both system bars so the lifted clone keeps the row position', async () => {
+      const { getByTestId } = await render(
+        <OperationActionMenu menu={makeMenu()} {...baseProps()} />,
+      );
+      const modal = getByTestId('operation-action-menu-window');
+      expect(modal.props.statusBarTranslucent).toBe(true);
+      expect(modal.props.navigationBarTranslucent).toBe(true);
+    });
+  });
 });

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -102,7 +102,22 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
   return (
     <>
       <ModalBlurOverlay />
-      <Modal visible transparent animationType="none" onRequestClose={onClose}>
+      {/* `statusBarTranslucent`/`navigationBarTranslucent` are load-bearing here, not
+          cosmetic: the app runs edge-to-edge, so `measureInWindow` reports the row's
+          position in a coordinate space whose origin is the top of the screen. Without
+          these props the Modal's native window starts *below* the status bar, and the
+          lifted clone (positioned at `layout.y`) lands one status-bar height lower than
+          the row it is supposed to replace — the row visibly jumps on long press. The
+          same offset would skew `panelTop` and the `insets`-based clamping below. */}
+      <Modal
+        testID="operation-action-menu-window"
+        visible
+        transparent
+        statusBarTranslucent
+        navigationBarTranslucent
+        animationType="none"
+        onRequestClose={onClose}
+      >
         <Pressable
           testID="operation-action-menu-backdrop"
           style={styles.fill}


### PR DESCRIPTION
## Problem

Long-pressing an operation row lifts a clone of that row above the blurred backdrop. The clone was rendered one status-bar height *below* the real row, so the operation visibly jumped down the moment it got selected.

## Cause

The app runs edge-to-edge (`edgeToEdgeEnabled: true`), so `measureInWindow` in `OperationListItem` reports the row's position with the top of the screen as origin. `OperationActionMenu`'s `<Modal>` had no `statusBarTranslucent`, so its native window started *below* the status bar — the clone positioned at `layout.y` landed a status-bar height too low. The same offset skewed `panelTop` and the `insets`-based clamping for the floating icon bar.

`UpdateAvailableModal` already sets both props for exactly this reason (see its comment); the action menu was the odd one out.

## Fix

Add `statusBarTranslucent` / `navigationBarTranslucent` to the action menu's `Modal` so its window spans under both system bars and shares the coordinate space `measureInWindow` reports in.

## Tests

- New regression test asserts the modal window spans under both system bars.
- Full suite green: 170 suites / 4996 tests. Lint clean (`--max-warnings 0`).
