### PR TITLE
feat(graphs): let the burndown norm line be toggled off, hidden by default

### DIFF
--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -456,7 +456,8 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(4);
+      // Rendered: actual + prevMonth + zero (the burndown norm is off by default)
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
       const { data, series } = computeBalanceChart({
         balanceHistoryData: mockBalanceHistoryData,
         spendingPrediction: null,
@@ -594,7 +595,8 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(5);
+      // Rendered: actual + forecast + prevMonth + zero (norm off by default)
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(4);
       const { series } = computeBalanceChart({
         balanceHistoryData: mockBalanceHistoryData,
         spendingPrediction: mockSpendingPrediction,
@@ -636,7 +638,8 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(4);
+      // Rendered: actual + prevMonth + zero (the burndown norm is off by default)
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
       const { series } = computeBalanceChart({
         balanceHistoryData: mockBalanceHistoryData,
         spendingPrediction: null,
@@ -681,7 +684,8 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
+      // Rendered: actual + zero (the burndown norm is off by default)
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(2);
       const { series } = computeBalanceChart({
         balanceHistoryData: dataWithoutPrevMonth,
         spendingPrediction: null,
@@ -724,7 +728,8 @@ describe('BalanceHistoryCard', () => {
         />,
       );
 
-      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
+      // Rendered: actual + zero (the burndown norm is off by default)
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(2);
       const { series } = computeBalanceChart({
         balanceHistoryData: dataWithUndefinedPrevMonth,
         spendingPrediction: null,
@@ -812,7 +817,8 @@ describe('BalanceHistoryCard', () => {
       );
 
       expect(getByText('Actual')).toBeTruthy();
-      expect(getByText('Plain avg')).toBeTruthy();
+      // The burndown norm is off by default; its row appears only once toggled on
+      expect(queryByText('Plain avg')).toBeNull();
       // Forecast only shows when isCurrentMonth and spendingPrediction are provided
       expect(queryByText('Forecast')).toBeNull();
       expect(getByText('Prev Month')).toBeTruthy();
@@ -833,7 +839,7 @@ describe('BalanceHistoryCard', () => {
       const mockDate = new Date(2024, 0, 16);
       jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
 
-      const { getByText } = await render(
+      const { getByText, queryByText } = await render(
         <BalanceHistoryCard
           colors={mockColors}
           t={mockT}
@@ -860,7 +866,8 @@ describe('BalanceHistoryCard', () => {
 
       // Actual row now includes forecast data (combined line)
       expect(getByText('Actual')).toBeTruthy();
-      expect(getByText('Plain avg')).toBeTruthy();
+      // The burndown norm is off by default (see the Plain Avg Toggle block)
+      expect(queryByText('Plain avg')).toBeNull();
       // Forecast is now combined with Actual, no separate row
 
       global.Date.mockRestore();
@@ -2132,6 +2139,110 @@ describe('BalanceHistoryCard', () => {
       expect(onShowCalendar).toHaveBeenCalledTimes(1);
     });
   });
+  describe('Plain Avg Toggle', () => {
+    const plainAvgData = {
+      labels: [1, 2, 3, 4, 5, 6, 7],
+      actual: [
+        { x: 1, y: 1000 },
+        { x: 4, y: 900 },
+        { x: 7, y: 800 },
+      ],
+      actualForChart: [1000, 1000, 1000, 900, 900, 900, 800],
+      burndown: [],
+      prevMonth: [950, 940, 930, 920, 910, 900, 890],
+      plainAvgMax: 5000,
+    };
+
+    const renderCard = (overrides = {}) => render(
+      <BalanceHistoryCard
+        colors={mockColors}
+        t={mockT}
+        selectedAccount="acc1"
+        onAccountChange={jest.fn()}
+        accountItems={mockAccountItems}
+        loadingBalanceHistory={false}
+        balanceHistoryData={plainAvgData}
+        selectedYear={2024}
+        selectedMonth={0}
+        accounts={mockAccounts}
+        isCurrentMonth={false}
+        spendingPrediction={null}
+        balanceHistoryTableData={[]}
+        editingBalanceValue=""
+        onEditingBalanceValueChange={jest.fn()}
+        onEditBalance={jest.fn()}
+        onCancelEdit={jest.fn()}
+        onSaveBalance={jest.fn()}
+        onDeleteBalance={jest.fn()}
+        onShowCalendar={jest.fn()}
+        {...overrides}
+      />,
+    );
+
+    it('starts with the burndown norm hidden', async () => {
+      const { container, queryByText } = await renderCard();
+
+      expect(queryByText('Plain avg')).toBeNull();
+      // actual + prev month + zero baseline only
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
+    });
+
+    it('draws the line and its legend row once toggled on, and drops both again', async () => {
+      const { container, getByTestId, getByText, queryByText } = await renderCard();
+
+      await fireEvent.press(getByTestId('plain-avg-toggle-btn'));
+
+      await waitFor(() => expect(getByText('Plain avg')).toBeTruthy());
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(4);
+
+      await fireEvent.press(getByTestId('plain-avg-toggle-btn'));
+
+      await waitFor(() => expect(queryByText('Plain avg')).toBeNull());
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
+    });
+
+    it('hides the toggle in the year view and while the calendar is open', async () => {
+      const { queryByTestId: queryYear } = await renderCard({ selectedMonth: null });
+      expect(queryYear('plain-avg-toggle-btn')).toBeNull();
+
+      const { getByTestId, queryByTestId } = await renderCard();
+      await fireEvent.press(getByTestId('calendar-toggle-btn'));
+      await waitFor(() => expect(queryByTestId('plain-avg-toggle-btn')).toBeNull());
+    });
+
+    it('omits the plainAvg series and keeps the y-axis off it when hidden', () => {
+      const hidden = computeBalanceChart({
+        balanceHistoryData: plainAvgData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+        thirdLine: 'none',
+        showPlainAvg: false,
+      });
+      const shown = computeBalanceChart({
+        balanceHistoryData: plainAvgData,
+        spendingPrediction: null,
+        isCurrentMonth: false,
+        selectedYear: 2024,
+        selectedMonth: 0,
+        primaryColor: mockColors.primary,
+        thirdLine: 'none',
+        showPlainAvg: true,
+      });
+
+      expect(hidden.series.map(s => s.yKey)).toEqual(['actual', 'zero']);
+      expect(shown.series.map(s => s.yKey)).toEqual(['actual', 'plainAvg', 'zero']);
+      expect(hidden.computed.showPlainAvg).toBe(false);
+      expect(hidden.data.every(d => d.plainAvg === null)).toBe(true);
+      // plainAvgMax (5000) is well above the actual peak (1000): only the visible
+      // line may stretch the axis
+      expect(shown.computed.niceMax).toBeGreaterThan(1000);
+      expect(hidden.computed.niceMax).toBeLessThan(shown.computed.niceMax);
+    });
+  });
+
   describe('Third Line Toggle (prev month / year avg / none)', () => {
     const thirdLineData = {
       labels: [1, 2, 3, 4, 5, 6, 7],
@@ -2198,8 +2309,8 @@ describe('BalanceHistoryCard', () => {
 
       await waitFor(() => expect(queryByText('Year avg')).toBeNull());
       expect(queryByText('Prev Month')).toBeNull();
-      // actual + plain avg + zero baseline only
-      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(3);
+      // actual + zero baseline only (the burndown norm is off by default)
+      expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(2);
     });
 
     it('hides the toggle while the calendar view is open', async () => {

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -188,6 +188,7 @@ export const computeBalanceChart = ({
   lineColors = DEFAULT_LINE_COLORS,
   baselineColor = DEFAULT_BASELINE_COLOR,
   thirdLine = 'prevMonth',
+  showPlainAvg = true,
 }) => {
   if (!balanceHistoryData.actual || balanceHistoryData.actual.length === 0) {
     return { computed: null, data: [], series: [] };
@@ -246,7 +247,14 @@ export const computeBalanceChart = ({
     ? balanceHistoryData.yearAvg
     : (thirdLine === 'prevMonth' ? balanceHistoryData.prevMonth : []);
   const comparisonValues = (comparisonSource || []).filter(v => v !== undefined && v !== null);
-  const allValues = [...actualValues, ...forecastValues, ...comparisonValues, ...plainAvgData];
+  // Same rule for the burndown norm: when it is switched off it must not keep the
+  // y-axis stretched up to the month's spendable ceiling.
+  const allValues = [
+    ...actualValues,
+    ...forecastValues,
+    ...comparisonValues,
+    ...(showPlainAvg ? plainAvgData : []),
+  ];
   const maxValue = allValues.length > 0 ? Math.max(...allValues) : 0;
   const minValue = allValues.length > 0 ? Math.min(...allValues) : 0;
   const hasNegativeValues = minValue < 0;
@@ -366,6 +374,7 @@ export const computeBalanceChart = ({
 
   const computed = {
     thirdLine,
+    showPlainAvg,
     hasYearAvgData,
     yearAvgMax,
     yearAvgCurrent,
@@ -417,7 +426,7 @@ export const computeBalanceChart = ({
       actual: isForecastDay ? null : value,
       // include the boundary day in the forecast series too so the segments touch
       forecast: (isForecastDay || isBoundaryDay) ? value : null,
-      plainAvg: plainAvgData[i] ?? null,
+      plainAvg: showPlainAvg ? (plainAvgData[i] ?? null) : null,
       prevMonth: prevMonth[i] ?? null,
       yearAvg: yearAvgSeries[i] ?? null,
       zero: 0,
@@ -430,7 +439,9 @@ export const computeBalanceChart = ({
   if (showForecast) {
     series.push({ yKey: 'forecast', color: primaryColor, strokeWidth: 2, curveType: 'monotoneX', dashed: true });
   }
-  series.push({ yKey: 'plainAvg', color: lineColors.norm, strokeWidth: 2, curveType: 'linear', dashed: false });
+  if (showPlainAvg) {
+    series.push({ yKey: 'plainAvg', color: lineColors.norm, strokeWidth: 2, curveType: 'linear', dashed: false });
+  }
   if (hasPrevMonthData) {
     series.push({ yKey: 'prevMonth', color: lineColors.prevMonth, strokeWidth: 2, curveType: 'monotoneX', dashed: false });
   }
@@ -855,6 +866,10 @@ const BalanceHistoryCard = ({
   // Which comparison line rides along with the actual balance: last month, the
   // 12-month median, or nothing at all (the year view offers last year / nothing).
   const [thirdLine, setThirdLine] = useState('prevMonth');
+  // The burndown norm ("plain avg") is a second opinion on the same month, not a
+  // reading of it — off by default so the chart opens with just the actual line,
+  // and switched on from the header when the reader wants the comparison.
+  const [showPlainAvg, setShowPlainAvg] = useState(false);
   const [contentHeight, setContentHeight] = useState(340);
   // Day currently under the finger while scrubbing the chart (null when idle).
   const [scrubDay, setScrubDay] = useState(null);
@@ -903,8 +918,9 @@ const BalanceHistoryCard = ({
         lineColors: chartLineColors,
         baselineColor: colors.border,
         thirdLine: effectiveThirdLine,
+        showPlainAvg,
       })),
-    [isYearView, balanceHistoryData, spendingPrediction, isCurrentMonth, selectedYear, selectedMonth, colors.primary, colors.border, chartLineColors, effectiveThirdLine],
+    [isYearView, balanceHistoryData, spendingPrediction, isCurrentMonth, selectedYear, selectedMonth, colors.primary, colors.border, chartLineColors, effectiveThirdLine, showPlainAvg],
   );
 
   // yKeys drive Victory's shared y-domain (the always-present "zero" key keeps the
@@ -995,6 +1011,29 @@ const BalanceHistoryCard = ({
             </View>
           )}
         </View>
+        {/* Burndown-norm toggle. Month view only — the year chart never draws
+            that line (see computeYearBalanceChart). */}
+        {!calendarVisible && !isYearView && balanceHistoryData.actual && balanceHistoryData.actual.length > 0 && (
+          <TouchableOpacity
+            testID="plain-avg-toggle-btn"
+            style={[styles.calendarToggleBtn, { backgroundColor: colors.surface }]}
+            onPress={() => setShowPlainAvg(prev => !prev)}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityState={{ selected: showPlainAvg }}
+            accessibilityLabel={t('plain_avg') || 'Plain avg'}
+          >
+            {/* One icon in both states, muted when off: the comparison toggle
+                next to it already uses eye-off for its own "none" step, and two
+                identical eye-off glyphs side by side say nothing about which
+                line each button owns. */}
+            <Icon
+              name="trending-down"
+              size={18}
+              color={showPlainAvg ? chartLineColors.norm : colors.mutedText}
+            />
+          </TouchableOpacity>
+        )}
         {/* Comparison line toggle: month view steps prev month → year average →
             off, year view steps prev year → off. */}
         {!calendarVisible && balanceHistoryData.actual && balanceHistoryData.actual.length > 0 && (
@@ -1091,7 +1130,7 @@ const BalanceHistoryCard = ({
                       onScrub={handleScrub}
                       xTickValues={isYearView ? chartComputed.monthTicks : undefined}
                       monthByDay={isYearView ? chartComputed.monthByDay : undefined}
-                      showDeviationBand={!isYearView}
+                      showDeviationBand={!isYearView && showPlainAvg}
                     />
                   </View>
                 )}
@@ -1123,7 +1162,7 @@ const BalanceHistoryCard = ({
 
                   {/* Plain avg row — the burndown norm, month view only (see
                       computeYearBalanceChart for why a year has none) */}
-                  {!isYearView && (
+                  {!isYearView && showPlainAvg && (
                     <View style={styles.legendTableRow} testID="legend-row-plain-avg">
                       <View style={styles.legendTableLabelCell}>
                         <View style={[styles.legendDot, { backgroundColor: chartLineColors.norm }]} />


### PR DESCRIPTION
## Summary

The balance chart drew three lines at once. The burndown norm ("plain avg") is a second opinion on the month rather than a reading of it, so it now has its own header toggle beside the comparison-line toggle and starts hidden — the chart opens with just the actual balance and whichever comparison line is selected.

## Changes

- **app/components/graphs/BalanceHistoryCard.js** — new `plain-avg-toggle-btn` in the card header, immediately left of the existing comparison-line toggle. It flips a `showPlainAvg` state that defaults to `false`. `computeBalanceChart` takes a matching `showPlainAvg` option: when off it omits the `plainAvg` series, nulls the field in the chart records, and keeps those values out of the y-domain, so the axis is not left stretched up to the month's spendable ceiling around a line nobody can see. Hiding the line also drops its legend row and the deviation band (which is drawn between the actual line and that norm). The button is month-view only — the year chart never draws the norm.
- **__tests__/components/BalanceHistoryCard.test.js** — new `Plain Avg Toggle` block covering the hidden default, toggling the line and legend row on and off, the toggle being absent in the year view and while the calendar is open, and the y-domain staying off the hidden line. Existing expectations that assumed the norm was always drawn were updated to the new default.

No new user-facing strings — the toggle reuses the existing `plain_avg` key, which is already translated in all 11 locales.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 181 suites / 5182 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

Note on existing behaviour, unchanged here: toggling any line remounts the Skia canvas (the press state is allocated per series key), which resets an active pan/zoom. The comparison-line toggle already did this; the new button behaves the same way rather than introducing a second convention.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a, reuses the existing `plain_avg` key
- [x] Linked the related issue with `Closes #NNN` below — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgURCFnKMYeMymyFprauaj)_