### PR TITLE
fix(operations): anchor the long-press menu to the row on a scrolled list

### DIFF
--- a/__tests__/modals/OperationModal.test.js
+++ b/__tests__/modals/OperationModal.test.js
@@ -682,6 +682,69 @@ describe('OperationModal', () => {
 
       expect(queryByText('save')).toBeFalsy();
     });
+
+    // A balance adjustment is read-only here, but skewed charts are exactly what a
+    // correction causes — so the hide-from-charts switch stays live and writes itself
+    // straight to the DB (there is no Save button to press afterwards).
+    it('offers the hide-from-charts switch for a balance adjustment and persists it immediately', async () => {
+      const useOperationForm = require('../../app/hooks/useOperationForm');
+      useOperationForm.mockReturnValue({
+        ...useOperationForm(),
+        isShadowOperation: true,
+      });
+
+      const mockOperation = {
+        id: 'op1',
+        type: 'expense',
+        amount: '292380.35',
+        accountId: 'acc1',
+        categoryId: 'shadow-adjustment-expense',
+        date: '2024-01-15',
+      };
+
+      const { getByTestId } = await render(
+        <OperationModal
+          visible={true}
+          onClose={mockOnClose}
+          operation={mockOperation}
+          isNew={false}
+        />,
+      );
+
+      fireEvent(getByTestId('exclude-from-charts-switch'), 'valueChange', true);
+
+      expect(mockUpdateOperation).toHaveBeenCalledWith('op1', { excludeFromCharts: true });
+    });
+
+    it('does not write on toggle for an ordinary operation — Save does that', async () => {
+      const useOperationForm = require('../../app/hooks/useOperationForm');
+      useOperationForm.mockReturnValue({
+        ...useOperationForm(),
+        isShadowOperation: false,
+      });
+
+      const mockOperation = {
+        id: 'op2',
+        type: 'expense',
+        amount: '12',
+        accountId: 'acc1',
+        categoryId: 'cat2',
+        date: '2024-01-15',
+      };
+
+      const { getByTestId } = await render(
+        <OperationModal
+          visible={true}
+          onClose={mockOnClose}
+          operation={mockOperation}
+          isNew={false}
+        />,
+      );
+
+      fireEvent(getByTestId('exclude-from-charts-switch'), 'valueChange', true);
+
+      expect(mockUpdateOperation).not.toHaveBeenCalled();
+    });
   });
 
   describe('Picker Interactions', () => {

--- a/__tests__/utils/overlayGeometry.test.js
+++ b/__tests__/utils/overlayGeometry.test.js
@@ -1,0 +1,51 @@
+/**
+ * Regression coverage for the long-press menu anchoring off-screen (#1495 follow-up).
+ *
+ * The menu draws a lifted clone of the pressed row in the app-wide overlay layer. The
+ * row was being measured with `measureLayout(host)`, which reports the row's layout
+ * offset inside the list's CONTENT — with the scroll translation missing. Long-pressing
+ * anything past the first screenful therefore anchored the clone a full scroll offset
+ * below the row, i.e. off the bottom of the screen: the backdrop blurred, but the menu
+ * was nowhere to be seen.
+ *
+ * The fix measures the row and the host in window coordinates and subtracts, which is
+ * what this helper does.
+ */
+import { anchorRectInHost } from '../../app/utils/overlayGeometry';
+
+describe('anchorRectInHost', () => {
+  it('re-expresses a window rect in the host space', () => {
+    // Host starts 48px down the window (status bar), row sits at 400 on screen.
+    const rect = anchorRectInHost(
+      { x: 16, y: 400, width: 320, height: 72 },
+      { x: 0, y: 48 },
+    );
+    expect(rect).toEqual({ x: 16, y: 352, width: 320, height: 72 });
+  });
+
+  it('keeps a scrolled row on screen — the returned y is where it is drawn, not its offset in the list', () => {
+    // The 40th row of a scrolled list: window y is a screen position (300), while its
+    // layout offset inside the list content would be thousands of pixels down.
+    const rect = anchorRectInHost(
+      { x: 0, y: 300, width: 400, height: 64 },
+      { x: 0, y: 0 },
+    );
+    expect(rect.y).toBe(300);
+    expect(rect.y).toBeLessThan(1000);
+  });
+
+  it('treats a missing host origin as (0, 0)', () => {
+    expect(anchorRectInHost({ x: 5, y: 10, width: 100, height: 20 }, null))
+      .toEqual({ x: 5, y: 10, width: 100, height: 20 });
+  });
+
+  it.each([
+    ['a zero-height box', { x: 0, y: 0, width: 100, height: 0 }],
+    ['a zero-width box', { x: 0, y: 0, width: 0, height: 40 }],
+    ['no rect at all', null],
+  ])('returns null for %s so the menu falls back to centred', (_name, rect) => {
+    // A collapsed or not-yet-laid-out node reports a zero size; anchoring to it would
+    // draw a zero-width clone with the action bar pinned to it.
+    expect(anchorRectInHost(rect, { x: 0, y: 0 })).toBeNull();
+  });
+});

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -5,6 +5,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
+import { anchorRectInHost } from '../../utils/overlayGeometry';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
 import { useOverlayHost } from '../../contexts/OverlayHostContext';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
@@ -54,15 +55,24 @@ const OperationListItem = ({
     const host = hostRef?.current;
     // No host (or no measurement support, as under test): the menu still opens, just
     // centred instead of anchored.
-    if (!node || !host || typeof node.measureLayout !== 'function') {
+    if (!node || !host
+      || typeof node.measureInWindow !== 'function'
+      || typeof host.measureInWindow !== 'function') {
       onLongPress(operation, null);
       return;
     }
-    node.measureLayout(
-      host,
-      (x, y, width, height) => onLongPress(operation, { x, y, width, height }),
-      () => onLongPress(operation, null),
-    );
+    // Both ends are measured in WINDOW coordinates and then subtracted (see
+    // anchorRectInHost) rather than measuring the row against the host directly —
+    // `measureLayout` ignores the list's scroll translation, which put the lifted
+    // clone a whole scroll offset below the row it was copying.
+    host.measureInWindow((hostX, hostY) => {
+      node.measureInWindow((x, y, width, height) => {
+        onLongPress(
+          operation,
+          anchorRectInHost({ x, y, width, height }, { x: hostX, y: hostY }),
+        );
+      });
+    });
   }, [onLongPress, operation, hostRef]);
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -320,14 +320,19 @@ export default function OperationModal({
     }
   }, [isShadowOperation, setValues]);
 
-  // Handler for the "hide from the charts" toggle. Balance adjustments have no
-  // editable form at all (every field above is disabled), so they are toggled
-  // from the operations list's long-press menu instead.
+  // Handler for the "hide from the charts" toggle.
+  //
+  // A balance adjustment is read-only here — every field above is disabled and
+  // ModalShell shows no Save button — so for one the flag is written straight to
+  // the DB on toggle. `values` is updated first so the switch tracks the finger
+  // rather than the round-trip; a failed write surfaces via the dialog inside
+  // OperationsActionsContext, and reopening the row shows the persisted state.
   const handleToggleExcludeFromCharts = useCallback((val) => {
-    if (!isShadowOperation) {
-      setValues(v => ({ ...v, excludeFromCharts: val }));
+    setValues(v => ({ ...v, excludeFromCharts: val }));
+    if (isShadowOperation && operation?.id != null) {
+      updateOperation(operation.id, { excludeFromCharts: val });
     }
-  }, [isShadowOperation, setValues]);
+  }, [isShadowOperation, setValues, updateOperation, operation]);
 
   // Handler for description focus (auto-scroll to end)
   // We scroll twice: immediately for initial positioning, then again after the
@@ -629,8 +634,12 @@ export default function OperationModal({
         )}
 
         {/* Hide-from-charts toggle. Expenses and income both feed a donut and the
-            summary totals; a transfer feeds neither, so it has nothing to hide. */}
-        {!isNew && !isShadowOperation && values.type !== 'transfer' && (
+            summary totals; a transfer feeds neither, so it has nothing to hide.
+            Shown for a balance adjustment too — it is the one control that is live
+            on an otherwise read-only form, and skewed charts are exactly what a
+            correction causes (it writes itself straight to the DB, see the
+            handler). */}
+        {!isNew && values.type !== 'transfer' && (
           <View style={styles.excludeAvgRow}>
             <View style={styles.excludeAvgTextContainer}>
               <Text style={[modalSharedStyles.fieldLabel, styles.excludeAvgLabel, { color: colors.mutedText }]}>

--- a/app/utils/overlayGeometry.js
+++ b/app/utils/overlayGeometry.js
@@ -1,0 +1,31 @@
+/**
+ * Geometry helpers for anchoring an overlay (see OverlayHostContext) to something
+ * already drawn on screen.
+ */
+
+/**
+ * Turn a WINDOW-measured rect into one expressed in the overlay host's space.
+ *
+ * Why window coordinates and not `measureLayout(host)`: `measureLayout` walks
+ * layout positions, and a row's layout position inside a VirtualizedList is its
+ * offset within the list's CONTENT — the scroll translation is not part of it. On
+ * a scrolled list that anchors the overlay a full scroll offset below the row,
+ * i.e. off-screen for anything past the first screenful. `measureInWindow` already
+ * accounts for the scroll, so measuring both the row and the host that way and
+ * subtracting gives a rect the overlay can use directly.
+ *
+ * @param {{x: number, y: number, width: number, height: number}|null} rowRect - row, measured in window coordinates
+ * @param {{x: number, y: number}|null} hostOrigin - overlay host's window origin
+ * @returns {{x: number, y: number, width: number, height: number}|null} rect in host space,
+ *   or null when the row has no usable box (a collapsed or not-yet-laid-out node
+ *   reports a zero size; anchoring to that would draw a zero-width clone).
+ */
+export const anchorRectInHost = (rowRect, hostOrigin) => {
+  if (!rowRect || !rowRect.width || !rowRect.height) return null;
+  return {
+    x: rowRect.x - (hostOrigin?.x || 0),
+    y: rowRect.y - (hostOrigin?.y || 0),
+    width: rowRect.width,
+    height: rowRect.height,
+  };
+};


### PR DESCRIPTION
## The bug

Long-pressing an operation looked like nothing happened: the backdrop blurred, but no lifted row and no action bar. Reported against 0.245.0, reproducible on any list scrolled past the first screenful — which is why it showed up right after the hide-from-charts action landed (#1495): balance adjustments are old, so you reach them by scrolling or searching.

## Cause

`OperationListItem` measured the pressed row with `measureLayout(host)` (introduced by #1488 to share a coordinate space with the overlay layer). `measureLayout` walks **layout** positions, and a row's layout position inside a VirtualizedList is its offset within the list's **content** — the scroll translation is not part of it. So a row drawn at y≈400 on screen, sitting 3000px into the list, was anchored at y≈3000: clone and action bar both below the bottom of the screen.

## Fix

Measure the row **and** the host in window coordinates and subtract (`anchorRectInHost`). Window coordinates already include the scroll; the subtraction re-expresses them in the host's space, so #1488's "one coordinate space" property is kept and the anchor survives scrolling.

A row that reports a zero box (collapsed, or not yet laid out) now returns `null` and the menu falls back to its centred placement, instead of anchoring to a zero-width rect.

## Also here: the switch works for balance adjustments

The hide-from-charts toggle is now rendered for a shadow-category operation too, and for one it writes straight to the DB on toggle — that form is read-only and has no Save button. The long-press menu stays as the other entry point, but a balance correction is precisely the thing that skews the donut and the trend, so it should not depend on a gesture that can be missed.

## Testing

- `npx jest --silent` — 176 suites, 5099 tests, all passing.
- `npx eslint app/ __tests__/ --ext .js,.jsx --max-warnings 0` — clean.
- New: `__tests__/utils/overlayGeometry.test.js` pins the scrolled-row regression (window y stays a screen position) and the zero-box fallback; two cases in `OperationModal.test.js` cover the adjustment switch persisting immediately and the ordinary-operation switch deferring to Save.
- Not verified on a device: the local emulator would not boot. The geometry change is what the reporter observed directly ("the row drops below the screen"), and the arithmetic is covered by unit tests, but a manual pass on a scrolled list is worth doing before merge.
