### PR TITLE
fix(budgets): mark the plan bar's target boundary with a gap

### DIFF
--- a/__tests__/components/budgets/PlanProgressBar.test.js
+++ b/__tests__/components/budgets/PlanProgressBar.test.js
@@ -91,6 +91,44 @@ describe('PlanProgressBar', () => {
     });
   });
 
+  // The target boundary used to be nothing but the step in brightness between
+  // the two track zones — which the fill covers on any row at or past its
+  // target, i.e. on most rows of a month-end plan. What was left on such a row
+  // was the pace tick, a lone vertical some 7% to the boundary's left, and that
+  // is what a reader took the boundary to be.
+  describe('Target boundary', () => {
+    it('leaves a gap between the two zones, so the target is marked on an empty track', async () => {
+      const { getByTestId } = await renderBar({ ratio: 0.4 });
+      expect(styleOf(getByTestId('bar-plan-zone')).width).toBe('72%');
+      expect(styleOf(getByTestId('bar-over-zone')).left).toBe('72.8%');
+    });
+
+    it('keeps the gap when the fill has covered the whole plan zone', async () => {
+      // The case the old brightness step could not survive: solid fill up to the
+      // target, solid overspend past it, and nothing in between to read.
+      const { getByTestId } = await renderBar({ ratio: 1.8 });
+      expect(styleOf(getByTestId('bar-plan')).width).toBe('72%');
+      expect(styleOf(getByTestId('bar-over')).left).toBe('72.8%');
+    });
+
+    it('starts the overspend segment where its zone starts, not at the target', async () => {
+      // Both zone and fill move together; an overspend segment still anchored to
+      // 72% would paint over the gap the moment a row went over.
+      const { getByTestId } = await renderBar({ ratio: 2 });
+      expect(styleOf(getByTestId('bar-over')).left)
+        .toBe(styleOf(getByTestId('bar-over-zone')).left);
+      expect(styleOf(getByTestId('bar-over')).width).toBe('27.2%');
+    });
+
+    it('keeps the pace tick clear of the boundary it was being mistaken for', async () => {
+      // Even at the end of the month the tick lands ON the target rather than in
+      // the gap, so the gap stays the only thing that separates the zones.
+      const { getByTestId } = await renderBar({ ratio: 1.8, pace: 1 });
+      expect(styleOf(getByTestId('bar-pace')).left).toBe('72%');
+      expect(styleOf(getByTestId('bar-over-zone')).left).toBe('72.8%');
+    });
+  });
+
   describe('Pace marker', () => {
     it('is absent when the month has no pace to speak of', async () => {
       const { queryByTestId } = await renderBar({ pace: null });

--- a/app/components/budgets/PlanProgressBar.js
+++ b/app/components/budgets/PlanProgressBar.js
@@ -12,13 +12,44 @@ import { TIMING_ENTER } from '../../utils/motion';
  * of a month most envelopes are at or past their number — so a bar that simply
  * saturates at the end would flatten 101% and 348% into the same full bar, which
  * is exactly what the old background wash did (it clamped the fraction to 1).
- * Reserving the last 28% for the overspend means the bar keeps saying something
- * after the target is passed.
+ * Reserving the last quarter or so of the track for the overspend means the bar
+ * keeps saying something after the target is passed.
  */
 const PLAN_STOP = 0.72;
 
+/**
+ * A hairline of nothing at the target, separating the two zones.
+ *
+ * The step in brightness between the zones was supposed to be the target mark,
+ * and it is — right up until the fill covers it. Every row at or past its target
+ * paints the whole plan zone solid, and on a month-end plan that is most of
+ * them, so the one place the mark is needed is the one place it disappeared.
+ * What was left on such a row was a single vertical line, the pace tick, sitting
+ * some 7% to its left — and a reader looking for the target boundary reads
+ * whatever vertical is there as the boundary. It is a gap rather than a drawn
+ * tick because the track has no background of its own: the zones are the
+ * background, so leaving a slice unpainted shows the card through it, and it
+ * reads over the fill and the overspend alike without needing to know either
+ * colour. It also says "boundary" in a different language than the pace tick
+ * does — negative space against a line — so the two can no longer be confused.
+ *
+ * As a fraction of the track: ~2dp on the ~250dp bar this screen draws.
+ */
+const BOUNDARY_GAP = 0.008;
+
+/** Left edge of the overspend zone: the target, plus the gap that marks it. */
+const OVER_START = PLAN_STOP + BOUNDARY_GAP;
+
 /** What is left of the track for the overspend to grow into. */
-const OVER_ZONE = 1 - PLAN_STOP;
+const OVER_ZONE = 1 - OVER_START;
+
+/**
+ * A fraction as a percentage string, without binary-float debris.
+ *
+ * `${(1 - 0.728) * 100}%` is "27.200000000000003%" — which Yoga parses fine, but
+ * which turns every style assertion in the tests into a guess about rounding.
+ */
+const pct = (fraction) => `${Number((fraction * 100).toFixed(4))}%`;
 
 /**
  * How the overspend zone is compressed.
@@ -89,12 +120,19 @@ const PlanProgressBar = ({
 
   return (
     <View style={[styles.track, { height, borderRadius: height / 2 }]} testID={testID}>
-      {/* Two track zones rather than one track plus a tick at the boundary. The
-          step in brightness between them IS the target marker, so the bar reads
-          "this much was the plan" without carrying a separate mark for it — one
-          fewer element on a 4dp strip that repeats down the whole screen. */}
-      <View style={[styles.planZone, { backgroundColor: trackColor }]} />
-      <View style={[styles.overZone, { backgroundColor: trackColor }]} />
+      {/* Two track zones rather than one track plus a tick at the boundary, with
+          BOUNDARY_GAP of bare card between them. The step in brightness plus that
+          gap IS the target marker, so the bar reads "this much was the plan"
+          without carrying a separate mark for it — one fewer element on a 4dp
+          strip that repeats down the whole screen. */}
+      <View
+        testID={testID ? `${testID}-plan-zone` : undefined}
+        style={[styles.planZone, { backgroundColor: trackColor }]}
+      />
+      <View
+        testID={testID ? `${testID}-over-zone` : undefined}
+        style={[styles.overZone, { backgroundColor: trackColor }]}
+      />
 
       <Animated.View
         testID={testID ? `${testID}-plan` : undefined}
@@ -118,7 +156,7 @@ const PlanProgressBar = ({
       {pace != null && (
         <View
           testID={testID ? `${testID}-pace` : undefined}
-          style={[styles.paceTick, { backgroundColor: paceColor, left: `${Math.min(Math.max(pace, 0), 1) * PLAN_STOP * 100}%` }]}
+          style={[styles.paceTick, { backgroundColor: paceColor, left: pct(Math.min(Math.max(pace, 0), 1) * PLAN_STOP) }]}
         />
       )}
     </View>
@@ -154,19 +192,19 @@ export const PAIR_COLUMN_WIDTH = 96;
 const styles = StyleSheet.create({
   overFill: {
     bottom: 0,
-    left: `${PLAN_STOP * 100}%`,
+    left: pct(OVER_START),
     position: 'absolute',
     top: 0,
     // Without this the segment grows from its centre and detaches from the
     // target boundary it is supposed to spill out of.
     transformOrigin: 'left',
-    width: `${OVER_ZONE * 100}%`,
+    width: pct(OVER_ZONE),
   },
   overZone: {
     bottom: 0,
-    left: `${PLAN_STOP * 100}%`,
-    // Dimmer than the plan zone, so the step between them reads as the target
-    // mark without a separate tick sitting on the boundary.
+    left: pct(OVER_START),
+    // Dimmer than the plan zone, so that on a track the fill has not reached the
+    // step in brightness says where the target is even before the gap does.
     opacity: 0.4,
     position: 'absolute',
     right: 0,
@@ -184,14 +222,14 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     transformOrigin: 'left',
-    width: `${PLAN_STOP * 100}%`,
+    width: pct(PLAN_STOP),
   },
   planZone: {
     bottom: 0,
     left: 0,
     position: 'absolute',
     top: 0,
-    width: `${PLAN_STOP * 100}%`,
+    width: pct(PLAN_STOP),
   },
   track: {
     // Clips the overspend segment to the rounded ends.


### PR DESCRIPTION
## Problem

On a plan row the target boundary sits at a fixed 72% of the track, and it was marked only by the step in brightness between the plan zone and the dimmer overspend zone. That step is visible on an *empty* track — and invisible the moment the fill covers it, which is every row at or past its target, i.e. most rows of a month-end plan.

What is left on such a row is a single vertical: the pace tick (where the month says spending should have reached by today, up to 7% of the track to the boundary's left). A reader looking for "where does my budget end" reads whatever vertical is there as the boundary, and then the red segment appears to start somewhere else entirely.

Reported from a live plan: Такси at 10.6K / 6K draws grey to 72% and red from 72%, while the pace tick on 28 July sat at 0.90 × 72% = 65%.

## Fix

Leave `BOUNDARY_GAP` (~2dp, 0.8% of the track) unpainted at the target: the overspend zone and its fill both start at 72.8% instead of 72%.

The track has no background of its own — the two zones *are* the background — so an unpainted slice shows the card through it and reads over the neutral fill and the saturated overspend alike, without needing to know either colour. It also states the boundary as negative space rather than as a line, a different visual language than the pace tick's, so the two no longer compete for the same reading.

Also adds a `pct()` helper so the percentage strings stop carrying binary-float debris (`27.200000000000003%`), which makes the style assertions readable.

## Tests

New `Target boundary` group in `PlanProgressBar.test.js` (4 cases): the gap exists on an empty track, survives a fully covered plan zone, moves the overspend fill together with its zone, and stays clear of the pace tick at month end.

Full suite: 5091 passed / 175 suites. Lint clean at `--max-warnings 0`.
