### PR TITLE
fix(accounts): lay the account grid three across

### DIFF
--- a/app/components/AccountGridSelector.js
+++ b/app/components/AccountGridSelector.js
@@ -7,9 +7,10 @@ import * as Currency from '../services/currency';
 import currencies from '../../assets/currencies.json';
 import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 
-// Accounts carry a name AND a balance, so two across rather than the category
-// grid's three — a third column turns every real account name into an ellipsis.
-const COLUMNS = 2;
+// Three across, matching the category grid. An account chip carries a name AND a
+// balance, so the name gets two lines and the balance a smaller size than the
+// category chips need — at two across the row was mostly air.
+const COLUMNS = 3;
 
 // Selection is a tint of the accent rather than a solid fill: white-on-accent
 // sits at ~2.8:1 in the dark theme. Same treatment as CategoryGridSelector.


### PR DESCRIPTION
Follow-up to #1491, which merged before this commit landed on it.

## What

`AccountGridSelector` laid its chips two across. On a real account set that is mostly air: an account chip is a name over a balance, not a paragraph, and the picker ends up a very tall column of very wide cards.

Three across, matching `CategoryGridSelector`, so the two pickers read as one system.

Everything else is unchanged — currency grouping, header suppression for a single currency, search, `hideBalances`.

## Tests

- `npx jest --testPathIgnorePatterns=/node_modules/ --silent` → **175 suites, 5091 tests, all passing**
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` → clean

No test changes: nothing asserted the column count, and the grid's row chunking already pads the last row with invisible spacers at any width.
