### PR TITLE
fix(accounts): group every account picker by currency in a shared grid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,31 @@ Options, each off by default:
 
 The grid renders a plain `View`, so a host that can overflow wraps it in a `ScrollView`. Hosts: `BudgetPlanLineModal`, `SplitOperationModal`, `PickerModal`, `OperationModal`, `NotificationBindingCard`, `NotificationProcessingContentPanel`.
 
+### Account Selection
+
+**Rule: the same applies to accounts — every account picker renders `app/components/AccountGridSelector.js`.**
+
+A chip grid grouped by currency. The groups are *not* a hierarchy — there is nothing to drill into, they are containers you read past — but "which account" is nearly always asked inside a currency, and a flat list of a dozen accounts makes the reader do that sort in their head every time.
+
+```javascript
+<AccountGridSelector
+  accounts={accounts}            // already filtered by the host (e.g. source account removed)
+  selectedAccountId={id}
+  onSelect={handleSelect}        // called with the chosen account id
+  colors={colors}
+  t={t}
+  icon="bank-transfer-in"        // optional leading glyph, defaults to wallet-outline
+  query={query}                  // optional, filters by account name
+  testIDPrefix="plan-account-option"
+/>
+```
+
+- Group order follows the accounts' own order (first currency to appear wins), so it matches what the user arranged on the Accounts screen; accounts are never reordered within a group.
+- A single-currency set gets **no** headers — one header over everything says nothing. The same applies after a search narrows the set to one currency.
+- The grid reads `hideBalances` from `DisplaySettingsContext` itself rather than taking it as a prop, so a host cannot forget the setting.
+
+Hosts: `PickerModal`, `OperationModal`, `BudgetPlanLineModal` (transfer target + execution account), `AccountsScreen` (transfer-on-delete).
+
 ### Testing
 
 The app uses Jest with React Native Testing Library for unit, integration, and regression testing.

--- a/__tests__/components/AccountGridSelector.test.js
+++ b/__tests__/components/AccountGridSelector.test.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import AccountGridSelector from '../../app/components/AccountGridSelector';
+
+const mockDisplaySettings = { hideBalances: false };
+jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: () => mockDisplaySettings,
+}));
+
+jest.mock('../../assets/currencies.json', () => ({
+  USD: { symbol: '$', decimal_digits: 2 },
+  AMD: { symbol: '֏', decimal_digits: 2 },
+}));
+
+const press = async (element) => {
+  await act(async () => {
+    fireEvent.press(element);
+  });
+};
+
+const colors = {
+  text: '#000', mutedText: '#888', border: '#ddd', selected: '#eee',
+  primary: '#6200ee', surface: '#fff', inputBackground: '#f0f0f0',
+};
+const t = (k) => k;
+
+// Deliberately interleaved currencies: the grid has to group them without
+// reordering the accounts themselves.
+const ACCOUNTS = [
+  { id: 'a1', name: 'T-bank card', balance: '100', currency: 'AMD' },
+  { id: 'a2', name: 'Cash usd', balance: '50', currency: 'USD' },
+  { id: 'a3', name: 'Ameria card', balance: '200', currency: 'AMD' },
+];
+
+describe('AccountGridSelector', () => {
+  beforeEach(() => {
+    mockDisplaySettings.hideBalances = false;
+  });
+
+  it('shows an empty message when there is nothing to pick', async () => {
+    const { getByTestId } = await render(
+      <AccountGridSelector accounts={[]} onSelect={jest.fn()} colors={colors} t={t} />,
+    );
+    expect(getByTestId('account-grid-empty')).toHaveTextContent('no_accounts');
+  });
+
+  it('renders every account with its balance', async () => {
+    const { getByTestId, getByText } = await render(
+      <AccountGridSelector accounts={ACCOUNTS} onSelect={jest.fn()} colors={colors} t={t} />,
+    );
+    expect(getByTestId('account-grid-a1')).toBeTruthy();
+    expect(getByText('$50.00')).toBeTruthy();
+    expect(getByText('֏100.00')).toBeTruthy();
+  });
+
+  it('reports the tapped account', async () => {
+    const onSelect = jest.fn();
+    const { getByTestId } = await render(
+      <AccountGridSelector accounts={ACCOUNTS} onSelect={onSelect} colors={colors} t={t} />,
+    );
+    await press(getByTestId('account-grid-a3'));
+    expect(onSelect).toHaveBeenCalledWith('a3');
+  });
+
+  it('marks the current selection', async () => {
+    const { getByTestId } = await render(
+      <AccountGridSelector accounts={ACCOUNTS} selectedAccountId="a2" onSelect={jest.fn()} colors={colors} t={t} />,
+    );
+    expect(getByTestId('account-grid-a2').props.accessibilityState.selected).toBe(true);
+    expect(getByTestId('account-grid-a1').props.accessibilityState.selected).toBe(false);
+  });
+
+  describe('Currency grouping', () => {
+    it('heads one group per currency, in the order the accounts introduce them', async () => {
+      const { getByTestId } = await render(
+        <AccountGridSelector accounts={ACCOUNTS} onSelect={jest.fn()} colors={colors} t={t} />,
+      );
+      expect(getByTestId('account-grid-group-AMD')).toHaveTextContent('AMD');
+      expect(getByTestId('account-grid-group-USD')).toHaveTextContent('USD');
+    });
+
+    it('drops the headers when every account shares a currency', async () => {
+      const sameCurrency = ACCOUNTS.filter((a) => a.currency === 'AMD');
+      const { queryByTestId, getByTestId } = await render(
+        <AccountGridSelector accounts={sameCurrency} onSelect={jest.fn()} colors={colors} t={t} />,
+      );
+      // One header over everything says nothing.
+      expect(queryByTestId('account-grid-group-AMD')).toBeNull();
+      expect(getByTestId('account-grid-a1')).toBeTruthy();
+    });
+
+    it('drops a group that the search emptied', async () => {
+      const { getByTestId, queryByTestId } = await render(
+        <AccountGridSelector accounts={ACCOUNTS} onSelect={jest.fn()} colors={colors} t={t} query="cash" />,
+      );
+      expect(getByTestId('account-grid-a2')).toBeTruthy();
+      expect(queryByTestId('account-grid-a1')).toBeNull();
+      // Only USD survived, so its header stops earning its space too.
+      expect(queryByTestId('account-grid-group-USD')).toBeNull();
+    });
+  });
+
+  describe('Search', () => {
+    it('says nothing was found rather than showing an empty grid', async () => {
+      const { getByTestId } = await render(
+        <AccountGridSelector accounts={ACCOUNTS} onSelect={jest.fn()} colors={colors} t={t} query="zzz" />,
+      );
+      expect(getByTestId('account-grid-empty')).toHaveTextContent('no_results');
+    });
+  });
+
+  describe('Hidden balances', () => {
+    it('honours the app-wide setting instead of spelling the balance out', async () => {
+      mockDisplaySettings.hideBalances = true;
+      const { queryByText, getByTestId } = await render(
+        <AccountGridSelector accounts={ACCOUNTS} onSelect={jest.fn()} colors={colors} t={t} />,
+      );
+      expect(queryByText('$50.00')).toBeNull();
+      expect(getByTestId('account-grid-a2')).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/components/budgets/BudgetPlanLineModal.test.js
+++ b/__tests__/components/budgets/BudgetPlanLineModal.test.js
@@ -222,6 +222,47 @@ describe('BudgetPlanLineModal', () => {
     });
   });
 
+  describe('Account pickers', () => {
+    const multiCurrency = [
+      { id: 1, name: 'Savings', currency: 'USD', balance: '100' },
+      { id: 2, name: 'Cash amd', currency: 'AMD', balance: '5000' },
+      { id: 3, name: 'Checking', currency: 'USD', balance: '20' },
+    ];
+
+    it('groups transfer targets by currency', async () => {
+      const props = { ...baseProps(), accounts: multiCurrency };
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await fireEvent.press(getByTestId('plan-target-picker'));
+      await waitFor(() => expect(getByTestId('plan-target-tab-account')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-tab-account'));
+      await waitFor(() => expect(getByTestId('plan-target-option-acc-1')).toBeTruthy());
+      expect(getByTestId('plan-target-option-acc-group-USD')).toBeTruthy();
+      expect(getByTestId('plan-target-option-acc-group-AMD')).toBeTruthy();
+    });
+
+    it('groups execution accounts by currency, and still offers none', async () => {
+      const props = { ...baseProps(), accounts: multiCurrency };
+      const { getByTestId } = await render(<BudgetPlanLineModal {...props} />);
+      await fireEvent.press(getByTestId('plan-account-picker'));
+      await waitFor(() => expect(getByTestId('plan-account-option-2')).toBeTruthy());
+      expect(getByTestId('plan-account-option-group-AMD')).toBeTruthy();
+      expect(getByTestId('plan-account-option-none')).toBeTruthy();
+
+      await fireEvent.press(getByTestId('plan-account-option-2'));
+      await fireEvent.changeText(getByTestId('plan-line-amount'), '10');
+      await fireEvent.press(getByTestId('plan-target-picker'));
+      await waitFor(() => expect(getByTestId('plan-target-option-cat-cat1')).toBeTruthy());
+      await fireEvent.press(getByTestId('plan-target-option-cat-cat1'));
+      await fireEvent.press(getByTestId('plan-target-done'));
+      await fireEvent.press(getByTestId('plan-line-save'));
+      expect(props.onSaveLine).toHaveBeenCalledWith(expect.objectContaining({
+        accountId: 2,
+        // An executable line is priced in its account's currency.
+        currency: 'AMD',
+      }));
+    });
+  });
+
   describe('Target picker search', () => {
     const manyCategories = Array.from({ length: 10 }, (_, i) => ({
       id: `c${i}`, name: `Category ${i}`, categoryType: 'expense',

--- a/app/components/AccountGridSelector.js
+++ b/app/components/AccountGridSelector.js
@@ -1,0 +1,261 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
+import * as Currency from '../services/currency';
+import currencies from '../../assets/currencies.json';
+import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
+
+// Accounts carry a name AND a balance, so two across rather than the category
+// grid's three — a third column turns every real account name into an ellipsis.
+const COLUMNS = 2;
+
+// Selection is a tint of the accent rather than a solid fill: white-on-accent
+// sits at ~2.8:1 in the dark theme. Same treatment as CategoryGridSelector.
+const TINT = '1F';
+const tintOf = (primary, fallback) => (
+  typeof primary === 'string' && /^#[0-9a-f]{6}$/i.test(primary) ? primary + TINT : fallback
+);
+
+const DEFAULT_TEST_ID_PREFIX = 'account-grid';
+
+const symbolOf = (code) => (code ? (currencies[code]?.symbol || code) : '');
+
+/**
+ * The app's one account picker.
+ *
+ * A chip grid grouped by currency — the accounts of one currency sit together
+ * under its code, because "which account" is nearly always asked inside a
+ * currency ("pay this AMD expense from…"), and a flat list of a dozen accounts
+ * makes the reader do that sort in their head every time. The groups are NOT a
+ * hierarchy: there is nothing to drill into, they are containers you read past.
+ *
+ * Group order follows the accounts' own order (first appearance wins), so it
+ * matches the order the user arranged on the Accounts screen. A single-currency
+ * set gets no headers at all — one header over everything says nothing.
+ *
+ * See CLAUDE.md ("Account selection"). Hosts: PickerModal, OperationModal,
+ * BudgetPlanLineModal, AccountsScreen.
+ *
+ * @param {Array}    accounts          Accounts to offer, already filtered by the
+ *   host (e.g. the source account removed from a transfer's destination list).
+ * @param {string}   [selectedAccountId] Currently chosen account (highlighted).
+ * @param {Function} onSelect          Called with the tapped account id.
+ * @param {Object}   colors            Theme colours.
+ * @param {Function} t                 Translation function.
+ * @param {string}   [icon]            Leading glyph for every chip.
+ * @param {string}   [query]           Search text; filters by account name.
+ * @param {string}   [testIDPrefix]    Chip testID prefix, so a host can keep the
+ *   ids its own tests already know.
+ * @param {string}   [emptyText]       Message for an empty grid (defaults to
+ *   `no_accounts`; a fruitless search always says `no_results`).
+ */
+export default function AccountGridSelector({
+  accounts,
+  selectedAccountId = null,
+  onSelect,
+  colors,
+  t,
+  icon = 'wallet-outline',
+  query = '',
+  testIDPrefix = DEFAULT_TEST_ID_PREFIX,
+  emptyText = null,
+}) {
+  // Balances are hidden app-wide from Settings; a picker that spelled them out
+  // anyway would be the one place the setting leaks. Read here rather than taken
+  // as a prop so no host can forget it. The `|| {}` is for host tests that render
+  // the grid outside the provider — in the app it is always there.
+  const { hideBalances } = useDisplaySettings() || {};
+
+  const searchTerm = String(query || '').trim().toLowerCase();
+  const searching = searchTerm.length > 0;
+
+  const visible = useMemo(
+    () => (searching
+      ? accounts.filter((a) => String(a.name || '').toLowerCase().includes(searchTerm))
+      : accounts),
+    [accounts, searching, searchTerm],
+  );
+
+  // One group per currency, in the order the currencies first appear, each
+  // chunked into rows and padded with invisible spacers so chips keep an even
+  // width on the last row.
+  const groups = useMemo(() => {
+    const byCurrency = new Map();
+    visible.forEach((account) => {
+      const code = account.currency || '';
+      if (!byCurrency.has(code)) byCurrency.set(code, []);
+      byCurrency.get(code).push(account);
+    });
+
+    return Array.from(byCurrency.entries()).map(([code, items]) => {
+      const rows = [];
+      for (let i = 0; i < items.length; i += COLUMNS) rows.push(items.slice(i, i + COLUMNS));
+      const last = rows[rows.length - 1];
+      while (last.length < COLUMNS) last.push(null);
+      return { code, rows };
+    });
+  }, [visible]);
+
+  // Headers earn their space only when there is more than one currency to tell
+  // apart.
+  const showHeaders = groups.length > 1;
+
+  const selectedBackground = tintOf(colors.primary, colors.selected);
+
+  const renderChip = (account, key) => {
+    if (!account) {
+      return <View key={key} style={[styles.chip, styles.invisible]} />;
+    }
+
+    const isSelected = selectedAccountId === account.id;
+    const tone = isSelected ? colors.primary : colors.text;
+
+    return (
+      <Pressable
+        key={key}
+        testID={`${testIDPrefix}-${account.id}`}
+        onPress={() => onSelect(account.id)}
+        accessibilityRole="button"
+        accessibilityState={{ selected: isSelected }}
+        accessibilityLabel={account.name}
+        style={({ pressed }) => [
+          styles.chip,
+          { backgroundColor: colors.inputBackground || colors.surface, borderColor: colors.border },
+          isSelected && { backgroundColor: selectedBackground, borderColor: colors.primary },
+          pressed && !isSelected && { backgroundColor: colors.selected },
+        ]}
+      >
+        <Icon name={icon} size={18} color={tone} />
+        <Text style={[styles.chipName, { color: tone }]} numberOfLines={2}>
+          {account.name}
+        </Text>
+        <Text style={[styles.chipBalance, { color: colors.mutedText }]} numberOfLines={1}>
+          {hideBalances
+            ? '••••'
+            : `${symbolOf(account.currency)}${Currency.formatAmount(account.balance, account.currency)}`}
+        </Text>
+        {isSelected && (
+          <View style={styles.checkBadge}>
+            <Icon name="check-circle" size={12} color={colors.primary} />
+          </View>
+        )}
+      </Pressable>
+    );
+  };
+
+  if (groups.length === 0) {
+    return (
+      <Text testID={`${testIDPrefix}-empty`} style={[styles.empty, { color: colors.mutedText }]}>
+        {searching
+          ? (t('no_results') || 'Nothing found')
+          : (emptyText || t('no_accounts') || 'No accounts')}
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.grid}>
+      {groups.map((group) => (
+        <View key={`group-${group.code}`} style={styles.group}>
+          {showHeaders && (
+            <View style={styles.groupHeader}>
+              <Text
+                testID={`${testIDPrefix}-group-${group.code}`}
+                style={[styles.groupTitle, { color: colors.mutedText }]}
+                numberOfLines={1}
+              >
+                {group.code}
+              </Text>
+              <View style={[styles.groupRule, { backgroundColor: colors.border }]} />
+            </View>
+          )}
+          {group.rows.map((row, ri) => (
+            <View key={`row-${group.code}-${ri}`} style={styles.row}>
+              {row.map((account, ci) => renderChip(account, account ? account.id : `spacer-${ri}-${ci}`))}
+            </View>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+AccountGridSelector.propTypes = {
+  accounts: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    name: PropTypes.string,
+    balance: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    currency: PropTypes.string,
+  })).isRequired,
+  selectedAccountId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onSelect: PropTypes.func.isRequired,
+  colors: PropTypes.object.isRequired,
+  t: PropTypes.func.isRequired,
+  icon: PropTypes.string,
+  query: PropTypes.string,
+  testIDPrefix: PropTypes.string,
+  emptyText: PropTypes.string,
+};
+
+const styles = StyleSheet.create({
+  checkBadge: {
+    position: 'absolute',
+    right: 4,
+    top: 4,
+  },
+  chip: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    flex: 1,
+    gap: 2,
+    justifyContent: 'center',
+    minHeight: 64,
+    paddingHorizontal: SPACING.xs,
+    paddingVertical: SPACING.sm,
+    position: 'relative',
+  },
+  chipBalance: {
+    fontSize: FONT_SIZE.xs,
+  },
+  chipName: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+  empty: {
+    fontSize: FONT_SIZE.md,
+    paddingVertical: SPACING.md,
+    textAlign: 'center',
+  },
+  grid: {
+    gap: SPACING.sm,
+  },
+  group: {
+    gap: SPACING.xs,
+  },
+  groupHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: SPACING.sm,
+    paddingHorizontal: SPACING.xs,
+  },
+  groupRule: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+  },
+  groupTitle: {
+    fontSize: FONT_SIZE.xs,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+  },
+  invisible: {
+    opacity: 0,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: SPACING.xs,
+  },
+});

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -23,6 +23,7 @@ import { useDialog } from '../../contexts/DialogContext';
 import FormInput from '../FormInput';
 import ModalShell from '../ModalShell';
 import CategoryGridSelector from '../CategoryGridSelector';
+import AccountGridSelector from '../AccountGridSelector';
 import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';
 import * as Currency from '../../services/currency';
 
@@ -228,10 +229,6 @@ PanelHeader.propTypes = {
   backTestID: PropTypes.string,
   children: PropTypes.node,
 };
-
-const matchesQuery = (name, query) => (
-  !query || String(name || '').toLowerCase().includes(query.toLowerCase())
-);
 
 /**
  * BudgetPlanLineModal — editor for a single budget line: a monthly target that
@@ -526,16 +523,17 @@ export default function BudgetPlanLineModal({
     ));
   }, []);
 
-  const handleSelectTransferTarget = useCallback((acc) => {
-    setToAccountId(acc.id);
+  const handleSelectTransferTargetId = useCallback((id) => {
+    setToAccountId(id);
     setCategoryIds([]);
     setKind('transfer');
     setError(null);
     closeSubPanel();
   }, [closeSubPanel]);
 
-  const handleSelectExecutionAccount = useCallback((acc) => {
-    setAccountId(acc ? acc.id : null);
+  // null clears the template account, turning the line back into a pure target.
+  const handleSelectExecutionAccountId = useCallback((id) => {
+    setAccountId(id ?? null);
     setError(null);
     closeSubPanel();
   }, [closeSubPanel]);
@@ -661,32 +659,6 @@ export default function BudgetPlanLineModal({
   // Whether the panel earns a search field. Categories are counted whole (the grid
   // searches the entire tree, not the folder level it happens to be showing).
   const targetOptionCount = showingCategories ? targetCategories.length : accounts.length;
-  const visibleAccounts = useMemo(
-    () => accounts.filter(item => matchesQuery(item.name, query)),
-    [accounts, query],
-  );
-
-  const renderTransferTargetItem = useCallback(({ item }) => (
-    <OptionRow
-      colors={colors}
-      icon="bank-transfer"
-      label={item.name}
-      selected={toAccountId === item.id}
-      onPress={() => handleSelectTransferTarget(item)}
-      testID={`plan-target-option-acc-${item.id}`}
-    />
-  ), [toAccountId, colors, handleSelectTransferTarget]);
-
-  const renderExecutionAccountItem = useCallback(({ item }) => (
-    <OptionRow
-      colors={colors}
-      icon="wallet-outline"
-      label={`${item.name} · ${item.currency}`}
-      selected={accountId === item.id}
-      onPress={() => handleSelectExecutionAccount(item)}
-      testID={`plan-account-option-${item.id}`}
-    />
-  ), [accountId, colors, handleSelectExecutionAccount]);
 
   const title = isEditingLine ? t('edit_allocation') : t('add_allocation');
   const panelStyle = [
@@ -694,7 +666,6 @@ export default function BudgetPlanLineModal({
     { backgroundColor: colors.card, paddingBottom: insets.bottom + SPACING.md },
     { opacity: subPanelAnim, transform: [{ translateX: subPanelTranslateX }] },
   ];
-  const emptyListText = query ? t('no_results') : null;
 
   const subPanel = activeSubPanel ? (
     <Animated.View testID={`plan-${activeSubPanel}-subpanel`} style={panelStyle}>
@@ -772,19 +743,24 @@ export default function BudgetPlanLineModal({
               />
             </ScrollView>
           ) : (
-            <FlatList
-              data={visibleAccounts}
-              keyExtractor={(item) => String(item.id)}
-              renderItem={renderTransferTargetItem}
-              keyboardShouldPersistTaps="handled"
+            /* Accounts group by currency in the shared account grid — a transfer
+               target is almost always chosen within one currency. */
+            <ScrollView
               style={styles.panelListBody}
               contentContainerStyle={styles.panelList}
-              ListEmptyComponent={(
-                <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                  {emptyListText || t('no_accounts')}
-                </Text>
-              )}
-            />
+              keyboardShouldPersistTaps="handled"
+            >
+              <AccountGridSelector
+                accounts={accounts}
+                selectedAccountId={toAccountId}
+                onSelect={handleSelectTransferTargetId}
+                colors={colors}
+                t={t}
+                icon="bank-transfer-in"
+                query={query}
+                testIDPrefix="plan-target-option-acc"
+              />
+            </ScrollView>
           )}
         </>
       )}
@@ -889,23 +865,25 @@ export default function BudgetPlanLineModal({
             icon="close-circle-outline"
             label={t('no_template_account')}
             selected={accountId == null}
-            onPress={() => handleSelectExecutionAccount(null)}
+            onPress={() => handleSelectExecutionAccountId(null)}
             testID="plan-account-option-none"
           />
 
-          <FlatList
-            data={visibleAccounts}
-            keyExtractor={(item) => String(item.id)}
-            renderItem={renderExecutionAccountItem}
-            keyboardShouldPersistTaps="handled"
+          <ScrollView
             style={styles.panelListBody}
             contentContainerStyle={styles.panelList}
-            ListEmptyComponent={(
-              <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                {emptyListText || t('no_accounts')}
-              </Text>
-            )}
-          />
+            keyboardShouldPersistTaps="handled"
+          >
+            <AccountGridSelector
+              accounts={accounts}
+              selectedAccountId={accountId}
+              onSelect={handleSelectExecutionAccountId}
+              colors={colors}
+              t={t}
+              query={query}
+              testIDPrefix="plan-account-option"
+            />
+          </ScrollView>
         </>
       )}
     </Animated.View>

--- a/app/components/operations/PickerModal.js
+++ b/app/components/operations/PickerModal.js
@@ -1,28 +1,18 @@
 import React, { useCallback } from 'react';
-import { View, Text, StyleSheet, FlatList, ScrollView, Modal, Pressable } from 'react-native';
+import { Text, StyleSheet, ScrollView, Modal, Pressable } from 'react-native';
 import PropTypes from 'prop-types';
-import * as Currency from '../../services/currency';
-import currencies from '../../../assets/currencies.json';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import CategoryGridSelector from '../CategoryGridSelector';
+import AccountGridSelector from '../AccountGridSelector';
 import { SPACING } from '../../styles/designTokens';
-
-/**
- * Get currency symbol from currency code
- */
-const getCurrencySymbol = (currencyCode) => {
-  if (!currencyCode) return '';
-  const currency = currencies[currencyCode];
-  return currency ? currency.symbol : currencyCode;
-};
 
 /**
  * Unified picker modal for account and category selection.
  *
- * Accounts are a list and render as one. Categories are a tree, so they render
- * through CategoryGridSelector — the app's shared category grid, which owns the
- * drill-down (see CLAUDE.md, "Category selection"). `pickerData` is therefore the
- * whole category list, not one folder level.
+ * Neither list is rendered here: categories go through CategoryGridSelector and
+ * accounts through AccountGridSelector, the app's two shared pickers (see
+ * CLAUDE.md, "Category selection" and "Account selection"). `pickerData` is the
+ * whole list in both cases — the grids decide what to show.
  */
 const PickerModal = ({
   visible,
@@ -41,37 +31,23 @@ const PickerModal = ({
   onAutoAddWithCategory,
   onAutoAddWithAccount,
 }) => {
-  const renderAccountItem = useCallback(({ item }) => (
-    <Pressable
-      onPress={() => {
-        if (pickerType === 'account') {
-          onSelectAccount(item.id);
-          onClose();
-        } else {
-          const hasValidAmount = quickAddValues?.amount &&
-          quickAddValues.amount.trim() !== '';
-          if (hasValidAmount && onAutoAddWithAccount) {
-            onAutoAddWithAccount(item.id);
-          } else {
-            onSelectToAccount(item.id);
-            onClose();
-          }
-        }
-      }}
-      style={({ pressed }) => [
-        styles.pickerOption,
-        { borderColor: colors.border },
-        pressed && { backgroundColor: colors.selected },
-      ]}
-    >
-      <View style={styles.accountOption}>
-        <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
-        <Text style={[styles.pickerSmallText, { color: colors.mutedText }]} numberOfLines={1}>
-          {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
-        </Text>
-      </View>
-    </Pressable>
-  ), [pickerType, quickAddValues, colors, onClose, onSelectAccount, onSelectToAccount, onAutoAddWithAccount]);
+  // The source account replaces the selection outright. A transfer destination
+  // with an amount already typed completes the operation on the spot — the same
+  // shortcut the category grid offers below.
+  const handleSelectAccount = useCallback((accountId) => {
+    if (pickerType === 'account') {
+      onSelectAccount(accountId);
+      onClose();
+      return;
+    }
+    const hasValidAmount = quickAddValues?.amount && quickAddValues.amount.trim() !== '';
+    if (hasValidAmount && onAutoAddWithAccount) {
+      onAutoAddWithAccount(accountId);
+    } else {
+      onSelectToAccount(accountId);
+      onClose();
+    }
+  }, [pickerType, quickAddValues, onClose, onSelectAccount, onSelectToAccount, onAutoAddWithAccount]);
 
   // A category tapped with an amount already typed completes the operation on the
   // spot — that shortcut is the whole point of the quick-add flow.
@@ -109,16 +85,16 @@ const PickerModal = ({
               </ScrollView>
             ) : (
               <>
-                <FlatList
-                  data={pickerType === 'account' || pickerType === 'toAccount' ? pickerData : []}
-                  keyExtractor={(item) => item.id || item.key}
-                  renderItem={renderAccountItem}
-                  ListEmptyComponent={
-                    <Text style={[styles.centeredPaddedText, { color: colors.mutedText }]}>
-                      {t('no_accounts')}
-                    </Text>
-                  }
-                />
+                <ScrollView contentContainerStyle={styles.gridContent} keyboardShouldPersistTaps="handled">
+                  <AccountGridSelector
+                    accounts={pickerType === 'account' || pickerType === 'toAccount' ? pickerData : []}
+                    selectedAccountId={pickerType === 'account' ? quickAddValues?.accountId : quickAddValues?.toAccountId}
+                    onSelect={handleSelectAccount}
+                    colors={colors}
+                    t={t}
+                    icon={pickerType === 'toAccount' ? 'bank-transfer-in' : 'wallet-outline'}
+                  />
+                </ScrollView>
                 <Pressable style={styles.closeButton} onPress={onClose}>
                   <Text style={[styles.closeButtonText, { color: colors.primary }]}>{t('close')}</Text>
                 </Pressable>
@@ -132,20 +108,6 @@ const PickerModal = ({
 };
 
 const styles = StyleSheet.create({
-  accountName: {
-    flex: 1,
-    marginRight: 4,
-  },
-  accountOption: {
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  centeredPaddedText: {
-    paddingVertical: 40,
-    textAlign: 'center',
-  },
   closeButton: {
     alignItems: 'center',
     paddingVertical: 12,
@@ -167,19 +129,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 20,
     maxHeight: '70%',
     width: '100%',
-  },
-  pickerOption: {
-    borderBottomWidth: 1,
-    flexDirection: 'row',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  pickerOptionText: {
-    fontSize: 16,
-  },
-  pickerSmallText: {
-    fontSize: 14,
-    marginLeft: 8,
   },
 });
 

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -35,6 +35,7 @@ import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
 import useOperationForm from '../hooks/useOperationForm';
 import ModalShell from '../components/ModalShell';
 import CategoryGridSelector from '../components/CategoryGridSelector';
+import AccountGridSelector from '../components/AccountGridSelector';
 import { modalSharedStyles } from '../styles/modalStyles';
 import useOperationPicker from '../hooks/useOperationPicker';
 
@@ -419,32 +420,10 @@ export default function OperationModal({
     }
   }, [values, setValues, closePicker, isNew, isForeignCurrencyOp, addOperation, onClose, hasOperation, evaluateExpression, attachLocation, location]);
 
-  // FlatList key extractor
-  const keyExtractor = useCallback((item) => {
-    return item.id || item.key;
-  }, []);
-
-  // FlatList render item — accounts only; categories render as the shared grid.
-  const renderPickerItem = useCallback(({ item }) => {
-    const handlePress = pickerState.type === 'account' ? handleAccountSelect : handleToAccountSelect;
-    return (
-      <Pressable
-        onPress={() => handlePress(item.id)}
-        style={({ pressed }) => [
-          styles.pickerOption,
-          { borderColor: colors.border },
-          pressed && { backgroundColor: colors.selected },
-        ]}
-      >
-        <View style={styles.accountOption}>
-          <Text style={[styles.pickerOptionText, styles.accountName, { color: colors.text }]} numberOfLines={1}>{item.name}</Text>
-          <Text style={[styles.pickerOptionCurrency, { color: colors.mutedText }]} numberOfLines={1}>
-            {getCurrencySymbol(item.currency)}{Currency.formatAmount(item.balance, item.currency)}
-          </Text>
-        </View>
-      </Pressable>
-    );
-  }, [pickerState.type, colors, handleAccountSelect, handleToAccountSelect]);
+  const handleSelectPickedAccount = useCallback((accountId) => {
+    const select = pickerState.type === 'account' ? handleAccountSelect : handleToAccountSelect;
+    select(accountId);
+  }, [pickerState.type, handleAccountSelect, handleToAccountSelect]);
 
   const TYPES = [
     { key: 'expense', label: t('expense'), icon: 'minus-circle' },
@@ -690,16 +669,18 @@ export default function OperationModal({
                 />
               </ScrollView>
             ) : (
-              <FlatList
-                data={pickerState.type === 'account' || pickerState.type === 'toAccount' ? pickerState.data : []}
-                keyExtractor={keyExtractor}
-                renderItem={renderPickerItem}
-                ListEmptyComponent={
-                  <Text style={[styles.pickerEmptyText, { color: colors.mutedText }]}>
-                    {t('no_accounts')}
-                  </Text>
-                }
-              />
+              // Accounts group by currency in the shared account grid
+              // (CLAUDE.md, "Account selection").
+              <ScrollView contentContainerStyle={styles.gridContent} keyboardShouldPersistTaps="handled">
+                <AccountGridSelector
+                  accounts={pickerState.type === 'account' || pickerState.type === 'toAccount' ? pickerState.data : []}
+                  selectedAccountId={pickerState.type === 'account' ? values.accountId : values.toAccountId}
+                  onSelect={handleSelectPickedAccount}
+                  colors={colors}
+                  t={t}
+                  icon={pickerState.type === 'toAccount' ? 'bank-transfer-in' : 'wallet-outline'}
+                />
+              </ScrollView>
             )}
             {(pickerState.type !== 'category' || !isNew) && (
               <Pressable style={styles.closeButton} onPress={closePicker}>
@@ -714,15 +695,6 @@ export default function OperationModal({
 }
 
 const styles = StyleSheet.create({
-  accountName: {
-    flex: 1,
-    marginRight: SPACING.sm,
-  },
-  accountOption: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
   categoryDateRow: {
     flexDirection: 'row',
     gap: SPACING.sm,
@@ -786,29 +758,12 @@ const styles = StyleSheet.create({
   pickerButtonText: {
     fontSize: 13,
   },
-  pickerEmptyText: {
-    padding: 20,
-    textAlign: 'center',
-  },
   pickerModalContent: {
     borderTopLeftRadius: BORDER_RADIUS.lg,
     borderTopRightRadius: BORDER_RADIUS.lg,
     maxHeight: '70%',
     padding: SPACING.md,
     width: '100%',
-  },
-  pickerOption: {
-    borderBottomWidth: 1,
-    justifyContent: 'center',
-    minHeight: 44,
-    paddingHorizontal: 8,
-    paddingVertical: 8,
-  },
-  pickerOptionCurrency: {
-    fontSize: 14,
-  },
-  pickerOptionText: {
-    fontSize: 16,
   },
   pickerOverlay: {
     alignItems: 'center',

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -4,6 +4,7 @@ import { View, StyleSheet, Keyboard, FlatList, TouchableOpacity, Pressable, Anim
 import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
 import { Text, TextInput as PaperTextInput, Button, Portal, Modal, TouchableRipple, Switch } from 'react-native-paper';
 import AddFAB from '../components/AddFAB';
+import AccountGridSelector from '../components/AccountGridSelector';
 import LoadingView from '../components/LoadingView';
 import EmptyState from '../components/EmptyState';
 import { NestableScrollContainer, NestableDraggableFlatList } from 'react-native-draggable-flatlist';
@@ -102,36 +103,10 @@ CurrencyPickerModal.propTypes = {
 };
 
 // Memoized transfer account picker modal component
-const TransferAccountPickerModal = memo(({ visible = false, onClose = () => {}, accounts = [], accountToDelete = null, accountCurrency = null, operationCount = 0, colors = {}, t = (k) => k, onSelect = () => {}, currencies = DEFAULT_CURRENCIES }) => {
-  const { hideBalances } = useDisplaySettings();
+const TransferAccountPickerModal = memo(({ visible = false, onClose = () => {}, accounts = [], accountToDelete = null, accountCurrency = null, operationCount = 0, colors = {}, t = (k) => k, onSelect = () => {} }) => {
   const availableAccounts = useMemo(() => {
     return accounts.filter(a => a.id !== accountToDelete && a.currency === accountCurrency);
   }, [accounts, accountToDelete, accountCurrency]);
-
-  const renderAccountItem = useCallback(({ item }) => {
-    const currencySymbol = currencies[item.currency]?.symbol || item.currency;
-    const decimals = currencies[item.currency]?.decimal_digits ?? 2;
-    const formattedBalance = parseFloat(item.balance).toFixed(decimals);
-
-    return (
-      <TouchableRipple
-        onPress={() => onSelect(item.id)}
-        style={styles.pickerOption}
-        rippleColor="rgba(0, 0, 0, .12)"
-      >
-        <View>
-          <Text style={styles.pickerAccountName}>{item.name}</Text>
-          {hideBalances ? (
-            <View style={[styles.hiddenBalance, styles.hiddenBalancePicker]} />
-          ) : (
-            <Text style={[styles.pickerAccountBalance, { color: colors.mutedText }]}>
-              {formattedBalance} {currencySymbol}
-            </Text>
-          )}
-        </View>
-      </TouchableRipple>
-    );
-  }, [onSelect, colors, currencies, hideBalances]);
 
   return (
     <Portal>
@@ -149,12 +124,18 @@ const TransferAccountPickerModal = memo(({ visible = false, onClose = () => {}, 
         <Text variant="bodySmall" style={[styles.centeredBodySmall, { color: colors.mutedText }]}>
           {`${operationCount} ${operationCount === 1 ? 'transaction' : 'transactions'}`}
         </Text>
-        <FlatList
-          data={availableAccounts}
-          keyExtractor={(item) => item.id}
-          renderItem={renderAccountItem}
-          style={styles.pickerList}
-        />
+        {/* Same shared account grid as every other account picker. The candidates
+            are already narrowed to the deleted account's currency, so its currency
+            headers stay out of the way here. */}
+        <ScrollView style={styles.pickerList}>
+          <AccountGridSelector
+            accounts={availableAccounts}
+            onSelect={onSelect}
+            colors={colors}
+            t={t}
+            testIDPrefix="transfer-account-option"
+          />
+        </ScrollView>
         <Button mode="text" onPress={onClose} style={styles.pickerCloseButton}>
           {t('cancel') || 'Cancel'}
         </Button>
@@ -175,7 +156,6 @@ TransferAccountPickerModal.propTypes = {
   colors: PropTypes.object,
   t: PropTypes.func,
   onSelect: PropTypes.func,
-  currencies: PropTypes.object,
 };
 
 // Memoized confirmation dialog component
@@ -1318,7 +1298,6 @@ export default function AccountsScreen({ onBackStateChange }) {
         accountToDelete={accountToDelete}
         accountCurrency={accountToDeleteCurrency}
         operationCount={operationCount}
-        currencies={currencies}
         colors={colors}
         t={t}
         onSelect={handleTransferAndDelete}
@@ -1616,10 +1595,6 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xs,
     width: 160,
   },
-  hiddenBalancePicker: {
-    marginTop: 4,
-    width: 70,
-  },
   monthlyChangeRow: {
     marginTop: SPACING.sm,
   },
@@ -1669,14 +1644,6 @@ const styles = StyleSheet.create({
   netWorthWarningText: {
     flex: 1,
     fontSize: 12,
-  },
-  pickerAccountBalance: {
-    fontSize: 14,
-    marginTop: SPACING.xs,
-  },
-  pickerAccountName: {
-    fontSize: 16,
-    fontWeight: '600',
   },
   pickerCloseButton: {
     marginTop: SPACING.sm,


### PR DESCRIPTION
Follow-up to #1486, rebased onto `main` now that it has shipped.

## What

Same treatment as the categories, now for accounts. Four places asked "which account" and all four answered with the same undifferentiated list:

| where | |
| --- | --- |
| `PickerModal` | quick-add source / transfer destination |
| `OperationModal` | source / destination |
| `BudgetPlanLineModal` | transfer target **and** execution account |
| `AccountsScreen` | transfer-on-delete dialog |

With a dozen accounts across four currencies, that list makes the reader sort by currency in their head every single time — and "which account" is nearly always asked *inside* a currency ("pay this AMD expense from…").

`AccountGridSelector` is now the app's only account picker: a chip grid with name, balance and selection state, grouped under the currency code.

## Grouping rules

- Groups are **not** a hierarchy — nothing to drill into, they are containers you read past. No folders, no navigation.
- Group order follows the accounts' own order (first currency to appear wins), so it matches what the user arranged on the Accounts screen. Accounts are never reordered inside a group.
- A single-currency set gets **no headers** — one header over everything says nothing. Same after a search narrows the set down to one currency.
- The grid reads `hideBalances` from `DisplaySettingsContext` itself instead of taking it as a prop, so a host can't forget it. Two of the four used to print balances regardless of the setting — that's fixed as a side effect.

Selection matches the category grid: accent tint + check badge, not a solid fill.

## Behaviour changes

- Every account picker is a two-column grid with currency headers instead of a flat list.
- The quick-add and operation pickers now **highlight the currently selected account**; they didn't before.
- Balances read as `$100.00` everywhere; the delete dialog was the one place printing `100.00 $`.
- The transfer-on-delete dialog is already narrowed to one currency, so it shows no headers — it just inherits the grid layout and the `hideBalances` fix.

## Tests

- `npx jest --testPathIgnorePatterns=/node_modules/ --silent` → **171 suites, 5009 tests, all passing**
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` → clean
- New `AccountGridSelector` suite: grouping order, header suppression for a single currency (and after a search), search + empty states, selection marking, `hideBalances`.
- New `BudgetPlanLineModal` coverage: both account pickers group by currency, and the execution-account pick still prices the line in that account's currency.

No new strings — currency codes are the group headers.
