### PR TITLE
fix(budgets): glyph the one-off lines, dock the month jump beside the label

### DIFF
--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -530,12 +530,37 @@ describe('MonthlyPlanSection', () => {
       await waitFor(() => expect(getByTestId('plan-line-l-rec')).toBeTruthy());
       expect(getByTestId('plan-empty-state')).toBeTruthy();
       expect(queryByTestId('plan-line-execute-l-rec')).toBeNull(); // no template → not executable
-      // Scope is a glyph beside the name now, not an uppercase text line.
-      expect(getByTestId('plan-line-recurring-l-rec')).toBeTruthy();
+      // Monthly repetition is the default, so it carries no glyph — only a
+      // one-off line is marked.
+      expect(queryByTestId('plan-line-one-time-l-rec')).toBeNull();
       // ...but NOT the "no plan yet" copy: it sat directly under a populated
       // list and above a totals row, contradicting both.
       expect(queryByTestId('plan-create-empty')).toBeTruthy();
       expect(() => getByText('no_plan_for_month')).toThrow();
+    });
+
+    it('glyphs the one-off line and leaves the recurring one unmarked', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }],
+        lines: [
+          recurringLine,
+          {
+            id: 'l-once', planId: 'p1', amount: '4000', label: 'Gift', comment: null,
+            categoryId: 'cat1', toAccountId: null, sortOrder: 1, isBroken: false,
+            isRecurring: false, currency: null,
+          },
+        ],
+      });
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l-once')).toBeTruthy());
+      // The marked row is the exception (this month only); repeating every month
+      // is the default and says nothing worth a glyph.
+      expect(getByTestId('plan-line-one-time-l-once')).toBeTruthy();
+      expect(queryByTestId('plan-line-one-time-l-rec')).toBeNull();
+      // Both scopes stay spelled out for a screen reader, which cannot see the
+      // absence of a glyph.
+      expect(getByTestId('plan-line-l-rec').props.accessibilityLabel).toContain('recurring');
+      expect(getByTestId('plan-line-l-once').props.accessibilityLabel).toContain('one_time');
     });
 
     it('keeps the "no plan yet" copy for a genuinely blank month', async () => {
@@ -1406,15 +1431,16 @@ describe('MonthlyPlanSection', () => {
     // — and it kept saying so on months where execution is disabled anyway.
     // The uppercase "RECURRING · PENDING_EXECUTION" line under every row is gone
     // — it repeated the default on nearly all of them while being the loudest
-    // thing after the amount. Scope is a glyph beside the name, template state is
-    // a badge on the category icon, and both are spelled out in the row's
-    // accessibility label, which a screen reader reads and a glyph cannot say.
+    // thing after the amount. Template state is a badge on the category icon,
+    // scope is a glyph beside the name ON ONE-OFF ROWS ONLY, and both are
+    // spelled out in the row's accessibility label, which a screen reader reads
+    // and a glyph cannot say.
     it('marks a pending template with a badge and names the state for a screen reader', async () => {
       setPlans({ plans: [], lines: [TEMPLATE_LINE] });
-      const { queryByText, getByTestId } = await renderSection();
+      const { queryByText, getByTestId, queryByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l-tpl')).toBeTruthy());
       expect(getByTestId('plan-line-pending-l-tpl')).toBeTruthy();
-      expect(getByTestId('plan-line-recurring-l-tpl')).toBeTruthy();
+      expect(queryByTestId('plan-line-one-time-l-tpl')).toBeNull();
       expect(getByTestId('plan-line-l-tpl').props.accessibilityLabel)
         .toContain('recurring, pending_execution');
       expect(queryByText('recurring · pending_execution')).toBeNull();

--- a/__tests__/screens/BudgetScreen.test.js
+++ b/__tests__/screens/BudgetScreen.test.js
@@ -322,7 +322,7 @@ describe('BudgetScreen', () => {
 
   describe('Month navigation (Fix 4: jump back to the current month)', () => {
     it('shows a jump-to-current-month affordance after navigating away, and returns on press', async () => {
-      const { getByTestId, queryByTestId, getByText } = await render(<BudgetScreen />);
+      const { getByTestId, queryByTestId, queryByText } = await render(<BudgetScreen />);
       await waitFor(() => expect(getByTestId('budget-month-header')).toBeTruthy());
       const originalLabel = getByTestId('budget-month-label').props.children;
 
@@ -330,7 +330,11 @@ describe('BudgetScreen', () => {
       await waitFor(() => expect(getByTestId('budget-jump-current')).toBeTruthy());
       // The month label actually changed away from the current month.
       expect(getByTestId('budget-month-label').props.children).not.toBe(originalLabel);
-      expect(getByText('jump_to_current_period')).toBeTruthy();
+      // Icon-only, beside the label: the labelled button used to occupy a row of
+      // its own and pushed the hero figure and the whole plan down on any month
+      // but this one. The wording survives as the accessibility label.
+      expect(queryByText('jump_to_current_period')).toBeNull();
+      expect(getByTestId('budget-jump-current').props.accessibilityLabel).toBe('jump_to_current_period');
 
       fireEvent.press(getByTestId('budget-jump-current'));
       await waitFor(() => expect(queryByTestId('budget-jump-current')).toBeNull());

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -252,16 +252,18 @@ const PlanLineRow = memo(function PlanLineRow({
               >
                 {name}
               </Text>
-              {/* Replaces a full uppercase "RECURRING" line that sat on nearly
-                  every row, saying the same thing each time while being the
-                  loudest thing after the amount. A one-off line gets no marker:
-                  the glyph is the exception, not the label. */}
-              {line.isRecurring && (
+              {/* Marks the EXCEPTION, not the rule. A plan line repeats every
+                  month by default — that is what a monthly plan is — so a
+                  repeat glyph on nearly every row was a column of identical
+                  marks carrying no information. What a reader actually needs to
+                  spot is the row that lives for this month only, and that is
+                  what gets the glyph. */}
+              {!line.isRecurring && (
                 <Icon
-                  name="repeat"
+                  name="numeric-1-circle-outline"
                   size={13}
                   color={colors.mutedText}
-                  testID={`plan-line-recurring-${line.id}`}
+                  testID={`plan-line-one-time-${line.id}`}
                 />
               )}
             </View>

--- a/app/screens/BudgetScreen.js
+++ b/app/screens/BudgetScreen.js
@@ -218,9 +218,40 @@ const BudgetScreen = () => {
         >
           <Icon name="chevron-left" size={26} color={colors.text} />
         </Pressable>
-        <Text style={[styles.monthTitle, { color: colors.text }]} testID="budget-month-label">
-          {formatMonthLabel(month, language)}
-        </Text>
+        {/* Fix 4: the screen never unmounts across tab switches, so a user who
+            wanders off-month and returns later needs an explicit, visible way
+            back — silently auto-resetting the month would be surprising.
+            It used to be a labelled button on a row of its own under the title,
+            which pushed the hero figure and the whole plan down by ~22dp the
+            moment you stepped one month back — the content shifting under the
+            thumb that navigated. Now it is a glyph beside the label, in a slot
+            mirrored on the other side so the month name stays on the same
+            centre line whether or not the button is up. */}
+        <View style={styles.monthTitleWrap}>
+          {!isCurrentMonth && <View style={styles.jumpSlot} />}
+          <Text
+            style={[styles.monthTitle, { color: colors.text }]}
+            numberOfLines={1}
+            testID="budget-month-label"
+          >
+            {formatMonthLabel(month, language)}
+          </Text>
+          {!isCurrentMonth && (
+            <Pressable
+              onPress={handleJumpToCurrentMonth}
+              style={styles.jumpSlot}
+              // The glyph's own box is 26×18; the slop is what brings the target
+              // up to a thumb's worth without widening the slot the label is
+              // centred against.
+              hitSlop={12}
+              accessibilityRole="button"
+              accessibilityLabel={t('jump_to_current_period')}
+              testID="budget-jump-current"
+            >
+              <Icon name="calendar-today" size={18} color={colors.primary} />
+            </Pressable>
+          )}
+        </View>
         <Pressable
           onPress={handleNextMonth}
           hitSlop={8}
@@ -232,24 +263,6 @@ const BudgetScreen = () => {
           <Icon name="chevron-right" size={26} color={colors.text} />
         </Pressable>
       </View>
-      {/* Fix 4: the screen never unmounts across tab switches, so a user who
-          wanders off-month and returns later needs an explicit, visible way
-          back — silently auto-resetting the month would be surprising. */}
-      {!isCurrentMonth && (
-        <Pressable
-          onPress={handleJumpToCurrentMonth}
-          style={styles.jumpToCurrentButton}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel={t('jump_to_current_period')}
-          testID="budget-jump-current"
-        >
-          <Icon name="calendar-today" size={14} color={colors.primary} />
-          <Text style={[styles.jumpToCurrentText, { color: colors.primary }]}>
-            {t('jump_to_current_period')}
-          </Text>
-        </Pressable>
-      )}
       {/* The month's headline figure. It used to sit at the very bottom of the
           plan card in 14px muted text, below every row and the allocated/actual
           totals — the one number a person acts on, placed where they would reach
@@ -445,17 +458,12 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     letterSpacing: -0.5,
   },
-  jumpToCurrentButton: {
+  // Both sides of the label reserve the same box, so mounting the jump button
+  // never moves the month name off centre.
+  jumpSlot: {
     alignItems: 'center',
-    alignSelf: 'center',
-    flexDirection: 'row',
-    gap: 4,
-    marginTop: 4,
-    paddingVertical: 2,
-  },
-  jumpToCurrentText: {
-    fontSize: 12,
-    fontWeight: '600',
+    justifyContent: 'center',
+    width: 26,
   },
   listContent: {
     flexGrow: 1,
@@ -477,8 +485,16 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   monthTitle: {
+    flexShrink: 1,
     fontSize: 17,
     fontWeight: '700',
+  },
+  monthTitleWrap: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    gap: 2,
+    justifyContent: 'center',
   },
   navButton: {
     padding: 4,


### PR DESCRIPTION
## What

Two bits of the Budgets tab said the obvious thing loudly.

**1. The recurrence marker is inverted.** A plan line repeats every month by default — that is what a monthly plan *is* — so the `repeat` glyph landed on nearly every row: a column of identical marks carrying no information. The exception worth spotting is the row that lives for **this month only**, so that is the row that now carries a glyph (`numeric-1-circle-outline`, same 13dp muted weight). Recurring rows are unmarked.

Both scopes stay spelled out in the row's accessibility label — a screen reader cannot read the absence of a glyph.

**2. The jump-to-current-month control no longer moves the content.** It was a labelled button on a row of its own under the month title, so stepping one month back pushed the hero figure and the entire plan down by ~22dp — the content shifting under the thumb that just navigated.

It is an icon button beside the label now, sitting in a 26dp slot that is mirrored on the other side of the title, so:
- the month name keeps exactly the same centre line whether or not the button is mounted,
- the header height never changes between months.

The wording survives as the accessibility label, and the glyph (`calendar-today`) matches what the Graphs period picker already uses for the same action.

## Tests

- `npx jest --testPathIgnorePatterns=/node_modules/ --silent` → **175 suites, 5081 tests, all passing**
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` → clean
- `MonthlyPlanSection` tests updated: the recurring row asserts *no* glyph, a new case asserts the one-off row gets one and that both scopes reach the a11y label
- `BudgetScreen` test now asserts the jump control is icon-only and carries the wording as `accessibilityLabel`

Not verified on a device — the layout change is pure flex (mirrored fixed-width slots), no measurement involved.
