### PR TITLE
fix(budgets): drop the month-pace tick from the plan bar

### DIFF
--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -1106,13 +1106,12 @@ describe('MonthlyPlanSection', () => {
     });
 
     // The bar carries the status now, in geometry: how much of the target is
-    // gone is its length, going PAST the target is a second segment beyond the
-    // mark at 72% of the track, and where the month says you should be is a tick
-    // on it. Colour was tried for all three and could not carry them — on a
-    // real month-end plan most rows are at or over target, so tinting them all
-    // separated nothing, and the amber and red tints were within a few units of
-    // each other at the alpha they were drawn with.
-    const pacedLine = (id, actual, amount, isExceeded = false) => ({
+    // gone is its length, and going PAST the target is a second segment beyond
+    // the mark at 72% of the track. Colour was tried for both and could not
+    // carry them — on a real month-end plan most rows are at or over target, so
+    // tinting them all separated nothing, and the amber and red tints were
+    // within a few units of each other at the alpha they were drawn with.
+    const trackedLine = (id, actual, amount, isExceeded = false) => ({
       plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }],
       lines: [{
         id, planId: 'p1', amount, label: 'Food', comment: null, kind: 'expense',
@@ -1139,35 +1138,22 @@ describe('MonthlyPlanSection', () => {
     const barFillColor = (getByTestId, id) =>
       StyleSheet.flatten(getByTestId(`plan-line-bar-${id}-plan`).props.style).backgroundColor;
 
-    it('marks where the month says the spend should be, on the current month', async () => {
-      // The marker EnvelopeFill had to drop, restored on a 4dp strip: as a
-      // hairline across a full-height row wash it stacked into one unbroken line
-      // down the card, because every row drew it at the same x. On the bars it
-      // sits at a different x per row and is 4dp tall.
-      setPlans(pacedLine('l-pace', '10', '100'));
-      const { getByTestId } = await renderSection();
-      await waitFor(() => expect(getByTestId('plan-line-bar-l-pace')).toBeTruthy());
-      expect(getByTestId('plan-line-bar-l-pace-pace')).toBeTruthy();
-    });
-
-    it('draws no pace marker on a month that is not the current one', async () => {
-      // "Ahead of pace" is not a thing that can be true about a finished month.
-      const previous = pacedLine('l-pace', '10', '100');
-      previous.plans[0].month = PREV_MONTH;
-      previous.planStatuses = new Map([['p1', {
-        ...previous.planStatuses.get('p1'), month: PREV_MONTH,
-      }]]);
-      setPlans(previous);
-      const { getByTestId, queryByTestId } = await renderSection(undefined, { month: PREV_MONTH });
-      await waitFor(() => expect(getByTestId('plan-line-bar-l-pace')).toBeTruthy());
-      expect(queryByTestId('plan-line-bar-l-pace-pace')).toBeNull();
+    it('draws the bar without a second mark for the month, on any month', async () => {
+      // A row's bar said two things at once: fill against target, and a tick for
+      // how far through the month today is. The tick was dropped — on a screen
+      // where every row draws a bar, a vertical per row is furniture, and the
+      // one vertical left on the strip is the target boundary.
+      setPlans(trackedLine('l-bar', '10', '100'));
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-bar-l-bar')).toBeTruthy());
+      expect(queryByTestId('plan-line-bar-l-bar-pace')).toBeNull();
     });
 
     it('gives a line inside its target no signal colour at all', async () => {
       // 1% spent. The fill is a neutral material, not a grade: the only
       // saturated colour left on the screen is the segment past the target, so
       // an alarm on the row means one thing and reads at a glance.
-      setPlans(pacedLine('l-calm', '1', '100'));
+      setPlans(trackedLine('l-calm', '1', '100'));
       const { getByTestId, queryByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-bar-l-calm')).toBeTruthy());
       const fill = barFillColor(getByTestId, 'l-calm');
@@ -1178,20 +1164,19 @@ describe('MonthlyPlanSection', () => {
       expect(flatColor(getByTestId('plan-line-primary-l-calm'))).toBe(COLORS.text);
     });
 
-    it('says how far a line is ahead of the month by position, not by tone', async () => {
-      // 99% spent — ahead of the month's pace on any day of it. That used to be
-      // an amber wash indistinguishable from the red one; it is now the fill
-      // reaching past the pace tick, and the row stays uncoloured.
-      setPlans(pacedLine('l-ahead', '99', '100'));
+    it('says how nearly spent a line is by length, not by tone', async () => {
+      // 99% spent but not over. That used to be an amber wash indistinguishable
+      // from the red one; it is now a fill that stops just short of the target
+      // gap, with no overspend segment and no colour on the row.
+      setPlans(trackedLine('l-ahead', '99', '100'));
       const { getByTestId, queryByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-bar-l-ahead')).toBeTruthy());
       expect(barFillColor(getByTestId, 'l-ahead')).not.toContain(COLORS.warning);
       expect(queryByTestId('plan-line-bar-l-ahead-over')).toBeNull();
-      expect(getByTestId('plan-line-bar-l-ahead-pace')).toBeTruthy();
     });
 
     it('spills a line past its target into the overspend segment', async () => {
-      setPlans(pacedLine('l-over', '140', '100', true));
+      setPlans(trackedLine('l-over', '140', '100', true));
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-bar-l-over')).toBeTruthy());
       expect(barOverColor(getByTestId, 'l-over')).toBe(COLORS.overspend);

--- a/__tests__/components/budgets/PlanProgressBar.test.js
+++ b/__tests__/components/budgets/PlanProgressBar.test.js
@@ -7,7 +7,6 @@ const COLORS = {
   track: '#aaaaaa26',
   fill: '#aaaaaa99',
   overspend: '#FF6B6B',
-  pace: '#ffffff59',
 };
 
 const renderBar = async (props = {}) => render(
@@ -16,7 +15,6 @@ const renderBar = async (props = {}) => render(
     trackColor={COLORS.track}
     fillColor={COLORS.fill}
     overspendColor={COLORS.overspend}
-    paceColor={COLORS.pace}
     testID="bar"
     {...props}
   />,
@@ -93,9 +91,8 @@ describe('PlanProgressBar', () => {
 
   // The target boundary used to be nothing but the step in brightness between
   // the two track zones — which the fill covers on any row at or past its
-  // target, i.e. on most rows of a month-end plan. What was left on such a row
-  // was the pace tick, a lone vertical some 7% to the boundary's left, and that
-  // is what a reader took the boundary to be.
+  // target, i.e. on most rows of a month-end plan, leaving nothing on the strip
+  // to read the target off.
   describe('Target boundary', () => {
     it('leaves a gap between the two zones, so the target is marked on an empty track', async () => {
       const { getByTestId } = await renderBar({ ratio: 0.4 });
@@ -120,37 +117,13 @@ describe('PlanProgressBar', () => {
       expect(styleOf(getByTestId('bar-over')).width).toBe('27.2%');
     });
 
-    it('keeps the pace tick clear of the boundary it was being mistaken for', async () => {
-      // Even at the end of the month the tick lands ON the target rather than in
-      // the gap, so the gap stays the only thing that separates the zones.
-      const { getByTestId } = await renderBar({ ratio: 1.8, pace: 1 });
-      expect(styleOf(getByTestId('bar-pace')).left).toBe('72%');
-      expect(styleOf(getByTestId('bar-over-zone')).left).toBe('72.8%');
-    });
-  });
-
-  describe('Pace marker', () => {
-    it('is absent when the month has no pace to speak of', async () => {
-      const { queryByTestId } = await renderBar({ pace: null });
+    it('leaves the gap as the only vertical on the strip', async () => {
+      // The bar used to carry a second mark for the month's pace, and a reader
+      // looking for the target read whichever vertical was there as the target.
+      // Nothing but the two zones and their fills is drawn now.
+      const { getByTestId, queryByTestId } = await renderBar({ ratio: 1.8 });
       expect(queryByTestId('bar-pace')).toBeNull();
-    });
-
-    it('sits inside the plan zone, proportionally to the month', async () => {
-      // The plan occupies 72% of the track, so half the month is at 36% — the
-      // mark has to land where the fill would be at that point, not at half the
-      // whole track.
-      const { getByTestId } = await renderBar({ pace: 0.5 });
-      expect(styleOf(getByTestId('bar-pace')).left).toBe('36%');
-    });
-
-    it('lands on the target boundary at the end of the month', async () => {
-      const { getByTestId } = await renderBar({ pace: 1 });
-      expect(styleOf(getByTestId('bar-pace')).left).toBe('72%');
-    });
-
-    it('clamps a pace outside the month rather than drawing off the track', async () => {
-      const { getByTestId } = await renderBar({ pace: 1.4 });
-      expect(styleOf(getByTestId('bar-pace')).left).toBe('72%');
+      expect(styleOf(getByTestId('bar-over-zone')).left).toBe('72.8%');
     });
   });
 });

--- a/__tests__/utils/monthUtils.test.js
+++ b/__tests__/utils/monthUtils.test.js
@@ -1,5 +1,5 @@
 // __tests__/utils/monthUtils.test.js
-import { currentMonthKey, addMonths, formatMonthLabel, monthProgressFraction } from '../../app/utils/monthUtils';
+import { currentMonthKey, addMonths, formatMonthLabel } from '../../app/utils/monthUtils';
 
 describe('monthUtils', () => {
   describe('currentMonthKey', () => {
@@ -49,29 +49,6 @@ describe('monthUtils', () => {
     it('falls back to the device locale when no language is given', () => {
       expect(typeof formatMonthLabel('2026-07')).toBe('string');
       expect(formatMonthLabel('2026-07')).toMatch(/2026/);
-    });
-  });
-
-  describe('monthProgressFraction', () => {
-    it('returns how far through the current month today is', () => {
-      const now = new Date();
-      const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-      expect(monthProgressFraction(currentMonthKey())).toBeCloseTo(now.getDate() / daysInMonth, 10);
-    });
-
-    it('stays within (0, 1]', () => {
-      const fraction = monthProgressFraction(currentMonthKey());
-      expect(fraction).toBeGreaterThan(0);
-      expect(fraction).toBeLessThanOrEqual(1);
-    });
-
-    it('returns null for any month but the current one', () => {
-      // A past month is fully spent and a future one has not started, so "are
-      // you ahead of pace" is not a question either can answer — the caller
-      // draws no today marker at all rather than pinning one to an edge.
-      expect(monthProgressFraction(addMonths(currentMonthKey(), -1))).toBeNull();
-      expect(monthProgressFraction(addMonths(currentMonthKey(), 1))).toBeNull();
-      expect(monthProgressFraction('2020-01')).toBeNull();
     });
   });
 });

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -17,7 +17,7 @@ import BudgetLineGroupModal from './BudgetLineGroupModal';
 import PlanLineRow from './PlanLineRow';
 import PlanGroupRow from './PlanGroupRow';
 import PlanTemplateSummary from './PlanTemplateSummary';
-import { currentMonthKey, addMonths, formatMonthLabel, monthProgressFraction } from '../../utils/monthUtils';
+import { currentMonthKey, addMonths, formatMonthLabel } from '../../utils/monthUtils';
 
 const CLOSED_MODAL = { visible: false, line: null, kind: 'expense' };
 const CLOSED_GROUP_MODAL = { visible: false, group: null };
@@ -127,10 +127,6 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   // shown month IS the current one; other months still show the templates and
   // their (historical) done state.
   const isCurrentMonth = month === currentMonthKey();
-  // Where "today" sits within the shown month, for the marker each row draws
-  // across its fill. Null for any month but the current one, where being ahead
-  // of pace is not a thing that can be true.
-  const pace = useMemo(() => monthProgressFraction(month), [month]);
 
   const planId = plan?.id ?? null;
   // The currency the section READS in, which is the one the host's chip names —
@@ -874,7 +870,6 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         canExecute={line.hasTemplate && isCurrentMonth && !executed}
         canUndo={line.hasTemplate && isCurrentMonth && executed}
         showProgress={line.kind !== 'income'}
-        pace={pace}
         listLength={list.length}
         onMove={onMove}
         onPress={openEditLine}
@@ -884,7 +879,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         onUndo={handleUndoExecuted}
       />
     );
-  }, [colors, t, month, isCurrentMonth, pace, lineStatusById, planCurrency, amountById, converting,
+  }, [colors, t, month, isCurrentMonth, lineStatusById, planCurrency, amountById, converting,
     openEditLine, handleLongPressLine, lineDisplayName, lineIcon, handleExecute,
     handleMarkExecuted, handleUndoExecuted]);
 
@@ -1004,7 +999,6 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
                 planCurrency={planCurrency}
                 colors={colors}
                 t={t}
-                pace={pace}
                 onMove={moveGroup}
                 onPress={openEditGroup}
                 onLongPress={handleLongPressGroup}

--- a/app/components/budgets/PlanGroupRow.js
+++ b/app/components/budgets/PlanGroupRow.js
@@ -10,11 +10,10 @@ import { SPACING } from '../../styles/layout';
 // PlanLineRow uses, for the same reason.
 const CONVERTING_PLACEHOLDER = '—';
 
-// Track / fill / pace tints, matching PlanLineRow so an envelope's bar and its
+// Track / fill tints, matching PlanLineRow so an envelope's bar and its
 // children's bars read as the same instrument at two sizes.
 const TRACK_ALPHA = '26'; // ~15%
 const FILL_ALPHA = '99'; // ~60%
-const PACE_ALPHA = '59'; // ~35%
 
 /**
  * The header row of a GROUP of allocations (migration 0022).
@@ -42,7 +41,6 @@ const PlanGroupRow = memo(function PlanGroupRow({
   planCurrency,
   colors,
   t,
-  pace = null,
   listLength,
   onMove = null,
   onPress,
@@ -146,11 +144,9 @@ const PlanGroupRow = memo(function PlanGroupRow({
             <View style={styles.meterBar}>
               <PlanProgressBar
                 ratio={ratio}
-                pace={pace}
                 trackColor={`${colors.mutedText}${TRACK_ALPHA}`}
                 fillColor={`${colors.mutedText}${FILL_ALPHA}`}
                 overspendColor={colors.overspend}
-                paceColor={`${colors.text}${PACE_ALPHA}`}
                 height={5}
                 testID={`plan-group-bar-${group.id}`}
               />
@@ -201,7 +197,6 @@ PlanGroupRow.propTypes = {
   planCurrency: PropTypes.string.isRequired,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
-  pace: PropTypes.number,
   onMove: PropTypes.func,
   onPress: PropTypes.func.isRequired,
   onLongPress: PropTypes.func.isRequired,

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -27,9 +27,6 @@ const TRACK_ALPHA = '26'; // ~15%
 // target is gone is said by the length, and the only saturated colour left on
 // this screen is the overspend segment past the target mark.
 const FILL_ALPHA = '99'; // ~60%
-// The pace mark has to stay legible over both the empty track and the fill, so
-// it is drawn in the row's text colour rather than in the track's.
-const PACE_ALPHA = '59'; // ~35%
 
 /**
  * One row of the unified Budgets list (Budgets v3 phase 3).
@@ -67,7 +64,6 @@ const PlanLineRow = memo(function PlanLineRow({
   showProgress = true,
   indented = false,
   envelopeColor = null,
-  pace = null,
   listLength,
   onMove = null,
   onPress,
@@ -140,9 +136,9 @@ const PlanLineRow = memo(function PlanLineRow({
   }
 
   // Over target is the one thing on this row that gets a colour. Everything else
-  // — on pace, ahead of pace, nearly spent — is said by the bar's length and by
-  // the mark on it, because colouring those too is how the previous design ended
-  // up with ten tinted rows and no hierarchy.
+  // — barely started, half gone, nearly spent — is said by the bar's length,
+  // because colouring those too is how the previous design ended up with ten
+  // tinted rows and no hierarchy.
   const overspent = remaining != null && Currency.isNegative(remaining);
   let primaryColor = colors.text;
   if (overspent) primaryColor = colors.overspend;
@@ -292,11 +288,9 @@ const PlanLineRow = memo(function PlanLineRow({
             <View style={styles.meterBar}>
               <PlanProgressBar
                 ratio={ratio}
-                pace={pace}
                 trackColor={`${colors.mutedText}${TRACK_ALPHA}`}
                 fillColor={`${colors.mutedText}${FILL_ALPHA}`}
                 overspendColor={colors.overspend}
-                paceColor={`${colors.text}${PACE_ALPHA}`}
                 testID={`plan-line-bar-${line.id}`}
               />
             </View>
@@ -427,7 +421,6 @@ PlanLineRow.propTypes = {
   showProgress: PropTypes.bool,
   indented: PropTypes.bool,
   envelopeColor: PropTypes.string,
-  pace: PropTypes.number,
   onMove: PropTypes.func,
   onPress: PropTypes.func.isRequired,
   onLongPress: PropTypes.func.isRequired,

--- a/app/components/budgets/PlanProgressBar.js
+++ b/app/components/budgets/PlanProgressBar.js
@@ -24,14 +24,12 @@ const PLAN_STOP = 0.72;
  * and it is — right up until the fill covers it. Every row at or past its target
  * paints the whole plan zone solid, and on a month-end plan that is most of
  * them, so the one place the mark is needed is the one place it disappeared.
- * What was left on such a row was a single vertical line, the pace tick, sitting
- * some 7% to its left — and a reader looking for the target boundary reads
- * whatever vertical is there as the boundary. It is a gap rather than a drawn
- * tick because the track has no background of its own: the zones are the
- * background, so leaving a slice unpainted shows the card through it, and it
- * reads over the fill and the overspend alike without needing to know either
- * colour. It also says "boundary" in a different language than the pace tick
- * does — negative space against a line — so the two can no longer be confused.
+ * It is a gap rather than a drawn tick because the track has no background of
+ * its own: the zones are the background, so leaving a slice unpainted shows the
+ * card through it, and it reads over the fill and the overspend alike without
+ * needing to know either colour. It is also the only vertical on the bar, which
+ * is what keeps it unambiguous: whatever break a reader finds in the strip is
+ * the target.
  *
  * As a fraction of the track: ~2dp on the ~250dp bar this screen draws.
  */
@@ -81,17 +79,20 @@ export function overspendFraction(ratio) {
  * belongs to (see envelopePalette) and this bar carries the status, in
  * geometry, where more spending always means more bar.
  *
+ * The bar says one thing: how the actual stands against the target. It used to
+ * carry a second mark for how far through the month today is, so that 99% spent
+ * read as fine on the 27th and alarming on the 3rd. That mark is gone — on a
+ * screen where every row draws a bar, a second vertical per row was more
+ * furniture than signal, and the calendar is not something a budget row has to
+ * restate.
+ *
  * @param {number} ratio - actual / target. May exceed 1; that is the point.
- * @param {?number} pace - How far through the month we are, 0..1, or null when
- *   the month is not the current one (a finished month has no "should be here").
  */
 const PlanProgressBar = ({
   ratio,
-  pace = null,
   trackColor,
   fillColor,
   overspendColor,
-  paceColor,
   height = 4,
   testID,
 }) => {
@@ -144,32 +145,15 @@ const PlanProgressBar = ({
           style={[styles.overFill, { backgroundColor: overspendColor }, overStyle]}
         />
       )}
-
-      {/* Where the month says the spending should have reached by today. This is
-          the marker EnvelopeFill had to drop: as a dashed hairline across a
-          full-height row wash, Android drew it solid, and every row carrying one
-          at the same x stacked into an unbroken line down the card that read as
-          a rendering artefact. On a 4dp strip there is no such stack — the marks
-          sit at different x on every row and are 4dp tall. Being ahead of pace
-          used to be said with an amber tone that was indistinguishable from the
-          red one at the alpha it was drawn with; it is a position now. */}
-      {pace != null && (
-        <View
-          testID={testID ? `${testID}-pace` : undefined}
-          style={[styles.paceTick, { backgroundColor: paceColor, left: pct(Math.min(Math.max(pace, 0), 1) * PLAN_STOP) }]}
-        />
-      )}
     </View>
   );
 };
 
 PlanProgressBar.propTypes = {
   ratio: PropTypes.number.isRequired,
-  pace: PropTypes.number,
   trackColor: PropTypes.string.isRequired,
   fillColor: PropTypes.string.isRequired,
   overspendColor: PropTypes.string.isRequired,
-  paceColor: PropTypes.string.isRequired,
   height: PropTypes.number,
   testID: PropTypes.string,
 };
@@ -209,12 +193,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 0,
     top: 0,
-  },
-  paceTick: {
-    bottom: 0,
-    position: 'absolute',
-    top: 0,
-    width: 1.5,
   },
   planFill: {
     bottom: 0,

--- a/app/contexts/ThemeColorsContext.js
+++ b/app/contexts/ThemeColorsContext.js
@@ -22,8 +22,8 @@ const lightTheme = {
     danger: 'red',
     // Budget-row signal colours. Real hex (unlike `danger`, a bare CSS keyword)
     // because a plan row tints its background with these at a low alpha, which
-    // needs an appendable hex channel. `warning` means "ahead of the month's
-    // pace", `overspend` means "past the target".
+    // needs an appendable hex channel. `overspend` means "past the target" — the
+    // one status a plan row states in colour.
     warning: '#C77700',
     overspend: '#C62828',
     delete: '#d9534f',

--- a/app/utils/monthUtils.js
+++ b/app/utils/monthUtils.js
@@ -17,27 +17,6 @@ export const addMonths = (monthKey, delta) => {
 };
 
 /**
- * How far through `monthKey` today is, as a 0..1 fraction — or null when the
- * month shown is not the current one.
- *
- * Drives the "today" marker on a plan row: the marker is what makes 99% spent
- * legible as fine on the 27th and alarming on the 3rd. A past month is fully
- * spent and a future one hasn't started, so in neither case does "are you ahead
- * of pace" mean anything, and the marker is not drawn at all.
- *
- * Measured at the END of today (day N of M → N/M), so the last day of the month
- * reads as a full month elapsed rather than one day short.
- * @param {string} monthKey - YYYY-MM
- * @returns {number|null}
- */
-export const monthProgressFraction = (monthKey) => {
-  if (monthKey !== currentMonthKey()) return null;
-  const now = new Date();
-  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  return now.getDate() / daysInMonth;
-};
-
-/**
  * Localized "Month YYYY" label for a YYYY-MM key.
  *
  * `language` is the app's own language code (LocalizationContext), NOT the device


### PR DESCRIPTION
## What

Every plan row drew a second vertical on its 4dp bar — a tick for how far through the current month today is — on top of the target-boundary gap. It's gone.

## Why

The tick answered "is 99% spent fine on the 27th or alarming on the 3rd?", but it cost more than it said:

- on a screen where **every** row carries a bar, one extra vertical per row is furniture, not signal;
- a reader looking for the target reads whichever vertical is nearest as the target — the gap landed at 72% of the track, the tick anywhere left of it. That ambiguity is exactly what #1500 was fighting.

The boundary gap is now the only break in the strip, so the bar states one thing: actual against target.

## Changes

- `PlanProgressBar` — `pace` / `paceColor` props, the tick and its style removed
- `PlanLineRow`, `PlanGroupRow` — `pace` prop and `PACE_ALPHA` removed
- `MonthlyPlanSection` — no longer computes or threads `pace`
- `monthUtils.monthProgressFraction` deleted; the tick was its only caller

## Tests

Pace-marker suites replaced with regression tests asserting the tick is absent and the gap is the only vertical left. Full suite green (4965 tests), eslint clean.