### PR TITLE
fix(motion): stop every horizontal swipe crashing the app

### DIFF
--- a/__tests__/utils/workletDefaults.test.js
+++ b/__tests__/utils/workletDefaults.test.js
@@ -1,0 +1,127 @@
+// __tests__/utils/workletDefaults.test.js
+/**
+ * A worklet may not take a DEFAULT PARAMETER that reads anything from outside
+ * its own parameter list.
+ *
+ * Reanimated's Babel plugin compiles a worklet into a function whose FIRST
+ * statement destructures the captured closure:
+ *
+ *   function clampWithRubberband(value, min, max, dimension, constant = RUBBERBAND_CONSTANT) {
+ *     const { RUBBERBAND_CONSTANT, rubberband } = this.__closure;   // <- injected
+ *     ...
+ *   }
+ *
+ * Default parameters are evaluated in the parameter scope, which is OUTSIDE the
+ * body — so the default reads a binding that does not exist there yet. On the UI
+ * thread (Hermes) that is a hard, app-killing `ReferenceError: Property
+ * 'RUBBERBAND_CONSTANT' doesn't exist`, thrown from inside the gesture handler.
+ * It took down every horizontal swipe in the app (tab navigation) until it was
+ * found, and nothing before this test could have caught it:
+ *
+ *   - Jest runs worklets as ordinary JS, where the module scope IS visible, so
+ *     every unit test of the function passes.
+ *   - The default only fires for callers that omit the argument, so a caller
+ *     that passes one (ModalShell, on the JS thread) never sees it.
+ *   - ESLint has no rule for it — the code is valid JavaScript everywhere except
+ *     inside a serialized worklet.
+ *
+ * So the check is static: parse every source file, find the functions carrying
+ * the `'worklet'` directive, and reject a default value that is anything but a
+ * self-contained literal.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const parser = require('@babel/parser');
+const traverse = require('@babel/traverse').default;
+
+const APP_DIR = path.join(__dirname, '..', '..', 'app');
+
+/** Every .js/.jsx file under app/, recursively. */
+function sourceFiles(dir) {
+  const found = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...sourceFiles(full));
+    else if (/\.jsx?$/.test(entry.name)) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Values a default parameter may safely hold: ones that need no scope at all.
+ * `-1` and friends are UnaryExpressions over a literal, hence the recursion.
+ */
+function isSelfContained(node) {
+  switch (node.type) {
+  case 'NumericLiteral':
+  case 'StringLiteral':
+  case 'BooleanLiteral':
+  case 'NullLiteral':
+  case 'RegExpLiteral':
+    return true;
+  case 'UnaryExpression':
+    return isSelfContained(node.argument);
+  case 'ObjectExpression':
+    return node.properties.length === 0;
+  case 'ArrayExpression':
+    return node.elements.length === 0;
+  default:
+    return false;
+  }
+}
+
+function isWorklet(node) {
+  return (node.body?.directives || []).some(d => d.value?.value === 'worklet');
+}
+
+function offendingDefaults(filePath) {
+  const code = fs.readFileSync(filePath, 'utf8');
+  const ast = parser.parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'classProperties', 'optionalChaining', 'nullishCoalescingOperator'],
+  });
+
+  const offences = [];
+  traverse(ast, {
+    Function(pathNode) {
+      if (!isWorklet(pathNode.node)) return;
+      for (const param of pathNode.node.params) {
+        if (param.type !== 'AssignmentPattern') continue;
+        if (isSelfContained(param.right)) continue;
+        const name = param.left.name || '<destructured>';
+        const line = param.loc?.start.line;
+        offences.push(`${path.relative(APP_DIR, filePath)}:${line} — parameter \`${name}\``);
+      }
+    },
+  });
+  return offences;
+}
+
+describe('worklet default parameters', () => {
+  it('never read a binding from outside the parameter list', () => {
+    const offences = sourceFiles(APP_DIR).flatMap(offendingDefaults);
+    expect(offences).toEqual([]);
+  });
+
+  it('detects the shape of the bug it exists to prevent', () => {
+    // Guards the guard: a rule that silently stops matching is worse than none.
+    const sample = path.join(__dirname, '..', '..', 'app', 'utils', 'motion.js');
+    const code = fs.readFileSync(sample, 'utf8')
+      .replace('export function rubberband(overshoot, dimension, constant) {',
+        'export function rubberband(overshoot, dimension, constant = RUBBERBAND_CONSTANT) {');
+    const ast = parser.parse(code, { sourceType: 'module', plugins: ['jsx'] });
+    const offences = [];
+    traverse(ast, {
+      Function(pathNode) {
+        if (!isWorklet(pathNode.node)) return;
+        for (const param of pathNode.node.params) {
+          if (param.type === 'AssignmentPattern' && !isSelfContained(param.right)) {
+            offences.push(param.left.name);
+          }
+        }
+      },
+    });
+    expect(offences).toContain('constant');
+  });
+});

--- a/app/utils/motion.js
+++ b/app/utils/motion.js
@@ -146,6 +146,10 @@ export const PAN_VELOCITY_TO_PER_SECOND = 1000;
  * at the very start of the over-drag (movement/drag → `constant` as the
  * overshoot approaches zero); lower is stiffer. The travel is bounded by
  * `dimension` regardless of the constant.
+ *
+ * NEVER put this (or any other module-level binding) in a DEFAULT PARAMETER of a
+ * worklet — see the note on `rubberband` below. It cost the app every horizontal
+ * swipe it has.
  */
 export const RUBBERBAND_CONSTANT = 0.55;
 
@@ -158,16 +162,31 @@ export const RUBBERBAND_CONSTANT = 0.55;
  * surface never quite runs away and never freezes either. Sign-preserving, so
  * it works for both edges.
  *
+ * The default is resolved in the BODY rather than in a default parameter, and
+ * that is not a style choice. Reanimated serializes a worklet with its captured
+ * closure unpacked by the first statement of the body:
+ *
+ *   function rubberband(overshoot, dimension, constant = RUBBERBAND_CONSTANT) {
+ *     const { RUBBERBAND_CONSTANT } = this.__closure;   // <- injected
+ *
+ * A default parameter is evaluated in the parameter scope, which is outside that
+ * body — so it reads a binding that does not exist there yet, and on the UI
+ * thread the call dies with `ReferenceError: Property 'RUBBERBAND_CONSTANT'
+ * doesn't exist`. That killed the app on every tab swipe until it was found. The
+ * crash is invisible in Jest (worklets run as plain JS there, where the module
+ * scope IS visible) and invisible to any caller that passes the argument.
+ *
  * @param {number} overshoot  Signed distance dragged past the boundary.
  * @param {number} dimension  Size of the container the drag happens in.
  * @param {number} [constant] Resistance constant; lower = stiffer.
  * @returns {number} Signed distance the surface should move.
  */
-export function rubberband(overshoot, dimension, constant = RUBBERBAND_CONSTANT) {
+export function rubberband(overshoot, dimension, constant) {
   'worklet';
+  const resistance = constant ?? RUBBERBAND_CONSTANT;
   if (!dimension || dimension <= 0) return 0;
   const magnitude = Math.abs(overshoot);
-  const resisted = (magnitude * dimension * constant) / (dimension + constant * magnitude);
+  const resisted = (magnitude * dimension * resistance) / (dimension + resistance * magnitude);
   return overshoot < 0 ? -resisted : resisted;
 }
 
@@ -179,10 +198,12 @@ export function rubberband(overshoot, dimension, constant = RUBBERBAND_CONSTANT)
  * @param {number} min        Lower bound.
  * @param {number} max        Upper bound.
  * @param {number} dimension  Size of the container (sets the resistance scale).
- * @param {number} [constant] Resistance constant; lower = stiffer.
+ * @param {number} [constant] Resistance constant; lower = stiffer. Omitted, it
+ *   is `rubberband`'s own default — passed through as `undefined` rather than
+ *   defaulted here, for the closure-capture reason documented on that function.
  * @returns {number} Position to render.
  */
-export function clampWithRubberband(value, min, max, dimension, constant = RUBBERBAND_CONSTANT) {
+export function clampWithRubberband(value, min, max, dimension, constant) {
   'worklet';
   if (value > max) return max + rubberband(value - max, dimension, constant);
   if (value < min) return min + rubberband(value - min, dimension, constant);


### PR DESCRIPTION
## The crash

Swiping left on a budget **group** row killed the app. The group row is not the cause — it simply has no `Swipeable` of its own, so the gesture reaches the tab pager. **Any** horizontal swipe that reaches it does the same thing, on every tab:

```
FATAL EXCEPTION: main
com.facebook.jni.CppException: Property 'RUBBERBAND_CONSTANT' doesn't exist
ReferenceError: Property 'RUBBERBAND_CONSTANT' doesn't exist
    at clampWithRubberband_motionJs2
    at SimpleTabsJs9
    at runWorklet_reactNativeGestureHandler_useAnimatedGestureTs3
```

Reproduced on a release build of 0.245.0 (`penny-v0.245.0_x86_64.apk`, x86_64 AVD): swipe left on the group row → process dies; swipe left on empty space on the same screen → identical stack. Tab swipe navigation has been broken in release builds since the motion unification (#1468).

## Cause

`rubberband` / `clampWithRubberband` took the resistance constant as a **default parameter**:

```js
export function clampWithRubberband(value, min, max, dimension, constant = RUBBERBAND_CONSTANT) {
  'worklet';
```

Reanimated serializes a worklet with its captured closure unpacked by the **first statement of the body** (from the compiled `__initData.code`):

```js
function clampWithRubberband_motionJs2(value, min, max, dimension, constant = RUBBERBAND_CONSTANT) {
  const { RUBBERBAND_CONSTANT, rubberband } = this.__closure;   // <- injected
```

A default parameter is evaluated in the *parameter* scope, which is outside that body — so it reads a binding that does not exist there yet. `SimpleTabs`' pan `onUpdate` calls `clampWithRubberband` with four arguments, so the default fired on every gesture update.

## Fix

Resolve the default in the body (`constant ?? RUBBERBAND_CONSTANT`), where the closure is in scope; `clampWithRubberband` passes the argument through and lets `rubberband` own the one default. Behaviour is unchanged for every caller.

## Test

Nothing existing could have caught it:

- Jest runs worklets as ordinary JS, where the module scope **is** visible — the existing `motion.test.js` suite passes against the broken code.
- The default only fires for callers that omit the argument (`ModalShell` passes one, and runs on the JS thread anyway).
- It is valid JavaScript everywhere except inside a serialized worklet, so ESLint has nothing to say.

So the regression test is static: parse every file under `app/`, find functions carrying the `'worklet'` directive, and reject a default value that is anything but a self-contained literal. A second case re-introduces the bug's shape in-memory and asserts the rule still fires, so the guard cannot rot into a no-op.

## Verification

Executed the serialized worklet the way the UI thread does — `__initData.code` from the production Babel output, called with a `__closure` object:

| build | result |
|---|---|
| before | `ReferenceError: RUBBERBAND_CONSTANT is not defined` |
| after | `-1142.19…` (rubber-banded position) |

Full suite green (5065 tests), `eslint --max-warnings 0` clean.
