### PR TITLE
fix(operations): draw the long-press menu in a shared coordinate space

### DIFF
--- a/.maestro/take-screenshots.yaml
+++ b/.maestro/take-screenshots.yaml
@@ -49,6 +49,19 @@ appId: com.heywood8.monkeep
 - waitForAnimationToEnd:
     timeout: 2000
 
+# Screenshot: long-press action menu. The lifted clone must sit exactly on top of the
+# row it copies — this frame is the regression check for that (see OverlayHostContext).
+- longPressOn:
+    id: "operation-item-0"
+- waitForAnimationToEnd:
+    timeout: 2000
+- takeScreenshot: screenshots/10_action_menu_light
+# Dismiss with the hardware back button: the overlay is not a native window, so this
+# also exercises the BackHandler the menu wires up in place of onRequestClose.
+- back
+- waitForAnimationToEnd:
+    timeout: 1000
+
 # Screenshot: Filter modal
 - tapOn:
     id: "filter-fab"

--- a/App.js
+++ b/App.js
@@ -20,6 +20,7 @@ import { DialogProvider } from './app/contexts/DialogContext';
 import { ImportProgressProvider } from './app/contexts/ImportProgressContext';
 import { UpdateDownloadProvider } from './app/contexts/UpdateDownloadContext';
 import { AppBlurProvider, useAppBlur } from './app/contexts/AppBlurContext';
+import { OverlayHostProvider, OverlayOutlet, useOverlayHost } from './app/contexts/OverlayHostContext';
 import { DisplaySettingsProvider } from './app/contexts/DisplaySettingsContext';
 import { SearchProvider } from './app/contexts/SearchContext';
 import ErrorBoundary from './app/components/ErrorBoundary';
@@ -51,15 +52,27 @@ function ThemedStatusBar() {
 function AppContent() {
   const paperTheme = useMaterialTheme();
   const { blurCount } = useAppBlur();
+  const { hostRef } = useOverlayHost();
 
+  // The content view and the overlay outlet are siblings filling the same parent, so
+  // they share an origin: anything measured against `hostRef` can be positioned in the
+  // outlet with no coordinate translation. Overlays sit outside the blurred view on
+  // purpose — the blur is for what's behind them (see OverlayHostContext).
   return (
-    <View style={[styles.container, blurCount > 0 && styles.blurred]}>
-      <PaperProvider theme={paperTheme}>
-        <ThemedStatusBar />
-        <AppInitializer />
-        <ImportProgressModal />
-      </PaperProvider>
-    </View>
+    <PaperProvider theme={paperTheme}>
+      <View style={styles.container}>
+        <View
+          ref={hostRef}
+          collapsable={false}
+          style={[styles.container, blurCount > 0 && styles.blurred]}
+        >
+          <ThemedStatusBar />
+          <AppInitializer />
+          <ImportProgressModal />
+        </View>
+        <OverlayOutlet />
+      </View>
+    </PaperProvider>
   );
 }
 
@@ -73,29 +86,31 @@ function App() {
               <DisplaySettingsProvider>
                 <ThemeColorsProvider>
                   <AppBlurProvider>
-                    <SearchProvider>
-                      <DialogProvider>
-                        <UpdateDownloadProvider>
-                          <ImportProgressProvider>
-                            <AccountsDataProvider>
-                              <AccountsActionsProvider>
-                                <CategoriesProvider>
-                                  <OperationsDataProvider>
-                                    <OperationsActionsProvider>
-                                      <BudgetsProvider>
-                                        <BudgetPlansProvider>
-                                          <AppContent />
-                                        </BudgetPlansProvider>
-                                      </BudgetsProvider>
-                                    </OperationsActionsProvider>
-                                  </OperationsDataProvider>
-                                </CategoriesProvider>
-                              </AccountsActionsProvider>
-                            </AccountsDataProvider>
-                          </ImportProgressProvider>
-                        </UpdateDownloadProvider>
-                      </DialogProvider>
-                    </SearchProvider>
+                    <OverlayHostProvider>
+                      <SearchProvider>
+                        <DialogProvider>
+                          <UpdateDownloadProvider>
+                            <ImportProgressProvider>
+                              <AccountsDataProvider>
+                                <AccountsActionsProvider>
+                                  <CategoriesProvider>
+                                    <OperationsDataProvider>
+                                      <OperationsActionsProvider>
+                                        <BudgetsProvider>
+                                          <BudgetPlansProvider>
+                                            <AppContent />
+                                          </BudgetPlansProvider>
+                                        </BudgetsProvider>
+                                      </OperationsActionsProvider>
+                                    </OperationsDataProvider>
+                                  </CategoriesProvider>
+                                </AccountsActionsProvider>
+                              </AccountsDataProvider>
+                            </ImportProgressProvider>
+                          </UpdateDownloadProvider>
+                        </DialogProvider>
+                      </SearchProvider>
+                    </OverlayHostProvider>
                   </AppBlurProvider>
                 </ThemeColorsProvider>
               </DisplaySettingsProvider>

--- a/__tests__/components/operations/OperationActionMenu.test.js
+++ b/__tests__/components/operations/OperationActionMenu.test.js
@@ -76,4 +76,19 @@ describe('OperationActionMenu', () => {
     fireEvent.press(getByTestId('operation-action-menu-backdrop'));
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
+
+  describe('Regression Tests', () => {
+    // The app runs edge-to-edge, so measureInWindow reports the pressed row's
+    // position relative to the top of the screen. A Modal window that stops at
+    // the status bar would render the lifted clone one status-bar height too
+    // low, making the row visibly jump on long press.
+    it('spans under both system bars so the lifted clone keeps the row position', async () => {
+      const { getByTestId } = await render(
+        <OperationActionMenu menu={makeMenu()} {...baseProps()} />,
+      );
+      const modal = getByTestId('operation-action-menu-window');
+      expect(modal.props.statusBarTranslucent).toBe(true);
+      expect(modal.props.navigationBarTranslucent).toBe(true);
+    });
+  });
 });

--- a/__tests__/components/operations/OperationActionMenu.test.js
+++ b/__tests__/components/operations/OperationActionMenu.test.js
@@ -3,9 +3,13 @@
  * operation row (Edit / Repeat / Delete on a lifted, blurred backdrop).
  */
 import React from 'react';
-import { Text } from 'react-native';
-import { render, fireEvent } from '@testing-library/react-native';
+import { BackHandler, StyleSheet, Text, View } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import OperationActionMenu from '../../../app/components/operations/OperationActionMenu';
+import {
+  OverlayHostProvider,
+  OverlayOutlet,
+} from '../../../app/contexts/OverlayHostContext';
 
 const colors = {
   surface: '#fff',
@@ -33,23 +37,37 @@ const baseProps = () => ({
   onDelete: jest.fn(),
 });
 
+const harnessStyles = StyleSheet.create({ fill: { flex: 1 } });
+
+// Mirrors App.js: the menu renders inside the (blurred) content view, its overlay
+// lands in the outlet next to it. Both fill the same parent — that shared origin is
+// what keeps the lifted clone on top of the row it copies.
+const tree = (props) => (
+  <OverlayHostProvider>
+    <View style={harnessStyles.fill}>
+      <View style={harnessStyles.fill}>
+        <OperationActionMenu {...props} />
+      </View>
+      <OverlayOutlet />
+    </View>
+  </OverlayHostProvider>
+);
+
+const renderMenu = (props) => render(tree(props));
+
 describe('OperationActionMenu', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('renders nothing when menu is null', async () => {
-    const { queryByTestId } = await render(
-      <OperationActionMenu menu={null} {...baseProps()} />,
-    );
+    const { queryByTestId } = await renderMenu({ menu: null, ...baseProps() });
+    await waitFor(() => expect(queryByTestId('overlay-outlet')).toBeNull());
     expect(queryByTestId('operation-action-edit')).toBeNull();
     expect(queryByTestId('operation-action-menu-backdrop')).toBeNull();
   });
 
   it('renders the three action buttons and the lifted row when open', async () => {
-    const props = baseProps();
-    const { getByTestId, getByText } = await render(
-      <OperationActionMenu menu={makeMenu()} {...props} />,
-    );
-    expect(getByTestId('operation-action-edit')).toBeTruthy();
+    const { getByTestId, getByText } = await renderMenu({ menu: makeMenu(), ...baseProps() });
+    await waitFor(() => expect(getByTestId('operation-action-edit')).toBeTruthy());
     expect(getByTestId('operation-action-repeat')).toBeTruthy();
     expect(getByTestId('operation-action-delete')).toBeTruthy();
     expect(getByText('Groceries')).toBeTruthy();
@@ -61,34 +79,79 @@ describe('OperationActionMenu', () => {
     ['operation-action-delete', 'onDelete'],
   ])('fires %s callback when pressed', async (testID, handler) => {
     const props = baseProps();
-    const { getByTestId } = await render(
-      <OperationActionMenu menu={makeMenu()} {...props} />,
-    );
+    const { getByTestId } = await renderMenu({ menu: makeMenu(), ...props });
+    await waitFor(() => expect(getByTestId(testID)).toBeTruthy());
     fireEvent.press(getByTestId(testID));
     expect(props[handler]).toHaveBeenCalledTimes(1);
   });
 
   it('dismisses when the backdrop is pressed', async () => {
     const props = baseProps();
-    const { getByTestId } = await render(
-      <OperationActionMenu menu={makeMenu()} {...props} />,
-    );
+    const { getByTestId } = await renderMenu({ menu: makeMenu(), ...props });
+    await waitFor(() => expect(getByTestId('operation-action-menu-backdrop')).toBeTruthy());
     fireEvent.press(getByTestId('operation-action-menu-backdrop'));
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  describe('Overlay placement', () => {
+    // The reason this component left <Modal> behind: a Modal is a separate native
+    // window, so a row measured in app coordinates and redrawn inside it drifts by
+    // whatever the two origins disagree on. The overlay shares a parent with the
+    // content, so `layout.y` addresses the same pixel on both sides.
+    it('draws the lifted clone at the measured row position', async () => {
+      const { getByTestId, getByText } = await renderMenu({ menu: makeMenu(), ...baseProps() });
+      await waitFor(() => expect(getByTestId('overlay-outlet')).toBeTruthy());
+
+      const clone = getByText('Groceries').parent;
+      expect(StyleSheet.flatten(clone.props.style)).toMatchObject({ top: 200, left: 16, width: 320 });
+    });
+
+    it('mounts the overlay into the outlet, not in place', async () => {
+      const { getByTestId } = await renderMenu({ menu: makeMenu(), ...baseProps() });
+      const outlet = await waitFor(() => getByTestId('overlay-outlet'));
+      // Walking up from the backdrop must reach the outlet: that is what proves the
+      // content and the menu live under one shared ancestor.
+      let node = getByTestId('operation-action-menu-backdrop').parent;
+      let found = false;
+      while (node) {
+        if (node === outlet) { found = true; break; }
+        node = node.parent;
+      }
+      expect(found).toBe(true);
+    });
+
+    it('unmounts the overlay when the menu closes', async () => {
+      const props = baseProps();
+      const { queryByTestId, rerender } = await renderMenu({ menu: makeMenu(), ...props });
+      await waitFor(() => expect(queryByTestId('operation-action-menu-backdrop')).toBeTruthy());
+
+      rerender(tree({ menu: null, ...props }));
+
+      await waitFor(() => expect(queryByTestId('operation-action-menu-backdrop')).toBeNull());
+    });
+  });
+
   describe('Regression Tests', () => {
-    // The app runs edge-to-edge, so measureInWindow reports the pressed row's
-    // position relative to the top of the screen. A Modal window that stops at
-    // the status bar would render the lifted clone one status-bar height too
-    // low, making the row visibly jump on long press.
-    it('spans under both system bars so the lifted clone keeps the row position', async () => {
-      const { getByTestId } = await render(
-        <OperationActionMenu menu={makeMenu()} {...baseProps()} />,
-      );
-      const modal = getByTestId('operation-action-menu-window');
-      expect(modal.props.statusBarTranslucent).toBe(true);
-      expect(modal.props.navigationBarTranslucent).toBe(true);
+    // Without a Modal window there is no onRequestClose, so back has to be wired by
+    // hand — otherwise the hardware back button would leave the screen with the menu
+    // still up.
+    it('closes on hardware back while open', async () => {
+      const props = baseProps();
+      const spy = jest.spyOn(BackHandler, 'addEventListener');
+      await renderMenu({ menu: makeMenu(), ...props });
+
+      await waitFor(() => expect(spy).toHaveBeenCalledWith('hardwareBackPress', expect.any(Function)));
+      const handler = spy.mock.calls.at(-1)[1];
+      expect(handler()).toBe(true);
+      expect(props.onClose).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    it('does not intercept hardware back while closed', async () => {
+      const spy = jest.spyOn(BackHandler, 'addEventListener');
+      await renderMenu({ menu: null, ...baseProps() });
+      await waitFor(() => expect(spy).not.toHaveBeenCalled());
+      spy.mockRestore();
     });
   });
 });

--- a/__tests__/components/operations/OperationListItem.test.js
+++ b/__tests__/components/operations/OperationListItem.test.js
@@ -285,15 +285,28 @@ describe('OperationListItem', () => {
 
   describe('Long press', () => {
     it('forwards the operation on long press without throwing', async () => {
-      // The row measures itself (measureInWindow) before reporting layout to the
-      // caller; that native call is a no-op in the test renderer (it never invokes
-      // its callback), so the (operation, layout) payload can't be observed here.
-      // We assert the wiring holds — long-press runs the handler without throwing.
+      // The row measures itself against the overlay host before reporting layout to
+      // the caller; that native call is a no-op in the test renderer (it never
+      // invokes its callback), so the (operation, layout) payload can't be observed
+      // here. We assert the wiring holds — long-press runs the handler without
+      // throwing.
       const onLongPress = jest.fn();
       const { getByTestId } = await render(
         <OperationListItem {...baseProps} testID="op-row" onLongPress={onLongPress} />,
       );
       expect(() => fireEvent(getByTestId('op-row'), 'longPress')).not.toThrow();
+    });
+
+    it('reports a null layout when there is no overlay host to measure against', async () => {
+      // Rendered outside OverlayHostProvider (as here), there is no shared ancestor
+      // to resolve coordinates in. The menu must still open — just centred rather
+      // than anchored — instead of silently swallowing the long press.
+      const onLongPress = jest.fn();
+      const { getByTestId } = await render(
+        <OperationListItem {...baseProps} testID="op-row" onLongPress={onLongPress} />,
+      );
+      fireEvent(getByTestId('op-row'), 'longPress');
+      expect(onLongPress).toHaveBeenCalledWith(baseProps.operation, null);
     });
 
     it('does not throw when onLongPress is omitted', async () => {

--- a/__tests__/contexts/OverlayHostContext.test.js
+++ b/__tests__/contexts/OverlayHostContext.test.js
@@ -1,0 +1,152 @@
+/* eslint-disable react/prop-types */
+/**
+ * Tests for OverlayHostContext — the app-wide overlay layer that shares a coordinate
+ * space with the content it covers.
+ *
+ * The point of the layer is positional integrity: anything measured against `hostRef`
+ * can be drawn in the outlet with no translation, because both live under one parent.
+ * These tests pin the plumbing that makes that true (single shared ref, overlays
+ * mounted into the outlet rather than in place, clean teardown).
+ */
+import React, { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import {
+  OverlayHostProvider,
+  OverlayOutlet,
+  OverlayPortal,
+  useOverlayHost,
+} from '../../app/contexts/OverlayHostContext';
+
+const HostProbe = ({ onRef }) => {
+  const { hostRef } = useOverlayHost();
+  useEffect(() => { onRef(hostRef); }, [hostRef, onRef]);
+  return null;
+};
+
+const Harness = ({ children }) => (
+  <OverlayHostProvider>
+    <View testID="content">{children}</View>
+    <OverlayOutlet />
+  </OverlayHostProvider>
+);
+
+describe('OverlayHostContext', () => {
+  describe('Portal', () => {
+    it('renders portal children into the outlet, not at the call site', async () => {
+      const { getByTestId, getByText } = await render(
+        <Harness>
+          <OverlayPortal><Text>lifted</Text></OverlayPortal>
+        </Harness>,
+      );
+
+      const outlet = await waitFor(() => getByTestId('overlay-outlet'));
+      const content = getByTestId('content');
+
+      let node = getByText('lifted').parent;
+      const ancestors = [];
+      while (node) { ancestors.push(node); node = node.parent; }
+
+      expect(ancestors).toContain(outlet);
+      expect(ancestors).not.toContain(content);
+    });
+
+    it('updates the mounted overlay when its children change', async () => {
+      const { getByText, queryByText, rerender } = await render(
+        <Harness>
+          <OverlayPortal><Text>first</Text></OverlayPortal>
+        </Harness>,
+      );
+      await waitFor(() => expect(getByText('first')).toBeTruthy());
+
+      rerender(
+        <Harness>
+          <OverlayPortal><Text>second</Text></OverlayPortal>
+        </Harness>,
+      );
+
+      await waitFor(() => expect(getByText('second')).toBeTruthy());
+      expect(queryByText('first')).toBeNull();
+    });
+
+    it('removes the overlay — and the outlet — once the portal unmounts', async () => {
+      const { queryByTestId, queryByText, rerender } = await render(
+        <Harness>
+          <OverlayPortal><Text>lifted</Text></OverlayPortal>
+        </Harness>,
+      );
+      await waitFor(() => expect(queryByText('lifted')).toBeTruthy());
+
+      rerender(<Harness>{null}</Harness>);
+
+      await waitFor(() => expect(queryByText('lifted')).toBeNull());
+      expect(queryByTestId('overlay-outlet')).toBeNull();
+    });
+
+    it('keeps several overlays side by side', async () => {
+      const { getByText } = await render(
+        <Harness>
+          <OverlayPortal><Text>menu</Text></OverlayPortal>
+          <OverlayPortal><Text>snackbar</Text></OverlayPortal>
+        </Harness>,
+      );
+
+      await waitFor(() => expect(getByText('menu')).toBeTruthy());
+      expect(getByText('snackbar')).toBeTruthy();
+    });
+
+    it('renders no outlet while nothing is mounted', async () => {
+      const { queryByTestId } = await render(<Harness>{null}</Harness>);
+      await waitFor(() => expect(queryByTestId('overlay-outlet')).toBeNull());
+    });
+  });
+
+  describe('Host ref', () => {
+    it('hands every consumer the same ref object', async () => {
+      const refs = [];
+      const collect = (ref) => refs.push(ref);
+
+      await render(
+        <Harness>
+          <HostProbe onRef={collect} />
+          <HostProbe onRef={collect} />
+        </Harness>,
+      );
+
+      await waitFor(() => expect(refs).toHaveLength(2));
+      expect(refs[0]).toBe(refs[1]);
+    });
+
+    it('stays the same ref across overlay mounts', async () => {
+      const refs = [];
+      const collect = (ref) => refs.push(ref);
+
+      const { rerender } = await render(
+        <Harness><HostProbe onRef={collect} /></Harness>,
+      );
+      await waitFor(() => expect(refs).toHaveLength(1));
+
+      rerender(
+        <Harness>
+          <HostProbe onRef={collect} />
+          <OverlayPortal><Text>lifted</Text></OverlayPortal>
+        </Harness>,
+      );
+
+      // A ref that changed identity mid-flight would leave a row measuring against
+      // one container while the clone is drawn in another — the exact drift this
+      // layer exists to make impossible.
+      await waitFor(() => expect(refs.length).toBeGreaterThan(0));
+      refs.forEach((ref) => expect(ref).toBe(refs[0]));
+    });
+  });
+
+  describe('Without a provider', () => {
+    it('degrades to a no-op instead of throwing', async () => {
+      const { queryByText } = await render(
+        <OverlayPortal><Text>orphan</Text></OverlayPortal>,
+      );
+      await waitFor(() => expect(queryByText('orphan')).toBeNull());
+    });
+  });
+});

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -102,7 +102,22 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
   return (
     <>
       <ModalBlurOverlay />
-      <Modal visible transparent animationType="none" onRequestClose={onClose}>
+      {/* `statusBarTranslucent`/`navigationBarTranslucent` are load-bearing here, not
+          cosmetic: the app runs edge-to-edge, so `measureInWindow` reports the row's
+          position in a coordinate space whose origin is the top of the screen. Without
+          these props the Modal's native window starts *below* the status bar, and the
+          lifted clone (positioned at `layout.y`) lands one status-bar height lower than
+          the row it is supposed to replace — the row visibly jumps on long press. The
+          same offset would skew `panelTop` and the `insets`-based clamping below. */}
+      <Modal
+        testID="operation-action-menu-window"
+        visible
+        transparent
+        statusBarTranslucent
+        navigationBarTranslucent
+        animationType="none"
+        onRequestClose={onClose}
+      >
         <Pressable
           testID="operation-action-menu-backdrop"
           style={styles.fill}

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -1,9 +1,10 @@
-import React, { useEffect, useRef } from 'react';
-import { Modal, View, Text, Pressable, StyleSheet, Animated, Dimensions } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { BackHandler, View, Text, Pressable, StyleSheet, Animated, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import ModalBlurOverlay from '../ModalBlurOverlay';
+import { OverlayPortal } from '../../contexts/OverlayHostContext';
 import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';
 import { isReduceMotionEnabled } from '../../utils/reducedMotion';
 
@@ -16,9 +17,17 @@ const GAP = 10;
  * Context action menu shown on long-pressing an operation row.
  *
  * Instead of a plain "choose action" dialog, the pressed row is lifted above a
- * blurred backdrop (a static clone rendered at its measured window position) and
- * a compact icon bar floats just above (or below) it. Tapping the backdrop or
- * pressing back dismisses it.
+ * blurred backdrop (a static clone rendered at its measured position) and a compact
+ * icon bar floats just above (or below) it. Tapping the backdrop or pressing back
+ * dismisses it.
+ *
+ * The clone is drawn in the app-wide overlay layer (OverlayPortal), NOT in a core
+ * `<Modal>`. That is the whole trick: a Modal is a separate native window, so a row
+ * measured in the app's coordinates and re-drawn inside that window drifts by
+ * whatever the two origins disagree on — a status bar's worth of offset on
+ * edge-to-edge Android, which is exactly what made the row visibly jump on long
+ * press. The overlay shares a parent with the content it covers, so `layout.y` means
+ * the same thing on both sides and the clone always lands on the row.
  *
  * The parent owns visibility: pass a `menu` object to open, `null` to close.
  * Entrance is animated; closing unmounts immediately (a snappy dismiss is the
@@ -28,6 +37,26 @@ const GAP = 10;
 export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, onRepeat, onDelete }) {
   const insets = useSafeAreaInsets();
   const progress = useRef(new Animated.Value(0)).current;
+  // Height of the overlay layer itself, not of the screen: the layer is the box the
+  // panel is being placed in, so clamping against anything else re-introduces the
+  // guesswork this component just got rid of. Seeded from window height for the
+  // first frame, corrected by the first onLayout.
+  const [layerHeight, setLayerHeight] = useState(() => Dimensions.get('window').height);
+
+  const handleLayerLayout = useCallback((e) => {
+    const { height } = e.nativeEvent.layout;
+    setLayerHeight((prev) => (height > 0 && height !== prev ? height : prev));
+  }, []);
+
+  // The overlay is not a native window, so the hardware back button is ours to handle.
+  useEffect(() => {
+    if (!menu) return undefined;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onClose();
+      return true;
+    });
+    return () => sub.remove();
+  }, [menu, onClose]);
 
   useEffect(() => {
     if (menu) {
@@ -51,7 +80,6 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
   if (!menu) return null;
 
   const { layout, row } = menu;
-  const screenHeight = Dimensions.get('window').height;
 
   // Where the floating icon bar goes. Prefer above the row; fall back to below.
   // Both edges are bounded so the bar never lands under the status bar / notch
@@ -60,7 +88,7 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
   let panelPlacedAbove = true;
   if (layout) {
     const topLimit = insets.top + SPACING.sm;
-    const bottomLimit = screenHeight - insets.bottom - SPACING.sm - PANEL_HEIGHT;
+    const bottomLimit = layerHeight - insets.bottom - SPACING.sm - PANEL_HEIGHT;
     const above = layout.y - GAP - PANEL_HEIGHT;
     const below = layout.y + layout.height + GAP;
     if (above >= topLimit) {
@@ -74,7 +102,7 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
     }
   } else {
     // No measurement (rare): center the bar on screen.
-    panelTop = screenHeight / 2 - PANEL_HEIGHT / 2;
+    panelTop = layerHeight / 2 - PANEL_HEIGHT / 2;
     panelPlacedAbove = false;
   }
 
@@ -102,26 +130,12 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
   return (
     <>
       <ModalBlurOverlay />
-      {/* `statusBarTranslucent`/`navigationBarTranslucent` are load-bearing here, not
-          cosmetic: the app runs edge-to-edge, so `measureInWindow` reports the row's
-          position in a coordinate space whose origin is the top of the screen. Without
-          these props the Modal's native window starts *below* the status bar, and the
-          lifted clone (positioned at `layout.y`) lands one status-bar height lower than
-          the row it is supposed to replace — the row visibly jumps on long press. The
-          same offset would skew `panelTop` and the `insets`-based clamping below. */}
-      <Modal
-        testID="operation-action-menu-window"
-        visible
-        transparent
-        statusBarTranslucent
-        navigationBarTranslucent
-        animationType="none"
-        onRequestClose={onClose}
-      >
+      <OverlayPortal>
         <Pressable
           testID="operation-action-menu-backdrop"
           style={styles.fill}
           onPress={onClose}
+          onLayout={handleLayerLayout}
         >
           <Animated.View style={[styles.backdrop, backdropStyle]} pointerEvents="none" />
 
@@ -153,11 +167,14 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
               panelStyle,
               {
                 top: panelTop,
-                left: layout ? layout.x : SPACING.lg,
-                width: layout ? layout.width : Dimensions.get('window').width - SPACING.lg * 2,
                 backgroundColor: colors.surface,
                 borderColor: colors.border,
               },
+              // Anchored to the row when it was measured; otherwise inset from both
+              // edges of the layer, which needs no width arithmetic at all.
+              layout
+                ? { left: layout.x, width: layout.width }
+                : { left: SPACING.lg, right: SPACING.lg },
             ]}
           >
             <Pressable style={styles.panelRow} onPress={() => {}}>
@@ -188,7 +205,7 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
             </Pressable>
           </Animated.View>
         </Pressable>
-      </Modal>
+      </OverlayPortal>
     </>
   );
 }

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
+import { useOverlayHost } from '../../contexts/OverlayHostContext';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
 
@@ -34,9 +35,13 @@ const OperationListItem = ({
   onApplySuggestion = () => {},
   onDismissSuggestion = () => {},
 }) => {
-  // Measure the row in window coordinates on long-press so the caller can float
-  // an action menu / lifted clone exactly over it (see OperationActionMenu).
+  // Measure the row on long-press so the caller can float an action menu / lifted
+  // clone exactly over it (see OperationActionMenu). Measured against the overlay
+  // host — the shared ancestor of this row and of the layer the clone is drawn in —
+  // rather than the window: same origin on both ends, so the clone cannot land
+  // anywhere but on top of the row it copies.
   const rowRef = useRef(null);
+  const { hostRef } = useOverlayHost();
   // Bind the operation to the edit handler INSIDE the row so the stable `onEdit`
   // prop can flow down unchanged. This keeps OperationListItem's React.memo
   // compare stable — the list no longer hands each row a fresh inline
@@ -46,14 +51,19 @@ const OperationListItem = ({
   }, [onEdit, operation]);
   const handleLongPress = useCallback(() => {
     const node = rowRef.current;
-    if (!node || typeof node.measureInWindow !== 'function') {
+    const host = hostRef?.current;
+    // No host (or no measurement support, as under test): the menu still opens, just
+    // centred instead of anchored.
+    if (!node || !host || typeof node.measureLayout !== 'function') {
       onLongPress(operation, null);
       return;
     }
-    node.measureInWindow((x, y, width, height) => {
-      onLongPress(operation, { x, y, width, height });
-    });
-  }, [onLongPress, operation]);
+    node.measureLayout(
+      host,
+      (x, y, width, height) => onLongPress(operation, { x, y, width, height }),
+      () => onLongPress(operation, null),
+    );
+  }, [onLongPress, operation, hostRef]);
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
   const isTransfer = operation.type === 'transfer';

--- a/app/contexts/OverlayHostContext.js
+++ b/app/contexts/OverlayHostContext.js
@@ -1,0 +1,134 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { StyleSheet, View } from 'react-native';
+import PropTypes from 'prop-types';
+
+/**
+ * A screen-wide overlay layer that shares its coordinate space with the app content.
+ *
+ * Why this exists: an overlay that has to line up with something already on screen
+ * (a lifted clone of a long-pressed row, a spotlight, a coach mark) needs the target's
+ * position. A core `<Modal>` cannot be trusted for that — it owns a *separate native
+ * window* whose origin may or may not match the app's, depending on edge-to-edge, the
+ * system bars and the vendor's Android skin. Positioning window-measured coordinates
+ * inside that window is a guess that happens to be right on some devices.
+ *
+ * So the layer lives in the same tree instead:
+ *
+ *   <View style={container}>              ← the shared origin
+ *     <View ref={hostRef} style={container}>  ← app content (blurred when a modal is up)
+ *       ...screens, lists, rows...
+ *     </View>
+ *     <OverlayOutlet />                   ← absolute fill, same origin, not blurred
+ *   </View>
+ *
+ * Both children fill the same parent, so `(0, 0)` means the same point for each. A row
+ * measured with `measureLayout(hostRef.current)` therefore lands exactly where it was
+ * drawn — no status-bar or inset arithmetic anywhere, and nothing left to drift.
+ *
+ * The outlet is a sibling of the content rather than a child so the root-level blur
+ * (`filter` in App.js) does not bleed into the overlay: the lifted row must stay sharp
+ * while everything behind it goes soft.
+ *
+ * Usage: render `<OverlayPortal>` anywhere below the provider; its children are mounted
+ * into the outlet. Read `hostRef` via `useOverlayHost()` to measure against the layer.
+ */
+
+const DEFAULT_HOST = {
+  hostRef: { current: null },
+  mountOverlay: () => {},
+  unmountOverlay: () => {},
+};
+
+const OverlayHostContext = createContext(DEFAULT_HOST);
+// Slots live in their own context so mounting/updating an overlay re-renders the outlet
+// only — not every consumer that merely wants `hostRef` to measure against.
+const OverlaySlotsContext = createContext(null);
+
+export function OverlayHostProvider({ children }) {
+  const hostRef = useRef(null);
+  const [slots, setSlots] = useState(() => new Map());
+
+  const mountOverlay = useCallback((id, node) => {
+    setSlots((prev) => {
+      const next = new Map(prev);
+      next.set(id, node);
+      return next;
+    });
+  }, []);
+
+  const unmountOverlay = useCallback((id) => {
+    setSlots((prev) => {
+      // Returning `prev` untouched keeps an unmount of something that was never
+      // mounted from scheduling a pointless render of the outlet.
+      if (!prev.has(id)) return prev;
+      const next = new Map(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
+  const host = useMemo(
+    () => ({ hostRef, mountOverlay, unmountOverlay }),
+    [mountOverlay, unmountOverlay],
+  );
+
+  return (
+    <OverlayHostContext.Provider value={host}>
+      <OverlaySlotsContext.Provider value={slots}>
+        {children}
+      </OverlaySlotsContext.Provider>
+    </OverlayHostContext.Provider>
+  );
+}
+
+OverlayHostProvider.propTypes = { children: PropTypes.node };
+
+export const useOverlayHost = () => useContext(OverlayHostContext);
+
+/**
+ * Renders the mounted overlays. Place as a sibling of the view carrying `hostRef`,
+ * inside the same parent — that shared parent is what makes the coordinates line up.
+ */
+export function OverlayOutlet() {
+  const slots = useContext(OverlaySlotsContext);
+
+  if (!slots || slots.size === 0) return null;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none" testID="overlay-outlet">
+      {Array.from(slots.entries(), ([id, node]) => (
+        <React.Fragment key={id}>{node}</React.Fragment>
+      ))}
+    </View>
+  );
+}
+
+/**
+ * Teleports its children into the overlay outlet. Renders nothing in place.
+ */
+export function OverlayPortal({ children }) {
+  const id = useId();
+  const { mountOverlay, unmountOverlay } = useOverlayHost();
+
+  useEffect(() => {
+    mountOverlay(id, children);
+  }, [id, children, mountOverlay]);
+
+  // Unmount only when the portal itself goes away. Tying this to the effect above
+  // would tear the overlay down and rebuild it on every content update, which reads
+  // as a flicker mid-animation.
+  useEffect(() => () => unmountOverlay(id), [id, unmountOverlay]);
+
+  return null;
+}
+
+OverlayPortal.propTypes = { children: PropTypes.node };


### PR DESCRIPTION
## Problem

The lifted clone of a long-pressed operation row still sits off its original position. #1484 (`statusBarTranslucent`) narrowed the gap but did not close it.

## Why the previous fix was the wrong shape

The clone is measured with `measureInWindow` in the app's window and drawn inside a core `<Modal>` — **a separate native window**. Whether those two origins agree depends on edge-to-edge, the system bars and the vendor's Android skin. Every fix in that design is a guess about the size of the disagreement, and the guess is device-dependent.

## Approach

Stop guessing; remove the second coordinate space.

`app/contexts/OverlayHostContext.js` adds an app-wide overlay layer that is a **sibling of the content view**, both filling the same parent in `App.js`:

```
<View>                      ← shared origin
  <View ref={hostRef}>      ← app content (blurred when a modal is up)
  <OverlayOutlet />         ← absolute fill, same origin, not blurred
</View>
```

- rows measure with `measureLayout(hostRef.current)` — against that shared ancestor;
- the menu renders into the layer via `<OverlayPortal>`;
- `(0, 0)` means the same pixel on both ends, so the clone lands on the row by construction. No status-bar or inset arithmetic left in the component.

Falling out of it:

- the action bar clamps against the layer's own measured height (`onLayout`) instead of `Dimensions.get('window')` — a different box than the one it is placed in;
- the overlay stays outside the blurred view, so the lifted row is sharp over a soft background, as before;
- no native window means no `onRequestClose`, so the hardware back button is wired explicitly.

## Verification

- New `__tests__/contexts/OverlayHostContext.test.js` (10 tests): portal mounts into the outlet and not at the call site, teardown, several overlays, ref identity stable.
- `OperationActionMenu` tests extended: clone drawn at the measured position, overlay reachable from the outlet, back-button dismissal, no interception while closed.
- Full suite: 171 suites / 5009 tests green. Lint clean (`--max-warnings 0`).
- The Maestro screenshot flow now long-presses a row and captures `10_action_menu_light`, so alignment is checkable in CI artifacts. Comment `/screenshots` on this PR to render it.

Honest note: not yet confirmed on a device — the local dev-client APK is too old to run current JS, so the screenshot job is the check that matters here.
