### PR TITLE
fix(categories): show the category tree in every picker, not a flat list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,6 +330,32 @@ const closeSubPanel = useCallback(() => {
 
 **Log/chat-style lists:** Use `FlatList` with `inverted={true}` and `data={entries.slice().reverse()}`. Newest entry is always item[0], shown at the bottom automatically — no `scrollToEnd` calls needed, and no mount cost from rendering all entries at once.
 
+### Category Selection
+
+**Rule: never render a list of categories yourself. Any UI that asks the user to pick a category renders `app/components/CategoryGridSelector.js`.**
+
+Categories are a tree (folders holding entries). Every picker that flattened that tree into a `FlatList` lost the hierarchy and showed parents and children as equals — which is what happened four separate times before these were consolidated. The shared grid owns the drill-down (folder chips walk in, a Back chip walks out, a breadcrumb names where you are), so a host only supplies data and receives an id:
+
+```javascript
+<CategoryGridSelector
+  categories={categories}        // the WHOLE list — the grid slices each level itself
+  categoryType={type}            // 'expense' | 'income'; shadow categories are filtered out
+  selectedCategoryId={id}        // single-select
+  onSelect={handleSelect}        // called with the chosen category id
+  colors={colors}
+  t={t}
+/>
+```
+
+Options, each off by default:
+- `selectedCategoryIds={[...]}` — multi-select. Chips become checkboxes and report every tap; the host keeps the array (see `BudgetPlanLineModal`).
+- `selectableFolders` — a folder may itself be the target. The folder chip still drills in; a "whole category" chip inside it picks the folder, so navigating and selecting never fight over one tap.
+- `query` + `onQueryChange` — external search field. A non-empty query searches the whole tree instead of one level; the grid clears it through `onQueryChange` when a folder result takes over the navigation.
+- `topCategoryIds={[...]}` — QuickAdd-style suggestions layout (frequent leaves four across, plus "All categories").
+- `testIDPrefix` — keep a host's existing chip testIDs.
+
+The grid renders a plain `View`, so a host that can overflow wraps it in a `ScrollView`. Hosts: `BudgetPlanLineModal`, `SplitOperationModal`, `PickerModal`, `OperationModal`, `NotificationBindingCard`, `NotificationProcessingContentPanel`.
+
 ### Testing
 
 The app uses Jest with React Native Testing Library for unit, integration, and regression testing.

--- a/__tests__/components/CategoryGridSelector.test.js
+++ b/__tests__/components/CategoryGridSelector.test.js
@@ -1,6 +1,14 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import CategoryGridSelector from '../../app/components/CategoryGridSelector';
+
+// A bare fireEvent leaves the state flush outside act, which in this suite leaves
+// LATER tests rendering nothing at all. Every press goes through here.
+const press = async (element) => {
+  await act(async () => {
+    fireEvent.press(element);
+  });
+};
 
 const colors = {
   text: '#000', mutedText: '#888', border: '#ddd', selected: '#eee',
@@ -52,7 +60,7 @@ describe('CategoryGridSelector', () => {
     const { getByTestId } = await render(
       <CategoryGridSelector categories={CATEGORIES} categoryType="expense" onSelect={onSelect} colors={colors} t={t} />,
     );
-    fireEvent.press(getByTestId('category-grid-food'));
+    await press(getByTestId('category-grid-food'));
     expect(onSelect).toHaveBeenCalledWith('food');
   });
 
@@ -62,18 +70,123 @@ describe('CategoryGridSelector', () => {
       <CategoryGridSelector categories={CATEGORIES} categoryType="expense" onSelect={onSelect} colors={colors} t={t} />,
     );
     // Tapping a folder does not select; it reveals the nested category + a Back chip.
-    fireEvent.press(getByTestId('category-grid-bills'));
+    await press(getByTestId('category-grid-bills'));
     await waitFor(() => expect(getByTestId('category-grid-rent')).toBeTruthy());
     expect(getByTestId('category-grid-back')).toBeTruthy();
     expect(onSelect).not.toHaveBeenCalled();
     // The root entry is no longer visible while inside the folder.
     expect(queryByTestId('category-grid-food')).toBeNull();
     // Selecting the nested leaf reports its id.
-    fireEvent.press(getByTestId('category-grid-rent'));
+    await press(getByTestId('category-grid-rent'));
     expect(onSelect).toHaveBeenCalledWith('rent');
     // Back returns to the root level.
-    fireEvent.press(getByTestId('category-grid-back'));
+    await press(getByTestId('category-grid-back'));
     await waitFor(() => expect(getByTestId('category-grid-food')).toBeTruthy());
     expect(queryByTestId('category-grid-rent')).toBeNull();
+  });
+
+  it('names the folder it is standing in, and only then', async () => {
+    const { getByTestId, queryByTestId } = await render(
+      <CategoryGridSelector categories={CATEGORIES} categoryType="expense" onSelect={jest.fn()} colors={colors} t={t} />,
+    );
+    expect(queryByTestId('category-grid-breadcrumb')).toBeNull();
+    await press(getByTestId('category-grid-bills'));
+    await waitFor(() => expect(getByTestId('category-grid-breadcrumb')).toBeTruthy());
+    expect(getByTestId('category-grid-breadcrumb')).toHaveTextContent('Bills');
+  });
+
+  it('lets a host keep its own chip testIDs', async () => {
+    const { getByTestId } = await render(
+      <CategoryGridSelector
+        categories={CATEGORIES} categoryType="expense" onSelect={jest.fn()}
+        colors={colors} t={t} testIDPrefix="plan-target-option-cat"
+      />,
+    );
+    expect(getByTestId('plan-target-option-cat-food')).toBeTruthy();
+  });
+
+  describe('Multi-select', () => {
+    it('marks every selected chip and reports each tap for the host to toggle', async () => {
+      const onSelect = jest.fn();
+      const { getByTestId } = await render(
+        <CategoryGridSelector
+          categories={CATEGORIES} categoryType="expense"
+          selectedCategoryIds={['food']} onSelect={onSelect} colors={colors} t={t}
+        />,
+      );
+      const chip = getByTestId('category-grid-food');
+      // Checkbox rather than button — a multi-select chip toggles, it does not replace.
+      expect(chip.props.accessibilityRole).toBe('checkbox');
+      expect(chip.props.accessibilityState.checked).toBe(true);
+      await press(chip);
+      // Tapping a selected chip still reports it; dropping it is the host's call.
+      expect(onSelect).toHaveBeenCalledWith('food');
+    });
+  });
+
+  describe('Selectable folders', () => {
+    it('offers the folder itself as a target from inside it', async () => {
+      const onSelect = jest.fn();
+      const { getByTestId, queryByTestId } = await render(
+        <CategoryGridSelector
+          categories={CATEGORIES} categoryType="expense" selectableFolders
+          selectedCategoryIds={[]} onSelect={onSelect} colors={colors} t={t}
+        />,
+      );
+      // Not at the root: a folder chip there is still the way in, not a target.
+      expect(queryByTestId('category-grid-whole-bills')).toBeNull();
+      await press(getByTestId('category-grid-bills'));
+      await waitFor(() => expect(getByTestId('category-grid-whole-bills')).toBeTruthy());
+      await press(getByTestId('category-grid-whole-bills'));
+      expect(onSelect).toHaveBeenCalledWith('bills');
+    });
+
+    it('keeps the whole-category chip out of a grid that cannot use it', async () => {
+      const { getByTestId, queryByTestId } = await render(
+        <CategoryGridSelector categories={CATEGORIES} categoryType="expense" onSelect={jest.fn()} colors={colors} t={t} />,
+      );
+      await press(getByTestId('category-grid-bills'));
+      await waitFor(() => expect(getByTestId('category-grid-rent')).toBeTruthy());
+      expect(queryByTestId('category-grid-whole-bills')).toBeNull();
+    });
+  });
+
+  describe('Search', () => {
+    it('reaches across the whole tree, not just the open level', async () => {
+      const { getByTestId, queryByTestId } = await render(
+        <CategoryGridSelector
+          categories={CATEGORIES} categoryType="expense" onSelect={jest.fn()}
+          colors={colors} t={t} query="rent" onQueryChange={jest.fn()}
+        />,
+      );
+      // 'Rent' lives inside the Bills folder and still surfaces at the root.
+      expect(getByTestId('category-grid-rent')).toBeTruthy();
+      expect(queryByTestId('category-grid-food')).toBeNull();
+      // A search stands outside the hierarchy, so there is nothing to go back to.
+      expect(queryByTestId('category-grid-back')).toBeNull();
+    });
+
+    it('says nothing was found rather than showing an empty grid', async () => {
+      const { getByTestId } = await render(
+        <CategoryGridSelector
+          categories={CATEGORIES} categoryType="expense" onSelect={jest.fn()}
+          colors={colors} t={t} query="zzz" onQueryChange={jest.fn()}
+        />,
+      );
+      expect(getByTestId('category-grid-empty')).toHaveTextContent('no_results');
+    });
+
+    it('clears the search when a folder result takes over the navigation', async () => {
+      const onQueryChange = jest.fn();
+      const { getByTestId } = await render(
+        <CategoryGridSelector
+          categories={CATEGORIES} categoryType="expense" onSelect={jest.fn()}
+          colors={colors} t={t} query="bills" onQueryChange={onQueryChange}
+        />,
+      );
+      await press(getByTestId('category-grid-bills'));
+      // Otherwise the filter would hide the very children the tap asked to see.
+      expect(onQueryChange).toHaveBeenCalledWith('');
+    });
   });
 });

--- a/__tests__/components/budgets/BudgetPlanLineModal.test.js
+++ b/__tests__/components/budgets/BudgetPlanLineModal.test.js
@@ -168,6 +168,60 @@ describe('BudgetPlanLineModal', () => {
     }));
   });
 
+  // Categories nest, and the picker used to lay every level out as one flat list.
+  // It now renders the app's shared category grid.
+  describe('Target picker hierarchy', () => {
+    const nested = [
+      { id: 'food', name: 'Food', type: 'folder', categoryType: 'expense' },
+      { id: 'groceries', name: 'Groceries', type: 'entry', categoryType: 'expense', parentId: 'food' },
+      { id: 'taxi', name: 'Taxi', type: 'entry', categoryType: 'expense' },
+    ];
+
+    it('keeps a folder\'s children behind it until it is opened', async () => {
+      const props = { ...baseProps(), expenseCategories: nested };
+      const { getByTestId, queryByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await fireEvent.press(getByTestId('plan-target-picker'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-food')).toBeTruthy());
+      expect(queryByTestId('plan-target-option-cat-groceries')).toBeNull();
+
+      await fireEvent.press(getByTestId('plan-target-option-cat-food'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-groceries')).toBeTruthy());
+      expect(queryByTestId('plan-target-option-cat-taxi')).toBeNull();
+    });
+
+    it('saves a nested category reached through its folder', async () => {
+      const props = { ...baseProps(), expenseCategories: nested };
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await fireEvent.press(getByTestId('plan-target-picker'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-food')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-option-cat-food'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-groceries')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-option-cat-groceries'));
+      await fireEvent.press(getByTestId('plan-target-done'));
+      await fireEvent.changeText(getByTestId('plan-line-amount'), '150');
+      await fireEvent.press(getByTestId('plan-line-save'));
+      expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
+        categoryIds: ['groceries'],
+      }));
+    });
+
+    it('saves the folder itself as a target — its subtree rolls up into it', async () => {
+      const props = { ...baseProps(), expenseCategories: nested };
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await fireEvent.press(getByTestId('plan-target-picker'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-food')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-option-cat-food'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-whole-food')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-option-cat-whole-food'));
+      await fireEvent.press(getByTestId('plan-target-done'));
+      await fireEvent.changeText(getByTestId('plan-line-amount'), '150');
+      await fireEvent.press(getByTestId('plan-line-save'));
+      expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
+        categoryIds: ['food'],
+      }));
+    });
+  });
+
   describe('Target picker search', () => {
     const manyCategories = Array.from({ length: 10 }, (_, i) => ({
       id: `c${i}`, name: `Category ${i}`, categoryType: 'expense',

--- a/__tests__/components/operations/PickerModal.test.js
+++ b/__tests__/components/operations/PickerModal.test.js
@@ -199,29 +199,28 @@ describe('PickerModal', () => {
     });
   });
 
+  // Categories render through the shared CategoryGridSelector, so the tree walk
+  // itself is covered in __tests__/components/CategoryGridSelector.test.js; what
+  // matters here is that the modal wires the grid to the quick-add callbacks.
   describe('Category picker', () => {
     const categoryData = [
-      { id: 'cat-1', name: 'Food', icon: 'food', type: 'entry' },
-      { id: 'cat-2', name: 'Transport', icon: 'car', type: 'entry' },
-      { id: 'cat-3', name: 'Shopping', icon: 'cart', type: 'folder' },
+      { id: 'cat-1', name: 'Food', icon: 'food', type: 'entry', categoryType: 'expense' },
+      { id: 'cat-2', name: 'Transport', icon: 'car', type: 'entry', categoryType: 'expense' },
+      { id: 'cat-3', name: 'Shopping', icon: 'cart', type: 'folder', categoryType: 'expense' },
+      { id: 'cat-4', name: 'Clothes', icon: 'tshirt-crew', type: 'entry', categoryType: 'expense', parentId: 'cat-3' },
     ];
-
-    const categoryNavigation = {
-      breadcrumb: [],
-    };
 
     const quickAddValues = {
       amount: '',
       categoryId: null,
     };
 
-    it('renders category list', async () => {
-      const { getByText } = await render(
+    it('renders the root level of the category tree', async () => {
+      const { getByText, queryByText } = await render(
         <PickerModal
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddValues}
         />,
       );
@@ -229,6 +228,8 @@ describe('PickerModal', () => {
       expect(getByText('Food')).toBeTruthy();
       expect(getByText('Transport')).toBeTruthy();
       expect(getByText('Shopping')).toBeTruthy();
+      // Nested categories stay behind their folder.
+      expect(queryByText('Clothes')).toBeNull();
     });
 
     it('renders category icons', async () => {
@@ -237,7 +238,6 @@ describe('PickerModal', () => {
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddValues}
         />,
       );
@@ -252,7 +252,6 @@ describe('PickerModal', () => {
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddValues}
         />,
       );
@@ -261,22 +260,23 @@ describe('PickerModal', () => {
       expect(folderBadges.length).toBe(1); // Only Shopping folder has badge
     });
 
-    it('calls onNavigateIntoFolder when folder is pressed', async () => {
-      const onNavigateIntoFolder = jest.fn();
-      const { getByText } = await render(
+    it('drills into a folder instead of selecting it', async () => {
+      const onSelectCategory = jest.fn();
+      const { getByText, queryByText } = await render(
         <PickerModal
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddValues}
-          onNavigateIntoFolder={onNavigateIntoFolder}
+          onSelectCategory={onSelectCategory}
         />,
       );
 
       await fireEvent.press(getByText('Shopping'));
 
-      expect(onNavigateIntoFolder).toHaveBeenCalledWith(categoryData[2]);
+      await waitFor(() => expect(getByText('Clothes')).toBeTruthy());
+      expect(onSelectCategory).not.toHaveBeenCalled();
+      expect(queryByText('Food')).toBeNull();
     });
 
     it('calls onSelectCategory when entry category is pressed without amount', async () => {
@@ -287,7 +287,6 @@ describe('PickerModal', () => {
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddValues}
           onSelectCategory={onSelectCategory}
           onClose={onClose}
@@ -311,7 +310,6 @@ describe('PickerModal', () => {
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddWithAmount}
           onAutoAddWithCategory={onAutoAddWithCategory}
         />,
@@ -324,13 +322,50 @@ describe('PickerModal', () => {
       });
     });
 
+    it('picks a nested category reached through its folder', async () => {
+      const onSelectCategory = jest.fn();
+      const { getByText } = await render(
+        <PickerModal
+          {...defaultProps}
+          pickerType="category"
+          pickerData={categoryData}
+          quickAddValues={quickAddValues}
+          onSelectCategory={onSelectCategory}
+        />,
+      );
+
+      await fireEvent.press(getByText('Shopping'));
+      await waitFor(() => expect(getByText('Clothes')).toBeTruthy());
+      await fireEvent.press(getByText('Clothes'));
+
+      expect(onSelectCategory).toHaveBeenCalledWith('cat-4');
+    });
+
+    it('shows the income tree when the picker is opened for income', async () => {
+      const mixed = [
+        ...categoryData,
+        { id: 'inc-1', name: 'Salary', icon: 'cash', type: 'entry', categoryType: 'income' },
+      ];
+      const { getByText, queryByText } = await render(
+        <PickerModal
+          {...defaultProps}
+          pickerType="category"
+          pickerData={mixed}
+          categoryType="income"
+          quickAddValues={quickAddValues}
+        />,
+      );
+
+      expect(getByText('Salary')).toBeTruthy();
+      expect(queryByText('Food')).toBeNull();
+    });
+
     it('does not show close button for category picker', async () => {
       const { queryByText } = await render(
         <PickerModal
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddValues}
         />,
       );
@@ -340,7 +375,7 @@ describe('PickerModal', () => {
 
     it('uses translated nameKey if available', async () => {
       const categoryWithNameKey = [
-        { id: 'cat-1', name: 'Food', nameKey: 'food_category', icon: 'food', type: 'entry' },
+        { id: 'cat-1', name: 'Food', nameKey: 'food_category', icon: 'food', type: 'entry', categoryType: 'expense' },
       ];
       const mockTWithKey = (key) => {
         if (key === 'food_category') return 'Translated Food';
@@ -352,7 +387,6 @@ describe('PickerModal', () => {
           {...defaultProps}
           pickerType="category"
           pickerData={categoryWithNameKey}
-          categoryNavigation={categoryNavigation}
           quickAddValues={quickAddValues}
           t={mockTWithKey}
         />,
@@ -360,64 +394,29 @@ describe('PickerModal', () => {
 
       expect(getByText('Translated Food')).toBeTruthy();
     });
-  });
 
-  describe('Breadcrumb navigation', () => {
-    const categoryNavigation = {
-      breadcrumb: [{ id: 'parent-1', name: 'Parent Category' }],
-    };
-
-    const quickAddValues = {
-      amount: '',
-      categoryId: null,
-    };
-
-    it('shows breadcrumb when navigation has items', async () => {
-      const { getByText, getByTestId } = await render(
+    it('names the folder it walked into, and walks back out of it', async () => {
+      const { getByText, getByTestId, queryByTestId } = await render(
         <PickerModal
           {...defaultProps}
           pickerType="category"
-          pickerData={[]}
-          categoryNavigation={categoryNavigation}
+          pickerData={categoryData}
           quickAddValues={quickAddValues}
         />,
       );
 
-      expect(getByText('Parent Category')).toBeTruthy();
-      expect(getByTestId('icon-arrow-left')).toBeTruthy();
-    });
+      // At the root there is nowhere to go back to.
+      expect(queryByTestId('category-grid-breadcrumb')).toBeNull();
 
-    it('does not show breadcrumb when navigation is empty', async () => {
-      const emptyNavigation = { breadcrumb: [] };
-      const { queryByTestId } = await render(
-        <PickerModal
-          {...defaultProps}
-          pickerType="category"
-          pickerData={[]}
-          categoryNavigation={emptyNavigation}
-          quickAddValues={quickAddValues}
-        />,
-      );
+      await fireEvent.press(getByText('Shopping'));
 
-      expect(queryByTestId('icon-arrow-left')).toBeNull();
-    });
+      await waitFor(() => expect(getByTestId('category-grid-breadcrumb')).toBeTruthy());
+      expect(getByTestId('category-grid-breadcrumb')).toHaveTextContent('Shopping');
 
-    it('calls onNavigateBack when back button is pressed', async () => {
-      const onNavigateBack = jest.fn();
-      const { getByTestId } = await render(
-        <PickerModal
-          {...defaultProps}
-          pickerType="category"
-          pickerData={[]}
-          categoryNavigation={categoryNavigation}
-          quickAddValues={quickAddValues}
-          onNavigateBack={onNavigateBack}
-        />,
-      );
+      await fireEvent.press(getByTestId('category-grid-back'));
 
-      await fireEvent.press(getByTestId('icon-arrow-left').parent);
-
-      expect(onNavigateBack).toHaveBeenCalled();
+      await waitFor(() => expect(getByText('Food')).toBeTruthy());
+      expect(queryByTestId('category-grid-breadcrumb')).toBeNull();
     });
   });
 
@@ -436,7 +435,6 @@ describe('PickerModal', () => {
           {...defaultProps}
           pickerType="category"
           pickerData={[]}
-          categoryNavigation={{ breadcrumb: [] }}
           quickAddValues={{ amount: '', categoryId: null }}
         />,
       );
@@ -520,25 +518,23 @@ describe('PickerModal', () => {
   describe('Selected category highlighting', () => {
     it('highlights selected category', async () => {
       const categoryData = [
-        { id: 'cat-1', name: 'Food', icon: 'food', type: 'entry' },
+        { id: 'cat-1', name: 'Food', icon: 'food', type: 'entry', categoryType: 'expense' },
       ];
       const quickAddValues = {
         amount: '',
         categoryId: 'cat-1', // This category is selected
       };
 
-      const { getByText } = await render(
+      const { getByTestId } = await render(
         <PickerModal
           {...defaultProps}
           pickerType="category"
           pickerData={categoryData}
-          categoryNavigation={{ breadcrumb: [] }}
           quickAddValues={quickAddValues}
         />,
       );
 
-      // Category should await render (highlight is applied via style)
-      expect(getByText('Food')).toBeTruthy();
+      expect(getByTestId('category-grid-cat-1').props.accessibilityState.selected).toBe(true);
     });
   });
 });

--- a/__tests__/components/operations/SplitOperationModal.test.js
+++ b/__tests__/components/operations/SplitOperationModal.test.js
@@ -66,6 +66,7 @@ describe('SplitOperationModal', () => {
     { id: 'cat-2', name: 'Transport', icon: 'car', categoryType: 'expense', type: 'entry' },
     { id: 'cat-3', name: 'Salary', icon: 'cash', categoryType: 'income', type: 'entry' },
     { id: 'cat-4', name: 'Shopping', icon: 'cart', categoryType: 'expense', type: 'folder' },
+    { id: 'cat-5', name: 'Clothes', icon: 'tshirt-crew', categoryType: 'expense', type: 'entry', parentId: 'cat-4' },
   ];
 
   const defaultProps = {
@@ -179,8 +180,26 @@ describe('SplitOperationModal', () => {
       expect(getByText('Transport')).toBeTruthy();
       // Should not show income categories
       expect(queryByText('Salary')).toBeNull();
-      // Should not show folders
-      expect(queryByText('Shopping')).toBeNull();
+      // A folder shows at its own level as somewhere to go, not as a target, and
+      // its children stay behind it until it is opened.
+      expect(getByText('Shopping')).toBeTruthy();
+      expect(queryByText('Clothes')).toBeNull();
+    });
+
+    it('drills into a folder to reach a nested category', async () => {
+      const { getByTestId, getByText, queryByText } = await render(
+        <SplitOperationModal {...defaultProps} />,
+      );
+
+      await fireEvent.press(getByTestId('category-picker-button'));
+      await fireEvent.press(getByTestId('category-option-cat-4'));
+
+      await waitFor(() => expect(getByText('Clothes')).toBeTruthy());
+      // The level swapped — the root categories are behind the folder now.
+      expect(queryByText('Food')).toBeNull();
+
+      await fireEvent.press(getByTestId('category-option-back'));
+      await waitFor(() => expect(getByText('Food')).toBeTruthy());
     });
 
     it('filters categories by operation type (income)', async () => {

--- a/__tests__/hooks/useOperationPicker.test.js
+++ b/__tests__/hooks/useOperationPicker.test.js
@@ -16,16 +16,14 @@ jest.mock('react-native', () => {
   });
 });
 
+// Folder navigation is NOT tested here any more: the hook only tracks which
+// picker is open, and walking the category tree belongs to CategoryGridSelector
+// (see __tests__/components/CategoryGridSelector.test.js).
 describe('useOperationPicker', () => {
-  const mockT = (key) => key;
-
   const mockCategories = [
     { id: 'cat-1', name: 'Food', nameKey: 'food', parentId: null, type: 'folder' },
     { id: 'cat-2', name: 'Groceries', parentId: 'cat-1', type: 'entry' },
-    { id: 'cat-3', name: 'Dining', parentId: 'cat-1', type: 'entry' },
-    { id: 'cat-4', name: 'Transport', nameKey: 'transport', parentId: null, type: 'folder' },
-    { id: 'cat-5', name: 'Public', parentId: 'cat-4', type: 'entry' },
-    { id: 'cat-6', name: 'Income', parentId: null, type: 'entry' },
+    { id: 'cat-3', name: 'Income', parentId: null, type: 'entry' },
   ];
 
   const mockAccounts = [
@@ -39,24 +37,19 @@ describe('useOperationPicker', () => {
 
   describe('Initialization', () => {
     it('should initialize with default state', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
+      const { result } = await renderHook(() => useOperationPicker());
 
       expect(result.current.pickerState).toEqual({
         visible: false,
         type: null,
         data: [],
-        allCategories: [],
-      });
-      expect(result.current.categoryNavigation).toEqual({
-        currentFolderId: null,
-        breadcrumb: [],
       });
     });
   });
 
   describe('openPicker', () => {
     it('should open picker for non-category type', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
+      const { result } = await renderHook(() => useOperationPicker());
 
       await act(async () => {
         result.current.openPicker('account', mockAccounts);
@@ -67,59 +60,26 @@ describe('useOperationPicker', () => {
         visible: true,
         type: 'account',
         data: mockAccounts,
-        allCategories: [],
       });
     });
 
-    it('should open picker for categories with root items only', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
+    it('hands the category picker the whole tree, not one level of it', async () => {
+      const { result } = await renderHook(() => useOperationPicker());
 
       await act(async () => {
         result.current.openPicker('category', mockCategories);
       });
 
-      expect(Keyboard.dismiss).toHaveBeenCalled();
       expect(result.current.pickerState.visible).toBe(true);
       expect(result.current.pickerState.type).toBe('category');
-      expect(result.current.pickerState.allCategories).toEqual(mockCategories);
-
-      // Should only show root items (no parentId)
-      expect(result.current.pickerState.data).toHaveLength(3);
-      expect(result.current.pickerState.data).toContainEqual(mockCategories[0]); // Food
-      expect(result.current.pickerState.data).toContainEqual(mockCategories[3]); // Transport
-      expect(result.current.pickerState.data).toContainEqual(mockCategories[5]); // Income
-    });
-
-    it('should reset category navigation on open', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      // First navigate into a folder
-      await act(async () => {
-        result.current.openPicker('category', mockCategories);
-      });
-
-      await act(async () => {
-        result.current.navigateIntoFolder(mockCategories[0]); // Food folder
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBe('cat-1');
-
-      // Open picker again
-      await act(async () => {
-        result.current.openPicker('category', mockCategories);
-      });
-
-      // Navigation should be reset
-      expect(result.current.categoryNavigation).toEqual({
-        currentFolderId: null,
-        breadcrumb: [],
-      });
+      // Nested categories included — the grid decides what to show at each level.
+      expect(result.current.pickerState.data).toEqual(mockCategories);
     });
   });
 
   describe('closePicker', () => {
     it('should close picker and reset state', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
+      const { result } = await renderHook(() => useOperationPicker());
 
       await act(async () => {
         result.current.openPicker('account', mockAccounts);
@@ -135,263 +95,36 @@ describe('useOperationPicker', () => {
         visible: false,
         type: null,
         data: [],
-        allCategories: [],
       });
-      expect(result.current.categoryNavigation).toEqual({
-        currentFolderId: null,
-        breadcrumb: [],
-      });
-    });
-  });
-
-  describe('navigateIntoFolder', () => {
-    it('should navigate into folder and show children', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', mockCategories);
-      });
-
-      await act(async () => {
-        result.current.navigateIntoFolder(mockCategories[0]); // Food folder
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBe('cat-1');
-      expect(result.current.categoryNavigation.breadcrumb).toEqual([
-        { id: 'cat-1', name: 'food' }, // nameKey is translated
-      ]);
-
-      // Should show children of Food folder
-      expect(result.current.pickerState.data).toHaveLength(2);
-      expect(result.current.pickerState.data).toContainEqual(mockCategories[1]); // Groceries
-      expect(result.current.pickerState.data).toContainEqual(mockCategories[2]); // Dining
-    });
-
-    it('should use name if nameKey is not present', async () => {
-      const categoriesWithoutKeys = [
-        { id: 'cat-1', name: 'Food', parentId: null, type: 'folder' },
-        { id: 'cat-2', name: 'Groceries', parentId: 'cat-1', type: 'entry' },
-      ];
-
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', categoriesWithoutKeys);
-      });
-
-      await act(async () => {
-        result.current.navigateIntoFolder(categoriesWithoutKeys[0]);
-      });
-
-      expect(result.current.categoryNavigation.breadcrumb).toEqual([
-        { id: 'cat-1', name: 'Food' },
-      ]);
-    });
-
-    it('should build breadcrumb trail for nested navigation', async () => {
-      const deepCategories = [
-        ...mockCategories,
-        { id: 'cat-7', name: 'Subfolder', parentId: 'cat-1', type: 'folder' },
-        { id: 'cat-8', name: 'Subentry', parentId: 'cat-7', type: 'entry' },
-      ];
-
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', deepCategories);
-      });
-
-      // Navigate into Food
-      await act(async () => {
-        result.current.navigateIntoFolder(deepCategories[0]);
-      });
-
-      // Navigate into Subfolder
-      const subfolder = deepCategories.find(c => c.id === 'cat-7');
-      await act(async () => {
-        result.current.navigateIntoFolder(subfolder);
-      });
-
-      expect(result.current.categoryNavigation.breadcrumb).toHaveLength(2);
-      expect(result.current.categoryNavigation.breadcrumb[0].id).toBe('cat-1');
-      expect(result.current.categoryNavigation.breadcrumb[1].id).toBe('cat-7');
-    });
-  });
-
-  describe('navigateBack', () => {
-    it('should navigate back to parent folder', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', mockCategories);
-      });
-
-      // Navigate into Food folder
-      await act(async () => {
-        result.current.navigateIntoFolder(mockCategories[0]);
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBe('cat-1');
-
-      // Navigate back
-      await act(async () => {
-        result.current.navigateBack();
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBeNull();
-      expect(result.current.categoryNavigation.breadcrumb).toEqual([]);
-
-      // Should show root items again
-      expect(result.current.pickerState.data).toHaveLength(3);
-    });
-
-    it('should navigate back through multiple levels', async () => {
-      const deepCategories = [
-        ...mockCategories,
-        { id: 'cat-7', name: 'Subfolder', parentId: 'cat-1', type: 'folder' },
-        { id: 'cat-8', name: 'Subentry', parentId: 'cat-7', type: 'entry' },
-      ];
-
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', deepCategories);
-      });
-
-      // Navigate into Food
-      await act(async () => {
-        result.current.navigateIntoFolder(deepCategories[0]);
-      });
-
-      // Navigate into Subfolder
-      const subfolder = deepCategories.find(c => c.id === 'cat-7');
-      await act(async () => {
-        result.current.navigateIntoFolder(subfolder);
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBe('cat-7');
-
-      // Navigate back to Food
-      await act(async () => {
-        result.current.navigateBack();
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBe('cat-1');
-      expect(result.current.categoryNavigation.breadcrumb).toHaveLength(1);
-
-      // Navigate back to root
-      await act(async () => {
-        result.current.navigateBack();
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBeNull();
-      expect(result.current.categoryNavigation.breadcrumb).toHaveLength(0);
-    });
-
-    it('should handle navigateBack from root gracefully', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', mockCategories);
-      });
-
-      // Already at root, navigateBack should not crash
-      await act(async () => {
-        result.current.navigateBack();
-      });
-
-      expect(result.current.categoryNavigation.currentFolderId).toBeNull();
-      expect(result.current.categoryNavigation.breadcrumb).toEqual([]);
     });
   });
 
   describe('Edge Cases', () => {
     it('should handle empty category list', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
+      const { result } = await renderHook(() => useOperationPicker());
 
       await act(async () => {
         result.current.openPicker('category', []);
       });
 
       expect(result.current.pickerState.data).toEqual([]);
-      expect(result.current.pickerState.allCategories).toEqual([]);
     });
 
-    it('should handle navigating into folder with no children', async () => {
-      const categoriesWithEmptyFolder = [
-        { id: 'cat-1', name: 'Empty Folder', parentId: null, type: 'folder' },
-      ];
-
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', categoriesWithEmptyFolder);
-      });
-
-      await act(async () => {
-        result.current.navigateIntoFolder(categoriesWithEmptyFolder[0]);
-      });
-
-      expect(result.current.pickerState.data).toEqual([]);
-      expect(result.current.categoryNavigation.currentFolderId).toBe('cat-1');
-    });
-
-    it('should handle category without nameKey', async () => {
-      const categories = [
-        { id: 'cat-1', name: 'Custom Category', parentId: null, type: 'folder' },
-        { id: 'cat-2', name: 'Child', parentId: 'cat-1', type: 'entry' },
-      ];
-
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', categories);
-      });
-
-      await act(async () => {
-        result.current.navigateIntoFolder(categories[0]);
-      });
-
-      expect(result.current.categoryNavigation.breadcrumb[0].name).toBe('Custom Category');
-    });
-  });
-
-  describe('Regression Tests', () => {
-    it('should maintain allCategories throughout navigation', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
-
-      await act(async () => {
-        result.current.openPicker('category', mockCategories);
-      });
-
-      const allCategoriesBefore = result.current.pickerState.allCategories;
-
-      // Navigate into folder
-      await act(async () => {
-        result.current.navigateIntoFolder(mockCategories[0]);
-      });
-
-      const allCategoriesAfter = result.current.pickerState.allCategories;
-
-      // Should maintain reference to all categories
-      expect(allCategoriesAfter).toEqual(allCategoriesBefore);
-    });
-
-    it('should filter by parentId correctly', async () => {
-      const { result } = await renderHook(() => useOperationPicker(mockT));
+    it('replaces the previous picker rather than merging into it', async () => {
+      const { result } = await renderHook(() => useOperationPicker());
 
       await act(async () => {
         result.current.openPicker('category', mockCategories);
       });
 
       await act(async () => {
-        result.current.navigateIntoFolder(mockCategories[0]); // Food
+        result.current.openPicker('account', mockAccounts);
       });
 
-      // Should only show items with parentId === 'cat-1'
-      const data = result.current.pickerState.data;
-      data.forEach(item => {
-        expect(item.parentId).toBe('cat-1');
+      expect(result.current.pickerState).toEqual({
+        visible: true,
+        type: 'account',
+        data: mockAccounts,
       });
     });
   });

--- a/__tests__/modals/OperationModal.test.js
+++ b/__tests__/modals/OperationModal.test.js
@@ -165,13 +165,8 @@ jest.mock('../../app/hooks/useOperationPicker', () => {
       type: null,
       data: [],
     },
-    categoryNavigation: {
-      breadcrumb: [],
-    },
     openPicker: jest.fn(),
     closePicker: jest.fn(),
-    navigateIntoFolder: jest.fn(),
-    navigateBack: jest.fn(),
   }));
 });
 
@@ -701,18 +696,13 @@ describe('OperationModal', () => {
               id: 'cat1',
               name: 'Food',
               type: 'folder',
-              category_type: 'expense',
+              categoryType: 'expense',
               icon: 'food',
             },
           ],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -723,29 +713,31 @@ describe('OperationModal', () => {
       expect(getByText('Food')).toBeTruthy();
     });
 
-    it('shows breadcrumb navigation for category picker', async () => {
+    it('names the folder the category picker walked into', async () => {
       const useOperationPicker = require('../../app/hooks/useOperationPicker');
       useOperationPicker.mockReturnValue({
         pickerState: {
           visible: true,
           type: 'category',
-          data: [],
-        },
-        categoryNavigation: {
-          breadcrumb: [{ id: 'cat1', name: 'Food' }],
+          data: [
+            { id: 'cat1', name: 'Food', type: 'folder', categoryType: 'expense', icon: 'food' },
+            { id: 'cat2', name: 'Groceries', type: 'entry', categoryType: 'expense', icon: 'cart', parentId: 'cat1' },
+          ],
         },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
-      const { getByText } = await render(
+      const { getByText, getByTestId, queryByTestId } = await render(
         <OperationModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
-      // Should show breadcrumb
-      expect(getByText('Food')).toBeTruthy();
+      expect(queryByTestId('category-grid-breadcrumb')).toBeNull();
+
+      await fireEvent.press(getByText('Food'));
+
+      await waitFor(() => expect(getByTestId('category-grid-breadcrumb')).toBeTruthy());
+      expect(getByTestId('category-grid-breadcrumb')).toHaveTextContent('Food');
     });
 
     it('shows close button for non-category pickers', async () => {
@@ -756,13 +748,8 @@ describe('OperationModal', () => {
           type: 'account',
           data: [{ id: 'acc1', name: 'Checking', currency: 'USD', balance: '1000' }],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getAllByText } = await render(
@@ -942,13 +929,8 @@ describe('OperationModal', () => {
             { id: 'acc2', name: 'Savings', currency: 'EUR', balance: '500' },
           ],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -977,13 +959,8 @@ describe('OperationModal', () => {
             { id: 'acc1', name: 'Checking', currency: 'USD', balance: '1000' },
           ],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: mockClosePicker,
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1014,13 +991,8 @@ describe('OperationModal', () => {
             { id: 'acc2', name: 'Savings', currency: 'EUR', balance: '500' },
           ],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: mockClosePicker,
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1043,17 +1015,12 @@ describe('OperationModal', () => {
           visible: true,
           type: 'category',
           data: [
-            { id: 'cat1', name: 'Food', type: 'folder', icon: 'food' },
-            { id: 'cat2', name: 'Groceries', type: 'entry', icon: 'cart' },
+            { id: 'cat1', name: 'Food', type: 'folder', categoryType: 'expense', icon: 'food' },
+            { id: 'cat2', name: 'Groceries', type: 'entry', categoryType: 'expense', icon: 'cart' },
           ],
-        },
-        categoryNavigation: {
-          breadcrumb: [],
         },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1065,32 +1032,30 @@ describe('OperationModal', () => {
     });
 
     it('navigates into folder when folder is pressed', async () => {
-      const mockNavigateIntoFolder = jest.fn();
       const useOperationPicker = require('../../app/hooks/useOperationPicker');
       useOperationPicker.mockReturnValue({
         pickerState: {
           visible: true,
           type: 'category',
           data: [
-            { id: 'cat1', name: 'Food', type: 'folder', icon: 'food' },
+            { id: 'cat1', name: 'Food', type: 'folder', categoryType: 'expense', icon: 'food' },
+            { id: 'cat2', name: 'Groceries', type: 'entry', categoryType: 'expense', icon: 'cart', parentId: 'cat1' },
           ],
-        },
-        categoryNavigation: {
-          breadcrumb: [],
         },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: mockNavigateIntoFolder,
-        navigateBack: jest.fn(),
       });
 
-      const { getByText } = await render(
+      const { getByText, queryByText } = await render(
         <OperationModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
+      // The folder's children stay hidden until it is opened.
+      expect(queryByText('Groceries')).toBeNull();
+
       await fireEvent.press(getByText('Food'));
 
-      expect(mockNavigateIntoFolder).toHaveBeenCalledWith({ id: 'cat1', name: 'Food', type: 'folder', icon: 'food' });
+      await waitFor(() => expect(getByText('Groceries')).toBeTruthy());
     });
 
     it('selects category entry when entry is pressed', async () => {
@@ -1115,16 +1080,11 @@ describe('OperationModal', () => {
           visible: true,
           type: 'category',
           data: [
-            { id: 'cat2', name: 'Groceries', type: 'entry', icon: 'cart' },
+            { id: 'cat2', name: 'Groceries', type: 'entry', categoryType: 'expense', icon: 'cart' },
           ],
-        },
-        categoryNavigation: {
-          breadcrumb: [],
         },
         openPicker: jest.fn(),
         closePicker: mockClosePicker,
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1144,16 +1104,11 @@ describe('OperationModal', () => {
           visible: true,
           type: 'category',
           data: [
-            { id: 'cat1', name: 'Unnamed', nameKey: 'category_food', type: 'entry', icon: 'food' },
+            { id: 'cat1', name: 'Unnamed', nameKey: 'category_food', type: 'entry', categoryType: 'expense', icon: 'food' },
           ],
-        },
-        categoryNavigation: {
-          breadcrumb: [],
         },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1189,16 +1144,11 @@ describe('OperationModal', () => {
           visible: true,
           type: 'category',
           data: [
-            { id: 'cat2', name: 'Groceries', type: 'entry', icon: 'cart' },
+            { id: 'cat2', name: 'Groceries', type: 'entry', categoryType: 'expense', icon: 'cart' },
           ],
-        },
-        categoryNavigation: {
-          breadcrumb: [],
         },
         openPicker: jest.fn(),
         closePicker: mockClosePicker,
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1235,16 +1185,11 @@ describe('OperationModal', () => {
           visible: true,
           type: 'category',
           data: [
-            { id: 'cat2', name: 'Groceries', type: 'entry', icon: 'cart' },
+            { id: 'cat2', name: 'Groceries', type: 'entry', categoryType: 'expense', icon: 'cart' },
           ],
-        },
-        categoryNavigation: {
-          breadcrumb: [],
         },
         openPicker: jest.fn(),
         closePicker: mockClosePicker,
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const mockOperation = {
@@ -1510,13 +1455,8 @@ describe('OperationModal', () => {
             { id: 'item1', name: 'Unknown Item' },
           ],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       // This tests the fallback path in keyExtractor
@@ -1539,13 +1479,8 @@ describe('OperationModal', () => {
           type: 'category',
           data: [],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1563,13 +1498,8 @@ describe('OperationModal', () => {
           type: 'account',
           data: [],
         },
-        categoryNavigation: {
-          breadcrumb: [],
-        },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: jest.fn(),
       });
 
       const { getByText } = await render(
@@ -1581,35 +1511,32 @@ describe('OperationModal', () => {
   });
 
   describe('Breadcrumb Navigation', () => {
-    it('calls navigateBack when back button is pressed', async () => {
-      const mockNavigateBack = jest.fn();
+    it('walks back out of a folder', async () => {
       const useOperationPicker = require('../../app/hooks/useOperationPicker');
       useOperationPicker.mockReturnValue({
         pickerState: {
           visible: true,
           type: 'category',
           data: [
-            { id: 'cat2', name: 'Groceries', type: 'entry', icon: 'cart' },
+            { id: 'cat1', name: 'Food', type: 'folder', categoryType: 'expense', icon: 'food' },
+            { id: 'cat2', name: 'Groceries', type: 'entry', categoryType: 'expense', icon: 'cart', parentId: 'cat1' },
           ],
-        },
-        categoryNavigation: {
-          breadcrumb: [{ id: 'cat1', name: 'Food' }],
         },
         openPicker: jest.fn(),
         closePicker: jest.fn(),
-        navigateIntoFolder: jest.fn(),
-        navigateBack: mockNavigateBack,
       });
 
-      const { getByTestId } = await render(
+      const { getByText, getByTestId, queryByText } = await render(
         <OperationModal visible={true} onClose={mockOnClose} isNew={true} />,
       );
 
-      // Find the back button by its icon
-      const backIcon = getByTestId('icon-arrow-left');
-      await fireEvent.press(backIcon.parent);
+      await fireEvent.press(getByText('Food'));
+      await waitFor(() => expect(getByText('Groceries')).toBeTruthy());
 
-      expect(mockNavigateBack).toHaveBeenCalled();
+      await fireEvent.press(getByTestId('category-grid-back'));
+
+      await waitFor(() => expect(getByText('Food')).toBeTruthy());
+      expect(queryByText('Groceries')).toBeNull();
     });
   });
 

--- a/app/components/CategoryGridSelector.js
+++ b/app/components/CategoryGridSelector.js
@@ -14,14 +14,33 @@ const SUGGEST_COLUMNS = 4;
 const TOP_WITH_ALL = 7;
 const TOP_WITHOUT_ALL = 8;
 
+// Chips carry their selection as a tint of the accent rather than a solid fill:
+// white-on-accent sits at ~2.8:1 in the dark theme, which is what a filled chip
+// used to be. Hex alpha suffix on `colors.primary` (a real hex in both themes —
+// see ThemeColorsContext), with a graceful fallback for any palette that isn't.
+const TINT = '1F';
+const tintOf = (primary, fallback) => (
+  typeof primary === 'string' && /^#[0-9a-f]{6}$/i.test(primary) ? primary + TINT : fallback
+);
+
+const DEFAULT_TEST_ID_PREFIX = 'category-grid';
+
+const displayName = (item, t) => (item.nameKey ? t(item.nameKey) : item.name);
+
 /**
- * Inline hierarchical category grid.
+ * The app's one category picker.
+ *
+ * Categories are a tree (folders holding entries), so every place that asks the
+ * user to pick one renders THIS component — a chip grid that drills through the
+ * hierarchy — rather than flattening the tree into a list of its own. See
+ * CLAUDE.md ("Category selection"); the call sites are the budget line target
+ * picker, the split-operation picker, the operations/quick-add picker and the
+ * bank-notification binding panels.
  *
  * Two layouts, selected by whether `topCategoryIds` is supplied:
  *
- * - **Legacy (no `topCategoryIds`)**: a flat grid of the current folder level's
- *   categories (folders drill in, a Back chip pops out), three chips across.
- *   Used by the Settings → Notification processing review queue.
+ * - **Hierarchy (no `topCategoryIds`)**: the current folder level's categories
+ *   (folders drill in, a Back chip pops out), three chips across.
  *
  * - **Suggestions (`topCategoryIds` given)**: mirrors the QuickAdd category
  *   picker — an "All categories" entry plus the most-frequent leaf shortcuts,
@@ -33,30 +52,60 @@ const TOP_WITHOUT_ALL = 8;
  * @param {Array}    categories        All categories (folders + entries).
  * @param {string}   categoryType      'expense' | 'income' — restricts the grid.
  * @param {string}   selectedCategoryId Currently chosen leaf id (highlighted).
- * @param {Function} onSelect          Called with the tapped leaf category id.
+ * @param {string[]} [selectedCategoryIds] Multi-select: presence switches chips to
+ *   checkboxes that toggle, and the host is expected to keep the array. Takes
+ *   precedence over `selectedCategoryId`.
+ * @param {Function} onSelect          Called with the tapped category id.
  * @param {Object}   colors            Theme colours.
  * @param {Function} t                 Translation function.
  * @param {string[]} [topCategoryIds]  Most-frequent-first category ids; presence
  *   switches the grid into the QuickAdd-style suggestions layout.
+ * @param {boolean}  [selectableFolders] A folder may be picked as a target in its
+ *   own right (a budget on a parent category covers its whole subtree). Tapping
+ *   the folder still drills in — inside it, a leading "whole category" chip picks
+ *   the folder itself, so navigating and selecting never fight over one tap.
+ * @param {string}   [query]           External search text. While it is non-empty
+ *   the grid shows every match in the tree instead of one folder level; entering
+ *   a folder from a result clears it through `onQueryChange`.
+ * @param {Function} [onQueryChange]   Required alongside `query` — the grid clears
+ *   the search when navigation takes over.
+ * @param {string}   [testIDPrefix]    Chip testID prefix, so a host can keep the
+ *   ids its own tests already know.
+ * @param {string}   [emptyText]       Message for an empty grid (defaults to
+ *   `no_categories`; a fruitless search always says `no_results`).
  */
 export default function CategoryGridSelector({
   categories,
   categoryType,
   selectedCategoryId = null,
+  selectedCategoryIds = null,
   onSelect,
   colors,
   t,
   topCategoryIds = null,
+  selectableFolders = false,
+  query = '',
+  onQueryChange = null,
+  testIDPrefix = DEFAULT_TEST_ID_PREFIX,
+  emptyText = null,
 }) {
   const suggestMode = Array.isArray(topCategoryIds);
+  const multiSelect = Array.isArray(selectedCategoryIds);
   const columns = suggestMode ? SUGGEST_COLUMNS : LEGACY_COLUMNS;
+  const searchTerm = String(query || '').trim().toLowerCase();
+  const searching = searchTerm.length > 0;
 
   // Folders drilled into: [{ id, name }]. Empty array = root level.
   const [breadcrumb, setBreadcrumb] = useState([]);
   // In suggestions mode the grid opens on the shortcuts; "All categories" flips
-  // it to the hierarchy browser. In legacy mode the hierarchy is always shown.
+  // it to the hierarchy browser. Otherwise the hierarchy is always shown.
   const [browsing, setBrowsing] = useState(!suggestMode);
-  const currentFolderId = breadcrumb.length ? breadcrumb[breadcrumb.length - 1].id : null;
+  const currentFolder = breadcrumb.length ? breadcrumb[breadcrumb.length - 1] : null;
+  const currentFolderId = currentFolder ? currentFolder.id : null;
+
+  const selectedIds = useMemo(() => new Set(
+    multiSelect ? selectedCategoryIds : (selectedCategoryId ? [selectedCategoryId] : []),
+  ), [multiSelect, selectedCategoryIds, selectedCategoryId]);
 
   // Non-shadow categories (folders + entries) of the requested type.
   const typed = useMemo(
@@ -68,6 +117,15 @@ export default function CategoryGridSelector({
   const levelItems = useMemo(
     () => typed.filter((c) => (currentFolderId == null ? !c.parentId : c.parentId === currentFolderId)),
     [typed, currentFolderId],
+  );
+
+  // A search reaches across the whole tree — the point of typing is to skip the
+  // walk down to a category, so results ignore which folder is open.
+  const searchResults = useMemo(
+    () => (searching
+      ? typed.filter((c) => String(displayName(c, t) || '').toLowerCase().includes(searchTerm))
+      : []),
+    [searching, typed, searchTerm, t],
   );
 
   // Leaf entries of this type, used for the suggestions shortcuts and to decide
@@ -91,9 +149,11 @@ export default function CategoryGridSelector({
   }, [suggestMode, showAllButton, typedLeaves, topCategoryIds]);
 
   const enterFolder = useCallback((folder) => {
-    const name = folder.nameKey ? t(folder.nameKey) : folder.name;
-    setBreadcrumb((prev) => [...prev, { id: folder.id, name }]);
-  }, [t]);
+    // Navigation takes over from the search: results span every level, so the
+    // filter would otherwise hide the very children the tap asked to see.
+    if (onQueryChange) onQueryChange('');
+    setBreadcrumb((prev) => [...prev, { id: folder.id, name: displayName(folder, t) }]);
+  }, [t, onQueryChange]);
 
   // Back: pop a folder level; at root in suggestions mode, return to the shortcuts.
   const goBack = useCallback(() => {
@@ -112,30 +172,34 @@ export default function CategoryGridSelector({
     setBrowsing(true);
   }, []);
 
-  // Select a leaf; in suggestions mode also collapse the browser back to the
-  // shortcuts so the next open starts clean.
-  const selectLeaf = useCallback((id) => {
+  // Select a category. In suggestions mode a pick also collapses the browser back
+  // to the shortcuts so the next open starts clean; a multi-select grid stays put,
+  // since picking several is the whole point.
+  const select = useCallback((id) => {
     onSelect(id);
-    if (suggestMode) {
+    if (suggestMode && !multiSelect) {
       setBrowsing(false);
       setBreadcrumb([]);
     }
-  }, [onSelect, suggestMode]);
+  }, [onSelect, suggestMode, multiSelect]);
 
   const chipBackground = colors.inputBackground || colors.surface;
+  const selectedBackground = tintOf(colors.primary, colors.selected);
 
   // Build the slot list for the current view, then chunk into rows and pad the
   // final row with invisible spacers so chips keep an even width.
   const rows = useMemo(() => {
     const slots = [];
-    if (suggestMode && !browsing) {
+    if (searching) {
+      searchResults.forEach((item) => slots.push({ kind: 'item', item }));
+    } else if (suggestMode && !browsing) {
       if (showAllButton) slots.push({ kind: 'all' });
       topCategories.forEach((item) => slots.push({ kind: 'item', item }));
     } else {
-      // Hierarchy browser (legacy always, or suggestions after "All categories").
-      // Suggestions mode shows a Back chip at every level (root Back returns to
-      // the shortcuts); legacy only inside a folder.
+      // Hierarchy browser. Suggestions mode shows a Back chip at every level (root
+      // Back returns to the shortcuts); otherwise only inside a folder.
       if (breadcrumb.length > 0 || suggestMode) slots.push({ kind: 'back' });
+      if (selectableFolders && currentFolder) slots.push({ kind: 'whole', item: currentFolder });
       levelItems.forEach((item) => slots.push({ kind: 'item', item }));
     }
 
@@ -146,13 +210,22 @@ export default function CategoryGridSelector({
       while (last.length < columns) last.push({ kind: 'spacer', id: `spacer-${last.length}` });
     }
     return chunked;
-  }, [suggestMode, browsing, showAllButton, topCategories, breadcrumb.length, levelItems, columns]);
+  }, [searching, searchResults, suggestMode, browsing, showAllButton, topCategories,
+    breadcrumb.length, selectableFolders, currentFolder, levelItems, columns]);
 
   // In suggestions mode the grid sits over the quick-add panel, so its chips
   // adopt the compact proportions the quick-add category shortcuts use — shorter,
   // smaller text and icons — to occupy the same vertical space.
   const affixIconSize = suggestMode ? 16 : 18; // "All categories" / Back
   const itemIconSize = suggestMode ? 18 : 20;
+
+  const chipStyle = (extra) => ({ pressed }) => [
+    styles.chip,
+    suggestMode && styles.chipCompact,
+    { backgroundColor: chipBackground, borderColor: colors.border },
+    extra,
+    pressed && { backgroundColor: colors.selected },
+  ];
 
   const renderSlot = (slot, key) => {
     if (slot.kind === 'spacer') {
@@ -163,16 +236,11 @@ export default function CategoryGridSelector({
       return (
         <Pressable
           key={key}
-          testID="category-grid-all"
+          testID={`${testIDPrefix}-all`}
           onPress={openBrowse}
           accessibilityRole="button"
           accessibilityLabel={t('all_categories') || 'All categories'}
-          style={({ pressed }) => [
-            styles.chip,
-            suggestMode && styles.chipCompact,
-            { backgroundColor: chipBackground, borderColor: colors.border },
-            pressed && { backgroundColor: colors.selected },
-          ]}
+          style={chipStyle(null)}
         >
           <Icon name="menu" size={affixIconSize} color={colors.text} />
           <Text style={[styles.chipText, suggestMode && styles.chipTextCompact, { color: colors.text }]} numberOfLines={2}>
@@ -186,16 +254,11 @@ export default function CategoryGridSelector({
       return (
         <Pressable
           key={key}
-          testID="category-grid-back"
+          testID={`${testIDPrefix}-back`}
           onPress={goBack}
           accessibilityRole="button"
           accessibilityLabel={t('back') || 'Back'}
-          style={({ pressed }) => [
-            styles.chip,
-            suggestMode && styles.chipCompact,
-            { backgroundColor: chipBackground, borderColor: colors.border },
-            pressed && { backgroundColor: colors.selected },
-          ]}
+          style={chipStyle(null)}
         >
           <Icon name="arrow-left" size={affixIconSize} color={colors.text} />
           <Text style={[styles.chipText, suggestMode && styles.chipTextCompact, { color: colors.text }]} numberOfLines={1}>
@@ -205,36 +268,62 @@ export default function CategoryGridSelector({
       );
     }
 
+    // "Whole category": picks the folder you are standing in, so a parent can be
+    // a target without stealing the tap that walks into it.
+    if (slot.kind === 'whole') {
+      const folderId = slot.item.id;
+      const isSelected = selectedIds.has(folderId);
+      const tone = isSelected ? colors.primary : colors.text;
+      return (
+        <Pressable
+          key={key}
+          testID={`${testIDPrefix}-whole-${folderId}`}
+          onPress={() => select(folderId)}
+          accessibilityRole={multiSelect ? 'checkbox' : 'button'}
+          accessibilityState={multiSelect ? { checked: isSelected } : { selected: isSelected }}
+          accessibilityLabel={`${t('whole_category') || 'Whole category'}: ${slot.item.name}`}
+          style={chipStyle(isSelected && { backgroundColor: selectedBackground, borderColor: colors.primary })}
+        >
+          <Icon name="select-all" size={itemIconSize} color={tone} />
+          <Text style={[styles.chipText, suggestMode && styles.chipTextCompact, { color: tone }]} numberOfLines={2}>
+            {t('whole_category') || 'Whole category'}
+          </Text>
+          {isSelected && (
+            <View style={styles.checkBadge}>
+              <Icon name="check-circle" size={12} color={colors.primary} />
+            </View>
+          )}
+        </Pressable>
+      );
+    }
+
     const { item } = slot;
     const isFolder = item.type === 'folder';
-    const isSelected = !isFolder && selectedCategoryId === item.id;
-    const name = item.nameKey ? t(item.nameKey) : item.name;
-    const textColor = isSelected ? '#ffffff' : colors.text;
+    const isSelected = selectedIds.has(item.id);
+    const name = displayName(item, t);
+    const tone = isSelected ? colors.primary : colors.text;
 
     return (
       <Pressable
         key={key}
-        testID={`category-grid-${item.id}`}
-        onPress={() => (isFolder ? enterFolder(item) : selectLeaf(item.id))}
-        accessibilityRole="button"
-        accessibilityState={{ selected: isSelected }}
-        style={({ pressed }) => [
-          styles.chip,
-          suggestMode && styles.chipCompact,
-          {
-            backgroundColor: isSelected ? colors.primary : chipBackground,
-            borderColor: isSelected ? colors.primary : colors.border,
-          },
-          pressed && !isSelected && { backgroundColor: colors.selected },
-        ]}
+        testID={`${testIDPrefix}-${item.id}`}
+        onPress={() => (isFolder ? enterFolder(item) : select(item.id))}
+        accessibilityRole={multiSelect && !isFolder ? 'checkbox' : 'button'}
+        accessibilityState={multiSelect && !isFolder ? { checked: isSelected } : { selected: isSelected }}
+        style={chipStyle(isSelected && { backgroundColor: selectedBackground, borderColor: colors.primary })}
       >
-        <Icon name={item.icon || (isFolder ? 'folder' : 'tag')} size={itemIconSize} color={textColor} />
-        <Text style={[styles.chipText, suggestMode && styles.chipTextCompact, { color: textColor }]} numberOfLines={2}>
+        <Icon name={item.icon || (isFolder ? 'folder' : 'tag')} size={itemIconSize} color={tone} />
+        <Text style={[styles.chipText, suggestMode && styles.chipTextCompact, { color: tone }]} numberOfLines={2}>
           {name}
         </Text>
         {isFolder && (
           <View style={styles.folderBadge}>
             <Icon name="folder-outline" size={11} color={colors.mutedText} />
+          </View>
+        )}
+        {isSelected && (
+          <View style={styles.checkBadge}>
+            <Icon name="check-circle" size={12} color={colors.primary} />
           </View>
         )}
       </Pressable>
@@ -243,9 +332,22 @@ export default function CategoryGridSelector({
 
   return (
     <View style={styles.grid}>
+      {/* Where you are, once you are anywhere but the root — a Back chip alone
+          says there is a way out, not what you walked into. */}
+      {!searching && breadcrumb.length > 0 && (
+        <Text
+          testID={`${testIDPrefix}-breadcrumb`}
+          style={[styles.breadcrumb, { color: colors.mutedText }]}
+          numberOfLines={1}
+        >
+          {breadcrumb.map((crumb) => crumb.name).join(' › ')}
+        </Text>
+      )}
       {rows.length === 0 ? (
-        <Text testID="category-grid-empty" style={[styles.empty, { color: colors.mutedText }]}>
-          {t('no_categories') || 'No categories yet.'}
+        <Text testID={`${testIDPrefix}-empty`} style={[styles.empty, { color: colors.mutedText }]}>
+          {searching
+            ? (t('no_results') || 'Nothing found')
+            : (emptyText || t('no_categories') || 'No categories yet.')}
         </Text>
       ) : (
         rows.map((row, ri) => (
@@ -278,13 +380,29 @@ CategoryGridSelector.propTypes = {
   })).isRequired,
   categoryType: PropTypes.oneOf(['expense', 'income']).isRequired,
   selectedCategoryId: PropTypes.string,
+  selectedCategoryIds: PropTypes.arrayOf(PropTypes.string),
   onSelect: PropTypes.func.isRequired,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
   topCategoryIds: PropTypes.arrayOf(PropTypes.string),
+  selectableFolders: PropTypes.bool,
+  query: PropTypes.string,
+  onQueryChange: PropTypes.func,
+  testIDPrefix: PropTypes.string,
+  emptyText: PropTypes.string,
 };
 
 const styles = StyleSheet.create({
+  breadcrumb: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '600',
+    paddingHorizontal: SPACING.xs,
+  },
+  checkBadge: {
+    position: 'absolute',
+    right: 4,
+    top: 4,
+  },
   chip: {
     alignItems: 'center',
     borderRadius: BORDER_RADIUS.md,
@@ -319,8 +437,8 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   folderBadge: {
+    left: 4,
     position: 'absolute',
-    right: 4,
     top: 4,
   },
   grid: {

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -6,6 +6,7 @@ import {
   Pressable,
   StyleSheet,
   FlatList,
+  ScrollView,
   Keyboard,
   Animated,
   Easing,
@@ -21,6 +22,7 @@ import { motionDuration } from '../../utils/reducedMotion';
 import { useDialog } from '../../contexts/DialogContext';
 import FormInput from '../FormInput';
 import ModalShell from '../ModalShell';
+import CategoryGridSelector from '../CategoryGridSelector';
 import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';
 import * as Currency from '../../services/currency';
 
@@ -515,12 +517,12 @@ export default function BudgetPlanLineModal({
   // Categories toggle rather than replace, and the panel STAYS OPEN — picking a
   // set of them is the point, and closing on the first tap would make adding a
   // second category a four-tap round trip. "Done" (or back) closes it.
-  const handleToggleCategory = useCallback((cat) => {
+  const handleToggleCategory = useCallback((categoryId) => {
     setToAccountId(null);
     setKind(prev => (prev === 'transfer' ? 'expense' : prev));
     setError(null);
     setCategoryIds(prev => (
-      prev.includes(cat.id) ? prev.filter(id => id !== cat.id) : [...prev, cat.id]
+      prev.includes(categoryId) ? prev.filter(id => id !== categoryId) : [...prev, categoryId]
     ));
   }, []);
 
@@ -653,35 +655,27 @@ export default function BudgetPlanLineModal({
   const mainOpacity = mainAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 0] });
   const switchTranslateX = recurringAnim.interpolate({ inputRange: [0, 1], outputRange: [0, SWITCH_TRAVEL] });
 
-  // The picker's list, filtered by whatever is in the panel's search field.
-  const targetOptions = kind !== 'income' && pickerKind === 'account' ? accounts : targetCategories;
-  const visibleTargetOptions = useMemo(
-    () => targetOptions.filter(item => matchesQuery(item.name, query)),
-    [targetOptions, query],
-  );
+  // Which of the two lists the target picker is showing. An income line tracks no
+  // transfer target, so for one of those it is always the categories.
+  const showingCategories = kind === 'income' || pickerKind === 'category';
+  // Whether the panel earns a search field. Categories are counted whole (the grid
+  // searches the entire tree, not the folder level it happens to be showing).
+  const targetOptionCount = showingCategories ? targetCategories.length : accounts.length;
   const visibleAccounts = useMemo(
     () => accounts.filter(item => matchesQuery(item.name, query)),
     [accounts, query],
   );
 
-  const renderTargetItem = useCallback(({ item }) => {
-    const isCat = pickerKind === 'category' || kind === 'income';
-    const selected = isCat ? categoryIds.includes(item.id) : toAccountId === item.id;
-    return (
-      <OptionRow
-        colors={colors}
-        icon={isCat ? (item.icon || 'shape-outline') : 'bank-transfer'}
-        label={item.name}
-        selected={selected}
-        onPress={() => (isCat ? handleToggleCategory(item) : handleSelectTransferTarget(item))}
-        // A category toggles in and out of the set; an account replaces the
-        // target outright, so they get different a11y roles.
-        accessibilityRole={isCat ? 'checkbox' : 'button'}
-        accessibilityState={isCat ? { checked: selected } : { selected }}
-        testID={`plan-target-option-${isCat ? 'cat' : 'acc'}-${item.id}`}
-      />
-    );
-  }, [pickerKind, kind, categoryIds, toAccountId, colors, handleToggleCategory, handleSelectTransferTarget]);
+  const renderTransferTargetItem = useCallback(({ item }) => (
+    <OptionRow
+      colors={colors}
+      icon="bank-transfer"
+      label={item.name}
+      selected={toAccountId === item.id}
+      onPress={() => handleSelectTransferTarget(item)}
+      testID={`plan-target-option-acc-${item.id}`}
+    />
+  ), [toAccountId, colors, handleSelectTransferTarget]);
 
   const renderExecutionAccountItem = useCallback(({ item }) => (
     <OptionRow
@@ -716,7 +710,7 @@ export default function BudgetPlanLineModal({
             {/* Categories toggle in place instead of closing the panel, so there
                 has to be something that says "I'm finished picking". The account
                 tab needs none — one tap there is the whole selection. */}
-            {(pickerKind === 'category' || kind === 'income') && (
+            {showingCategories && (
               <Pressable
                 onPress={closeSubPanel}
                 style={styles.panelDone}
@@ -744,7 +738,7 @@ export default function BudgetPlanLineModal({
             />
           )}
 
-          {targetOptions.length >= SEARCH_THRESHOLD && (
+          {targetOptionCount >= SEARCH_THRESHOLD && (
             <FormInput
               value={query}
               onChangeText={setQuery}
@@ -754,20 +748,44 @@ export default function BudgetPlanLineModal({
             />
           )}
 
-          <FlatList
-            data={visibleTargetOptions}
-            keyExtractor={(item) => String(item.id)}
-            renderItem={renderTargetItem}
-            keyboardShouldPersistTaps="handled"
-            style={styles.panelListBody}
-            contentContainerStyle={styles.panelList}
-            ListEmptyComponent={(
-              <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                {emptyListText
-                  || (pickerKind === 'category' || kind === 'income' ? t('no_categories') : t('no_accounts'))}
-              </Text>
-            )}
-          />
+          {/* Categories are a tree, so they get the app's shared category grid
+              rather than a list that pretends they are all siblings. A folder is
+              a legitimate target here — spending in a parent's whole subtree rolls
+              up into it — which is what `selectableFolders` offers inside it. */}
+          {showingCategories ? (
+            <ScrollView
+              style={styles.panelListBody}
+              contentContainerStyle={styles.panelList}
+              keyboardShouldPersistTaps="handled"
+            >
+              <CategoryGridSelector
+                categories={targetCategories}
+                categoryType={kind === 'income' ? 'income' : 'expense'}
+                selectedCategoryIds={categoryIds}
+                onSelect={handleToggleCategory}
+                colors={colors}
+                t={t}
+                selectableFolders
+                query={query}
+                onQueryChange={setQuery}
+                testIDPrefix="plan-target-option-cat"
+              />
+            </ScrollView>
+          ) : (
+            <FlatList
+              data={visibleAccounts}
+              keyExtractor={(item) => String(item.id)}
+              renderItem={renderTransferTargetItem}
+              keyboardShouldPersistTaps="handled"
+              style={styles.panelListBody}
+              contentContainerStyle={styles.panelList}
+              ListEmptyComponent={(
+                <Text style={[styles.emptyText, { color: colors.mutedText }]}>
+                  {emptyListText || t('no_accounts')}
+                </Text>
+              )}
+            />
+          )}
         </>
       )}
 

--- a/app/components/operations/PickerModal.js
+++ b/app/components/operations/PickerModal.js
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, Modal, Pressable, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, FlatList, ScrollView, Modal, Pressable } from 'react-native';
 import PropTypes from 'prop-types';
-import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import currencies from '../../../assets/currencies.json';
 import ModalBlurOverlay from '../ModalBlurOverlay';
-import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
+import CategoryGridSelector from '../CategoryGridSelector';
+import { SPACING } from '../../styles/designTokens';
 
 /**
  * Get currency symbol from currency code
@@ -17,8 +17,12 @@ const getCurrencySymbol = (currencyCode) => {
 };
 
 /**
- * Unified picker modal for account and category selection
- * Supports hierarchical category navigation with breadcrumbs
+ * Unified picker modal for account and category selection.
+ *
+ * Accounts are a list and render as one. Categories are a tree, so they render
+ * through CategoryGridSelector — the app's shared category grid, which owns the
+ * drill-down (see CLAUDE.md, "Category selection"). `pickerData` is therefore the
+ * whole category list, not one folder level.
  */
 const PickerModal = ({
   visible,
@@ -31,90 +35,55 @@ const PickerModal = ({
   onSelectAccount,
   onSelectToAccount,
   // Category selection
-  categoryNavigation,
+  categoryType = 'expense',
   quickAddValues,
-  onNavigateBack,
-  onNavigateIntoFolder,
   onSelectCategory,
   onAutoAddWithCategory,
   onAutoAddWithAccount,
 }) => {
-  const renderItem = useCallback(({ item }) => {
-    if (pickerType === 'account' || pickerType === 'toAccount') {
-      return (
-        <Pressable
-          onPress={() => {
-            if (pickerType === 'account') {
-              onSelectAccount(item.id);
-              onClose();
-            } else {
-              const hasValidAmount = quickAddValues?.amount &&
-              quickAddValues.amount.trim() !== '';
-              if (hasValidAmount && onAutoAddWithAccount) {
-                onAutoAddWithAccount(item.id);
-              } else {
-                onSelectToAccount(item.id);
-                onClose();
-              }
-            }
-          }}
-          style={({ pressed }) => [
-            styles.pickerOption,
-            { borderColor: colors.border },
-            pressed && { backgroundColor: colors.selected },
-          ]}
-        >
-          <View style={styles.accountOption}>
-            <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
-            <Text style={[styles.pickerSmallText, { color: colors.mutedText }]} numberOfLines={1}>
-              {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
-            </Text>
-          </View>
-        </Pressable>
-      );
-    } else if (pickerType === 'category') {
-      const isFolder = item.type === 'folder';
-      const isSelected = !isFolder && quickAddValues?.categoryId === item.id;
-      const name = item.nameKey ? t(item.nameKey) : item.name;
+  const renderAccountItem = useCallback(({ item }) => (
+    <Pressable
+      onPress={() => {
+        if (pickerType === 'account') {
+          onSelectAccount(item.id);
+          onClose();
+        } else {
+          const hasValidAmount = quickAddValues?.amount &&
+          quickAddValues.amount.trim() !== '';
+          if (hasValidAmount && onAutoAddWithAccount) {
+            onAutoAddWithAccount(item.id);
+          } else {
+            onSelectToAccount(item.id);
+            onClose();
+          }
+        }
+      }}
+      style={({ pressed }) => [
+        styles.pickerOption,
+        { borderColor: colors.border },
+        pressed && { backgroundColor: colors.selected },
+      ]}
+    >
+      <View style={styles.accountOption}>
+        <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
+        <Text style={[styles.pickerSmallText, { color: colors.mutedText }]} numberOfLines={1}>
+          {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
+        </Text>
+      </View>
+    </Pressable>
+  ), [pickerType, quickAddValues, colors, onClose, onSelectAccount, onSelectToAccount, onAutoAddWithAccount]);
 
-      return (
-        <Pressable
-          onPress={() => {
-            if (isFolder) {
-              onNavigateIntoFolder(item);
-            } else {
-              const hasValidAmount = quickAddValues?.amount &&
-              quickAddValues.amount.trim() !== '';
-
-              if (hasValidAmount) {
-                onAutoAddWithCategory(item.id);
-              } else {
-                onSelectCategory(item.id);
-                onClose();
-              }
-            }
-          }}
-          style={({ pressed }) => [
-            styles.gridCell,
-            { backgroundColor: isSelected ? colors.selected : colors.altRow, borderColor: colors.border },
-            pressed && { backgroundColor: colors.selected },
-          ]}
-        >
-          <Icon name={item.icon} size={24} color={colors.text} />
-          <Text style={[styles.gridCellName, { color: colors.text }]} numberOfLines={2}>
-            {name}
-          </Text>
-          {isFolder && (
-            <View style={styles.folderBadge}>
-              <Icon name="folder-outline" size={12} color={colors.mutedText} />
-            </View>
-          )}
-        </Pressable>
-      );
+  // A category tapped with an amount already typed completes the operation on the
+  // spot — that shortcut is the whole point of the quick-add flow.
+  const handleSelectCategory = useCallback((categoryId) => {
+    const hasValidAmount = quickAddValues?.amount && quickAddValues.amount.trim() !== '';
+    if (hasValidAmount && onAutoAddWithCategory) {
+      onAutoAddWithCategory(categoryId);
+    } else {
+      onSelectCategory(categoryId);
+      onClose();
     }
-    return null;
-  }, [pickerType, quickAddValues, colors, t, onClose, onSelectAccount, onSelectToAccount,
-    onAutoAddWithAccount, onNavigateIntoFolder, onAutoAddWithCategory, onSelectCategory, onNavigateBack]);
+  }, [quickAddValues, onAutoAddWithCategory, onSelectCategory, onClose]);
 
   return (
     <>
@@ -127,36 +96,33 @@ const PickerModal = ({
       >
         <Pressable style={styles.modalOverlay} onPress={onClose}>
           <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={() => {}}>
-            {/* Breadcrumb navigation for categories */}
-            {pickerType === 'category' && categoryNavigation.breadcrumb.length > 0 && (
-              <View style={[styles.breadcrumbContainer, { borderBottomColor: colors.border }]}>
-                <Pressable onPress={onNavigateBack} style={styles.backButton}>
-                  <Icon name="arrow-left" size={24} color={colors.primary} />
+            {pickerType === 'category' ? (
+              <ScrollView contentContainerStyle={styles.gridContent} keyboardShouldPersistTaps="handled">
+                <CategoryGridSelector
+                  categories={pickerData}
+                  categoryType={categoryType}
+                  selectedCategoryId={quickAddValues?.categoryId || null}
+                  onSelect={handleSelectCategory}
+                  colors={colors}
+                  t={t}
+                />
+              </ScrollView>
+            ) : (
+              <>
+                <FlatList
+                  data={pickerType === 'account' || pickerType === 'toAccount' ? pickerData : []}
+                  keyExtractor={(item) => item.id || item.key}
+                  renderItem={renderAccountItem}
+                  ListEmptyComponent={
+                    <Text style={[styles.centeredPaddedText, { color: colors.mutedText }]}>
+                      {t('no_accounts')}
+                    </Text>
+                  }
+                />
+                <Pressable style={styles.closeButton} onPress={onClose}>
+                  <Text style={[styles.closeButtonText, { color: colors.primary }]}>{t('close')}</Text>
                 </Pressable>
-                <Text style={[styles.breadcrumbText, { color: colors.text }]} numberOfLines={1}>
-                  {categoryNavigation.breadcrumb[categoryNavigation.breadcrumb.length - 1].name}
-                </Text>
-              </View>
-            )}
-
-            <FlatList
-              data={pickerData}
-              keyExtractor={(item) => item.id || item.key}
-              numColumns={pickerType === 'category' ? 3 : 1}
-              columnWrapperStyle={pickerType === 'category' ? styles.gridRow : undefined}
-              contentContainerStyle={pickerType === 'category' ? styles.gridContent : undefined}
-              renderItem={renderItem}
-              ListEmptyComponent={
-                <Text style={[styles.centeredPaddedText, { color: colors.mutedText }]}>
-                  {pickerType === 'category' ? t('no_categories') : t('no_accounts')}
-                </Text>
-              }
-            />
-            {/* Action buttons - only show Close button for non-category pickers */}
-            {pickerType !== 'category' && (
-              <Pressable style={styles.closeButton} onPress={onClose}>
-                <Text style={[styles.closeButtonText, { color: colors.primary }]}>{t('close')}</Text>
-              </Pressable>
+              </>
             )}
           </Pressable>
         </Pressable>
@@ -176,22 +142,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
   },
-  backButton: {
-    marginRight: 8,
-    padding: 4,
-  },
-  breadcrumbContainer: {
-    alignItems: 'center',
-    borderBottomWidth: 1,
-    flexDirection: 'row',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  breadcrumbText: {
-    flex: 1,
-    fontSize: 16,
-    fontWeight: '600',
-  },
   centeredPaddedText: {
     paddingVertical: 40,
     textAlign: 'center',
@@ -204,31 +154,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-  folderBadge: {
-    position: 'absolute',
-    right: 4,
-    top: 4,
-  },
-  gridCell: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.lg,
-    borderWidth: 1,
-    gap: SPACING.sm,
-    margin: SPACING.xs,
-    padding: SPACING.md,
-    position: 'relative',
-    width: (Dimensions.get('window').width - SPACING.sm * 2 - SPACING.xs * 2 * 3) / 3,
-  },
-  gridCellName: {
-    fontSize: 12,
-    fontWeight: '500',
-    textAlign: 'center',
-  },
   gridContent: {
     padding: SPACING.sm,
-  },
-  gridRow: {
-    justifyContent: 'flex-start',
   },
   modalOverlay: {
     alignItems: 'center',
@@ -265,10 +192,8 @@ PickerModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSelectAccount: PropTypes.func,
   onSelectToAccount: PropTypes.func,
-  categoryNavigation: PropTypes.object,
+  categoryType: PropTypes.oneOf(['expense', 'income']),
   quickAddValues: PropTypes.object,
-  onNavigateBack: PropTypes.func,
-  onNavigateIntoFolder: PropTypes.func,
   onSelectCategory: PropTypes.func,
   onAutoAddWithCategory: PropTypes.func,
   onAutoAddWithAccount: PropTypes.func,

--- a/app/components/operations/SplitOperationModal.js
+++ b/app/components/operations/SplitOperationModal.js
@@ -7,7 +7,7 @@ import {
   Modal,
   Pressable,
   StyleSheet,
-  FlatList,
+  ScrollView,
   Animated,
   Easing,
   Dimensions,
@@ -18,6 +18,7 @@ import { SPACING, BORDER_RADIUS, HEIGHTS, FONT_SIZE } from '../../styles/designT
 import { DURATION_ENTER } from '../../utils/motion';
 import { motionDuration } from '../../utils/reducedMotion';
 import ModalBlurOverlay from '../ModalBlurOverlay';
+import CategoryGridSelector from '../CategoryGridSelector';
 import useKeyboardOffset from '../../hooks/useKeyboardOffset';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -63,15 +64,6 @@ export default function SplitOperationModal({
       pickerAnim.setValue(0);
     }
   }, [visible, pickerAnim]);
-
-  // Filter categories by operation type (expense or income) and exclude folders/shadow
-  const filteredCategories = useMemo(() => {
-    return categories.filter(cat => {
-      if (cat.isShadow) return false;
-      if (cat.type === 'folder') return false;
-      return cat.categoryType === operationType;
-    });
-  }, [categories, operationType]);
 
   // Get selected category name for display
   const selectedCategoryName = useMemo(() => {
@@ -156,29 +148,6 @@ export default function SplitOperationModal({
 
   // Empty handler for preventing event propagation
   const handleStopPropagation = useCallback(() => {}, []);
-
-  // Render category item
-  const renderCategoryItem = useCallback(({ item }) => (
-    <Pressable
-      onPress={() => handleCategorySelect(item.id)}
-      style={({ pressed }) => [
-        styles.categoryOption,
-        { borderColor: colors.border },
-        pressed && { backgroundColor: colors.selected },
-      ]}
-      testID={`category-option-${item.id}`}
-    >
-      <View style={styles.categoryOptionContent}>
-        <Icon name={item.icon} size={24} color={colors.text} />
-        <Text style={[styles.categoryOptionText, { color: colors.text }]}>
-          {item.nameKey ? t(item.nameKey) : item.name}
-        </Text>
-      </View>
-    </Pressable>
-  ), [colors, handleCategorySelect, t]);
-
-  // Key extractor for FlatList
-  const keyExtractor = useCallback((item) => item.id, []);
 
   // Subpanel slides in from the right; the overlay opacity fades it in.
   const pickerTranslateX = pickerAnim.interpolate({
@@ -297,16 +266,20 @@ export default function SplitOperationModal({
                   <Text style={[styles.pickerTitle, { color: colors.text }]}>
                     {t('select_category')}
                   </Text>
-                  <FlatList
-                    data={filteredCategories}
-                    keyExtractor={keyExtractor}
-                    renderItem={renderCategoryItem}
-                    ListEmptyComponent={
-                      <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                        {t('no_categories')}
-                      </Text>
-                    }
-                  />
+                  {/* The app's shared category grid — categories nest, so the
+                      picker drills through folders instead of flattening them
+                      into a list of equals. */}
+                  <ScrollView keyboardShouldPersistTaps="handled">
+                    <CategoryGridSelector
+                      categories={categories}
+                      categoryType={operationType}
+                      selectedCategoryId={selectedCategoryId || null}
+                      onSelect={handleCategorySelect}
+                      colors={colors}
+                      t={t}
+                      testIDPrefix="category-option"
+                    />
+                  </ScrollView>
                   <Pressable
                     style={styles.closeButton}
                     onPress={closeCategoryPicker}
@@ -343,21 +316,6 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.base,
     fontWeight: '500',
   },
-  categoryOption: {
-    borderBottomWidth: 1,
-    justifyContent: 'center',
-    minHeight: HEIGHTS.listItem,
-    paddingHorizontal: SPACING.sm,
-    paddingVertical: SPACING.md,
-  },
-  categoryOptionContent: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: SPACING.md,
-  },
-  categoryOptionText: {
-    fontSize: FONT_SIZE.lg,
-  },
   closeButton: {
     alignItems: 'center',
     alignSelf: 'center',
@@ -371,10 +329,6 @@ const styles = StyleSheet.create({
   closeButtonText: {
     fontSize: FONT_SIZE.base,
     fontWeight: '600',
-  },
-  emptyText: {
-    padding: SPACING.xl,
-    textAlign: 'center',
   },
   errorText: {
     color: '#ff6b6b',

--- a/app/hooks/useOperationPicker.js
+++ b/app/hooks/useOperationPicker.js
@@ -2,93 +2,33 @@ import { useState, useCallback } from 'react';
 import { Keyboard } from 'react-native';
 
 /**
- * Custom hook for managing picker state and category folder navigation
- * Handles hierarchical category selection with breadcrumb navigation
+ * Which picker is open and over what data.
+ *
+ * Walking the category tree is NOT this hook's job: a category picker renders
+ * CategoryGridSelector (see CLAUDE.md, "Category selection"), which owns the
+ * drill-down and hands back the chosen id — so `data` is simply the whole list
+ * the picker was opened with, at every level.
  */
-const useOperationPicker = (t) => {
+const useOperationPicker = () => {
   const [pickerState, setPickerState] = useState({
     visible: false,
     type: null,
     data: [],
-    allCategories: [], // Store all available categories for navigation
   });
 
-  // Category navigation state (for hierarchical folder navigation)
-  const [categoryNavigation, setCategoryNavigation] = useState({
-    currentFolderId: null, // null means showing root folders
-    breadcrumb: [], // Array of {id, name} for navigation history
-  });
-
-  // Open picker with data
   const openPicker = useCallback((type, data) => {
     Keyboard.dismiss();
-    if (type === 'category') {
-      // For categories, show root folders and root entry categories
-      // Root folders have type='folder' and no parentId
-      // Root entries have type='entry' and no parentId (like income categories)
-      const rootItems = data.filter(cat => !cat.parentId);
-      setPickerState({ visible: true, type, data: rootItems, allCategories: data });
-      setCategoryNavigation({ currentFolderId: null, breadcrumb: [] });
-    } else {
-      setPickerState({ visible: true, type, data, allCategories: [] });
-    }
+    setPickerState({ visible: true, type, data });
   }, []);
 
-  // Close picker
   const closePicker = useCallback(() => {
-    setPickerState({ visible: false, type: null, data: [], allCategories: [] });
-    setCategoryNavigation({ currentFolderId: null, breadcrumb: [] });
+    setPickerState({ visible: false, type: null, data: [] });
   }, []);
-
-  // Navigate into a category folder
-  const navigateIntoFolder = useCallback((folder) => {
-    setPickerState(prev => {
-      const folderName = folder.nameKey ? t(folder.nameKey) : folder.name;
-      const children = prev.allCategories.filter(cat => cat.parentId === folder.id);
-
-      setCategoryNavigation(prevNav => ({
-        currentFolderId: folder.id,
-        breadcrumb: [...prevNav.breadcrumb, { id: folder.id, name: folderName }],
-      }));
-
-      return { ...prev, data: children };
-    });
-  }, [t]);
-
-  // Navigate back to previous folder level
-  const navigateBack = useCallback(() => {
-    setPickerState(prev => {
-      const newBreadcrumb = categoryNavigation.breadcrumb.slice(0, -1);
-      const newFolderId = newBreadcrumb.length > 0
-        ? newBreadcrumb[newBreadcrumb.length - 1].id
-        : null;
-
-      // Get the appropriate categories for this level
-      let newData;
-      if (newFolderId === null) {
-        // Back to root - show all root items (folders and entries without parentId)
-        newData = prev.allCategories.filter(cat => !cat.parentId);
-      } else {
-        // Back to parent folder - show its children
-        newData = prev.allCategories.filter(cat => cat.parentId === newFolderId);
-      }
-
-      setCategoryNavigation({
-        currentFolderId: newFolderId,
-        breadcrumb: newBreadcrumb,
-      });
-
-      return { ...prev, data: newData };
-    });
-  }, [categoryNavigation.breadcrumb]);
 
   return {
     pickerState,
-    categoryNavigation,
     openPicker,
     closePicker,
-    navigateIntoFolder,
-    navigateBack,
   };
 };
 

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -7,6 +7,7 @@ import {
   Pressable,
   StyleSheet,
   FlatList,
+  ScrollView,
   Dimensions,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -33,6 +34,7 @@ import currencies from '../../assets/currencies.json';
 import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
 import useOperationForm from '../hooks/useOperationForm';
 import ModalShell from '../components/ModalShell';
+import CategoryGridSelector from '../components/CategoryGridSelector';
 import { modalSharedStyles } from '../styles/modalStyles';
 import useOperationPicker from '../hooks/useOperationPicker';
 
@@ -176,15 +178,12 @@ export default function OperationModal({
     onDelete,
   });
 
-  // Operation picker hook for category navigation
+  // Which picker is open (the category tree is walked by CategoryGridSelector).
   const {
     pickerState,
-    categoryNavigation,
     openPicker,
     closePicker,
-    navigateIntoFolder,
-    navigateBack,
-  } = useOperationPicker(t);
+  } = useOperationPicker();
 
   // State for split modal
   const [showSplitModal, setShowSplitModal] = useState(false);
@@ -364,7 +363,7 @@ export default function OperationModal({
   }, [setValues, closePicker]);
 
   // Handler for category selection in picker
-  const handleCategorySelect = useCallback(async (category) => {
+  const handleCategorySelect = useCallback(async (categoryId) => {
     // Automatically evaluate any pending math operation before saving
     let finalAmount = values.amount;
 
@@ -376,7 +375,7 @@ export default function OperationModal({
     }
 
     // Select entry category and update amount in one setState call
-    setValues(v => ({ ...v, categoryId: category.id, amount: finalAmount }));
+    setValues(v => ({ ...v, categoryId, amount: finalAmount }));
     closePicker();
 
     // Only auto-add for new operations, not when editing.
@@ -398,7 +397,7 @@ export default function OperationModal({
           type: values.type,
           amount: finalAmount, // Use the evaluated amount directly
           accountId: values.accountId,
-          categoryId: category.id,
+          categoryId,
           date: values.date,
           description: values.description || null,
           ...(buildLocationOverrides(attachLocation, location) || {}),
@@ -425,61 +424,27 @@ export default function OperationModal({
     return item.id || item.key;
   }, []);
 
-  // FlatList render item
+  // FlatList render item — accounts only; categories render as the shared grid.
   const renderPickerItem = useCallback(({ item }) => {
-    if (pickerState.type === 'account' || pickerState.type === 'toAccount') {
-      const handlePress = pickerState.type === 'account' ? handleAccountSelect : handleToAccountSelect;
-      return (
-        <Pressable
-          onPress={() => handlePress(item.id)}
-          style={({ pressed }) => [
-            styles.pickerOption,
-            { borderColor: colors.border },
-            pressed && { backgroundColor: colors.selected },
-          ]}
-        >
-          <View style={styles.accountOption}>
-            <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
-            <Text style={[styles.pickerOptionCurrency, { color: colors.mutedText }]} numberOfLines={1}>
-              {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
-            </Text>
-          </View>
-        </Pressable>
-      );
-    } else if (pickerState.type === 'category') {
-      const isFolder = item.type === 'folder';
-      const isSelected = !isFolder && values.categoryId === item.id;
-      const name = item.nameKey ? t(item.nameKey) : item.name;
-
-      return (
-        <Pressable
-          onPress={() => {
-            if (isFolder) {
-              navigateIntoFolder(item);
-            } else {
-              handleCategorySelect(item);
-            }
-          }}
-          style={({ pressed }) => [
-            styles.gridCell,
-            { backgroundColor: isSelected ? colors.selected : colors.altRow, borderColor: colors.border },
-            pressed && { backgroundColor: colors.selected },
-          ]}
-        >
-          <Icon name={item.icon} size={24} color={colors.text} />
-          <Text style={[styles.gridCellName, { color: colors.text }]} numberOfLines={2}>
-            {name}
+    const handlePress = pickerState.type === 'account' ? handleAccountSelect : handleToAccountSelect;
+    return (
+      <Pressable
+        onPress={() => handlePress(item.id)}
+        style={({ pressed }) => [
+          styles.pickerOption,
+          { borderColor: colors.border },
+          pressed && { backgroundColor: colors.selected },
+        ]}
+      >
+        <View style={styles.accountOption}>
+          <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
+          <Text style={[styles.pickerOptionCurrency, { color: colors.mutedText }]} numberOfLines={1}>
+            {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
           </Text>
-          {isFolder && (
-            <View style={styles.folderBadge}>
-              <Icon name="folder-outline" size={12} color={colors.mutedText} />
-            </View>
-          )}
-        </Pressable>
-      );
-    }
-    return null;
-  }, [pickerState.type, colors, values, handleAccountSelect, handleToAccountSelect, handleCategorySelect, navigateIntoFolder, t]);
+        </View>
+      </Pressable>
+    );
+  }, [pickerState.type, colors, handleAccountSelect, handleToAccountSelect]);
 
   const TYPES = [
     { key: 'expense', label: t('expense'), icon: 'minus-circle' },
@@ -711,29 +676,31 @@ export default function OperationModal({
       >
         <Pressable style={styles.pickerOverlay} onPress={closePicker}>
           <Pressable style={[styles.pickerModalContent, { backgroundColor: colors.card }]} onPress={handleStopPropagation}>
-            {pickerState.type === 'category' && categoryNavigation.breadcrumb.length > 0 && (
-              <View style={[styles.breadcrumbContainer, { borderBottomColor: colors.border }]}>
-                <Pressable onPress={navigateBack} style={styles.backButton}>
-                  <Icon name="arrow-left" size={24} color={colors.primary} />
-                </Pressable>
-                <Text style={[styles.breadcrumbText, { color: colors.text }]} numberOfLines={1}>
-                  {categoryNavigation.breadcrumb[categoryNavigation.breadcrumb.length - 1].name}
-                </Text>
-              </View>
+            {pickerState.type === 'category' ? (
+              // Categories nest, so the picker is the app's shared category grid
+              // (CLAUDE.md, "Category selection") rather than a list of its own.
+              <ScrollView contentContainerStyle={styles.gridContent} keyboardShouldPersistTaps="handled">
+                <CategoryGridSelector
+                  categories={pickerState.data}
+                  categoryType={values.type === 'income' ? 'income' : 'expense'}
+                  selectedCategoryId={values.categoryId || null}
+                  onSelect={handleCategorySelect}
+                  colors={colors}
+                  t={t}
+                />
+              </ScrollView>
+            ) : (
+              <FlatList
+                data={pickerState.type === 'account' || pickerState.type === 'toAccount' ? pickerState.data : []}
+                keyExtractor={keyExtractor}
+                renderItem={renderPickerItem}
+                ListEmptyComponent={
+                  <Text style={[styles.pickerEmptyText, { color: colors.mutedText }]}>
+                    {t('no_accounts')}
+                  </Text>
+                }
+              />
             )}
-            <FlatList
-              data={pickerState.data}
-              keyExtractor={keyExtractor}
-              numColumns={pickerState.type === 'category' ? 3 : 1}
-              columnWrapperStyle={pickerState.type === 'category' ? styles.gridRow : undefined}
-              contentContainerStyle={pickerState.type === 'category' ? styles.gridContent : undefined}
-              renderItem={renderPickerItem}
-              ListEmptyComponent={
-                <Text style={[styles.pickerEmptyText, { color: colors.mutedText }]}>
-                  {pickerState.type === 'category' ? t('no_categories') : t('no_accounts')}
-                </Text>
-              }
-            />
             {(pickerState.type !== 'category' || !isNew) && (
               <Pressable style={styles.closeButton} onPress={closePicker}>
                 <Text style={[styles.closeButtonText, { color: colors.primary }]}>{t('close')}</Text>
@@ -755,23 +722,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'space-between',
-  },
-  backButton: {
-    marginRight: SPACING.sm,
-    padding: SPACING.xs,
-  },
-  breadcrumbContainer: {
-    alignItems: 'center',
-    borderBottomWidth: 1,
-    flexDirection: 'row',
-    marginBottom: SPACING.sm,
-    paddingHorizontal: SPACING.sm,
-    paddingVertical: SPACING.md,
-  },
-  breadcrumbText: {
-    flex: 1,
-    fontSize: 18,
-    fontWeight: '600',
   },
   categoryDateRow: {
     flexDirection: 'row',
@@ -816,31 +766,8 @@ const styles = StyleSheet.create({
   excludeAvgTextContainer: {
     flex: 1,
   },
-  folderBadge: {
-    position: 'absolute',
-    right: 4,
-    top: 4,
-  },
-  gridCell: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.lg,
-    borderWidth: 1,
-    gap: SPACING.sm,
-    margin: SPACING.xs,
-    padding: SPACING.md,
-    position: 'relative',
-    width: (Dimensions.get('window').width - SPACING.md * 2 - SPACING.sm * 2 - SPACING.xs * 2 * 3) / 3,
-  },
-  gridCellName: {
-    fontSize: 12,
-    fontWeight: '500',
-    textAlign: 'center',
-  },
   gridContent: {
     padding: SPACING.sm,
-  },
-  gridRow: {
-    justifyContent: 'flex-start',
   },
   halfFieldWrapper: {
     flex: 1,

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -219,12 +219,9 @@ const OperationsScreen = () => {
 
   const {
     pickerState,
-    categoryNavigation,
     openPicker,
     closePicker,
-    navigateIntoFolder,
-    navigateBack,
-  } = useOperationPicker(t);
+  } = useOperationPicker();
 
   // Insert a placeholder row for a just-accepted notification suggestion so the
   // binding card can leave the deck immediately while its write runs in the
@@ -1279,10 +1276,8 @@ const OperationsScreen = () => {
         onClose={closePicker}
         onSelectAccount={handleSelectAccount}
         onSelectToAccount={handleSelectToAccount}
-        categoryNavigation={categoryNavigation}
+        categoryType={quickAddValues.type === 'income' ? 'income' : 'expense'}
         quickAddValues={quickAddValues}
-        onNavigateBack={navigateBack}
-        onNavigateIntoFolder={navigateIntoFolder}
         onSelectCategory={handleSelectCategory}
         onAutoAddWithCategory={handleAutoAddWithCategory}
         onAutoAddWithAccount={handleAutoAddWithAccount}

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -435,6 +435,7 @@
   "daily_avg": "Täglicher Ø",
   "tap_for_details": "Tippen für Details",
   "all_categories": "Alle Kategorien",
+  "whole_category": "Gesamte Kategorie",
   "all_accounts": "Alle Konten",
   "default_account": "Standardkonto",
   "default_account_hint": "Dieses Konto beim Hinzufügen von Operationen vorauswählen",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -442,6 +442,7 @@
   "daily_avg": "Daily Avg",
   "tap_for_details": "Tap for details",
   "all_categories": "All categories",
+  "whole_category": "Whole category",
   "all_accounts": "All accounts",
   "default_account": "Default account",
   "default_account_hint": "Pre-select this account when adding operations",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -435,6 +435,7 @@
   "daily_avg": "Prom. diario",
   "tap_for_details": "Toca para detalles",
   "all_categories": "Todas las categorías",
+  "whole_category": "Categoría completa",
   "all_accounts": "Todas las cuentas",
   "default_account": "Cuenta predeterminada",
   "default_account_hint": "Preseleccionar esta cuenta al añadir operaciones",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -439,6 +439,7 @@
   "daily_avg": "Moy. quotid.",
   "tap_for_details": "Appuyez pour les détails",
   "all_categories": "Toutes les catégories",
+  "whole_category": "Catégorie entière",
   "all_accounts": "Tous les comptes",
   "default_account": "Compte par défaut",
   "default_account_hint": "Présélectionner ce compte lors de l'ajout d'opérations",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -434,6 +434,7 @@
   "daily_avg": "Օրական միջին",
   "tap_for_details": "Սեղմեք մանրամասների համար",
   "all_categories": "Բոլոր կատեգորիաները",
+  "whole_category": "Ամբողջ կատեգորիան",
   "manual_rate_info": "Ձեռակի փոխարժեք",
   "all_accounts": "Բոլոր հաշվեր",
   "default_account": "Default account",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -439,6 +439,7 @@
   "daily_avg": "Media giorn.",
   "tap_for_details": "Tocca per i dettagli",
   "all_categories": "Tutte le categorie",
+  "whole_category": "Intera categoria",
   "all_accounts": "Tutti i conti",
   "default_account": "Conto predefinito",
   "default_account_hint": "Preseleziona questo conto quando aggiungi operazioni",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -439,6 +439,7 @@
   "daily_avg": "日平均",
   "tap_for_details": "タップして詳細を表示",
   "all_categories": "すべてのカテゴリー",
+  "whole_category": "カテゴリー全体",
   "all_accounts": "すべての口座",
   "default_account": "デフォルト口座",
   "default_account_hint": "操作を追加するときにこの口座を事前選択します",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -439,6 +439,7 @@
   "daily_avg": "일 평균",
   "tap_for_details": "상세 보기를 탭하세요",
   "all_categories": "모든 카테고리",
+  "whole_category": "카테고리 전체",
   "all_accounts": "모든 계정",
   "default_account": "기본 계좌",
   "default_account_hint": "작업 추가 시 이 계좌를 미리 선택",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -439,6 +439,7 @@
   "daily_avg": "Média diária",
   "tap_for_details": "Toque para detalhes",
   "all_categories": "Todas as categorias",
+  "whole_category": "Categoria inteira",
   "all_accounts": "Todas as contas",
   "default_account": "Conta padrão",
   "default_account_hint": "Pré-selecionar esta conta ao adicionar operações",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -442,6 +442,7 @@
   "daily_avg": "Дн. средн.",
   "tap_for_details": "Нажмите для деталей",
   "all_categories": "Все категории",
+  "whole_category": "Вся категория",
   "all_accounts": "Все счета",
   "default_account": "Счёт по умолчанию",
   "default_account_hint": "Предварительно выбирать этот счёт при добавлении операций",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -435,6 +435,7 @@
   "daily_avg": "日均",
   "tap_for_details": "点击查看详情",
   "all_categories": "所有类别",
+  "whole_category": "整个类别",
   "all_accounts": "所有账户",
   "default_account": "默认账户",
   "default_account_hint": "添加操作时预先选择此账户",


### PR DESCRIPTION
## What

The budget line target picker ("Выберите цель") laid every expense category out as one flat list — folders and their children shown as equals, with nothing to tell them apart. The split-operation picker did the same and dropped folders outright, so anything nested under one was unreachable.

Both are the same bug twice, because the app had **four** independent category pickers:

| where | what it did |
| --- | --- |
| `CategoryGridSelector` | hierarchical chip grid (notification panels) |
| `PickerModal` + `useOperationPicker` | its own hierarchical grid + breadcrumb state |
| `OperationModal` | a near-verbatim copy of that one, inline |
| `BudgetPlanLineModal` / `SplitOperationModal` | flat `FlatList`, hierarchy lost |

Rather than teaching the budget modal to walk the tree a fifth time, `CategoryGridSelector` is now the app's only category picker and every call site renders through it. Net −244 lines.

## The shared grid

New options, each off by default so existing hosts are unchanged:

- **`selectedCategoryIds`** — multi-select. Chips become checkboxes and report every tap; the host keeps the array (budget lines link a set of categories since migration 0021).
- **`selectableFolders`** — a folder may be a target in its own right. The folder chip still drills in; a **"whole category"** chip inside it picks the folder, so navigating and selecting never fight over one tap. This is what keeps a budget on a parent category possible — its subtree rolls up into it.
- **`query` / `onQueryChange`** — search spans the whole tree instead of the open level; the grid clears the search when a folder result takes over the navigation.
- **breadcrumb** — names the folder you walked into (a Back chip alone says there is a way out, not what you walked into).
- **`testIDPrefix`** — hosts keep their own chip ids.

Selection also moved from a solid accent fill to a tint of it: white-on-accent sits at ~2.8:1 in the dark theme, the same finding `BudgetPlanLineModal` already acted on for its own chips.

## Behaviour changes

- Budget target picker: hierarchical, searchable across the tree, folders reachable as targets via "whole category". Shadow categories are now filtered out (they were being listed).
- Split picker: folders appear and drill in; **categories nested under a folder are now selectable at all** (previously invisible).
- Picking a folder as a budget target is one tap deeper than before (drill in → "whole category") in exchange for the folder chip having one unambiguous meaning.

## Docs

`CLAUDE.md` gains a **Category Selection** section stating the rule — never render a list of categories yourself — so the next picker reaches for the grid instead of growing a fifth flat list.

## Tests

- `npx jest --testPathIgnorePatterns=/node_modules/ --silent` → **170 suites, 4998 tests, all passing**
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` → clean
- New coverage: multi-select chips, whole-category selection, tree-wide search + its empty state, breadcrumb, `testIDPrefix`, drill-down in the budget/split/operation pickers.
- `useOperationPicker`'s folder-navigation tests are gone with the code they covered; the tree walk is now tested once, on the grid.
- `whole_category` added to all 11 locales.
