### PR TITLE
feat(operations): tidy ALL-CAPS shop names in notification labels

### DIFF
--- a/__tests__/components/operations/NotificationBindingStack.test.js
+++ b/__tests__/components/operations/NotificationBindingStack.test.js
@@ -135,9 +135,11 @@ describe('NotificationBindingStack', () => {
     // Field captions (custom-name, ACCOUNT, CATEGORY) were dropped to reclaim
     // vertical space for three rows of the category grid — the inputs stay, their
     // captions don't. The label input is anchored by its merchant placeholder and
-    // the account picker by its selected account label.
+    // the account picker by its selected account label. The ALL-CAPS shop name is
+    // tidied to first-capital for the suggested label ('SAS SUPERMARKET' ->
+    // 'Sas Supermarket').
     const { getByText, getByPlaceholderText, getByTestId, queryByText } = await renderStack();
-    expect(getByPlaceholderText('SAS SUPERMARKET')).toBeTruthy();
+    expect(getByPlaceholderText('Sas Supermarket')).toBeTruthy();
     expect(getByText('Checking')).toBeTruthy();
     expect(getByTestId('category-grid-c1')).toBeTruthy();
     expect(queryByText('BANK_NOTIFICATIONS_CUSTOM_LABEL')).toBeNull();
@@ -165,7 +167,7 @@ describe('NotificationBindingStack', () => {
   it('propagates label edits as a choice patch for the item', async () => {
     const onChoiceChange = jest.fn();
     const { getByPlaceholderText } = await renderStack({ onChoiceChange });
-    fireEvent.changeText(getByPlaceholderText('SAS SUPERMARKET'), 'My grocery');
+    fireEvent.changeText(getByPlaceholderText('Sas Supermarket'), 'My grocery');
     expect(onChoiceChange).toHaveBeenCalledWith('p1', { labelOverride: 'My grocery' });
   });
 

--- a/__tests__/services/notifications/processBankNotifications.test.js
+++ b/__tests__/services/notifications/processBankNotifications.test.js
@@ -154,7 +154,7 @@ describe('processBankNotifications', () => {
     expect(OperationsDB.createOperation).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'expense', amount: '3900.00', accountId: 7,
-        categoryId: 'cat-food', date: '2026-06-28', description: 'NAREK MEHRABYAN',
+        categoryId: 'cat-food', date: '2026-06-28', description: 'Narek Mehrabyan',
       }),
     );
     expect(emitSpy).toHaveBeenCalledWith(EVENTS.RELOAD_ALL);
@@ -594,7 +594,7 @@ describe('processBankNotifications', () => {
       expect(OperationsDB.createOperation).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'transfer', amount: '200000', accountId: 7, toAccountId: 9,
-          date: '2026-07-01', description: 'ATM 401 REPUBLIC 67/1',
+          date: '2026-07-01', description: 'Atm 401 Republic 67/1',
         }),
       );
     });
@@ -941,9 +941,9 @@ describe('processBankNotifications', () => {
         accountId: 7, categoryId: 'cat-health', labelOverride: '',
       });
 
-      // The operation falls back to the raw shop name...
+      // The operation falls back to the raw shop name, tidied from ALL CAPS...
       expect(OperationsDB.createOperation).toHaveBeenCalledWith(
-        expect.objectContaining({ description: 'ECOSENSE BYUZAND' }),
+        expect.objectContaining({ description: 'Ecosense Byuzand' }),
       );
       // ...and the blanked field clears the stored override.
       expect(NotificationRulesDB.upsertMerchantLabel).toHaveBeenCalledWith(
@@ -984,14 +984,15 @@ describe('processBankNotifications', () => {
       expect(NotificationRulesDB.upsertMerchantLabel).not.toHaveBeenCalled();
     });
 
-    it('uses the raw merchant when there is no override at all', async () => {
+    it('tidies the raw ALL-CAPS merchant when there is no override at all', async () => {
       PendingNotificationsDB.getPendingNotificationById.mockResolvedValue(pending);
       NotificationRulesDB.getLabelForMerchant.mockResolvedValue(null);
 
       await pipeline.resolvePendingNotification('p1', { accountId: 7, categoryId: 'cat-food' });
 
+      // 'NAREK MEHRABYAN' -> 'Narek Mehrabyan' (first-capital per word).
       expect(OperationsDB.createOperation).toHaveBeenCalledWith(
-        expect.objectContaining({ description: 'NAREK MEHRABYAN' }),
+        expect.objectContaining({ description: 'Narek Mehrabyan' }),
       );
       expect(NotificationRulesDB.upsertMerchantLabel).not.toHaveBeenCalled();
     });
@@ -1046,7 +1047,7 @@ describe('processBankNotifications', () => {
       expect(OperationsDB.createOperation).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'transfer', amount: '200000', accountId: 7, toAccountId: 9,
-          date: '2026-07-01', description: 'ATM 401 REPUBLIC 67/1',
+          date: '2026-07-01', description: 'Atm 401 Republic 67/1',
         }),
       );
       // Learns the card -> source-account binding.

--- a/__tests__/utils/labelUtils.test.js
+++ b/__tests__/utils/labelUtils.test.js
@@ -17,6 +17,7 @@ import {
   visibleListLabels,
   isProtectedOperation,
   displayLabel,
+  normalizeMerchantLabel,
 } from '../../app/utils/labelUtils';
 
 describe('labelUtils', () => {
@@ -387,6 +388,52 @@ describe('labelUtils', () => {
       expect(isProtectedOperation('')).toBe(false);
       expect(isProtectedOperation(null)).toBe(false);
       expect(isProtectedOperation(undefined)).toBe(false);
+    });
+  });
+
+  describe('normalizeMerchantLabel', () => {
+    it('title-cases an all-caps single-word shop name', () => {
+      expect(normalizeMerchantLabel('GURMAN')).toBe('Gurman');
+    });
+
+    it('title-cases each word of an all-caps multi-word name', () => {
+      expect(normalizeMerchantLabel('YANDEX GO')).toBe('Yandex Go');
+    });
+
+    it('title-cases all-caps Cyrillic names', () => {
+      expect(normalizeMerchantLabel('ПЯТЁРОЧКА')).toBe('Пятёрочка');
+      expect(normalizeMerchantLabel('ООО РОГА')).toBe('Ооо Рога');
+    });
+
+    it('leaves an already mixed-case name untouched', () => {
+      expect(normalizeMerchantLabel('МегаФон')).toBe('МегаФон');
+      expect(normalizeMerchantLabel('iHerb')).toBe('iHerb');
+      expect(normalizeMerchantLabel('McDonald\'s')).toBe('McDonald\'s');
+      expect(normalizeMerchantLabel('Yandex Go')).toBe('Yandex Go');
+    });
+
+    it('leaves a name with no cased letters untouched', () => {
+      expect(normalizeMerchantLabel('7-11')).toBe('7-11');
+      expect(normalizeMerchantLabel('1234')).toBe('1234');
+    });
+
+    it('keeps digits alongside letters and tidies only the letters', () => {
+      expect(normalizeMerchantLabel('GURMAN 24')).toBe('Gurman 24');
+    });
+
+    it('trims surrounding whitespace', () => {
+      expect(normalizeMerchantLabel('  GURMAN  ')).toBe('Gurman');
+    });
+
+    it('returns non-string input unchanged', () => {
+      expect(normalizeMerchantLabel(null)).toBe(null);
+      expect(normalizeMerchantLabel(undefined)).toBe(undefined);
+      expect(normalizeMerchantLabel(42)).toBe(42);
+    });
+
+    it('returns an empty string for blank input', () => {
+      expect(normalizeMerchantLabel('')).toBe('');
+      expect(normalizeMerchantLabel('   ')).toBe('');
     });
   });
 });

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -44,6 +44,7 @@ import { getPendingNotifications } from '../services/PendingNotificationsDB';
 import { reconcilePendingNotifications } from '../services/notifications/duplicateOperations';
 import { getLabelForMerchant } from '../services/NotificationRulesDB';
 import { getRecentNotifications } from '../services/NotificationAccess';
+import { normalizeMerchantLabel } from '../utils/labelUtils';
 import * as Currency from '../services/currency';
 
 // How often the panel silently re-runs the pipeline and reloads its lists so
@@ -512,7 +513,9 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
               <FormInput
                 value={choice.labelOverride ?? ''}
                 onChangeText={(v) => setChoice(item.id, { labelOverride: v })}
-                placeholder={item.merchant || ''}
+                // The suggested label matches what a blank field books: the raw
+                // shop name tidied from ALL CAPS ("GURMAN" -> "Gurman").
+                placeholder={normalizeMerchantLabel(item.merchant) || ''}
               />
               <Text style={[styles.helpText, { color: colors.mutedText }]}>
                 {isTransfer

--- a/app/components/operations/NotificationBindingCard.js
+++ b/app/components/operations/NotificationBindingCard.js
@@ -14,6 +14,7 @@ import CategoryGridSelector from '../CategoryGridSelector';
 import useTopCategoryIds from '../../hooks/useTopCategoryIds';
 import { canSaveSuggestion } from '../../hooks/usePendingOperationSuggestions';
 import { getCategoryDisplayName } from '../../utils/categoryUtils';
+import { normalizeMerchantLabel } from '../../utils/labelUtils';
 import * as Currency from '../../services/currency';
 import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
 
@@ -135,7 +136,9 @@ const NotificationBindingCard = ({
         <FormInput
           value={choice.labelOverride ?? ''}
           onChangeText={(v) => onChoiceChange({ labelOverride: v })}
-          placeholder={item.merchant || ''}
+          // The suggested label matches what a blank field books: the raw shop
+          // name tidied from ALL CAPS ("GURMAN" -> "Gurman").
+          placeholder={normalizeMerchantLabel(item.merchant) || ''}
           style={styles.nameInput}
         />
 

--- a/app/services/notifications/processBankNotifications.js
+++ b/app/services/notifications/processBankNotifications.js
@@ -16,7 +16,7 @@ import * as AccountsDB from '../AccountsDB';
 import * as Currency from '../currency';
 import * as NotificationRulesDB from '../NotificationRulesDB';
 import * as PendingNotificationsDB from '../PendingNotificationsDB';
-import { serializeLabels, sanitizeLabel } from '../../utils/labelUtils';
+import { serializeLabels, sanitizeLabel, normalizeMerchantLabel } from '../../utils/labelUtils';
 import { appEvents, EVENTS } from '../eventEmitter';
 import { captureLocationIfEnabled, isAttachLocationEnabled, operationLocationFields } from '../operationLocation';
 import { parseBankNotification, kindRequiresCategory } from './parseBankNotification';
@@ -424,8 +424,9 @@ const bookExpenseOrQueue = async (descriptor, resolution, date, allowedPackages,
     }
 
     // A learned label override (e.g. "ECOSENSE BYUZAND" -> "Ecosense") wins over
-    // the raw merchant for the operation's label.
-    const label = resolution.labelOverride || descriptor.merchant;
+    // the raw merchant for the operation's label. Otherwise the raw shop name is
+    // tidied from ALL CAPS to first-capital ("GURMAN" -> "Gurman").
+    const label = resolution.labelOverride || normalizeMerchantLabel(descriptor.merchant);
     const location = getLocation ? await getLocation() : null;
     const created = await OperationsDB.createOperation({
       type: descriptor.type,
@@ -542,7 +543,9 @@ const bookTransferOrQueue = async (descriptor, resolution, date, allowedPackages
       accountId: resolution.accountId,
       toAccountId: target.id,
       date,
-      description: descriptor.merchant ? serializeLabels([descriptor.merchant]) : null,
+      description: descriptor.merchant
+        ? serializeLabels([normalizeMerchantLabel(descriptor.merchant)])
+        : null,
       ...operationLocationFields(location),
     });
     if (options.claimedOpIds && created && created.id != null) options.claimedOpIds.add(created.id);
@@ -733,7 +736,9 @@ export const resolvePendingNotification = async (pendingId, choices = {}) => {
     ? (await NotificationRulesDB.getLabelForMerchant(pending.merchant, pending.packageName)) || ''
     : '';
   const chosenLabel = hasLabelChoice ? typedLabel : learnedLabel;
-  const label = chosenLabel || pending.merchant;
+  // Fall back to the raw shop name, tidied from ALL CAPS to first-capital
+  // ("GURMAN" -> "Gurman"), when neither a typed nor a learned label is present.
+  const label = chosenLabel || normalizeMerchantLabel(pending.merchant);
 
   // Fetch the chosen account once: its currency drives conversion and its
   // rounding setting is applied to the booked amount below.
@@ -938,7 +943,7 @@ const resolvePendingTransfer = async (pending, choices = {}) => {
   // otherwise the raw ATM location (merchant) is used. No merchant rule is learned
   // for a transfer — an ATM location is not a category to remember.
   const typedLabel = sanitizeLabel(choices.labelOverride);
-  const label = typedLabel || pending.merchant;
+  const label = typedLabel || normalizeMerchantLabel(pending.merchant);
 
   // Prefer the fix captured at ingestion (near the ATM); fall back to a live,
   // opt-in-gated capture only when the pending row carries no stored coordinates.

--- a/app/utils/labelUtils.js
+++ b/app/utils/labelUtils.js
@@ -74,6 +74,43 @@ export const normalizeLabel = (label) => {
 export const sanitizeLabel = (label) => normalizeLabel(label).slice(0, MAX_LABEL_LENGTH).trim();
 
 /**
+ * Tidy a raw merchant name for use as a *suggested* operation label.
+ *
+ * Bank notifications frequently shout the shop name in ALL CAPS ("GURMAN",
+ * "YANDEX GO"). When that name is proposed to the user as the operation's label
+ * — or booked automatically without review — this converts it to first-capital,
+ * rest-lowercase per word ("Gurman", "Yandex Go") so the label reads naturally.
+ *
+ * Only genuinely all-caps names are reformatted. A name that already carries any
+ * lower-case letter ("МегаФон", "iHerb", "McDonald's") is left untouched: that
+ * casing was chosen deliberately and lower-casing it would lose information. A
+ * name with no cased letters at all (digits, CJK) is likewise returned as-is.
+ *
+ * This never applies to a learned/user-typed label override — those are the
+ * user's own casing and are always authoritative.
+ *
+ * @param {*} merchant
+ * @returns {*} the tidied name, the original string when not all-caps, or the
+ *   input unchanged when it is not a string.
+ */
+export const normalizeMerchantLabel = (merchant) => {
+  if (typeof merchant !== 'string') return merchant;
+  const trimmed = merchant.trim();
+  if (!trimmed) return trimmed;
+  // Not all-caps (has a lower-case letter) or has no cased letters at all → leave
+  // the deliberate casing intact.
+  if (trimmed !== trimmed.toUpperCase() || trimmed === trimmed.toLowerCase()) {
+    return trimmed;
+  }
+  // Capitalize the first character of each whitespace-separated word and
+  // lower-case the rest. \S+ preserves the original spacing between words.
+  return trimmed.replace(
+    /\S+/g,
+    (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+  );
+};
+
+/**
  * Parse a description string into an ordered, de-duplicated list of labels.
  * De-duplication is case-insensitive; the first occurrence's casing is kept.
  * Every delimiter-separated segment becomes a label, including legacy markers


### PR DESCRIPTION
## Summary

When new operations are suggested from bank notifications, the merchant name is often shouted in ALL CAPS ("GURMAN", "YANDEX GO"). The label proposed to the user (and the label booked when no override exists) is now tidied to first-capital, rest-lowercase per word — "GURMAN" → "Gurman", "YANDEX GO" → "Yandex Go" — so it reads naturally.

Only genuinely all-caps names are reformatted. A name that already carries deliberate mixed case (`МегаФон`, `iHerb`, `McDonald's`) or has no cased letters (digits, CJK) is left untouched. Learned merchant-rule labels and anything the user types stay authoritative and are never reformatted, and the raw merchant is still stored on the pending row so merchant-rule matching keys are preserved.

## Changes

- **app/utils/labelUtils.js** — add `normalizeMerchantLabel(merchant)`: tidies an ALL-CAPS name to first-capital per word, leaves already-mixed-case / caseless names and non-strings unchanged.
- **app/services/notifications/processBankNotifications.js** — apply `normalizeMerchantLabel` to the raw-merchant fallback at every point it becomes the operation label: auto-created expense/income, auto-created ATM transfer, and the review-queue resolve for both expenses and transfers. Learned/typed overrides continue to win.
- **app/components/operations/NotificationBindingCard.js** — the main-page review card's label placeholder now shows the tidied name, matching what a blank field books.
- **app/components/NotificationProcessingContentPanel.js** — same tidied placeholder in the Settings → Notification processing review card.
- **__tests__/utils/labelUtils.test.js** — unit tests for `normalizeMerchantLabel` (all-caps Latin/Cyrillic, mixed-case untouched, caseless untouched, trimming, non-string/blank input).
- **__tests__/services/notifications/processBankNotifications.test.js**, **__tests__/components/operations/NotificationBindingStack.test.js** — update expectations to the tidied label/placeholder.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 177 suites / 5130 tests pass.
- `npx eslint … --max-warnings 0` on all changed files — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [ ] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new strings)
- [ ] Linked the related issue with `Closes #NNN` below — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZFDtHtNkDfDAYiEYa1DuC)_