### PR TITLE
feat(notifications): drop review cards for operations already recorded

### DIFF
--- a/__tests__/components/NotificationProcessingContentPanel.test.js
+++ b/__tests__/components/NotificationProcessingContentPanel.test.js
@@ -38,6 +38,9 @@ jest.mock('../../app/contexts/CategoriesContext', () => ({
 }));
 
 jest.mock('../../app/services/notifications/processBankNotifications');
+jest.mock('../../app/services/notifications/duplicateOperations', () => ({
+  reconcilePendingNotifications: jest.fn(() => Promise.resolve(0)),
+}));
 jest.mock('../../app/services/PendingNotificationsDB');
 jest.mock('../../app/services/NotificationAccess');
 jest.mock('../../app/services/notifications/notificationFilters', () => ({

--- a/__tests__/hooks/usePendingOperationSuggestions.test.js
+++ b/__tests__/hooks/usePendingOperationSuggestions.test.js
@@ -14,6 +14,9 @@ import { kindRequiresCategory } from '../../app/services/notifications/parseBank
 import { appEvents, EVENTS } from '../../app/services/eventEmitter';
 
 jest.mock('../../app/services/notifications/processBankNotifications');
+jest.mock('../../app/services/notifications/duplicateOperations', () => ({
+  reconcilePendingNotifications: jest.fn(() => Promise.resolve(0)),
+}));
 jest.mock('../../app/services/PendingNotificationsDB');
 jest.mock('../../app/services/NotificationRulesDB', () => ({
   getLabelForMerchant: jest.fn(),

--- a/__tests__/services/notifications/duplicateOperations.test.js
+++ b/__tests__/services/notifications/duplicateOperations.test.js
@@ -7,7 +7,6 @@
 import {
   operationMatchesNotification,
   findMatchingOperation,
-  hasMatchingOperation,
   reconcilePendingNotifications,
 } from '../../../app/services/notifications/duplicateOperations';
 import * as OperationsDB from '../../../app/services/OperationsDB';
@@ -93,6 +92,20 @@ describe('operationMatchesNotification', () => {
     const eurOp = op({ amount: '55000', destinationAmount: null });
     expect(operationMatchesNotification(eurOp, eurItem, AMD)).toBe(false);
   });
+
+  it('never cross-currency matches a transfer (its amount is not the foreign charge)', () => {
+    // A cross-currency ATM transfer books `amount` in the source currency and
+    // never preserves the dispensed foreign amount, so it must not match.
+    const eurItem = item({ type: 'transfer', currency: 'EUR', amount: '129.99' });
+    const eurTransfer = op({ type: 'transfer', amount: '55000', destinationAmount: '129.99' });
+    expect(operationMatchesNotification(eurTransfer, eurItem, AMD)).toBe(false);
+  });
+
+  it('still matches a same-currency transfer', () => {
+    const transferItem = item({ type: 'transfer' });
+    const transferOp = op({ type: 'transfer' });
+    expect(operationMatchesNotification(transferOp, transferItem, AMD)).toBe(true);
+  });
 });
 
 describe('findMatchingOperation', () => {
@@ -125,11 +138,15 @@ describe('findMatchingOperation', () => {
     expect(OperationsDB.getOperationsByAccountTypeAndDate).not.toHaveBeenCalled();
   });
 
-  it('hasMatchingOperation reflects findMatchingOperation', async () => {
-    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op()]);
-    expect(await hasMatchingOperation(item(), AMD)).toBe(true);
-    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([]);
-    expect(await hasMatchingOperation(item(), AMD)).toBe(false);
+  it('excludes operations already claimed by an earlier notification', async () => {
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op({ id: 1 })]);
+    const claimed = new Set([1]);
+    // The only candidate is already claimed → no match despite matching fields.
+    expect(await findMatchingOperation(item(), AMD, claimed)).toBeNull();
+    // A second, unclaimed candidate is still matchable.
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op({ id: 1 }), op({ id: 2 })]);
+    const match = await findMatchingOperation(item(), AMD, claimed);
+    expect(match.id).toBe(2);
   });
 });
 
@@ -152,6 +169,21 @@ describe('reconcilePendingNotifications', () => {
     expect(pruned).toBe(1);
     expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledTimes(1);
     expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledWith('p1');
+  });
+
+  it('prunes only one of two identical queued items against a single operation', async () => {
+    // Two genuinely distinct same-day/same-amount charges, but only one matching
+    // recorded operation — exactly one card should be pruned, not both.
+    PendingNotificationsDB.getPendingNotifications.mockResolvedValue([
+      { id: 'p1', ...item() },
+      { id: 'p2', ...item() },
+    ]);
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op({ id: 1 })]);
+
+    const pruned = await reconcilePendingNotifications();
+
+    expect(pruned).toBe(1);
+    expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledTimes(1);
   });
 
   it('returns 0 and deletes nothing when the queue is empty', async () => {

--- a/__tests__/services/notifications/duplicateOperations.test.js
+++ b/__tests__/services/notifications/duplicateOperations.test.js
@@ -1,0 +1,177 @@
+/**
+ * Tests for duplicate detection between bank notifications and operations the
+ * user has already recorded by hand. Uses the real currency math; mocks the DB
+ * ports.
+ */
+
+import {
+  operationMatchesNotification,
+  findMatchingOperation,
+  hasMatchingOperation,
+  reconcilePendingNotifications,
+} from '../../../app/services/notifications/duplicateOperations';
+import * as OperationsDB from '../../../app/services/OperationsDB';
+import * as AccountsDB from '../../../app/services/AccountsDB';
+import * as PendingNotificationsDB from '../../../app/services/PendingNotificationsDB';
+
+jest.mock('../../../app/services/OperationsDB');
+jest.mock('../../../app/services/AccountsDB');
+jest.mock('../../../app/services/PendingNotificationsDB');
+
+const AMD = { id: 9, currency: 'AMD', autoTxnRounding: null, autoTxnRoundingMode: null };
+const AMD_ROUND_100 = { id: 9, currency: 'AMD', autoTxnRounding: 100, autoTxnRoundingMode: 'nearest' };
+
+const op = (over = {}) => ({
+  id: 1,
+  type: 'expense',
+  amount: '1683',
+  accountId: 9,
+  date: '2026-07-30',
+  destinationAmount: null,
+  sourceCurrency: null,
+  destinationCurrency: null,
+  ...over,
+});
+
+const item = (over = {}) => ({
+  type: 'expense',
+  amount: '1683',
+  currency: 'AMD',
+  date: '2026-07-30',
+  accountId: 9,
+  ...over,
+});
+
+describe('operationMatchesNotification', () => {
+  it('matches same type, account, date, and amount', () => {
+    expect(operationMatchesNotification(op(), item(), AMD)).toBe(true);
+  });
+
+  it('matches "1683.00" against "1683" (decimal-safe)', () => {
+    expect(operationMatchesNotification(op({ amount: '1683.00' }), item(), AMD)).toBe(true);
+  });
+
+  it('matches the account-rounded amount when the account rounds transactions', () => {
+    // 1683 rounded to the nearest 100 = 1700, the value a hand-entry may carry.
+    expect(operationMatchesNotification(op({ amount: '1700' }), item(), AMD_ROUND_100)).toBe(true);
+  });
+
+  it('does not match the rounded amount when the account has no rounding', () => {
+    expect(operationMatchesNotification(op({ amount: '1700' }), item(), AMD)).toBe(false);
+  });
+
+  it('does not match a different date', () => {
+    expect(operationMatchesNotification(op({ date: '2026-07-29' }), item(), AMD)).toBe(false);
+  });
+
+  it('does not match a different account', () => {
+    expect(operationMatchesNotification(op({ accountId: 8 }), item(), AMD)).toBe(false);
+  });
+
+  it('does not match a different type', () => {
+    expect(operationMatchesNotification(op({ type: 'income' }), item(), AMD)).toBe(false);
+  });
+
+  it('does not match a different amount', () => {
+    expect(operationMatchesNotification(op({ amount: '2000' }), item(), AMD)).toBe(false);
+  });
+
+  it('never matches a dateless notification', () => {
+    expect(operationMatchesNotification(op(), item({ date: null }), AMD)).toBe(false);
+  });
+
+  it('matches a cross-currency charge on the preserved foreign amount', () => {
+    // 129.99 EUR booked on an AMD account: the account amount differs, but the
+    // original foreign charge is kept in destination_amount.
+    const eurItem = item({ currency: 'EUR', amount: '129.99' });
+    const eurOp = op({ amount: '55000', destinationAmount: '129.99', sourceCurrency: 'EUR', destinationCurrency: 'AMD' });
+    expect(operationMatchesNotification(eurOp, eurItem, AMD)).toBe(true);
+  });
+
+  it('does not cross-currency match when the foreign amount was not preserved', () => {
+    const eurItem = item({ currency: 'EUR', amount: '129.99' });
+    const eurOp = op({ amount: '55000', destinationAmount: null });
+    expect(operationMatchesNotification(eurOp, eurItem, AMD)).toBe(false);
+  });
+});
+
+describe('findMatchingOperation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the matching operation from the account/type/date lookup', async () => {
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op()]);
+    const match = await findMatchingOperation(item(), AMD);
+    expect(match).toEqual(op());
+    expect(OperationsDB.getOperationsByAccountTypeAndDate).toHaveBeenCalledWith(9, 'expense', '2026-07-30');
+  });
+
+  it('returns null when no candidate matches', async () => {
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op({ amount: '999' })]);
+    expect(await findMatchingOperation(item(), AMD)).toBeNull();
+  });
+
+  it('fetches the account by id when none is passed', async () => {
+    AccountsDB.getAccountById.mockResolvedValue(AMD_ROUND_100);
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op({ amount: '1700' })]);
+    const match = await findMatchingOperation(item());
+    expect(AccountsDB.getAccountById).toHaveBeenCalledWith(9);
+    expect(match).not.toBeNull();
+  });
+
+  it('returns null (no lookup) for an item without a resolved account', async () => {
+    expect(await findMatchingOperation(item({ accountId: null }), AMD)).toBeNull();
+    expect(OperationsDB.getOperationsByAccountTypeAndDate).not.toHaveBeenCalled();
+  });
+
+  it('hasMatchingOperation reflects findMatchingOperation', async () => {
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([op()]);
+    expect(await hasMatchingOperation(item(), AMD)).toBe(true);
+    OperationsDB.getOperationsByAccountTypeAndDate.mockResolvedValue([]);
+    expect(await hasMatchingOperation(item(), AMD)).toBe(false);
+  });
+});
+
+describe('reconcilePendingNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AccountsDB.getAccountById.mockResolvedValue(AMD);
+  });
+
+  it('deletes queued items that now have a matching operation', async () => {
+    PendingNotificationsDB.getPendingNotifications.mockResolvedValue([
+      { id: 'p1', ...item() },
+      { id: 'p2', ...item({ amount: '5000' }) },
+    ]);
+    // p1 has a match; p2 does not.
+    OperationsDB.getOperationsByAccountTypeAndDate.mockImplementation(async () => [op()]);
+
+    const pruned = await reconcilePendingNotifications();
+
+    expect(pruned).toBe(1);
+    expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledTimes(1);
+    expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledWith('p1');
+  });
+
+  it('returns 0 and deletes nothing when the queue is empty', async () => {
+    PendingNotificationsDB.getPendingNotifications.mockResolvedValue([]);
+    expect(await reconcilePendingNotifications()).toBe(0);
+    expect(PendingNotificationsDB.deletePendingNotification).not.toHaveBeenCalled();
+  });
+
+  it('skips items without a resolved account', async () => {
+    PendingNotificationsDB.getPendingNotifications.mockResolvedValue([
+      { id: 'p1', ...item({ accountId: null }) },
+    ]);
+    expect(await reconcilePendingNotifications()).toBe(0);
+    expect(OperationsDB.getOperationsByAccountTypeAndDate).not.toHaveBeenCalled();
+    expect(PendingNotificationsDB.deletePendingNotification).not.toHaveBeenCalled();
+  });
+
+  it('is best-effort: a read failure leaves the queue untouched', async () => {
+    PendingNotificationsDB.getPendingNotifications.mockRejectedValue(new Error('db down'));
+    expect(await reconcilePendingNotifications()).toBe(0);
+    expect(PendingNotificationsDB.deletePendingNotification).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -1232,6 +1232,28 @@ describe('processBankNotifications', () => {
       expect(PendingNotificationsDB.addPendingNotification).toHaveBeenCalled();
     });
 
+    it('only suppresses one of two identical charges against a single recorded operation', async () => {
+      // Two genuinely distinct purchases the same day for the same amount (distinct
+      // postTime → distinct signatures), a trusted auto-create source, and a single
+      // matching operation already recorded. Exactly one notification should be
+      // suppressed; the other must still be created — not both absorbed by the op.
+      const A = { ...PURCHASE, postTime: PURCHASE.postTime + 1000 };
+      const B = { ...PURCHASE, postTime: PURCHASE.postTime + 2000 };
+      NotificationAccess.getRecentNotifications.mockResolvedValue([A, B]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+      OperationsDB.createOperation.mockResolvedValue({ id: 1 });
+      OperationsDB.getOperationsByAccountTypeAndDate.mockImplementation(async (accountId, type, date) => [
+        { id: 1, type, accountId, date, amount: '3900', destinationAmount: null },
+      ]);
+
+      const summary = await pipeline.processBankNotifications();
+
+      expect(summary).toEqual({ created: 1, pending: 0, skipped: 1 });
+      expect(OperationsDB.createOperation).toHaveBeenCalledTimes(1);
+    });
+
     it('prunes a queued item once a matching operation is recorded', async () => {
       // Nothing new to parse — the run only reconciles the existing queue.
       NotificationAccess.getRecentNotifications.mockResolvedValue([]);

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -1151,6 +1151,21 @@ describe('processBankNotifications', () => {
       expect(PendingNotificationsDB.addPendingNotification).toHaveBeenCalled();
     });
 
+    it('re-creates even when a matching operation already exists (explicit re-add)', async () => {
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      // A matching operation is already recorded — the duplicate check would skip
+      // this during normal ingestion, but a user-initiated re-add must bypass it.
+      OperationsDB.getOperationsByAccountTypeAndDate.mockImplementation(async (accountId, type, date) => [
+        { id: 1, type, accountId, date, amount: '3900', destinationAmount: null },
+      ]);
+
+      const summary = await pipeline.reAddNotification(PURCHASE);
+
+      expect(summary).toEqual({ created: 1, pending: 0, skipped: 0 });
+      expect(OperationsDB.createOperation).toHaveBeenCalled();
+    });
+
     it('re-adds an ATM cash withdrawal as a transfer when a cash account is bound', async () => {
       AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
       PreferencesDB.getNumberPreference.mockResolvedValue(9);
@@ -1179,6 +1194,60 @@ describe('processBankNotifications', () => {
 
       await pipeline.dismissPendingNotification('p1');
 
+      expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledWith('p1');
+      expect(emitSpy).toHaveBeenCalledWith(EVENTS.RELOAD_ALL);
+    });
+  });
+
+  describe('duplicate detection', () => {
+    it('skips (does not create or queue) a purchase already recorded by hand', async () => {
+      NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue({ categoryId: 'cat-food' });
+      // Trusted source: without a duplicate this would auto-create.
+      PreferencesDB.getJsonPreference.mockImplementation((key) => prefs([], [PKG])(key));
+      // An operation matching this notification (same account/type/date/amount) exists.
+      OperationsDB.getOperationsByAccountTypeAndDate.mockImplementation(async (accountId, type, date) => [
+        { id: 1, type, accountId, date, amount: '3900', destinationAmount: null },
+      ]);
+
+      const summary = await pipeline.processBankNotifications();
+
+      expect(summary).toEqual({ created: 0, pending: 0, skipped: 1 });
+      expect(OperationsDB.createOperation).not.toHaveBeenCalled();
+      expect(PendingNotificationsDB.addPendingNotification).not.toHaveBeenCalled();
+    });
+
+    it('still queues when the existing operation is on a different day', async () => {
+      NotificationAccess.getRecentNotifications.mockResolvedValue([PURCHASE]);
+      AccountsDB.getAccountByCardMask.mockResolvedValue({ id: 7, currency: 'AMD' });
+      NotificationRulesDB.getMerchantRule.mockResolvedValue(null); // no category → queue
+      OperationsDB.getOperationsByAccountTypeAndDate.mockImplementation(async (accountId, type) => [
+        { id: 1, type, accountId, date: '1999-01-01', amount: '3900', destinationAmount: null },
+      ]);
+
+      const summary = await pipeline.processBankNotifications();
+
+      expect(summary).toEqual({ created: 0, pending: 1, skipped: 0 });
+      expect(PendingNotificationsDB.addPendingNotification).toHaveBeenCalled();
+    });
+
+    it('prunes a queued item once a matching operation is recorded', async () => {
+      // Nothing new to parse — the run only reconciles the existing queue.
+      NotificationAccess.getRecentNotifications.mockResolvedValue([]);
+      PendingNotificationsDB.getPendingNotifications.mockResolvedValue([
+        { id: 'p1', type: 'expense', amount: '3900', currency: 'AMD', date: '2026-06-28', accountId: 7 },
+      ]);
+      AccountsDB.getAccountById.mockResolvedValue({ id: 7, currency: 'AMD' });
+      OperationsDB.getOperationsByAccountTypeAndDate.mockImplementation(async (accountId, type, date) => [
+        { id: 1, type, accountId, date, amount: '3900', destinationAmount: null },
+      ]);
+      PendingNotificationsDB.deletePendingNotification.mockResolvedValue();
+      const emitSpy = jest.spyOn(appEvents, 'emit');
+
+      const summary = await pipeline.processBankNotifications();
+
+      expect(summary).toEqual({ created: 0, pending: 0, skipped: 0 });
       expect(PendingNotificationsDB.deletePendingNotification).toHaveBeenCalledWith('p1');
       expect(emitSpy).toHaveBeenCalledWith(EVENTS.RELOAD_ALL);
     });

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -41,6 +41,7 @@ import {
   hidePackage,
 } from '../services/notifications/notificationFilters';
 import { getPendingNotifications } from '../services/PendingNotificationsDB';
+import { reconcilePendingNotifications } from '../services/notifications/duplicateOperations';
 import { getLabelForMerchant } from '../services/NotificationRulesDB';
 import { getRecentNotifications } from '../services/NotificationAccess';
 import * as Currency from '../services/currency';
@@ -126,6 +127,9 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
   }));
 
   const reloadPending = useCallback(async () => {
+    // Drop any queued item the user has already recorded by hand so it never
+    // shows as something still needing review.
+    await reconcilePendingNotifications();
     const items = await getPendingNotifications();
     // The bound cash account pre-fills the target picker on transfer (ATM) items.
     let atmAccount = null;

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -126,10 +126,11 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
     value: a.id,
   }));
 
-  const reloadPending = useCallback(async () => {
+  const reloadPending = useCallback(async ({ reconcile = true } = {}) => {
     // Drop any queued item the user has already recorded by hand so it never
-    // shows as something still needing review.
-    await reconcilePendingNotifications();
+    // shows as something still needing review. Skipped when the caller just ran
+    // the pipeline (which already reconciled the queue).
+    if (reconcile) await reconcilePendingNotifications();
     const items = await getPendingNotifications();
     // The bound cash account pre-fills the target picker on transfer (ATM) items.
     let atmAccount = null;
@@ -202,7 +203,8 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
         if (isOn) {
           await processBankNotifications();
         }
-        if (mountedRef.current) await Promise.all([reloadPending(), reloadRecent()]);
+        // The pipeline (when run) already reconciled the queue.
+        if (mountedRef.current) await Promise.all([reloadPending({ reconcile: !isOn }), reloadRecent()]);
       } catch (error) {
         // Non-fatal; show whatever loaded.
       } finally {
@@ -214,10 +216,12 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
   const handleRefresh = useCallback(async () => {
     setProcessing(true);
     try {
-      if (await isBankNotificationsEnabled()) {
+      const ran = await isBankNotificationsEnabled();
+      if (ran) {
         await processBankNotifications();
       }
-      await Promise.all([reloadPending(), reloadRecent()]);
+      // Skip a redundant reconcile when the pipeline just performed one.
+      await Promise.all([reloadPending({ reconcile: !ran }), reloadRecent()]);
     } finally {
       if (mountedRef.current) setProcessing(false);
     }
@@ -229,10 +233,11 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
     if (autoRefreshingRef.current) return;
     autoRefreshingRef.current = true;
     try {
-      if (await isBankNotificationsEnabled()) {
+      const ran = await isBankNotificationsEnabled();
+      if (ran) {
         await processBankNotifications();
       }
-      if (mountedRef.current) await Promise.all([reloadPending(), reloadRecent()]);
+      if (mountedRef.current) await Promise.all([reloadPending({ reconcile: !ran }), reloadRecent()]);
     } catch (error) {
       // Non-fatal; keep the last good data until the next tick.
     } finally {

--- a/app/hooks/usePendingOperationSuggestions.js
+++ b/app/hooks/usePendingOperationSuggestions.js
@@ -106,11 +106,12 @@ export default function usePendingOperationSuggestions({
   const mountedRef = useRef(true);
   useEffect(() => () => { mountedRef.current = false; }, []);
 
-  const reload = useCallback(async () => {
+  const reload = useCallback(async ({ reconcile = true } = {}) => {
     try {
       // Drop any card the user has already recorded by hand before reading the
       // queue, so a matching operation makes its suggestion disappear at once.
-      await reconcilePendingNotifications();
+      // Skipped when the caller just ran the pipeline (which already reconciled).
+      if (reconcile) await reconcilePendingNotifications();
       const [items, atmAccount] = await Promise.all([
         getPendingNotifications(),
         resolveAtmTargetAccount().catch(() => null),
@@ -225,8 +226,10 @@ export default function usePendingOperationSuggestions({
   // just-entered operation prunes its matching suggestion from the deck at once.
   useEffect(() => {
     reload();
-    const offReloadAll = appEvents.on(EVENTS.RELOAD_ALL, reload);
-    const offOperationChanged = appEvents.on(EVENTS.OPERATION_CHANGED, reload);
+    // Wrap so an event payload is never read as reload's options argument.
+    const onEvent = () => reload();
+    const offReloadAll = appEvents.on(EVENTS.RELOAD_ALL, onEvent);
+    const offOperationChanged = appEvents.on(EVENTS.OPERATION_CHANGED, onEvent);
     return () => {
       offReloadAll();
       offOperationChanged();
@@ -273,7 +276,8 @@ export default function usePendingOperationSuggestions({
     } catch (error) {
       // Ingestion failure is non-fatal — still reload whatever is queued.
     }
-    await reload();
+    // The pipeline already reconciled the queue, so skip a redundant second pass.
+    await reload({ reconcile: false });
   }, [reload]);
 
   /**

--- a/app/hooks/usePendingOperationSuggestions.js
+++ b/app/hooks/usePendingOperationSuggestions.js
@@ -7,6 +7,7 @@ import {
   dismissPendingNotification,
   resolveAtmTargetAccount,
 } from '../services/notifications/processBankNotifications';
+import { reconcilePendingNotifications } from '../services/notifications/duplicateOperations';
 import { kindRequiresCategory } from '../services/notifications/parseBankNotification';
 import { getLabelForMerchant } from '../services/NotificationRulesDB';
 import { getAccountByCardMask } from '../services/AccountsDB';
@@ -107,6 +108,9 @@ export default function usePendingOperationSuggestions({
 
   const reload = useCallback(async () => {
     try {
+      // Drop any card the user has already recorded by hand before reading the
+      // queue, so a matching operation makes its suggestion disappear at once.
+      await reconcilePendingNotifications();
       const [items, atmAccount] = await Promise.all([
         getPendingNotifications(),
         resolveAtmTargetAccount().catch(() => null),
@@ -216,10 +220,17 @@ export default function usePendingOperationSuggestions({
 
   // Initial load, then stay in sync with every app-wide data change: the
   // ingestion pipeline and the settings review panel both emit RELOAD_ALL after
-  // enqueueing/booking/dismissing notifications.
+  // enqueueing/booking/dismissing notifications. OPERATION_CHANGED (emitted when
+  // the user adds/edits/deletes an operation by hand) also triggers a reload so a
+  // just-entered operation prunes its matching suggestion from the deck at once.
   useEffect(() => {
     reload();
-    return appEvents.on(EVENTS.RELOAD_ALL, reload);
+    const offReloadAll = appEvents.on(EVENTS.RELOAD_ALL, reload);
+    const offOperationChanged = appEvents.on(EVENTS.OPERATION_CHANGED, reload);
+    return () => {
+      offReloadAll();
+      offOperationChanged();
+    };
   }, [reload]);
 
   // Drop save flags and choices for items that left the queue (accepted or

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -393,6 +393,33 @@ export const getFilteredOperationsAllDates = async (filters = {}) => {
 };
 
 /**
+ * Get operations for one account on a single date and of a single type.
+ *
+ * A focused lookup for duplicate detection: matching a bank notification against
+ * operations the user may have already recorded by hand only ever needs the rows
+ * sharing the notification's account, type, and calendar date, so this avoids
+ * loading (and mapping) an account's whole history. For transfers the account is
+ * matched on the source side (account_id), mirroring how a transfer is booked.
+ *
+ * @param {string|number} accountId
+ * @param {string} type - 'expense', 'income', or 'transfer'
+ * @param {string} date - ISO date string (YYYY-MM-DD)
+ * @returns {Promise<Array>}
+ */
+export const getOperationsByAccountTypeAndDate = async (accountId, type, date) => {
+  try {
+    const operations = await queryAll(
+      'SELECT * FROM operations WHERE account_id = ? AND type = ? AND date = ?',
+      [accountId, type, date],
+    );
+    return (operations || []).map(mapOperationFields).filter(Boolean);
+  } catch (error) {
+    console.error('Failed to get operations by account/type/date:', error);
+    throw error;
+  }
+};
+
+/**
  * Get operations by type
  * @param {string} type - 'expense', 'income', or 'transfer'
  * @returns {Promise<Array>}

--- a/app/services/notifications/duplicateOperations.js
+++ b/app/services/notifications/duplicateOperations.js
@@ -1,0 +1,153 @@
+/**
+ * Duplicate detection between bank notifications and already-recorded operations.
+ *
+ * A bank push often lands minutes after the user has already entered the same
+ * purchase by hand. Without this, the pipeline would queue (or, for a trusted
+ * source, auto-create) a second copy — leaving a "choose a category" card and a
+ * tray alert for something already in the ledger. This module recognizes when an
+ * operation matching a notification already exists so the notification can be
+ * skipped at ingestion and any stale queued copy pruned.
+ *
+ * Matching is deliberately strict — same type, account, date, and amount — so a
+ * genuinely new charge is never swallowed. A rare false positive (two identical
+ * charges on the same account/day) is recoverable: the notification stays in the
+ * recent feed and can be re-added by hand.
+ */
+
+import * as OperationsDB from '../OperationsDB';
+import * as AccountsDB from '../AccountsDB';
+import * as PendingNotificationsDB from '../PendingNotificationsDB';
+import * as Currency from '../currency';
+
+/**
+ * The amounts an operation booked from this notification could carry, in the
+ * account's currency: the raw charge, plus the value it would round to under the
+ * account's automatic-transaction rounding (so a 1 683 charge on an account that
+ * rounds to the nearest 100 also matches a hand-entered 1 700).
+ *
+ * @param {{ amount: string }} item
+ * @param {{ autoTxnRounding?: number|null, autoTxnRoundingMode?: string|null, currency?: string|null }} [account]
+ * @returns {string[]}
+ */
+const candidateAmounts = (item, account) => {
+  const amounts = [item.amount];
+  const rounding = account && account.autoTxnRounding;
+  if (rounding) {
+    amounts.push(
+      Currency.roundToStep(item.amount, rounding, account.autoTxnRoundingMode, account.currency),
+    );
+  }
+  return amounts;
+};
+
+/**
+ * Whether an existing operation is the same transaction a notification describes.
+ *
+ * @param {Object} op - a mapped operation row
+ * @param {{ type: string, amount: string, currency?: string|null, date?: string|null,
+ *   accountId: string|number|null }} item - notification descriptor or pending row
+ * @param {Object|null} [account] - the item's account (for currency + rounding)
+ * @returns {boolean}
+ */
+export const operationMatchesNotification = (op, item, account) => {
+  if (!op || !item) return false;
+  if (op.type !== item.type) return false;
+  if (op.accountId == null || item.accountId == null) return false;
+  if (String(op.accountId) !== String(item.accountId)) return false;
+  // A dateless notification can't be pinned to a specific day — never match it,
+  // rather than risk pruning an unrelated operation.
+  if (!item.date || op.date !== item.date) return false;
+
+  const accountCurrency = account ? account.currency : null;
+  const sameCurrency = !item.currency || !accountCurrency || item.currency === accountCurrency;
+
+  if (sameCurrency) {
+    // The booked amount is in the account currency; compare against the raw and
+    // account-rounded candidates.
+    return candidateAmounts(item, account).some(
+      (amt) => Currency.compare(op.amount, amt) === 0,
+    );
+  }
+
+  // Cross-currency: the operation preserves the original foreign charge in
+  // destination_amount (unrounded), so compare that against the notification.
+  if (op.destinationAmount == null) return false;
+  return Currency.compare(op.destinationAmount, item.amount) === 0;
+};
+
+/**
+ * Find an operation the user has already recorded that matches a notification.
+ *
+ * @param {{ type: string, amount: string, currency?: string|null, date?: string|null,
+ *   accountId: string|number|null }} item
+ * @param {Object|null} [account] - the item's account; fetched by id when omitted
+ * @returns {Promise<Object|null>} the matching operation, or null
+ */
+export const findMatchingOperation = async (item, account) => {
+  if (!item || item.accountId == null || !item.type || !item.date) return null;
+  try {
+    const resolvedAccount = account !== undefined
+      ? account
+      : await AccountsDB.getAccountById(item.accountId).catch(() => null);
+    const query = OperationsDB.getOperationsByAccountTypeAndDate;
+    if (typeof query !== 'function') return null;
+    const candidates = await query(item.accountId, item.type, item.date);
+    return (candidates || []).find(
+      (op) => operationMatchesNotification(op, item, resolvedAccount),
+    ) || null;
+  } catch (error) {
+    // Never let a duplicate-check failure block ingestion — treat it as "no match".
+    console.warn('[duplicateOperations] Failed to find matching operation:', error);
+    return null;
+  }
+};
+
+/**
+ * Whether an operation matching the notification already exists.
+ * @param {Object} item
+ * @param {Object|null} [account]
+ * @returns {Promise<boolean>}
+ */
+export const hasMatchingOperation = async (item, account) =>
+  (await findMatchingOperation(item, account)) != null;
+
+/**
+ * Remove queued review items the user has since recorded by hand.
+ *
+ * Runs on each pipeline pass and whenever a review surface reloads, so a card
+ * for an already-entered operation disappears from the in-app deck and the
+ * settings review queue alike. Best-effort: a read failure leaves the queue
+ * untouched rather than throwing.
+ *
+ * @returns {Promise<number>} how many pending items were pruned
+ */
+export const reconcilePendingNotifications = async () => {
+  let pruned = 0;
+  try {
+    const pending = await PendingNotificationsDB.getPendingNotifications();
+    if (!pending || pending.length === 0) return 0;
+
+    // Cache accounts by id so a batch of items on one account is fetched once.
+    const accountCache = new Map();
+    for (const item of pending) {
+      if (item.accountId == null || !item.date) continue;
+      if (!accountCache.has(item.accountId)) {
+        accountCache.set(
+          item.accountId,
+          await AccountsDB.getAccountById(item.accountId).catch(() => null),
+        );
+      }
+      const account = accountCache.get(item.accountId);
+      const match = await findMatchingOperation(item, account);
+      if (match) {
+        await PendingNotificationsDB.deletePendingNotification(item.id);
+        pruned += 1;
+      }
+    }
+  } catch (error) {
+    console.warn('[duplicateOperations] Failed to reconcile pending notifications:', error);
+  }
+  return pruned;
+};
+
+export default reconcilePendingNotifications;

--- a/app/services/notifications/duplicateOperations.js
+++ b/app/services/notifications/duplicateOperations.js
@@ -69,8 +69,15 @@ export const operationMatchesNotification = (op, item, account) => {
     );
   }
 
-  // Cross-currency: the operation preserves the original foreign charge in
-  // destination_amount (unrounded), so compare that against the notification.
+  // A transfer books its `amount` in the source-account currency and never
+  // preserves the notification's original charge (destination_amount is a second,
+  // unrelated source→target conversion), so a cross-currency transfer can't be
+  // compared reliably — don't risk a wrong match. The common same-currency
+  // transfer is already handled by the branch above.
+  if (op.type === 'transfer') return false;
+
+  // Cross-currency expense/income: the operation preserves the original foreign
+  // charge in destination_amount (unrounded), so compare that against the item.
   if (op.destinationAmount == null) return false;
   return Currency.compare(op.destinationAmount, item.amount) === 0;
 };
@@ -78,12 +85,18 @@ export const operationMatchesNotification = (op, item, account) => {
 /**
  * Find an operation the user has already recorded that matches a notification.
  *
+ * `claimedOpIds`, when supplied, excludes operations already paired with an
+ * earlier notification in the same batch, keeping matching 1:1: two genuinely
+ * distinct same-day/same-amount charges pair with two distinct operations rather
+ * than both being absorbed by the first one.
+ *
  * @param {{ type: string, amount: string, currency?: string|null, date?: string|null,
  *   accountId: string|number|null }} item
  * @param {Object|null} [account] - the item's account; fetched by id when omitted
+ * @param {Set<number|string>|null} [claimedOpIds] - operation ids already matched
  * @returns {Promise<Object|null>} the matching operation, or null
  */
-export const findMatchingOperation = async (item, account) => {
+export const findMatchingOperation = async (item, account, claimedOpIds = null) => {
   if (!item || item.accountId == null || !item.type || !item.date) return null;
   try {
     const resolvedAccount = account !== undefined
@@ -93,7 +106,8 @@ export const findMatchingOperation = async (item, account) => {
     if (typeof query !== 'function') return null;
     const candidates = await query(item.accountId, item.type, item.date);
     return (candidates || []).find(
-      (op) => operationMatchesNotification(op, item, resolvedAccount),
+      (op) => (!claimedOpIds || !claimedOpIds.has(op.id))
+        && operationMatchesNotification(op, item, resolvedAccount),
     ) || null;
   } catch (error) {
     // Never let a duplicate-check failure block ingestion — treat it as "no match".
@@ -101,15 +115,6 @@ export const findMatchingOperation = async (item, account) => {
     return null;
   }
 };
-
-/**
- * Whether an operation matching the notification already exists.
- * @param {Object} item
- * @param {Object|null} [account]
- * @returns {Promise<boolean>}
- */
-export const hasMatchingOperation = async (item, account) =>
-  (await findMatchingOperation(item, account)) != null;
 
 /**
  * Remove queued review items the user has since recorded by hand.
@@ -129,6 +134,9 @@ export const reconcilePendingNotifications = async () => {
 
     // Cache accounts by id so a batch of items on one account is fetched once.
     const accountCache = new Map();
+    // Track operations already claimed by an earlier item so two queued
+    // duplicates can't both be pruned against a single recorded operation.
+    const claimedOpIds = new Set();
     for (const item of pending) {
       if (item.accountId == null || !item.date) continue;
       if (!accountCache.has(item.accountId)) {
@@ -138,8 +146,9 @@ export const reconcilePendingNotifications = async () => {
         );
       }
       const account = accountCache.get(item.accountId);
-      const match = await findMatchingOperation(item, account);
+      const match = await findMatchingOperation(item, account, claimedOpIds);
       if (match) {
+        claimedOpIds.add(match.id);
         await PendingNotificationsDB.deletePendingNotification(item.id);
         pruned += 1;
       }

--- a/app/services/notifications/localNotifications.js
+++ b/app/services/notifications/localNotifications.js
@@ -121,6 +121,25 @@ export const presentPendingOperationsAlert = async ({ title, body, channelName }
 };
 
 /**
+ * Dismiss the "transactions to review" alert from the tray.
+ *
+ * Used when the review queue empties — every queued item resolved, dismissed, or
+ * pruned as a duplicate of an operation the user already recorded — so the shade
+ * no longer nags about transactions that are no longer waiting. Best-effort: a
+ * failed dismissal is non-fatal (the alert is low-urgency and self-replaces on
+ * the next background run).
+ *
+ * @returns {Promise<void>}
+ */
+export const dismissPendingOperationsAlert = async () => {
+  try {
+    await Notifications.dismissNotificationAsync(PENDING_ALERT_IDENTIFIER);
+  } catch (error) {
+    // Non-fatal — the alert is a low-urgency nudge and will refresh on its own.
+  }
+};
+
+/**
  * Whether a tapped-notification response is Penny's review-queue deep link.
  * @param {object|null} response - a Notifications.NotificationResponse
  * @returns {boolean}

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -321,20 +321,25 @@ const isAllowedSource = (packageName, allowed) =>
   !!packageName && allowed.includes(packageName);
 
 /**
- * Whether a notification describes an operation the user has already recorded by
- * hand — matched on the resolved account, date, amount, and type. Returns false
- * when the account didn't resolve (nothing to match against) or when the caller
- * opted out via `checkDuplicate: false` (an explicit re-add).
+ * The operation the user has already recorded by hand that this notification
+ * duplicates — matched on the resolved account, date, amount, and type — or null.
+ * Returns null when the account didn't resolve (nothing to match against) or when
+ * the caller opted out via `checkDuplicate: false` (an explicit re-add).
+ *
+ * `options.claimedOpIds` (when supplied) both excludes operations already paired
+ * with an earlier notification in this run and receives no writes here — the
+ * caller records the pairing so two distinct same-day/same-amount charges don't
+ * collapse onto one operation.
  *
  * @param {Object} descriptor - parsed notification
  * @param {Object} resolution - resolveNotification() result
  * @param {string} date - resolved ISO date
- * @param {{ checkDuplicate?: boolean }} options
- * @returns {Promise<boolean>}
+ * @param {{ checkDuplicate?: boolean, claimedOpIds?: Set }} options
+ * @returns {Promise<Object|null>}
  */
-const isAlreadyRecorded = async (descriptor, resolution, date, options) => {
-  if (options.checkDuplicate === false || resolution.accountId == null) return false;
-  const existing = await findMatchingOperation(
+const findExistingOperation = async (descriptor, resolution, date, options) => {
+  if (options.checkDuplicate === false || resolution.accountId == null) return null;
+  return findMatchingOperation(
     {
       type: descriptor.type,
       amount: descriptor.amount,
@@ -347,8 +352,8 @@ const isAlreadyRecorded = async (descriptor, resolution, date, options) => {
       autoTxnRounding: resolution.accountRounding,
       autoTxnRoundingMode: resolution.accountRoundingMode,
     },
+    options.claimedOpIds || null,
   );
-  return existing != null;
 };
 
 /**
@@ -367,10 +372,13 @@ const isAlreadyRecorded = async (descriptor, resolution, date, options) => {
  *   book even if a matching operation already exists (explicit re-add).
  */
 const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation, options = {}) => {
-  // Skip a charge the user has already recorded by hand (see isAlreadyRecorded):
-  // neither auto-create nor queue a duplicate. Counted as skipped; the caller
-  // still marks the notification seen so it isn't re-checked every run.
-  if (await isAlreadyRecorded(descriptor, resolution, date, options)) {
+  // Skip a charge the user has already recorded by hand: neither auto-create nor
+  // queue a duplicate. Claim the matched operation so a sibling notification in
+  // this run pairs with a different one. Counted as skipped; the caller still
+  // marks the notification seen so it isn't re-checked every run.
+  const duplicate = await findExistingOperation(descriptor, resolution, date, options);
+  if (duplicate) {
+    if (options.claimedOpIds && duplicate.id != null) options.claimedOpIds.add(duplicate.id);
     summary.skipped += 1;
     return;
   }
@@ -419,7 +427,7 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
     // the raw merchant for the operation's label.
     const label = resolution.labelOverride || descriptor.merchant;
     const location = getLocation ? await getLocation() : null;
-    await OperationsDB.createOperation({
+    const created = await OperationsDB.createOperation({
       type: descriptor.type,
       ...currencyFields,
       accountId: resolution.accountId,
@@ -428,6 +436,9 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
       description: label ? serializeLabels([label]) : null,
       ...operationLocationFields(location),
     });
+    // Claim the new operation so a later duplicate notification in this run pairs
+    // with a different existing operation rather than re-matching this one.
+    if (options.claimedOpIds && created && created.id != null) options.claimedOpIds.add(created.id);
     summary.created += 1;
 
     // Float the merchant's binding to the top of the bindings list on this
@@ -483,7 +494,9 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
 const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation, options = {}) => {
   // Skip an ATM withdrawal the user has already recorded by hand, mirroring the
   // expense/income path (matched on the source account, date, amount, and type).
-  if (await isAlreadyRecorded(descriptor, resolution, date, options)) {
+  const duplicate = await findExistingOperation(descriptor, resolution, date, options);
+  if (duplicate) {
+    if (options.claimedOpIds && duplicate.id != null) options.claimedOpIds.add(duplicate.id);
     summary.skipped += 1;
     return;
   }
@@ -523,7 +536,7 @@ const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages
       };
     }
     const location = getLocation ? await getLocation() : null;
-    await OperationsDB.createOperation({
+    const created = await OperationsDB.createOperation({
       type: 'transfer',
       ...transferFields,
       accountId: resolution.accountId,
@@ -532,6 +545,7 @@ const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages
       description: descriptor.merchant ? serializeLabels([descriptor.merchant]) : null,
       ...operationLocationFields(location),
     });
+    if (options.claimedOpIds && created && created.id != null) options.claimedOpIds.add(created.id);
     summary.created += 1;
   } else {
     // Capture the location NOW (at ingestion, near the ATM) and store it on the
@@ -615,6 +629,12 @@ const runProcess = async () => {
   // One best-effort location fix, shared by every operation auto-created this run.
   const getLocation = makeLocationProvider();
 
+  // Operations paired with a notification this run (matched-as-duplicate or
+  // freshly auto-created), so a second identical charge in the same batch pairs
+  // with a different operation instead of being absorbed by the first.
+  const claimedOpIds = new Set();
+  const bookOptions = { claimedOpIds };
+
   // Oldest first so operations are created in chronological order.
   const ordered = [...notifications].sort(
     (a, b) => (a.postTime || 0) - (b.postTime || 0),
@@ -645,9 +665,9 @@ const runProcess = async () => {
       // accounts, so they resolve a *target* account (a bound "cash" account)
       // instead of a category. Everything else books as expense/income.
       if (descriptor.isTransfer) {
-        await bookTransferOrQueue(descriptor, resolution, date, allowedPackages, summary, getLocation);
+        await bookTransferOrQueue(descriptor, resolution, date, allowedPackages, summary, getLocation, bookOptions);
       } else {
-        await bookExpenseOrQueue(descriptor, resolution, date, allowedPackages, summary, getLocation);
+        await bookExpenseOrQueue(descriptor, resolution, date, allowedPackages, summary, getLocation, bookOptions);
       }
 
       seen.add(signature);

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -22,6 +22,8 @@ import { captureLocationIfEnabled, isAttachLocationEnabled, operationLocationFie
 import { parseBankNotification, kindRequiresCategory } from './parseBankNotification';
 import { resolveNotification } from './resolveNotification';
 import { learnAccountBinding } from './accountBindings';
+import { findMatchingOperation, reconcilePendingNotifications } from './duplicateOperations';
+import { dismissPendingOperationsAlert } from './localNotifications';
 
 /**
  * A per-run location provider. Captures the device location at most once (lazily,
@@ -319,6 +321,37 @@ const isAllowedSource = (packageName, allowed) =>
   !!packageName && allowed.includes(packageName);
 
 /**
+ * Whether a notification describes an operation the user has already recorded by
+ * hand — matched on the resolved account, date, amount, and type. Returns false
+ * when the account didn't resolve (nothing to match against) or when the caller
+ * opted out via `checkDuplicate: false` (an explicit re-add).
+ *
+ * @param {Object} descriptor - parsed notification
+ * @param {Object} resolution - resolveNotification() result
+ * @param {string} date - resolved ISO date
+ * @param {{ checkDuplicate?: boolean }} options
+ * @returns {Promise<boolean>}
+ */
+const isAlreadyRecorded = async (descriptor, resolution, date, options) => {
+  if (options.checkDuplicate === false || resolution.accountId == null) return false;
+  const existing = await findMatchingOperation(
+    {
+      type: descriptor.type,
+      amount: descriptor.amount,
+      currency: descriptor.currency,
+      date,
+      accountId: resolution.accountId,
+    },
+    {
+      currency: resolution.accountCurrency,
+      autoTxnRounding: resolution.accountRounding,
+      autoTxnRoundingMode: resolution.accountRoundingMode,
+    },
+  );
+  return existing != null;
+};
+
+/**
  * Book a parsed expense/income notification: auto-create the operation when the
  * card resolves to an account, the merchant resolves to a category, and the source
  * is trusted; otherwise enqueue it for review. Mutates `summary`.
@@ -330,8 +363,18 @@ const isAllowedSource = (packageName, allowed) =>
  * @param {{ created: number, pending: number }} summary
  * @param {() => Promise<Object|null>} [getLocation] - best-effort location provider
  *   for auto-created operations; omitted callers book without coordinates.
+ * @param {{ checkDuplicate?: boolean }} [options] - when checkDuplicate is false,
+ *   book even if a matching operation already exists (explicit re-add).
  */
-const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation) => {
+const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation, options = {}) => {
+  // Skip a charge the user has already recorded by hand (see isAlreadyRecorded):
+  // neither auto-create nor queue a duplicate. Counted as skipped; the caller
+  // still marks the notification seen so it isn't re-checked every run.
+  if (await isAlreadyRecorded(descriptor, resolution, date, options)) {
+    summary.skipped += 1;
+    return;
+  }
+
   // Everything an auto-create needs except the currency match. Auto-create only
   // for trusted sources; kinds that require a manual category (C2C transfers,
   // DEBIT ACCOUNT) always wait in the queue.
@@ -434,8 +477,17 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
  * @param {{ created: number, pending: number }} summary
  * @param {() => Promise<Object|null>} [getLocation] - best-effort location provider
  *   for auto-created transfers; omitted callers book without coordinates.
+ * @param {{ checkDuplicate?: boolean }} [options] - when checkDuplicate is false,
+ *   book even if a matching operation already exists (explicit re-add).
  */
-const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation) => {
+const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages, summary, getLocation, options = {}) => {
+  // Skip an ATM withdrawal the user has already recorded by hand, mirroring the
+  // expense/income path (matched on the source account, date, amount, and type).
+  if (await isAlreadyRecorded(descriptor, resolution, date, options)) {
+    summary.skipped += 1;
+    return;
+  }
+
   const target = await resolveAtmTargetAccount();
   const eligibleForAutoCreate =
     resolution.matchedAccount &&
@@ -520,6 +572,22 @@ export const processBankNotifications = async () => {
   }
 };
 
+/**
+ * Dismiss the tray "transactions to review" alert once the review queue is empty,
+ * so a resolved/dismissed/pruned queue stops nagging from the shade. Best-effort.
+ * @returns {Promise<void>}
+ */
+const syncPendingOperationsAlert = async () => {
+  try {
+    const remaining = await PendingNotificationsDB.getPendingCount();
+    if (remaining === 0) {
+      await dismissPendingOperationsAlert();
+    }
+  } catch (error) {
+    // Non-fatal — the alert self-replaces on the next background run.
+  }
+};
+
 const runProcess = async () => {
   const summary = { created: 0, pending: 0, skipped: 0 };
 
@@ -527,8 +595,16 @@ const runProcess = async () => {
     return summary;
   }
 
+  // Drop any queued review item the user has already recorded by hand since it
+  // was enqueued, before parsing new notifications.
+  const prunedExisting = await reconcilePendingNotifications();
+
   const notifications = await getRecentNotifications();
   if (!notifications || notifications.length === 0) {
+    if (prunedExisting > 0) {
+      appEvents.emit(EVENTS.RELOAD_ALL);
+      await syncPendingOperationsAlert();
+    }
     return summary;
   }
 
@@ -587,8 +663,15 @@ const runProcess = async () => {
   }
 
   // Refresh on any change so a pending badge updates too, not just on creates.
-  if (summary.created > 0 || summary.pending > 0) {
+  // A prune (a queued item matched an already-recorded operation) counts too.
+  if (summary.created > 0 || summary.pending > 0 || prunedExisting > 0) {
     appEvents.emit(EVENTS.RELOAD_ALL);
+  }
+
+  // Clear the tray nudge if the review queue is now empty (e.g. every queued item
+  // was pruned as a duplicate this run).
+  if (prunedExisting > 0) {
+    await syncPendingOperationsAlert();
   }
 
   return summary;
@@ -771,6 +854,7 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
 
   await PendingNotificationsDB.deletePendingNotification(pendingId);
   appEvents.emit(EVENTS.RELOAD_ALL);
+  await syncPendingOperationsAlert();
   return operation;
 };
 
@@ -881,6 +965,7 @@ const resolvePendingTransfer = async (pending, choices = {}) => {
 
   await PendingNotificationsDB.deletePendingNotification(pending.id);
   appEvents.emit(EVENTS.RELOAD_ALL);
+  await syncPendingOperationsAlert();
   return operation;
 };
 
@@ -913,10 +998,14 @@ export const reAddNotification = async (notification) => {
   const trustedAllowlist = descriptor.packageName ? [descriptor.packageName] : [];
   const getLocation = makeLocationProvider();
 
+  // The user explicitly asked to re-add this notification, so book it even if a
+  // matching operation already exists (they may be intentionally recording a
+  // second identical charge, or re-adding one they deleted).
+  const options = { checkDuplicate: false };
   if (descriptor.isTransfer) {
-    await bookTransferOrQueue(descriptor, resolution, date, trustedAllowlist, summary, getLocation);
+    await bookTransferOrQueue(descriptor, resolution, date, trustedAllowlist, summary, getLocation, options);
   } else {
-    await bookExpenseOrQueue(descriptor, resolution, date, trustedAllowlist, summary, getLocation);
+    await bookExpenseOrQueue(descriptor, resolution, date, trustedAllowlist, summary, getLocation, options);
   }
 
   if (summary.created > 0 || summary.pending > 0) {
@@ -937,6 +1026,7 @@ export const reAddNotification = async (notification) => {
 export const dismissPendingNotification = async (pendingId) => {
   await PendingNotificationsDB.deletePendingNotification(pendingId);
   appEvents.emit(EVENTS.RELOAD_ALL);
+  await syncPendingOperationsAlert();
 };
 
 export default processBankNotifications;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1054,6 +1054,7 @@ jest.mock('expo-notifications', () => ({
   getPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', granted: true })),
   requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted', granted: true })),
   scheduleNotificationAsync: jest.fn(() => Promise.resolve('test-notification-id')),
+  dismissNotificationAsync: jest.fn(() => Promise.resolve()),
   addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
   getLastNotificationResponseAsync: jest.fn(() => Promise.resolve(null)),
   AndroidImportance: {


### PR DESCRIPTION
## Summary

A bank push often lands minutes after the user has already entered the same purchase by hand. Until now Penny would still queue that notification for review (and post a tray alert) — leaving a "choose a category" card for something already in the ledger. This teaches the pipeline to recognize when a matching operation already exists so the notification is skipped and any stale review card is pruned.

## Changes

- **app/services/notifications/duplicateOperations.js** (new) — matches a notification against existing operations on account, date, type, and amount (raw or account-rounded, and the preserved foreign amount for cross-currency charges); `reconcilePendingNotifications()` prunes queued items that now have a matching operation.
- **app/services/OperationsDB.js** — `getOperationsByAccountTypeAndDate()`, a focused lookup for the matcher.
- **app/services/notifications/processBankNotifications.js** — skip auto-creating/queuing a charge that already exists (`isAlreadyRecorded`), reconcile the queue on each run, and dismiss the tray alert when the review queue empties. Explicit re-adds bypass the check.
- **app/services/notifications/localNotifications.js** — `dismissPendingOperationsAlert()` clears the "transactions to review" tray alert.
- **app/hooks/usePendingOperationSuggestions.js** — reconcile before showing the deck; also reload on `OPERATION_CHANGED` so a just-entered operation clears its suggestion card at once.
- **app/components/NotificationProcessingContentPanel.js** — reconcile before showing the settings review queue.
- **jest.setup.js** — mock `Notifications.dismissNotificationAsync`.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 177 suites / 5117 tests pass (includes new `duplicateOperations` unit tests and pipeline skip/reconcile/re-add cases).
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new strings)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018KKrPB3fsPmVKtGMxbYHKD)_