### PR TITLE
fix(operations): keep every pickable account reachable as a transfer target

### DIFF
--- a/__tests__/components/OperationFormFields.test.js
+++ b/__tests__/components/OperationFormFields.test.js
@@ -458,6 +458,75 @@ describe('OperationFormFields', () => {
     });
   });
 
+  describe('Transfer Target Shortcuts', () => {
+    const makeAccounts = (count, prefix = 'T') =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `t-${i + 1}`,
+        name: `${prefix}${i + 1}`,
+        currency: 'USD',
+        balance: '100',
+      }));
+
+    const transferProps = (accounts, topTransferAccounts) => ({
+      ...defaultProps,
+      values: {
+        type: 'transfer',
+        amount: '100',
+        accountId: 'src',
+        toAccountId: '',
+        categoryId: '',
+      },
+      accounts: [{ id: 'src', name: 'Source', currency: 'USD', balance: '900' }, ...accounts],
+      topTransferAccounts,
+      transferLayout: 'sideBySide',
+      getAccountName: (id) => (id === 'src' ? 'Source' : accounts.find(a => a.id === id)?.name || 'Unknown'),
+      getAccountBalance: () => '',
+    });
+
+    it('should not show the all-accounts entry when the shortcuts reach every target', async () => {
+      const accounts = makeAccounts(3);
+      const { queryByTestId, getByText } = await render(
+        <OperationFormFields {...transferProps(accounts, accounts)} />,
+      );
+
+      expect(queryByTestId('all-accounts-button')).toBeNull();
+      accounts.forEach(acc => expect(getByText(acc.name)).toBeTruthy());
+    });
+
+    it('should show the all-accounts entry and seven shortcuts when targets overflow', async () => {
+      const accounts = makeAccounts(9);
+      const { getByTestId, getByText, queryByText } = await render(
+        <OperationFormFields {...transferProps(accounts, accounts.slice(0, 8))} />,
+      );
+
+      expect(getByTestId('all-accounts-button')).toBeTruthy();
+      // Seven chips fit beside the entry button; the eighth suggestion is dropped
+      accounts.slice(0, 7).forEach(acc => expect(getByText(acc.name)).toBeTruthy());
+      expect(queryByText('T8')).toBeNull();
+      expect(queryByText('T9')).toBeNull();
+    });
+
+    it('should offer the all-accounts entry when a pickable account is missing from the shortcuts', async () => {
+      // Regression: suggestions filled with accounts this picker does not offer
+      // (e.g. hidden ones) left a pickable account unreachable — no chip, no entry.
+      const accounts = makeAccounts(8);
+      const stale = Array.from({ length: 8 }, (_, i) => ({
+        id: `gone-${i + 1}`,
+        name: `Gone${i + 1}`,
+        currency: 'USD',
+        balance: '5',
+      }));
+      const props = transferProps(accounts, stale);
+
+      const { getByTestId } = await render(<OperationFormFields {...props} />);
+
+      const entry = getByTestId('all-accounts-button');
+      await fireEvent.press(entry);
+
+      expect(props.openPicker).toHaveBeenCalledWith('toAccount', accounts);
+    });
+  });
+
   describe('Account Balance Display', () => {
     it('should show account balance when showAccountBalance is true', async () => {
       const props = {

--- a/__tests__/hooks/useQuickAddForm.test.js
+++ b/__tests__/hooks/useQuickAddForm.test.js
@@ -814,6 +814,41 @@ describe('useQuickAddForm', () => {
 
       expect(result.current.topTransferAccountsForForm).toHaveLength(8);
     });
+
+    it('should not let hidden accounts occupy suggestion slots', async () => {
+      // Eight hidden accounts dominate the transfer history; the only pickable
+      // target besides the source has never received a transfer.
+      const hidden = Array.from({ length: 8 }, (_, i) => ({
+        id: `hid-${i + 1}`,
+        name: `Hidden ${i + 1}`,
+        currency: 'USD',
+        balance: '10',
+        hidden: true,
+      }));
+      const visible = [
+        { id: 'acc-1', name: 'Checking', currency: 'USD', balance: '1000' },
+        { id: 'acc-fresh', name: 'Fresh', currency: 'USD', balance: '0' },
+      ];
+
+      mockGetTopTransferTargets.mockResolvedValue(
+        hidden.map((acc, i) => ({ accountId: acc.id, count: 10 - i })),
+      );
+
+      const { result } = await renderHook(() =>
+        useQuickAddForm(visible, [...visible, ...hidden], mockCategories, mockT),
+      );
+
+      await waitFor(() => {
+        expect(mockGetTopTransferTargets).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        result.current.setQuickAddValues(prev => ({ ...prev, type: 'transfer', accountId: 'acc-1' }));
+      });
+
+      const ids = result.current.topTransferAccountsForForm.map(a => a.id);
+      expect(ids).toEqual(['acc-fresh']);
+    });
   });
 
   describe('operationCurrency (foreign currency expense/income)', () => {

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -570,8 +570,10 @@ const OperationFormFields = memo(({
 
   // Suggested-category shortcut rows (the default QuickAdd view)
   const renderCategorySuggestionRows = () => {
+    // Seven shortcuts fit next to the entry button, eight without it — the slices
+    // stop there so the row render never has to drop a chip on the floor.
     const firstRowCats = showAllCategoriesButton ? topCategoriesForType.slice(0, 3) : topCategoriesForType.slice(0, 4);
-    const secondRowCats = showAllCategoriesButton ? topCategoriesForType.slice(3) : topCategoriesForType.slice(4);
+    const secondRowCats = showAllCategoriesButton ? topCategoriesForType.slice(3, 7) : topCategoriesForType.slice(4, 8);
 
     return (
       <>
@@ -760,11 +762,20 @@ const OperationFormFields = memo(({
         }
       };
 
-      // Show "all" button only when there are more than 8 available target accounts
-      const availableAccountCount = accounts.filter(acc => acc.id !== values.accountId).length;
-      const showAllAccountsButton = availableAccountCount > 8;
+      // The "all accounts" entry appears whenever the eight shortcut slots can't
+      // reach every pickable target — more than eight of them, or shortcuts that
+      // point at accounts this picker doesn't offer. Keying it off the raw account
+      // count alone left a pickable account with no route to it at all.
+      const availableAccounts = accounts.filter(acc => acc.id !== values.accountId);
+      const availableIds = new Set(availableAccounts.map(acc => acc.id));
+      const reachableWithoutButton = new Set(
+        topTransferAccounts.slice(0, 8).map(acc => acc.id).filter(id => availableIds.has(id)),
+      ).size;
+      const showAllAccountsButton = availableAccounts.length > reachableWithoutButton;
+      // The entry button takes the first slot, so only seven shortcuts fit; slicing
+      // to seven keeps the eighth from being silently dropped by the row below.
       const firstRowAccounts = showAllAccountsButton ? topTransferAccounts.slice(0, 3) : topTransferAccounts.slice(0, 4);
-      const secondRowAccounts = showAllAccountsButton ? topTransferAccounts.slice(3) : topTransferAccounts.slice(4);
+      const secondRowAccounts = showAllAccountsButton ? topTransferAccounts.slice(3, 7) : topTransferAccounts.slice(4, 8);
 
       const renderAccountChip = (account) => {
         const isSelected = values.toAccountId === account.id;
@@ -815,6 +826,7 @@ const OperationFormFields = memo(({
           <View style={styles.categoryButtonsContainer}>
             {showAllAccountsButton && (
               <Pressable
+                testID="all-accounts-button"
                 style={[styles.categoryPickerButton, inputStyle, toAccountBorderStyle, disabledStyle]}
                 onPress={() => !disabled && openPicker('toAccount', accounts.filter(acc => acc.id !== values.accountId))}
                 disabled={disabled}

--- a/app/hooks/useQuickAddForm.js
+++ b/app/hooks/useQuickAddForm.js
@@ -221,28 +221,33 @@ const useQuickAddForm = (visibleAccounts, accounts, categories, t) => {
     return [...fromHistory, ...fillers];
   }, [topCategories, categories, quickAddValues.type]);
 
-  // Get top transfer target accounts, filtered to existing accounts excluding current source
+  // Get top transfer target accounts. The candidate pool is exactly what the form
+  // lets the user pick — visible accounts minus the source — and history only
+  // decides their order. Resolving history against the full account list used to
+  // let hidden accounts occupy suggestion slots, pushing pickable accounts out of
+  // a grid that the "all accounts" fallback then thought was already complete.
   const topTransferAccountsForForm = useMemo(() => {
     if (quickAddValues.type !== 'transfer') return [];
 
     const sourceId = quickAddValues.accountId;
+    const selectable = visibleAccounts.filter(acc => acc.id !== sourceId);
 
-    // Filter history targets to accounts that still exist and aren't the source
+    // Order history targets that are still selectable, most used first
     const fromHistory = topTransferTargets
-      .map(tt => accounts.find(acc => acc.id === tt.accountId))
-      .filter(acc => acc && acc.id !== sourceId)
+      .map(tt => selectable.find(acc => acc.id === tt.accountId))
+      .filter(Boolean)
       .slice(0, 8);
 
     if (fromHistory.length >= 8) return fromHistory;
 
-    // Fill remaining slots from visible accounts excluding source and already-included
+    // Fill remaining slots from the rest of the selectable accounts
     const historyIds = new Set(fromHistory.map(acc => acc.id));
-    const fillers = visibleAccounts
-      .filter(acc => acc.id !== sourceId && !historyIds.has(acc.id))
+    const fillers = selectable
+      .filter(acc => !historyIds.has(acc.id))
       .slice(0, 8 - fromHistory.length);
 
     return [...fromHistory, ...fillers];
-  }, [topTransferTargets, accounts, visibleAccounts, quickAddValues.type, quickAddValues.accountId]);
+  }, [topTransferTargets, visibleAccounts, quickAddValues.type, quickAddValues.accountId]);
 
   // Reset form but keep account and type; restore operationCurrency to account currency
   const resetForm = useCallback(() => {


### PR DESCRIPTION
## What

An account that had never received a transfer could be impossible to pick as a transfer target in QuickAdd — no shortcut chip for it, and no "all accounts" button to reach it through either.

Two halves of the same grid disagreed about which accounts exist:

- **The suggestions** were resolved against the *full* account list (`accounts`), so hidden accounts with transfer history claimed suggestion slots — even though no picker in the app offers a hidden account as a transfer target.
- **The "all accounts" entry button** was sized from the *visible* list, appearing only when `availableCount > 8`.

So with eight hidden-but-historic targets and eight visible ones, all eight slots went to accounts the user could not pick, the visible account with no history got pushed out, and `8 > 8` kept the escape hatch hidden. Dead end.

## Fix

- `useQuickAddForm`: the suggestion pool is now exactly what the form offers — visible accounts minus the source. History only decides their **order**, it no longer decides membership. This matches `OperationModal` and the full picker, which both already work off `visibleAccounts`.
- `OperationFormFields`: the entry button appears whenever the eight slots can't *reach* every available target, not merely when there are more than eight of them. A suggestion pointing at an account the picker won't offer no longer counts as coverage.
- Both shortcut grids (accounts and categories) now slice to **seven** when the entry button occupies the first slot, instead of handing the second row an eighth chip that the fixed 4-slot render silently dropped.

Net effect for the reported case: the grid drops to 7 chips and the first slot becomes "all accounts".

## Tests

- `npx jest --testPathIgnorePatterns=/node_modules/ --silent` → **176 suites, 5093 tests, all passing**
- `npx eslint … --max-warnings 0` → clean
- New: hook test asserting hidden accounts can't occupy suggestion slots (red before the fix)
- New: `OperationFormFields` cases for the entry button — absent when the shortcuts cover everything, present with seven chips on overflow, and present (opening the full picker) when a pickable account is missing from the shortcuts (red before the fix)

Not verified on a device; the change is list arithmetic plus one conditional chip.
