### PR TITLE
feat(ui): align the confirmation dialog with Material 3

### DIFF
--- a/__tests__/components/MaterialDialog.test.js
+++ b/__tests__/components/MaterialDialog.test.js
@@ -8,7 +8,7 @@ jest.unmock('../../app/contexts/ThemeColorsContext');
 
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Pressable } from 'react-native';
+import { Pressable, StyleSheet } from 'react-native';
 import MaterialDialog from '../../app/components/MaterialDialog';
 import { ThemeColorsProvider } from '../../app/contexts/ThemeColorsContext';
 
@@ -663,14 +663,187 @@ describe('MaterialDialog', () => {
         <MaterialDialog
           visible={true}
           title="Press test"
-          buttons={[{ text: 'OK', onPress: jest.fn() }]}
+          buttons={[
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'OK', onPress: jest.fn() },
+          ]}
         />,
         { wrapper },
       );
-      const btn = getByText('OK');
-      // pressIn triggers pressed=true branch in style function
+      // pressIn triggers pressed=true branch in the style function — only the
+      // unfilled actions have one, the confirming action is always filled.
+      const btn = getByText('Cancel');
       fireEvent(btn, 'pressIn');
       expect(btn).toBeTruthy();
+    });
+  });
+
+  describe('Material 3 styling', () => {
+    const flatten = (style) => StyleSheet.flatten(style) || {};
+
+    it('does not uppercase button labels', async () => {
+      const { getByText } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Confirm"
+          buttons={[{ text: 'Удалить', style: 'destructive' }]}
+        />,
+        { wrapper },
+      );
+
+      expect(flatten(getByText('Удалить').props.style).textTransform).toBeUndefined();
+    });
+
+    it('lays the actions out in a wrapping row, not a column', async () => {
+      const { getByTestId } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Confirm"
+          buttons={[
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Delete', style: 'destructive' },
+          ]}
+        />,
+        { wrapper },
+      );
+
+      const style = flatten(getByTestId('material-dialog-actions').props.style);
+      expect(style.flexDirection).toBe('row');
+      expect(style.flexWrap).toBe('wrap');
+      expect(style.justifyContent).toBe('flex-end');
+    });
+
+    it('gives every action a 48dp touch target', async () => {
+      const { getByText } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Confirm"
+          buttons={[
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Delete', style: 'destructive' },
+          ]}
+        />,
+        { wrapper },
+      );
+
+      ['Cancel', 'Delete'].forEach((label) => {
+        const action = getByText(label).parent;
+        const style = flatten(
+          typeof action.props.style === 'function'
+            ? action.props.style({ pressed: false })
+            : action.props.style,
+        );
+        expect(style.minHeight).toBe(48);
+      });
+    });
+
+    it('dims the screen behind the dialog with a scrim', async () => {
+      const { getByTestId } = await render(
+        <MaterialDialog visible={true} title="Confirm" />,
+        { wrapper },
+      );
+
+      const style = flatten(getByTestId('material-dialog-overlay').props.style);
+      expect(style.backgroundColor).toBeTruthy();
+      expect(style.backgroundColor).not.toBe('transparent');
+    });
+
+    it('labels actions for screen readers', async () => {
+      const { getByText } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Confirm"
+          buttons={[{ text: 'Delete', style: 'destructive' }]}
+        />,
+        { wrapper },
+      );
+
+      const action = getByText('Delete').parent;
+      expect(action.props.accessibilityRole).toBe('button');
+      expect(action.props.accessibilityLabel).toBe('Delete');
+    });
+  });
+
+  describe('Hero icon', () => {
+    it('shows a warning icon when a destructive action is present', async () => {
+      const { getByTestId } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Delete?"
+          buttons={[
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Delete', style: 'destructive' },
+          ]}
+        />,
+        { wrapper },
+      );
+
+      expect(getByTestId('material-dialog-icon')).toBeTruthy();
+    });
+
+    it('shows no icon for an ordinary dialog', async () => {
+      const { queryByTestId } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Done"
+          buttons={[{ text: 'OK' }]}
+        />,
+        { wrapper },
+      );
+
+      expect(queryByTestId('material-dialog-icon')).toBeNull();
+    });
+
+    it('lets a caller override the icon', async () => {
+      const { getByTestId } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Exported"
+          icon="check-circle-outline"
+          buttons={[{ text: 'OK' }]}
+        />,
+        { wrapper },
+      );
+
+      expect(getByTestId('material-dialog-icon')).toBeTruthy();
+    });
+
+    it('lets a destructive dialog suppress the icon with null', async () => {
+      const { queryByTestId } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Delete?"
+          icon={null}
+          buttons={[{ text: 'Delete', style: 'destructive' }]}
+        />,
+        { wrapper },
+      );
+
+      expect(queryByTestId('material-dialog-icon')).toBeNull();
+    });
+
+    it('centres the text when an icon is present and left-aligns it otherwise', async () => {
+      const { getByText, rerender } = await render(
+        <MaterialDialog
+          visible={true}
+          title="Delete?"
+          buttons={[{ text: 'Delete', style: 'destructive' }]}
+        />,
+        { wrapper },
+      );
+
+      expect(StyleSheet.flatten(getByText('Delete?').props.style).textAlign).toBe('center');
+
+      await rerender(
+        <MaterialDialog
+          visible={true}
+          title="Delete?"
+          icon={null}
+          buttons={[{ text: 'Delete', style: 'destructive' }]}
+        />,
+      );
+
+      expect(StyleSheet.flatten(getByText('Delete?').props.style).textAlign).toBeUndefined();
     });
   });
 });

--- a/__tests__/styles/layout.test.js
+++ b/__tests__/styles/layout.test.js
@@ -85,26 +85,32 @@ describe('Layout Constants', () => {
   });
 
   describe('BORDER_RADIUS', () => {
-    it('has exactly 3 values', async () => {
-      const keys = Object.keys(BORDER_RADIUS);
-      expect(keys.length).toBe(3);
-    });
-
-    it('has sm, md, lg keys', async () => {
-      expect(BORDER_RADIUS).toHaveProperty('sm');
-      expect(BORDER_RADIUS).toHaveProperty('md');
-      expect(BORDER_RADIUS).toHaveProperty('lg');
+    // The scale started at seven arbitrary values and was cut to three. The
+    // guard is not the number 3 — it is that the set is enumerated here, so
+    // widening it costs a deliberate edit to this test rather than happening by
+    // accident one component at a time.
+    it('is exactly the enumerated scale', async () => {
+      expect(Object.keys(BORDER_RADIUS)).toEqual(['sm', 'md', 'lg', 'xl', 'pill']);
     });
 
     it('has correct values', async () => {
       expect(BORDER_RADIUS.sm).toBe(4);
       expect(BORDER_RADIUS.md).toBe(8);
       expect(BORDER_RADIUS.lg).toBe(12);
+      expect(BORDER_RADIUS.xl).toBe(28);
     });
 
-    it('values increase in order', async () => {
+    it('size values increase in order', async () => {
       expect(BORDER_RADIUS.sm).toBeLessThan(BORDER_RADIUS.md);
       expect(BORDER_RADIUS.md).toBeLessThan(BORDER_RADIUS.lg);
+      expect(BORDER_RADIUS.lg).toBeLessThan(BORDER_RADIUS.xl);
+    });
+
+    // `pill` is a "fully round" sentinel rather than a size — any value past
+    // half the element's height clamps to the same shape — so it sits outside
+    // the ordered scale on purpose.
+    it('pill is large enough to round any action button', async () => {
+      expect(BORDER_RADIUS.pill).toBeGreaterThan(BORDER_RADIUS.xl * 2);
     });
   });
 

--- a/app/components/MaterialDialog.js
+++ b/app/components/MaterialDialog.js
@@ -1,8 +1,16 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, View, Text, StyleSheet, Pressable } from 'react-native';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
-import { HORIZONTAL_PADDING } from '../styles/layout';
+import {
+  SPACING,
+  BORDER_RADIUS,
+  FONT_SIZE,
+  FONT_WEIGHT,
+  ICON_SIZE,
+  ELEVATION,
+} from '../styles/designTokens';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import ModalBlurOverlay from './ModalBlurOverlay';
 import { TIMING_ENTER } from '../utils/motion';
@@ -12,15 +20,41 @@ import { TIMING_ENTER } from '../utils/motion';
 const OPEN_SCALE_FROM = 0.96;
 const OPEN_DURATION = 200;
 
+// Material 3's scrim: black at 32%. The root blur (App.js, `filter: [{ blur: 10 }]`)
+// only blurs, it does not dim — and on Android that filter needs API 31's
+// RenderEffect, so on an older device there was nothing at all between the card
+// and the screen. The blur is the atmosphere; this is the separation.
+const SCRIM = 'rgba(0,0,0,0.32)';
+
+// The confirming action is a tonal button: its accent at low alpha behind the
+// same accent at full strength. Tonal rather than solid because a solid fill has
+// to pick a legible text colour on top of it, and there is no single answer —
+// the light delete red (#d9534f) wants white, the dark one (#ff6b6b) wants
+// black. A tonal button never has to choose, so one rule covers both themes.
+const FILL_ALPHA = '22';
+const RIPPLE_ALPHA = '33';
+
+/**
+ * Append an alpha channel to a 6-digit hex colour.
+ *
+ * Returns the colour untouched if it is anything else — a CSS keyword like the
+ * theme's `danger: 'red'`, or an rgba() string. `'red22'` is not a colour, and
+ * a caller passing one would get a silently invisible button rather than an
+ * error, so the guard is the difference between a tint and a disappearance.
+ */
+const withAlpha = (color, alpha) => (
+  /^#[0-9a-f]{6}$/i.test(color) ? `${color}${alpha}` : color
+);
+
 // The card is a Pressable (it swallows taps so they don't reach the dismissing
 // overlay behind it) AND the thing that scales. Animating the Pressable itself
 // rather than wrapping it in an Animated.View keeps `styles.dialog` — which sizes
-// the card at 80% of the overlay — on a single node; a bare wrapper would have
-// had to size itself from its own child's percentage width.
+// the card — on a single node; a bare wrapper would have had to size itself from
+// its own child's percentage width.
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 /**
- * Material Design Dialog Component
+ * Material Design 3 Dialog Component
  * Replaces React Native Alert with a themed modal dialog
  *
  * @param {boolean} visible - Controls dialog visibility
@@ -28,6 +62,9 @@ const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
  * @param {string} message - Dialog message/content
  * @param {Array} buttons - Array of button configurations
  *   Each button: { text: string, onPress: function, style: 'default'|'cancel'|'destructive' }
+ * @param {string|null} icon - MaterialCommunityIcons glyph shown above the title.
+ *   Omitted, a dialog carrying a destructive action gets `alert-outline`; pass
+ *   `null` to suppress that, or a name to override it.
  * @param {function} onDismiss - Called when dialog is dismissed
  */
 export default function MaterialDialog({
@@ -35,6 +72,7 @@ export default function MaterialDialog({
   title,
   message,
   buttons = [],
+  icon,
   onDismiss,
 }) {
   const { colors } = useThemeColors();
@@ -69,16 +107,35 @@ export default function MaterialDialog({
     }
   };
 
-  const getButtonStyle = (style) => {
+  const destructiveColor = colors.delete || '#d32f2f';
+
+  /** The accent a button speaks in — its label colour, and the base of its fill. */
+  const accentFor = (style) => {
     switch (style) {
     case 'destructive':
-      return { color: colors.delete || '#d32f2f' };
+      return destructiveColor;
     case 'cancel':
-      return { color: colors.mutedText };
+      return colors.mutedText;
     default:
-      return { color: colors.primary };
+      return colors.primary;
     }
   };
+
+  // The last action is the one the dialog is asking for, so it gets the fill —
+  // unless it is a cancel, in which case the dialog is not asking for anything.
+  const confirmIndex = buttons.length - 1;
+  const isConfirmAction = (button, index) => (
+    index === confirmIndex && button.style !== 'cancel'
+  );
+
+  const hasDestructive = buttons.some((button) => button.style === 'destructive');
+  // `undefined` means "decide for me"; `null` means "no icon". Distinguishing the
+  // two is what lets a destructive dialog get the glyph for free at all 10 call
+  // sites while still leaving any one of them able to opt out.
+  const resolvedIcon = icon === undefined ? (hasDestructive ? 'alert-outline' : null) : icon;
+  // Material 3 centres the headline and supporting text when a hero icon is
+  // present, and left-aligns them when it is not.
+  const centered = !!resolvedIcon;
 
   return (
     <>
@@ -86,55 +143,87 @@ export default function MaterialDialog({
       <Modal
         visible={visible}
         transparent
+        statusBarTranslucent
         animationType="fade"
         onRequestClose={onDismiss}
       >
         <Pressable
           testID="material-dialog-overlay"
-          style={styles.overlay}
+          style={[styles.overlay, { backgroundColor: colors.scrim || SCRIM }]}
           onPress={onDismiss}
         >
           <AnimatedPressable
             testID="material-dialog-content"
+            accessibilityRole="alert"
+            accessibilityLiveRegion="polite"
             style={[styles.dialog, { backgroundColor: colors.card }, dialogStyle]}
             onPress={() => {}}
           >
+            {/* Hero icon */}
+            {resolvedIcon && (
+              <MaterialCommunityIcons
+                testID="material-dialog-icon"
+                name={resolvedIcon}
+                size={ICON_SIZE.base}
+                color={hasDestructive ? destructiveColor : colors.primary}
+                style={styles.icon}
+              />
+            )}
+
             {/* Title */}
             {title && (
-              <Text style={[styles.title, { color: colors.text }]}>
+              <Text style={[styles.title, centered && styles.centeredText, { color: colors.text }]}>
                 {title}
               </Text>
             )}
 
             {/* Message */}
             {message && (
-              <Text style={[styles.message, { color: colors.text }]}>
+              <Text
+                style={[
+                  styles.message,
+                  centered && styles.centeredText,
+                  { color: colors.mutedText },
+                ]}
+              >
                 {message}
               </Text>
             )}
 
-            {/* Buttons */}
-            <View style={styles.buttonContainer}>
-              {buttons.map((button, index) => (
-                <Pressable
-                  key={index}
-                  style={({ pressed }) => [
-                    styles.button,
-                    pressed && { backgroundColor: colors.selected },
-                  ]}
-                  onPress={() => handleButtonPress(button)}
-                >
-                  <Text
-                    style={[
-                      styles.buttonText,
-                      getButtonStyle(button.style),
-                      button.style === 'destructive' && styles.boldText,
+            {/* Actions. A row that wraps rather than a measured row/column
+                switch: two labels that do not fit side by side (German, or a
+                long Russian verb) fall onto separate lines in the order Material
+                3 stacks them anyway — confirming action last, both flush right. */}
+            <View testID="material-dialog-actions" style={styles.actions}>
+              {buttons.map((button, index) => {
+                const accent = accentFor(button.style);
+                const filled = isConfirmAction(button, index);
+                return (
+                  <Pressable
+                    key={index}
+                    accessibilityRole="button"
+                    accessibilityLabel={typeof button.text === 'string' ? button.text : undefined}
+                    android_ripple={{
+                      color: filled
+                        ? withAlpha(accent, RIPPLE_ALPHA)
+                        : colors.glassSurfaceStrong,
+                      borderless: false,
+                    }}
+                    style={({ pressed }) => [
+                      styles.action,
+                      filled && { backgroundColor: withAlpha(accent, FILL_ALPHA) },
+                      // Ripple covers Android; this keeps the press readable
+                      // anywhere it does not run (older API levels, tests).
+                      pressed && !filled && { backgroundColor: colors.glassSurfaceStrong },
                     ]}
+                    onPress={() => handleButtonPress(button)}
                   >
-                    {button.text}
-                  </Text>
-                </Pressable>
-              ))}
+                    <Text style={[styles.actionLabel, { color: accent }]}>
+                      {button.text}
+                    </Text>
+                  </Pressable>
+                );
+              })}
             </View>
           </AnimatedPressable>
         </Pressable>
@@ -154,44 +243,57 @@ MaterialDialog.propTypes = {
       style: PropTypes.oneOf(['default', 'cancel', 'destructive']),
     }),
   ),
+  icon: PropTypes.string,
   onDismiss: PropTypes.func,
 };
 
 const styles = StyleSheet.create({
-  boldText: {
-    fontWeight: '700',
+  // Content-sized and right-aligned, which is also the fix for a hazard the old
+  // column layout had: its buttons stretched the full width of the card with
+  // only the label drawn at the right end, so a tap on the empty space to the
+  // left of "Delete" deleted.
+  action: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.pill,
+    justifyContent: 'center',
+    minHeight: 48,
+    paddingHorizontal: SPACING.xl,
   },
-  button: {
-    alignItems: 'flex-end',
-    borderRadius: 8,
-    paddingHorizontal: HORIZONTAL_PADDING,
-    paddingVertical: 12,
+  actionLabel: {
+    fontSize: FONT_SIZE.md,
+    fontWeight: FONT_WEIGHT.medium,
+    letterSpacing: 0.1,
   },
-  buttonContainer: {
-    alignItems: 'stretch',
-    flexDirection: 'column',
-    gap: 4,
+  // No `textTransform: 'uppercase'`. Material dropped all-caps labels in M3, and
+  // the translations are already sentence case, so every language gets the fix
+  // for free — Cyrillic and CJK most of all, where capitals cost the reader the
+  // shape of the word.
+  actions: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: SPACING.sm,
+    justifyContent: 'flex-end',
   },
-  buttonText: {
-    fontSize: 14,
-    fontWeight: '600',
-    textTransform: 'uppercase',
+  centeredText: {
+    textAlign: 'center',
   },
   dialog: {
-    borderRadius: 12,
-    elevation: 8,
-    maxWidth: 400,
-    padding: HORIZONTAL_PADDING + 8,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 8,
-    width: '80%',
+    borderRadius: BORDER_RADIUS.xl,
+    maxWidth: 560,
+    minWidth: 280,
+    padding: SPACING.xxl,
+    width: '90%',
+    ...ELEVATION.medium,
+  },
+  icon: {
+    alignSelf: 'center',
+    marginBottom: SPACING.lg,
   },
   message: {
-    fontSize: 16,
-    lineHeight: 24,
-    marginBottom: 24,
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: SPACING.xxl,
   },
   overlay: {
     alignItems: 'center',
@@ -199,8 +301,9 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   title: {
-    fontSize: 20,
-    fontWeight: '600',
-    marginBottom: 16,
+    fontSize: FONT_SIZE.xxl,
+    fontWeight: FONT_WEIGHT.regular,
+    lineHeight: 32,
+    marginBottom: SPACING.lg,
   },
 });

--- a/app/contexts/ThemeColorsContext.js
+++ b/app/contexts/ThemeColorsContext.js
@@ -16,6 +16,11 @@ const lightTheme = {
     border: '#e6e6e6',
     card: '#fff',
     modalBackground: 'rgba(0,0,0,0.65)',
+    // Material 3's dialog scrim. Lighter than `modalBackground` on purpose: a
+    // dialog is already sitting on the root blur (App.js), so this only has to
+    // supply the separation the blur does not — and 0.65 on top of a blurred
+    // screen reads as a blackout rather than as a layer.
+    scrim: 'rgba(0,0,0,0.32)',
     inputBackground: '#fff',
     inputBorder: '#cccccc',
     calcButtonBackground: '#ffffff',
@@ -57,6 +62,10 @@ const darkTheme = {
     border: '#3a3a3a',
     card: '#222222',
     modalBackground: 'rgba(0,0,0,0.65)',
+    // See lightTheme note. Same value in both themes — M3 states the scrim as
+    // black at 32% regardless of scheme, and a dark-theme dialog needs the
+    // separation more, not less, since card and background are closer together.
+    scrim: 'rgba(0,0,0,0.32)',
     inputBackground: '#333333',
     inputBorder: '#555555',
     calcButtonBackground: '#1e1e1e',

--- a/app/styles/designTokens.js
+++ b/app/styles/designTokens.js
@@ -29,12 +29,22 @@ export const SPACING = {
 /**
  * Standardized border radius values
  * Previously had 7 different values (4, 6, 8, 12, 16, 20, 24px)
- * Now consolidated to just 3 for consistency
+ * Now consolidated to a short scale for consistency
  */
 export const BORDER_RADIUS = {
   sm: 4,    // Inputs, small interactive elements, calculator buttons
   md: 8,    // Cards, buttons, most containers
   lg: 12,   // Modals, major containers
+  // Material 3's `corner.extra-large`, the radius the platform gives to a
+  // surface that floats free of everything behind it — a dialog, a bottom
+  // sheet. It is a fourth value in a scale whose whole point was to stop at
+  // three, and it earns the exception by being a spec number rather than
+  // another judgement call: at `lg` a dialog reads as a 2019 AlertDialog no
+  // matter what else is done to it.
+  xl: 28,
+  // Fully-rounded, for pill-shaped action buttons. Not a size — any value past
+  // half the height gets clamped — so it does not compete with the scale above.
+  pill: 999,
 };
 
 // ============ COMPONENT HEIGHTS ============


### PR DESCRIPTION
## Summary

`MaterialDialog` is the app's only dialog — all 50 `showDialog` call sites render it — and it had stayed on Material Design 2 while the rest of the app moved on (react-native-paper 5, an MD3 library, already ships here). The visible tells were all-caps button labels, a 12dp radius, and actions stacked one per row.

Behind the styling sat a real hazard: the actions container was `alignItems: 'stretch'` with each button `alignItems: 'flex-end'`, so every button spanned the full width of the card with only its label drawn at the right end. A tap on the empty space to the *left* of "Delete" deleted. Moving the actions into a row removes the phantom target along with the stacking.

## Changes

- **app/components/MaterialDialog.js**
  - Actions in a wrapping row, confirming action last and flush right. Labels that don't fit side by side wrap into the order M3 stacks them in anyway, so no measurement pass is needed.
  - Dropped `textTransform: 'uppercase'`. M3 dropped all-caps labels; translations are already sentence case, so all 11 languages are fixed by the deletion — Cyrillic and CJK gain the most, since capitals cost the reader the shape of the word.
  - Confirming action is now a tonal pill: its accent at low alpha under the accent at full strength. Tonal rather than solid because a solid fill has to pick a legible colour on top and there's no single answer — the light delete red (`#d9534f`) wants white, the dark one (`#ff6b6b`) wants black.
  - 28dp corner, 90% width capped at 560, `ELEVATION.medium` (level 3) instead of `elevation: 8`.
  - Hero icon above the title when a destructive action is present — the same confirmation pattern `SettingsScreen`'s subpanels already use. New optional `icon` prop overrides the glyph; `null` suppresses it.
  - Headline 24/400, supporting text muted. The two had been the same weight of the same colour, so the card stated no hierarchy.
  - 48dp touch targets (was ~42), Android ripple instead of a flat pressed fill, `accessibilityRole`/`accessibilityLabel` on each action.
  - A scrim behind the card. The root blur only blurs, and its `filter: [{ blur: 10 }]` needs API 31's RenderEffect — below that, nothing separated the dialog from the screen.
- **app/contexts/ThemeColorsContext.js** — added the `scrim` token (black 32%) to both themes. Lighter than the existing `modalBackground` (0.65) on purpose: stacked on the root blur, 0.65 reads as a blackout rather than a layer.
- **app/styles/designTokens.js** — `BORDER_RADIUS` gains `xl` (28, M3 `corner.extra-large`) and `pill`.
- **__tests__/components/MaterialDialog.test.js** — new coverage for the row layout, sentence-case labels, 48dp targets, the scrim, action accessibility, and the hero icon's default / override / suppress behaviour.
- **__tests__/styles/layout.test.js** — the radius guard now enumerates the scale instead of counting it, so widening it still costs a deliberate edit to the test.

### Note on the token scale

`designTokens.js` states a rule of three radius values, and this adds a fourth. The exception is deliberate: 28dp is a spec number rather than another judgement call, and at 12dp a dialog reads as a 2019 `AlertDialog` no matter what else is done to it. The rule existed to stop the scale sprawling back to seven arbitrary values, and the rewritten test keeps that guard intact.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 181 suites / 5188 tests pass (baseline before the change: 181 / 5178).
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.
- Not yet run on a device; visual check of light/dark would be worthwhile before merge.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in all 11 `assets/i18n/*.json` files — n/a, no new strings; removing the uppercase transform lets the existing sentence-case translations through unchanged
- [x] Linked the related issue with `Closes #NNN` below — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2zWkSBDGD3nVGEkFMYjmC)_