### PR TITLE
refactor(ui): unify recurring element styles behind shared tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,11 @@ The app follows a feature-based organization under the `app/` directory:
 - **utils/** (4 files) - Utility functions
   - `resetDatabase.js`, `emergencyReset.js`, `categoryUtils.js`, `calculatorUtils.js`
 
-- **styles/** (2 files) - Shared style definitions
-  - `designTokens.js`, `layout.js`
+- **styles/** (4 files) - Shared style definitions
+  - `designTokens.js` - scalars (spacing, radii, font sizes, heights, icon sizes)
+  - `componentStyles.js` - composite styles for recurring elements (card, chip, badge, button, section label, modal title)
+  - `semanticColors.js` - scheme-keyed semantic colours for consumers that cannot read the theme context
+  - `layout.js` - deprecated re-export of `designTokens.js`, kept for backward compatibility
 
 ### Context-Based State Management
 
@@ -380,6 +383,31 @@ A chip grid grouped by currency. The groups are *not* a hierarchy — there is n
 - The grid reads `hideBalances` from `DisplaySettingsContext` itself rather than taking it as a prop, so a host cannot forget the setting.
 
 Hosts: `PickerModal`, `OperationModal`, `BudgetPlanLineModal` (transfer target + execution account), `AccountsScreen` (transfer-on-delete).
+
+### Shared Element Styles
+
+**Rule: a recurring UI element is styled from `app/styles/componentStyles.js`, never re-specified per file.**
+
+The same handful of elements appear on every screen, and each one had drifted into four or five versions — chips at five different radii, cards at two radii and two border widths, eyebrow labels at four weight/tracking pairs, nine different destructive reds. They are now single constants, spread into the host's own StyleSheet:
+
+```javascript
+import { CARD_SURFACE, CHIP, CHIP_TEXT } from '../styles/componentStyles';
+
+const styles = StyleSheet.create({
+  card: { ...CARD_SURFACE, padding: SPACING.lg },  // host keeps its own spacing
+  chip: CHIP,
+  chipText: CHIP_TEXT,
+});
+```
+
+Available: `CARD_SURFACE`, `CHIP` / `CHIP_TEXT`, `BADGE` / `BADGE_TEXT`, `BUTTON` / `BUTTON_COMPACT` / `BUTTON_TEXT`, `SECTION_LABEL` (eyebrow), `SECTION_HEADING`, `MODAL_TITLE`. Spread them and add the host's own layout (margins, flex, fixed sizes) alongside — the constants deliberately carry no spacing that varies by context.
+
+Two supporting rules:
+
+- **Scalars come from `designTokens.js`.** A bare number for `borderRadius`, `fontSize`, `gap` or padding is a defect unless it is genuinely one-off. In particular a radius that is half its element's own fixed height is `BORDER_RADIUS.pill`, not the computed half — `pill` clamps to half the height, so it renders identically and cannot fall out of sync when the height changes.
+- **There is one red: `colors.destructive`.** Errors, delete affordances and validation all read it. `colors.danger`, `colors.delete` and `colors.error` are aliases of the same value. Never hardcode a red at a call site — four of the old hardcoded ones were the *dark*-theme red, so they rendered unchanged on the light theme.
+
+**Empty states render `app/components/EmptyState.js`** rather than a local icon-plus-text block. `fill={false}` for one that sits inline in a scrolling panel; `iconSet="ionicons"` where the surrounding panel draws from Ionicons.
 
 ### Testing
 

--- a/__tests__/components/graphs/SpendingPredictionCard.test.js
+++ b/__tests__/components/graphs/SpendingPredictionCard.test.js
@@ -219,7 +219,12 @@ describe('SpendingPredictionCard', () => {
       );
     });
 
-    it('uses default expense color when not provided', async () => {
+    // The card used to fall back to a hardcoded `#ff4444` when `colors.expense`
+    // was missing — a red that was not the expense colour in either palette, so
+    // an incomplete theme rendered an amount in a colour the app never uses.
+    // Both real palettes always define `expense`; the card now just reads it,
+    // and an incomplete theme leaves the colour unset rather than inventing one.
+    it('renders without inventing a colour when expense is not provided', async () => {
       const colorsWithoutExpense = {
         text: '#000000',
         mutedText: '#888888',
@@ -238,11 +243,11 @@ describe('SpendingPredictionCard', () => {
         />,
       );
 
-      // Should render with default #ff4444 color
       const currentSpending = getByText('500.50 USD');
+      expect(currentSpending).toBeTruthy();
       expect(currentSpending.props.style).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ color: '#ff4444' }),
+          expect.objectContaining({ color: undefined }),
         ]),
       );
     });

--- a/app/components/AddFAB.js
+++ b/app/components/AddFAB.js
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 import { FAB } from 'react-native-paper';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { SPACING } from '../styles/layout';
+import { BORDER_RADIUS, SPACING } from '../styles/designTokens';
 
 const AddFAB = ({ onPress, testID, accessibilityLabel, accessibilityHint }) => {
   const { colors } = useThemeColors();
@@ -36,7 +36,7 @@ AddFAB.propTypes = {
 
 const styles = StyleSheet.create({
   fab: {
-    borderRadius: 28,
+    borderRadius: BORDER_RADIUS.xl,
     borderWidth: 1,
     bottom: 100,
     elevation: 8,

--- a/app/components/Calculator.js
+++ b/app/components/Calculator.js
@@ -2,12 +2,9 @@ import React, { useState, useEffect, useCallback, useMemo, memo, useRef } from '
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
-import { BORDER_RADIUS, SPACING, HEIGHTS } from '../styles/designTokens';
+import { BORDER_RADIUS, FONT_SIZE, HEIGHTS, SPACING } from '../styles/designTokens';
 import { hasOperation as checkHasOperation, evaluateExpression as evalExpr } from '../utils/calculatorUtils';
 import { getDecimalPlaces } from '../services/currency';
-
-// Validation-flash border color; mirrors FLASH_ERROR_COLOR in OperationFormFields.js
-const FLASH_ERROR_COLOR = '#ef4444';
 
 /**
  * Calculator button component - Memoized for performance
@@ -269,18 +266,18 @@ export default function Calculator({ value = '', onValueChange = () => {}, color
 
   const operationTextStyle = useMemo(() => ({
     color: colors.mutedText,
-    fontSize: 24,
+    fontSize: FONT_SIZE.xxl,
     fontWeight: 'bold',
   }), [colors.mutedText]);
 
   const numberTextStyle = useMemo(() => ({
     color: colors.text,
-    fontSize: 20,
+    fontSize: FONT_SIZE.xl,
   }), [colors.text]);
 
   const decimalTextStyle = useMemo(() => ({
     color: colors.text,
-    fontSize: 24,
+    fontSize: FONT_SIZE.xxl,
     fontWeight: 'bold',
   }), [colors.text]);
 
@@ -288,7 +285,7 @@ export default function Calculator({ value = '', onValueChange = () => {}, color
     // Use provided containerBackground or fallback to altRow for compatibility
     <View style={[styles.container, compact && styles.containerCompact, { backgroundColor: containerBackground || colors.altRow }]}>
       {/* Display */}
-      <View style={[styles.display, flashError && styles.displayError]}>
+      <View style={[styles.display, flashError && { borderColor: colors.destructive }]}>
         {onCurrencyPress ? (
           <Pressable
             onPress={onCurrencyPress}
@@ -498,7 +495,7 @@ const styles = StyleSheet.create({
     shadowRadius: 2,
   },
   buttonText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '500',
   },
   container: {
@@ -551,15 +548,12 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     width: 80,
   },
-  displayError: {
-    borderColor: FLASH_ERROR_COLOR,
-  },
   displayLeftSpacer: {
     width: 80,
   },
   displayText: {
     flex: 1,
-    fontSize: 20,
+    fontSize: FONT_SIZE.xl,
     fontWeight: '600',
     textAlign: 'center',
   },
@@ -572,7 +566,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.xs,
   },
   equalsButtonText: {
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: 'bold',
   },
   keypad: {

--- a/app/components/EmptyState.js
+++ b/app/components/EmptyState.js
@@ -2,18 +2,51 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Text } from 'react-native-paper';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { SPACING } from '../styles/layout';
-import { FONT_SIZE } from '../styles/designTokens';
+import { FONT_SIZE, SPACING } from '../styles/designTokens';
 
-const EmptyState = ({ icon, iconSize = 48, message, testID }) => {
+const ICON_SETS = {
+  material: Icon,
+  ionicons: Ionicons,
+};
+
+/**
+ * EmptyState — the "there is nothing here yet" block.
+ *
+ * Every list, chart and panel that can come up empty renders this. Before it
+ * was adopted app-wide there were eleven hand-rolled versions: message text at
+ * 14px and 16px, one with a fixed 120px height, one with 80px of top padding,
+ * some with `lineHeight: 20` and the rest without — all of them saying the same
+ * thing in a slightly different voice.
+ *
+ * Two props exist so the hosts that differ for real reasons can use it rather
+ * than fork it again:
+ *
+ *  - `iconSet` — the notification panels draw from Ionicons and everything else
+ *    from MaterialCommunityIcons. That is a glyph choice, not a layout one, so
+ *    it is a prop instead of a reason to keep a second component.
+ *  - `fill` — an empty state that owns a whole list viewport centres itself in
+ *    it (`flexGrow: 1`); one that sits inline in a scrolling panel, with other
+ *    content above and below it, must take only the height it needs.
+ */
+const EmptyState = ({
+  icon,
+  iconSet = 'material',
+  iconSize = 48,
+  message,
+  fill = true,
+  style,
+  testID,
+}) => {
   const { colors } = useThemeColors();
+  const IconComponent = ICON_SETS[iconSet];
 
   return (
-    <View testID={testID} style={styles.container}>
+    <View testID={testID} style={[styles.container, fill && styles.fill, style]}>
       {icon ? (
-        <Icon name={icon} size={iconSize} color={colors.mutedText} />
+        <IconComponent name={icon} size={iconSize} color={colors.mutedText} />
       ) : null}
       <Text style={[styles.message, { color: colors.mutedText }]}>{message}</Text>
     </View>
@@ -22,21 +55,27 @@ const EmptyState = ({ icon, iconSize = 48, message, testID }) => {
 
 EmptyState.propTypes = {
   icon: PropTypes.string,
+  iconSet: PropTypes.oneOf(['material', 'ionicons']),
   iconSize: PropTypes.number,
-  message: PropTypes.string.isRequired,
+  message: PropTypes.node.isRequired,
+  fill: PropTypes.bool,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   testID: PropTypes.string,
 };
 
 const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
-    flexGrow: 1,
     gap: SPACING.md,
     justifyContent: 'center',
     paddingVertical: SPACING.xxl,
   },
+  fill: {
+    flexGrow: 1,
+  },
   message: {
     fontSize: FONT_SIZE.md,
+    lineHeight: 20,
     textAlign: 'center',
   },
 });

--- a/app/components/ErrorBoundary.js
+++ b/app/components/ErrorBoundary.js
@@ -3,6 +3,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { captureException } from '../services/sentry';
+import { DESTRUCTIVE } from '../styles/semanticColors';
+import { BUTTON, BUTTON_TEXT } from '../styles/componentStyles';
+import { FONT_SIZE } from '../styles/designTokens';
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -54,15 +57,12 @@ class ErrorBoundary extends React.Component {
 
 const styles = StyleSheet.create({
   button: {
+    ...BUTTON,
     backgroundColor: '#007AFF',
-    borderRadius: 8,
-    paddingHorizontal: 24,
-    paddingVertical: 12,
   },
   buttonText: {
+    ...BUTTON_TEXT,
     color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
   },
   container: {
     alignItems: 'center',
@@ -72,20 +72,20 @@ const styles = StyleSheet.create({
     padding: 20,
   },
   error: {
-    color: '#ff0000',
+    color: DESTRUCTIVE.light,
     fontFamily: 'monospace',
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 20,
   },
   message: {
     color: '#666',
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     marginBottom: 24,
     textAlign: 'center',
   },
   title: {
     color: '#111',
-    fontSize: 24,
+    fontSize: FONT_SIZE.xxl,
     fontWeight: 'bold',
     marginBottom: 12,
   },

--- a/app/components/Header.js
+++ b/app/components/Header.js
@@ -1,6 +1,7 @@
 import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
+import { SPACING } from '../styles/designTokens';
 
 export default function Header({ rightContent = null }) {
   const { colors } = useThemeColors();
@@ -27,7 +28,7 @@ const styles = StyleSheet.create({
   buttonContainer: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
   },
   container: {
     alignItems: 'center',

--- a/app/components/IconPicker.js
+++ b/app/components/IconPicker.js
@@ -5,6 +5,8 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import ModalBlurOverlay from './ModalBlurOverlay';
+import { MODAL_TITLE } from '../styles/componentStyles';
+import { BORDER_RADIUS } from '../styles/designTokens';
 
 export const COMMON_ICONS = [
   // Money & Finance
@@ -138,7 +140,7 @@ const styles = StyleSheet.create({
   },
   iconButton: {
     alignItems: 'center',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 2,
     justifyContent: 'center',
     margin: 3,
@@ -154,8 +156,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
   },
   title: {
-    fontSize: 18,
-    fontWeight: '700',
+    ...MODAL_TITLE,
   },
 });
 

--- a/app/components/LoadingView.js
+++ b/app/components/LoadingView.js
@@ -3,7 +3,7 @@ import { View, StyleSheet } from 'react-native';
 import { ActivityIndicator, Text } from 'react-native-paper';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { SPACING } from '../styles/layout';
+import { SPACING } from '../styles/designTokens';
 
 const LoadingView = ({ message, testID }) => {
   const { colors } = useThemeColors();

--- a/app/components/MaterialDialog.js
+++ b/app/components/MaterialDialog.js
@@ -107,7 +107,7 @@ export default function MaterialDialog({
     }
   };
 
-  const destructiveColor = colors.delete || '#d32f2f';
+  const destructiveColor = colors.destructive;
 
   /** The accent a button speaks in — its label colour, and the base of its fill. */
   const accentFor = (style) => {

--- a/app/components/ModalHeader.js
+++ b/app/components/ModalHeader.js
@@ -3,8 +3,8 @@ import { StyleSheet } from 'react-native';
 import { Text } from 'react-native-paper';
 import PropTypes from 'prop-types';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { SPACING } from '../styles/layout';
-import { FONT_SIZE } from '../styles/designTokens';
+import { FONT_SIZE, SPACING } from '../styles/designTokens';
+import { MODAL_TITLE } from '../styles/componentStyles';
 
 const ModalHeader = ({ title, testID }) => {
   const { colors } = useThemeColors();
@@ -23,8 +23,7 @@ ModalHeader.propTypes = {
 
 const styles = StyleSheet.create({
   title: {
-    fontSize: FONT_SIZE.xl,
-    fontWeight: '700',
+    ...MODAL_TITLE,
     marginBottom: SPACING.lg,
     textAlign: 'center',
   },

--- a/app/components/ModalShell.js
+++ b/app/components/ModalShell.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
-import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../styles/designTokens';
 import { useBackShrink } from '../hooks/useBackShrink';
 import ModalBlurOverlay from './ModalBlurOverlay';
 import {
@@ -27,6 +27,7 @@ import {
   rubberband,
 } from '../utils/motion';
 import { isReduceMotionEnabled } from '../utils/reducedMotion';
+import { MODAL_TITLE } from '../styles/componentStyles';
 
 // Pressable that can animate layout props (paddingBottom) for keyboard avoidance.
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -460,7 +461,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.sm,
   },
   btnText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '600',
   },
   cancelBtn: {
@@ -528,12 +529,10 @@ const styles = StyleSheet.create({
     paddingBottom: 0,
   },
   subtitle: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 2,
   },
   title: {
-    fontSize: 18,
-    fontWeight: '700',
-    letterSpacing: -0.3,
+    ...MODAL_TITLE,
   },
 });

--- a/app/components/NotificationBindingsContentPanel.js
+++ b/app/components/NotificationBindingsContentPanel.js
@@ -12,7 +12,7 @@ import SimplePicker from './SimplePicker';
 import FormInput from './FormInput';
 import { getCategoryDisplayName } from '../utils/categoryUtils';
 import { parseCardMasks, cardMaskLast4 } from '../utils/cardMask';
-import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../styles/designTokens';
 import {
   getAllMerchantRules,
   clearMerchantRuleCategory,
@@ -26,6 +26,8 @@ import {
   setAtmTargetAccount,
   clearAtmTargetAccount,
 } from '../services/notifications/processBankNotifications';
+import { BUTTON_COMPACT, BUTTON_TEXT, CARD_SURFACE, SECTION_LABEL } from '../styles/componentStyles';
+import EmptyState from './EmptyState';
 
 /**
  * "Bindings" subpanel for notification processing (header three-dots → Bindings).
@@ -318,7 +320,7 @@ export default function NotificationBindingsContentPanel({ bottomInset = 0 }) {
             accessibilityLabel={t('delete') || 'Delete'}
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
-            <Ionicons name="trash" size={20} color={colors.delete || '#d9534f'} />
+            <Ionicons name="trash" size={20} color={colors.destructive} />
           </TouchableOpacity>
         </View>
       );
@@ -387,21 +389,23 @@ export default function NotificationBindingsContentPanel({ bottomInset = 0 }) {
       )}
 
       {!hasAnyBinding && !addingCard && (
-        <View style={styles.emptyState}>
-          <Ionicons name="link-outline" size={40} color={colors.mutedText} />
-          <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-            {t('notification_bindings_empty')
-              || 'No bindings yet. Penny learns them as you review notifications.'}
-          </Text>
-        </View>
+        <EmptyState
+          icon="link-outline"
+          iconSet="ionicons"
+          iconSize={40}
+          fill={false}
+          style={styles.emptyState}
+          message={t('notification_bindings_empty')
+            || 'No bindings yet. Penny learns them as you review notifications.'}
+        />
       )}
 
       {noSearchResults && (
-        <View style={styles.emptyState}>
-          <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-            {t('notification_bindings_no_results') || 'Nothing matches your search.'}
-          </Text>
-        </View>
+        <EmptyState
+          fill={false}
+          style={styles.emptyState}
+          message={t('notification_bindings_no_results') || 'Nothing matches your search.'}
+        />
       )}
 
       {/* ── Card bindings ── */}
@@ -651,8 +655,7 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   card: {
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: StyleSheet.hairlineWidth,
+    ...CARD_SURFACE,
     marginBottom: SPACING.sm,
     padding: SPACING.sm,
   },
@@ -690,11 +693,11 @@ const styles = StyleSheet.create({
   },
   editorButtonPrimaryText: {
     color: '#ffffff',
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   editorButtonText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   editorButtons: {
@@ -707,11 +710,6 @@ const styles = StyleSheet.create({
     gap: SPACING.md,
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.xl,
-  },
-  emptyText: {
-    fontSize: 14,
-    lineHeight: 20,
-    textAlign: 'center',
   },
   labelEditRow: {
     alignItems: 'center',
@@ -731,17 +729,12 @@ const styles = StyleSheet.create({
     padding: SPACING.xs,
   },
   saveButton: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.sm,
-    justifyContent: 'center',
+    ...BUTTON_COMPACT,
     minWidth: 72,
-    paddingHorizontal: SPACING.md,
-    paddingVertical: SPACING.sm,
   },
   saveButtonText: {
+    ...BUTTON_TEXT,
     color: '#ffffff',
-    fontSize: 14,
-    fontWeight: '600',
   },
   scroll: {
     flex: 1,
@@ -756,15 +749,13 @@ const styles = StyleSheet.create({
     marginTop: SPACING.lg,
   },
   sectionHint: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     lineHeight: 17,
     marginBottom: SPACING.sm,
   },
   sectionTitle: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.8,
-    marginBottom: 4,
+    ...SECTION_LABEL,
+    marginBottom: SPACING.xs,
     marginTop: SPACING.lg,
   },
   sectionTitleInRow: {

--- a/app/components/NotificationFiltersContentPanel.js
+++ b/app/components/NotificationFiltersContentPanel.js
@@ -5,7 +5,7 @@ import { Text, Switch } from 'react-native-paper';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
-import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../styles/designTokens';
 import {
   isBankNotificationsEnabled,
   setBankNotificationsEnabled,
@@ -28,6 +28,8 @@ import {
   togglePackageVisibility,
   isPackageHidden,
 } from '../services/notifications/notificationFilters';
+import { CARD_SURFACE, SECTION_LABEL } from '../styles/componentStyles';
+import EmptyState from './EmptyState';
 
 /**
  * "Filters" subpanel for notification processing (header three-dots → Filters).
@@ -286,13 +288,15 @@ export default function NotificationFiltersContentPanel({ bottomInset = 0 }) {
       </Text>
 
       {known.length === 0 ? (
-        <View style={styles.emptyState}>
-          <Ionicons name="apps-outline" size={40} color={colors.mutedText} />
-          <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-            {t('notification_filter_apps_empty') ||
-              "No apps yet. They'll appear here as notifications arrive."}
-          </Text>
-        </View>
+        <EmptyState
+          icon="apps-outline"
+          iconSet="ionicons"
+          iconSize={40}
+          fill={false}
+          style={styles.emptyState}
+          message={t('notification_filter_apps_empty') ||
+            "No apps yet. They'll appear here as notifications arrive."}
+        />
       ) : (
         orderedApps.map((pkg) => {
           const checked = !isPackageHidden(pkg, hidden);
@@ -339,7 +343,7 @@ const styles = StyleSheet.create({
   },
   appName: {
     flex: 1,
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
   appRow: {
@@ -363,15 +367,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.xl,
   },
-  emptyText: {
-    fontSize: 14,
-    lineHeight: 20,
-    textAlign: 'center',
-  },
   row: {
+    ...CARD_SURFACE,
     alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
     gap: SPACING.sm,
     marginTop: SPACING.md,
@@ -381,7 +379,7 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   rowHint: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     lineHeight: 17,
     marginTop: 2,
   },
@@ -397,15 +395,13 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   sectionHint: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     lineHeight: 17,
     marginBottom: SPACING.sm,
   },
   sectionTitle: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.8,
-    marginBottom: 4,
+    ...SECTION_LABEL,
+    marginBottom: SPACING.xs,
     marginTop: SPACING.lg,
   },
 });

--- a/app/components/NotificationProcessingContentPanel.js
+++ b/app/components/NotificationProcessingContentPanel.js
@@ -24,7 +24,7 @@ import FormInput from './FormInput';
 import CategoryGridSelector from './CategoryGridSelector';
 import { getCategoryDisplayName } from '../utils/categoryUtils';
 import { NotificationCard } from './NotificationsContentPanel';
-import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../styles/designTokens';
 import {
   isBankNotificationsEnabled,
   processBankNotifications,
@@ -46,6 +46,8 @@ import { getLabelForMerchant } from '../services/NotificationRulesDB';
 import { getRecentNotifications } from '../services/NotificationAccess';
 import { normalizeMerchantLabel } from '../utils/labelUtils';
 import * as Currency from '../services/currency';
+import { BUTTON_COMPACT, BUTTON_TEXT, CARD_SURFACE, SECTION_LABEL } from '../styles/componentStyles';
+import EmptyState from './EmptyState';
 
 // How often the panel silently re-runs the pipeline and reloads its lists so
 // newly-arrived notifications surface on their own, without a manual pull.
@@ -428,12 +430,14 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
       </Text>
 
       {pending.length === 0 ? (
-        <View style={styles.emptyState}>
-          <Ionicons name="checkmark-done-outline" size={40} color={colors.mutedText} />
-          <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-            {t('bank_notifications_empty') || 'Nothing to review. Matched notifications are saved automatically.'}
-          </Text>
-        </View>
+        <EmptyState
+          icon="checkmark-done-outline"
+          iconSet="ionicons"
+          iconSize={40}
+          fill={false}
+          style={styles.emptyState}
+          message={t('bank_notifications_empty') || 'Nothing to review. Matched notifications are saved automatically.'}
+        />
       ) : (
         pending.map((item) => {
           // Mid-save: the full form is collapsed into a compact progress row so
@@ -621,22 +625,20 @@ export default function NotificationProcessingContentPanel({ bottomInset = 0 }) 
       </Text>
 
       {visibleRecent.length === 0 ? (
-        <View style={styles.emptyState}>
-          {/* Distinguish "nothing captured" from "everything is hidden by the
-              app filters" so an empty feed never looks like a broken listener. */}
-          <Ionicons
-            name={recent.length > 0 ? 'funnel-outline' : 'notifications-off-outline'}
-            size={40}
-            color={colors.mutedText}
-          />
-          <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-            {recent.length > 0
-              ? (t('notifications_all_filtered') ||
-                'All recent notifications are hidden by your app filters.')
-              : (t('notifications_empty') ||
-                'No notifications recorded yet. New notifications will appear here.')}
-          </Text>
-        </View>
+        // Distinguish "nothing captured" from "everything is hidden by the
+        // app filters" so an empty feed never looks like a broken listener.
+        <EmptyState
+          icon={recent.length > 0 ? 'funnel-outline' : 'notifications-off-outline'}
+          iconSet="ionicons"
+          iconSize={40}
+          fill={false}
+          style={styles.emptyState}
+          message={recent.length > 0
+            ? (t('notifications_all_filtered') ||
+              'All recent notifications are hidden by your app filters.')
+            : (t('notifications_empty') ||
+              'No notifications recorded yet. New notifications will appear here.')}
+        />
       ) : (
         keyedRecent.map(({ notification, key }) => {
           // A card is "new" (and animates in) when its key wasn't shown before.
@@ -687,20 +689,11 @@ NotificationProcessingContentPanel.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  actionButton: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.sm,
-    justifyContent: 'center',
-    paddingHorizontal: SPACING.lg,
-    paddingVertical: SPACING.sm,
-  },
+  actionButton: BUTTON_COMPACT,
   actionButtonPrimary: {
     minWidth: 88,
   },
-  actionLabel: {
-    fontSize: 14,
-    fontWeight: '600',
-  },
+  actionLabel: BUTTON_TEXT,
   actionLabelPrimary: {
     color: '#ffffff',
   },
@@ -712,8 +705,7 @@ const styles = StyleSheet.create({
     marginTop: SPACING.md,
   },
   card: {
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: StyleSheet.hairlineWidth,
+    ...CARD_SURFACE,
     marginBottom: SPACING.md,
     padding: SPACING.md,
   },
@@ -722,7 +714,7 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   cardConversion: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontStyle: 'italic',
     marginTop: 2,
   },
@@ -738,7 +730,7 @@ const styles = StyleSheet.create({
     marginRight: SPACING.sm,
   },
   cardMeta: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 2,
   },
   categoryLabelRow: {
@@ -759,16 +751,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.xl,
   },
-  emptyText: {
-    fontSize: 14,
-    lineHeight: 20,
-    textAlign: 'center',
-  },
   fieldLabel: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.6,
-    marginBottom: 4,
+    ...SECTION_LABEL,
+    marginBottom: SPACING.xs,
     marginTop: SPACING.sm,
   },
   helpText: {
@@ -793,16 +778,14 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   savingStatus: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 2,
   },
   scroll: {
     flex: 1,
   },
   sectionTitle: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.8,
+    ...SECTION_LABEL,
     marginBottom: SPACING.sm,
     marginTop: SPACING.lg,
   },
@@ -810,10 +793,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     flexShrink: 1,
-    gap: 4,
+    gap: SPACING.xs,
   },
   selectedCategoryText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '600',
   },
   // Swipe-to-deactivate action revealed under a recent-notification card. The

--- a/app/components/NotificationsContentPanel.js
+++ b/app/components/NotificationsContentPanel.js
@@ -6,8 +6,9 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { parseBankNotification } from '../services/notifications/parseBankNotification';
-import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../styles/designTokens';
 import { motionDuration } from '../utils/reducedMotion';
+import { CARD_SURFACE, SECTION_LABEL } from '../styles/componentStyles';
 
 // Renders the "date · time" label for a notification's post time. Mirrors the
 // update panel's timestamp treatment so the two subpanels read alike.
@@ -231,21 +232,20 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     borderRadius: BORDER_RADIUS.sm,
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     marginBottom: SPACING.sm,
     paddingHorizontal: SPACING.sm,
     paddingVertical: 2,
   },
   badgeText: {
     color: '#ffffff',
-    fontSize: 10,
+    fontSize: FONT_SIZE.xs,
     fontWeight: '700',
     letterSpacing: 0.4,
     textTransform: 'uppercase',
   },
   card: {
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: StyleSheet.hairlineWidth,
+    ...CARD_SURFACE,
     marginBottom: SPACING.md,
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.md,
@@ -254,7 +254,7 @@ const styles = StyleSheet.create({
     borderLeftWidth: 3,
   },
   cardBody: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     lineHeight: 20,
   },
   cardHeader: {
@@ -272,11 +272,11 @@ const styles = StyleSheet.create({
   },
   cardSource: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
   },
   cardTime: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
   },
   cardTitle: {
@@ -305,7 +305,7 @@ const styles = StyleSheet.create({
     borderRadius: BORDER_RADIUS.sm,
     borderWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.xs,
   },
@@ -316,7 +316,7 @@ const styles = StyleSheet.create({
   reAddFeedback: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     paddingVertical: SPACING.xs,
   },
   reAddFeedbackText: {
@@ -337,10 +337,7 @@ const styles = StyleSheet.create({
     marginTop: SPACING.sm,
   },
   sectionTitle: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.8,
+    ...SECTION_LABEL,
     marginTop: SPACING.md,
-    textTransform: 'uppercase',
   },
 });

--- a/app/components/SimplePicker.js
+++ b/app/components/SimplePicker.js
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, StyleSheet, TouchableOpacity, Pressable, Modal, FlatList, Platform } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
-import { HORIZONTAL_PADDING } from '../styles/layout';
+import { FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../styles/designTokens';
 import ModalBlurOverlay from './ModalBlurOverlay';
 
 // Module-level so the default `colors` prop keeps a stable identity across
@@ -160,7 +160,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   androidButtonText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '800',
     textAlign: 'center',
   },
@@ -168,14 +168,14 @@ const styles = StyleSheet.create({
   chipButton: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     height: 44,
     paddingHorizontal: 14,
     width: '100%',
   },
   chipButtonText: {
     flex: 1,
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
   // Close button
@@ -184,12 +184,12 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
   },
   closeButtonText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '600',
   },
   // Left text label (currency symbol, etc.)
   leftText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
     minWidth: 16,
     textAlign: 'center',
@@ -210,12 +210,12 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
   },
   modalItemSubText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     marginLeft: 8,
   },
   modalItemText: {
     flex: 1,
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     marginRight: 4,
   },
   modalOverlay: {
@@ -231,7 +231,7 @@ const baseWebSelectStyle = {
   border: 'none',
   outline: 'none',
   backgroundColor: 'transparent',
-  fontSize: 14,
+  fontSize: FONT_SIZE.md,
   fontFamily: 'inherit',
   paddingLeft: 8,
   paddingRight: 8,

--- a/app/components/UpdateContentPanel.js
+++ b/app/components/UpdateContentPanel.js
@@ -5,7 +5,7 @@ import { Text, Divider } from 'react-native-paper';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
-import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../styles/designTokens';
 import { motionDuration } from '../utils/reducedMotion';
 
 const DATE_RE = /(\d{4}-\d{2}-\d{2})/;
@@ -699,7 +699,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   apkChipVersion: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '600',
     textAlign: 'center',
   },
@@ -716,7 +716,7 @@ const styles = StyleSheet.create({
     paddingVertical: 1,
   },
   buildProgressText: {
-    fontSize: 10,
+    fontSize: FONT_SIZE.xs,
     fontWeight: '700',
     letterSpacing: 0.5,
     textTransform: 'uppercase',
@@ -755,7 +755,7 @@ const styles = StyleSheet.create({
   },
   corruptNoteText: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     lineHeight: 17,
   },
   downloadedApksCompact: {
@@ -798,7 +798,7 @@ const styles = StyleSheet.create({
     paddingVertical: 1,
   },
   installedChipText: {
-    fontSize: 10,
+    fontSize: FONT_SIZE.xs,
     fontWeight: '700',
     letterSpacing: 0.5,
     textTransform: 'uppercase',
@@ -811,7 +811,7 @@ const styles = StyleSheet.create({
     paddingLeft: SPACING.sm,
   },
   installedHintText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
   },
   moreReleasesLink: {
@@ -844,7 +844,7 @@ const styles = StyleSheet.create({
   releaseBadge: {
     borderRadius: BORDER_RADIUS.sm,
     borderWidth: StyleSheet.hairlineWidth,
-    fontSize: 10,
+    fontSize: FONT_SIZE.xs,
     fontWeight: '600',
     letterSpacing: 0.5,
     overflow: 'hidden',
@@ -868,7 +868,7 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
   },
   releaseDate: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
   },
   releaseHeader: {
@@ -919,7 +919,7 @@ const styles = StyleSheet.create({
   },
   upToDateHeaderText: {
     flex: 1,
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     lineHeight: 20,
   },
   updateBottomRow: {

--- a/app/components/budgets/BudgetLineGroupModal.js
+++ b/app/components/budgets/BudgetLineGroupModal.js
@@ -19,6 +19,8 @@ import FormInput from '../FormInput';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import ModalHeader from '../ModalHeader';
 import * as Currency from '../../services/currency';
+import { BUTTON, BUTTON_TEXT, SECTION_LABEL } from '../../styles/componentStyles';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 // The overlay carries the keyboard inset, so it has to be animatable.
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
@@ -307,11 +309,9 @@ BudgetLineGroupModal.propTypes = {
 
 const styles = StyleSheet.create({
   button: {
-    alignItems: 'center',
-    borderRadius: 6,
+    ...BUTTON,
     flex: 1,
-    marginHorizontal: 8,
-    paddingVertical: 12,
+    marginHorizontal: SPACING.sm,
   },
   buttonDisabled: {
     opacity: 0.5,
@@ -323,24 +323,21 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingTop: 12,
   },
-  buttonText: {
-    fontSize: 16,
-    fontWeight: '500',
-  },
+  buttonText: BUTTON_TEXT,
   currencyChip: {
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
     paddingHorizontal: 14,
     paddingVertical: 8,
   },
   currencyChipText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   currencyRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 8,
+    gap: SPACING.sm,
   },
   deleteRow: {
     alignItems: 'center',
@@ -351,7 +348,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
   },
   deleteText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '500',
     marginLeft: 8,
   },
@@ -368,11 +365,11 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   fieldLabel: {
-    fontSize: 12,
-    marginBottom: 6,
+    ...SECTION_LABEL,
+    marginBottom: SPACING.xs,
   },
   modalContent: {
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     elevation: 5,
     maxHeight: '85%',
     overflow: 'hidden',
@@ -393,18 +390,18 @@ const styles = StyleSheet.create({
   },
   switchThumb: {
     backgroundColor: '#fff',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.pill,
     height: 16,
     width: 16,
   },
   switchTrack: {
-    borderRadius: 10,
+    borderRadius: BORDER_RADIUS.pill,
     height: 20,
     justifyContent: 'center',
     width: 36,
   },
   text16: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
   },
   toggleLabel: {
     alignItems: 'center',
@@ -413,7 +410,7 @@ const styles = StyleSheet.create({
   },
   toggleRow: {
     alignItems: 'center',
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.sm,
     borderWidth: 1,
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/app/components/budgets/BudgetPlanLineModal.js
+++ b/app/components/budgets/BudgetPlanLineModal.js
@@ -26,6 +26,8 @@ import CategoryGridSelector from '../CategoryGridSelector';
 import AccountGridSelector from '../AccountGridSelector';
 import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';
 import * as Currency from '../../services/currency';
+import EmptyState from '../EmptyState';
+import { SECTION_LABEL } from '../../styles/componentStyles';
 
 const KINDS = ['income', 'expense', 'transfer'];
 
@@ -832,9 +834,7 @@ export default function BudgetPlanLineModal({
               />
             )}
             ListEmptyComponent={(
-              <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                {t('no_groups_yet')}
-              </Text>
+              <EmptyState message={t('no_groups_yet')} fill={false} />
             )}
           />
         </>
@@ -1175,10 +1175,6 @@ const styles = StyleSheet.create({
     // instead of four boxed-off rows.
     marginLeft: 34 + SPACING.md + SPACING.md,
   },
-  emptyText: {
-    paddingVertical: SPACING.xxl,
-    textAlign: 'center',
-  },
   errorBanner: {
     alignItems: 'center',
     borderRadius: BORDER_RADIUS.md,
@@ -1192,7 +1188,7 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.md,
   },
   fieldLabel: {
-    fontSize: FONT_SIZE.sm,
+    ...SECTION_LABEL,
     marginBottom: SPACING.xs,
     marginTop: SPACING.sm,
   },
@@ -1320,13 +1316,13 @@ const styles = StyleSheet.create({
   },
   switchThumb: {
     backgroundColor: '#fff',
-    borderRadius: 11,
+    borderRadius: BORDER_RADIUS.pill,
     height: 22,
     margin: 2,
     width: 22,
   },
   switchTrack: {
-    borderRadius: 13,
+    borderRadius: BORDER_RADIUS.pill,
     height: 26,
     justifyContent: 'center',
     overflow: 'hidden',

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -10,13 +10,15 @@ import { useDialog } from '../../contexts/DialogContext';
 import { useBudgetPlans } from '../../contexts/BudgetPlansContext';
 import * as Currency from '../../services/currency';
 import usePlanLineAmounts from '../../hooks/usePlanLineAmounts';
-import { SPACING } from '../../styles/layout';
+import { FONT_SIZE, SPACING } from '../../styles/designTokens';
 import { envelopeHue } from '../../styles/envelopePalette';
 import BudgetPlanLineModal from './BudgetPlanLineModal';
 import BudgetLineGroupModal from './BudgetLineGroupModal';
 import PlanLineRow from './PlanLineRow';
 import PlanGroupRow from './PlanGroupRow';
 import { currentMonthKey, addMonths, formatMonthLabel } from '../../utils/monthUtils';
+import { CARD_SURFACE, SECTION_HEADING } from '../../styles/componentStyles';
+import EmptyState from '../EmptyState';
 
 const CLOSED_MODAL = { visible: false, line: null, kind: 'expense' };
 const CLOSED_GROUP_MODAL = { visible: false, group: null };
@@ -1020,10 +1022,12 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
                 contradicted everything around it — keep just the bootstrap
                 actions in that case. */}
             {!hasAnyLines && (
-              <>
-                <Icon name="clipboard-text-outline" size={40} color={colors.mutedText} />
-                <Text style={[styles.emptyText, { color: colors.mutedText }]}>{t('no_plan_for_month')}</Text>
-              </>
+              <EmptyState
+                icon="clipboard-text-outline"
+                iconSize={40}
+                fill={false}
+                message={t('no_plan_for_month')}
+              />
             )}
             <View style={styles.emptyActions}>
               <Pressable
@@ -1158,8 +1162,7 @@ export default MonthlyPlanSection;
 
 const styles = StyleSheet.create({
   card: {
-    borderRadius: 16,
-    borderWidth: 1,
+    ...CARD_SURFACE,
     marginBottom: SPACING.md,
     padding: SPACING.md,
   },
@@ -1171,7 +1174,7 @@ const styles = StyleSheet.create({
   },
   convertWarningText: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   emptyActions: {
     gap: SPACING.sm,
@@ -1182,10 +1185,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: SPACING.md,
   },
-  emptyText: {
-    marginTop: SPACING.sm,
-    textAlign: 'center',
-  },
   monthHeader: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -1193,7 +1192,7 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.sm,
   },
   monthTitle: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '700',
   },
   navButton: {
@@ -1203,7 +1202,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderRadius: 10,
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     justifyContent: 'center',
     paddingVertical: SPACING.sm,
   },
@@ -1221,7 +1220,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     borderWidth: 1,
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     justifyContent: 'center',
     paddingVertical: SPACING.sm,
   },
@@ -1230,7 +1229,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   sectionAmount: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '700',
   },
   sectionHeader: {
@@ -1246,28 +1245,24 @@ const styles = StyleSheet.create({
   sectionHeaderSpaced: {
     marginTop: SPACING.md,
   },
-  sectionTitle: {
-    fontSize: 15,
-    fontWeight: '700',
-    textTransform: 'uppercase',
-  },
+  sectionTitle: SECTION_HEADING,
   sectionTitleGroup: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
   },
   totalsHint: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   totalsLabel: {
     flexShrink: 1,
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
   },
   totalsLabelRight: {
     textAlign: 'right',
   },
   totalsRemainder: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '700',
   },
   totalsRow: {

--- a/app/components/budgets/PlanGroupRow.js
+++ b/app/components/budgets/PlanGroupRow.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import PlanProgressBar, { PAIR_COLUMN_WIDTH } from './PlanProgressBar';
-import { SPACING } from '../../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 // Stands in for a figure whose exchange rate is still resolving — same em dash
 // PlanLineRow uses, for the same reason.
@@ -206,7 +206,7 @@ export default PlanGroupRow;
 
 const styles = StyleSheet.create({
   groupAmount: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontVariant: ['tabular-nums'],
     fontWeight: '700',
     marginLeft: 8,
@@ -224,11 +224,11 @@ const styles = StyleSheet.create({
   groupMetaRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     marginTop: 1,
   },
   groupName: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '700',
     letterSpacing: 0.2,
   },
@@ -244,7 +244,7 @@ const styles = StyleSheet.create({
     // No hairline under the header any more: the rail down the left edge is what
     // joins this row to its children now, and a rule plus an indent plus a rail
     // would be three devices for one relationship.
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     marginTop: SPACING.sm,
     overflow: 'hidden',
     paddingVertical: 7,
@@ -269,10 +269,10 @@ const styles = StyleSheet.create({
   },
   noteText: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   rail: {
-    borderRadius: 1,
+    borderRadius: BORDER_RADIUS.pill,
     bottom: 0,
     left: 0,
     position: 'absolute',

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import PlanProgressBar, { PAIR_COLUMN_WIDTH } from './PlanProgressBar';
-import { SPACING } from '../../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 import { ENVELOPE_RAIL_CHILD_ALPHA } from '../../styles/envelopePalette';
 import { SPRING_BADGE_POP } from '../../utils/motion';
 
@@ -442,7 +442,7 @@ const styles = StyleSheet.create({
   },
   brokenText: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   checkBadge: {
     alignItems: 'center',
@@ -469,7 +469,7 @@ const styles = StyleSheet.create({
     marginLeft: 10,
   },
   lineComment: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 1,
   },
   lineInner: {
@@ -499,7 +499,7 @@ const styles = StyleSheet.create({
     width: PAIR_COLUMN_WIDTH,
   },
   lineRow: {
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     // Clips the rail to the row's rounded corners.
     overflow: 'hidden',
     paddingVertical: 7,
@@ -517,7 +517,7 @@ const styles = StyleSheet.create({
     marginTop: 6,
   },
   rail: {
-    borderRadius: 1,
+    borderRadius: BORDER_RADIUS.pill,
     bottom: 0,
     left: 0,
     position: 'absolute',
@@ -538,7 +538,7 @@ const styles = StyleSheet.create({
   },
   swipeActionText: {
     color: 'white',
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '600',
     marginTop: 2,
   },

--- a/app/components/graphs/BalanceHistoryCalendarView.js
+++ b/app/components/graphs/BalanceHistoryCalendarView.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, TextInput } from 'react-native';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
+import { BORDER_RADIUS, FONT_SIZE } from '../../styles/designTokens';
 
 const DAY_HEADERS = ['M', 'T', 'W', 'T', 'F', 'S', 'Su'];
 
@@ -180,7 +181,7 @@ const BalanceHistoryCalendarView = ({
           {selectedEntry?.balance && (
             <TouchableOpacity
               testID="calendar-delete-btn"
-              style={[styles.editBtn, styles.deleteBtn]}
+              style={[styles.editBtn, { backgroundColor: colors.destructive }]}
               onPress={handleDelete}
             >
               <Text style={styles.editBtnText}>🗑</Text>
@@ -214,18 +215,17 @@ BalanceHistoryCalendarView.propTypes = {
 
 const styles = StyleSheet.create({
   cancelBtn: { padding: 4 },
-  cancelBtnText: { fontSize: 18 },
+  cancelBtnText: { fontSize: FONT_SIZE.lg },
   cell: { alignItems: 'center', flex: 1, justifyContent: 'center', paddingVertical: 2 },
   dayBalance: { fontSize: 8, fontWeight: '600' },
-  dayCell: { borderRadius: 4, minHeight: 46, paddingVertical: 6 },
-  dayHeader: { fontSize: 10, fontWeight: '600' },
+  dayCell: { borderRadius: BORDER_RADIUS.sm, minHeight: 46, paddingVertical: 6 },
+  dayHeader: { fontSize: FONT_SIZE.xs, fontWeight: '600' },
   dayNumber: { fontSize: 11 },
-  deleteBtn: { backgroundColor: '#f44336' },
-  editBtn: { alignItems: 'center', borderRadius: 14, height: 28, justifyContent: 'center', width: 28 },
+  editBtn: { alignItems: 'center', borderRadius: BORDER_RADIUS.pill, height: 28, justifyContent: 'center', width: 28 },
   editBtnText: { color: '#fff', fontSize: 13, fontWeight: '700' },
-  editDateLabel: { fontSize: 12, marginRight: 8, minWidth: 24 },
-  editInput: { borderRadius: 4, borderWidth: 1, flex: 1, fontSize: 13, marginRight: 8, paddingHorizontal: 8, paddingVertical: 4, textAlign: 'right' },
-  editRow: { alignItems: 'center', borderRadius: 8, borderWidth: 1, flexDirection: 'row', gap: 6, marginTop: 10, padding: 8 },
+  editDateLabel: { fontSize: FONT_SIZE.sm, marginRight: 8, minWidth: 24 },
+  editInput: { borderRadius: BORDER_RADIUS.sm, borderWidth: 1, flex: 1, fontSize: 13, marginRight: 8, paddingHorizontal: 8, paddingVertical: 4, textAlign: 'right' },
+  editRow: { alignItems: 'center', borderRadius: BORDER_RADIUS.md, borderWidth: 1, flexDirection: 'row', gap: 6, marginTop: 10, padding: 8 },
   headerRow: { flexDirection: 'row', marginBottom: 4 },
   todayBorder: { borderWidth: 1 },
   weekRow: { flexDirection: 'row', marginBottom: 2 },

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -25,6 +25,8 @@ import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 import { balanceLineColors } from '../../styles/chartPalette';
 import BalanceHistoryCalendarView from './BalanceHistoryCalendarView';
 import { MONTH_ABBREVIATIONS } from './monthLabels';
+import { CARD_SURFACE } from '../../styles/componentStyles';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 // Helper to format numbers compactly (e.g., 10K, 1.5M)
 const formatCompact = (value, currency) => {
@@ -1294,7 +1296,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
   accountPickerWrapper: {
-    borderRadius: 16,
+    borderRadius: BORDER_RADIUS.pill,
     flexShrink: 0,
     width: 150,
   },
@@ -1306,7 +1308,7 @@ const styles = StyleSheet.create({
   balanceAmountRow: {
     alignItems: 'baseline',
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     marginTop: 4,
   },
   balanceDayContext: {
@@ -1314,9 +1316,8 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   balanceHistoryCard: {
-    borderRadius: 16,
-    borderWidth: 1,
-    marginBottom: 16,
+    ...CARD_SURFACE,
+    marginBottom: SPACING.lg,
     overflow: 'hidden',
     padding: 16,
   },
@@ -1349,7 +1350,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 32,
   },
   balanceHistoryNoDataText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     textAlign: 'center',
   },
   balanceHistoryTitleContainer: {
@@ -1362,14 +1363,14 @@ const styles = StyleSheet.create({
   },
   calendarToggleBtn: {
     alignItems: 'center',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     height: 32,
     justifyContent: 'center',
     marginRight: 8,
     width: 32,
   },
   legendDot: {
-    borderRadius: 6,
+    borderRadius: BORDER_RADIUS.pill,
     height: 12,
     marginRight: 6,
     width: 12,
@@ -1379,12 +1380,12 @@ const styles = StyleSheet.create({
   },
   legendTableHeader: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '600',
     textAlign: 'right',
   },
   legendTableLabel: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   legendTableLabelCell: {
     alignItems: 'center',
@@ -1398,7 +1399,7 @@ const styles = StyleSheet.create({
   },
   legendTableValue: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     textAlign: 'right',
   },
 });

--- a/app/components/graphs/CategoryBackChip.js
+++ b/app/components/graphs/CategoryBackChip.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
+import { CHIP, CHIP_TEXT } from '../../styles/componentStyles';
 
 /**
  * Shows the category a summary tab is currently drilled into, and pops back to
@@ -38,22 +39,15 @@ CategoryBackChip.propTypes = {
 
 const styles = StyleSheet.create({
   chip: {
-    alignItems: 'center',
-    borderRadius: 20,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 4,
+    ...CHIP,
     // Never wider than the slot it sits in — under the donut that slot is the
     // donut's own width, so a long category name ellipsises instead of pushing
     // the legend around.
     maxWidth: '100%',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
   },
   chipText: {
+    ...CHIP_TEXT,
     flexShrink: 1,
-    fontSize: 13,
-    fontWeight: '600',
   },
 });
 

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -7,11 +7,13 @@ import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
 import useCategoryMonthlySpending, { ALL_EXPENSE_CATEGORIES } from '../../hooks/useCategoryMonthlySpending';
-import { HORIZONTAL_PADDING } from '../../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../../styles/designTokens';
 import { comparisonSeriesColor } from '../../styles/chartPalette';
 import { MONTH_ABBREVIATIONS } from './monthLabels';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+import { CARD_SURFACE, SECTION_LABEL } from '../../styles/componentStyles';
+import EmptyState from '../EmptyState';
 
 const screenWidth = Dimensions.get('window').width;
 
@@ -641,11 +643,11 @@ const CategorySpendingCard = ({
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : !hasData ? (
-        <View style={styles.emptyContainer}>
-          <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-            {t('no_spending_data')}
-          </Text>
-        </View>
+        <EmptyState
+          message={t('no_spending_data')}
+          fill={false}
+          style={styles.emptyContainer}
+        />
       ) : (
         <SpendingBarChart
           // Remount when the vs-series appears/disappears: the chart press state
@@ -693,29 +695,28 @@ const styles = StyleSheet.create({
     gap: 5,
   },
   card: {
-    borderRadius: 16,
-    borderWidth: 1,
-    marginBottom: 16,
-    padding: 16,
+    ...CARD_SURFACE,
+    marginBottom: SPACING.lg,
+    padding: SPACING.lg,
   },
   categoryItem: {
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.sm,
     flex: 1,
     paddingHorizontal: 8,
     paddingVertical: 12,
   },
   categoryName: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '600',
   },
   categorySelector: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     marginTop: 4,
   },
   categoryText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '500',
   },
   chartCanvas: {
@@ -734,19 +735,13 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   currentAmount: {
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: '700',
     textAlign: 'right',
   },
   emptyContainer: {
-    alignItems: 'center',
     height: 120,
-    justifyContent: 'center',
-    paddingHorizontal: 32,
-  },
-  emptyText: {
-    fontSize: 14,
-    textAlign: 'center',
+    paddingHorizontal: SPACING.xxl,
   },
   expandButton: {
     alignItems: 'center',
@@ -776,7 +771,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   modalContent: {
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     maxHeight: '60%',
     overflow: 'hidden',
     width: '80%',
@@ -791,13 +786,9 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     flexDirection: 'row',
   },
-  sectionLabel: {
-    fontSize: 11,
-    fontWeight: '500',
-    letterSpacing: 0.5,
-  },
+  sectionLabel: SECTION_LABEL,
   seriesDot: {
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.pill,
     height: 8,
     width: 8,
   },
@@ -814,13 +805,13 @@ const styles = StyleSheet.create({
   },
   vsCategoryName: {
     flexShrink: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '600',
   },
   vsRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     marginTop: 4,
   },
   vsSelector: {
@@ -829,7 +820,7 @@ const styles = StyleSheet.create({
     gap: 3,
   },
   vsText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
   },
 });

--- a/app/components/graphs/CustomLegend.js
+++ b/app/components/graphs/CustomLegend.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
@@ -126,16 +127,16 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     minWidth: 0,
   },
   colorIndicator: {
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.pill,
     height: 8,
     width: 8,
   },
   legendAmount: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '600',
   },
   legendChevron: {
@@ -156,10 +157,10 @@ const styles = StyleSheet.create({
   },
   legendName: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   legendPercentage: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
   },
   percentageColumn: {

--- a/app/components/graphs/ExpensePieChart.js
+++ b/app/components/graphs/ExpensePieChart.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import DonutChart, { CHART_SIZE } from './DonutChart';
 import CustomLegend from './CustomLegend';
 import CategoryOperationsList from './CategoryOperationsList';
+import EmptyState from '../EmptyState';
+import { FONT_SIZE } from '../../styles/designTokens';
 
 const ExpensePieChart = ({
   colors,
@@ -62,9 +64,7 @@ const ExpensePieChart = ({
     return (
       <View>
         {chipHeader}
-        <Text style={[styles.noData, { color: colors.mutedText }]}>
-          {t('no_expense_data')}
-        </Text>
+        <EmptyState message={t('no_expense_data')} fill={false} />
       </View>
     );
   }
@@ -135,13 +135,8 @@ const styles = StyleSheet.create({
     paddingVertical: 32,
   },
   loadingText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     marginTop: 8,
-  },
-  noData: {
-    fontSize: 14,
-    paddingVertical: 32,
-    textAlign: 'center',
   },
   row: {
     // Top-aligned, not centred: the legend's height follows the category count,

--- a/app/components/graphs/HeatmapMapModal.js
+++ b/app/components/graphs/HeatmapMapModal.js
@@ -23,6 +23,9 @@ import {
   translateRegion,
   scaleRegion,
 } from '../../utils/mapProjection';
+import EmptyState from '../EmptyState';
+import { CARD_SURFACE } from '../../styles/componentStyles';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 // Fallback view when there is nothing to fit — the whole world.
 const WORLD_REGION = { latitude: 20, longitude: 0, zoom: 2 };
@@ -284,12 +287,13 @@ const HeatmapMapModal = ({
 
             {empty && (
               <View style={styles.centerOverlay} pointerEvents="none">
-                <View style={[styles.emptyBadge, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-                  <Icon name="map-marker-off-outline" size={28} color={colors.mutedText} />
-                  <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                    {t('graphs_map_no_locations')}
-                  </Text>
-                </View>
+                <EmptyState
+                  icon="map-marker-off-outline"
+                  iconSize={28}
+                  fill={false}
+                  message={t('graphs_map_no_locations')}
+                  style={[styles.emptyBadge, { backgroundColor: colors.surface, borderColor: colors.border }]}
+                />
               </View>
             )}
 
@@ -366,7 +370,7 @@ HeatmapMapModal.propTypes = {
 const styles = StyleSheet.create({
   allTimeChip: {
     alignItems: 'center',
-    borderRadius: 18,
+    borderRadius: BORDER_RADIUS.pill,
     borderWidth: 1,
     elevation: 4,
     flexDirection: 'row',
@@ -379,8 +383,8 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   attribution: {
-    borderRadius: 4,
-    fontSize: 10,
+    borderRadius: BORDER_RADIUS.sm,
+    fontSize: FONT_SIZE.xs,
     paddingHorizontal: 6,
     paddingVertical: 2,
   },
@@ -398,16 +402,14 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   emptyBadge: {
-    alignItems: 'center',
-    borderRadius: 16,
-    borderWidth: 1,
-    gap: 8,
-    marginHorizontal: 32,
-    padding: 20,
-  },
-  emptyText: {
-    fontSize: 14,
-    textAlign: 'center',
+    ...CARD_SURFACE,
+    marginHorizontal: SPACING.xxl,
+    // Both axes stated: EmptyState's container sets paddingVertical, and in
+    // React Native the longhand wins over `padding` regardless of merge order,
+    // so a lone `padding` here would silently keep the container's vertical
+    // value and only apply horizontally.
+    paddingHorizontal: SPACING.xl,
+    paddingVertical: SPACING.xl,
   },
   flex: {
     flex: 1,
@@ -415,14 +417,14 @@ const styles = StyleSheet.create({
   header: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     left: 12,
     position: 'absolute',
     right: 12,
   },
   headerButton: {
     alignItems: 'center',
-    borderRadius: 20,
+    borderRadius: BORDER_RADIUS.pill,
     borderWidth: 1,
     elevation: 4,
     height: 40,
@@ -448,7 +450,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
   },
   titleBadge: {
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     borderWidth: 1,
     elevation: 4,
     flex: 1,

--- a/app/components/graphs/IncomePieChart.js
+++ b/app/components/graphs/IncomePieChart.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import DonutChart, { CHART_SIZE } from './DonutChart';
 import CustomLegend from './CustomLegend';
 import CategoryOperationsList from './CategoryOperationsList';
+import EmptyState from '../EmptyState';
+import { FONT_SIZE } from '../../styles/designTokens';
 
 const IncomePieChart = ({
   colors,
@@ -62,9 +64,7 @@ const IncomePieChart = ({
     return (
       <View>
         {chipHeader}
-        <Text style={[styles.noData, { color: colors.mutedText }]}>
-          {t('no_income_data')}
-        </Text>
+        <EmptyState message={t('no_income_data')} fill={false} />
       </View>
     );
   }
@@ -135,13 +135,8 @@ const styles = StyleSheet.create({
     paddingVertical: 32,
   },
   loadingText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     marginTop: 8,
-  },
-  noData: {
-    fontSize: 14,
-    paddingVertical: 32,
-    textAlign: 'center',
   },
   row: {
     // Top-aligned, not centred: the legend's height follows the category count,

--- a/app/components/graphs/OperationsHeatmapCard.js
+++ b/app/components/graphs/OperationsHeatmapCard.js
@@ -3,6 +3,8 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import HeatmapMapModal from './HeatmapMapModal';
+import { CARD_SURFACE } from '../../styles/componentStyles';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 /**
  * Collapsed Graphs row for the operations location heatmap.
@@ -70,23 +72,22 @@ OperationsHeatmapCard.propTypes = {
 
 const styles = StyleSheet.create({
   card: {
+    ...CARD_SURFACE,
     alignItems: 'center',
-    borderRadius: 16,
-    borderWidth: 1,
     flexDirection: 'row',
-    gap: 12,
+    gap: SPACING.md,
     marginBottom: 16,
     padding: 16,
   },
   iconBadge: {
     alignItems: 'center',
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     height: 40,
     justifyContent: 'center',
     width: 40,
   },
   subtitle: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 2,
   },
   textColumn: {

--- a/app/components/graphs/SpendingPredictionCard.js
+++ b/app/components/graphs/SpendingPredictionCard.js
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
@@ -42,7 +43,7 @@ const SpendingPredictionCard = ({ colors, t, spendingPrediction, selectedCurrenc
           <Text style={[styles.predictionStatLabel, { color: colors.mutedText }]}>
             {t('current_spending')}
           </Text>
-          <Text style={[styles.predictionStatValue, { color: colors.expense || '#ff4444' }]}>
+          <Text style={[styles.predictionStatValue, { color: colors.expense }]}>
             {formatCurrency(spendingPrediction.currentSpending, selectedCurrency)}
           </Text>
         </View>
@@ -96,7 +97,7 @@ SpendingPredictionCard.propTypes = {
 
 const styles = StyleSheet.create({
   accountName: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   dailyAverageValue: {
     fontWeight: '600',
@@ -105,7 +106,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 8,
   },
   predictionCard: {
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
     marginBottom: 16,
     padding: 16,
@@ -117,18 +118,18 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   predictionProgressBar: {
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.pill,
     height: 8,
   },
   predictionProgressContainer: {
     marginBottom: 0,
   },
   predictionProgressText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     textAlign: 'center',
   },
   predictionProgressTrack: {
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.pill,
     height: 8,
     marginBottom: 8,
   },
@@ -136,11 +137,11 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   predictionStatLabel: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginBottom: 4,
   },
   predictionStatValue: {
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: 'bold',
   },
   predictionStats: {
@@ -150,13 +151,13 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   predictionTitle: {
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: 'bold',
   },
   predictionTitleContainer: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
   },
 });
 

--- a/app/components/graphs/SummaryTab.js
+++ b/app/components/graphs/SummaryTab.js
@@ -4,6 +4,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+import { FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 const formatCurrency = (amount, currency) => {
   const currencyInfo = currencies[currency];
@@ -88,7 +89,7 @@ SummaryTab.propTypes = {
 
 const styles = StyleSheet.create({
   amount: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '700',
     letterSpacing: -0.3,
     marginTop: 1,
@@ -106,7 +107,7 @@ const styles = StyleSheet.create({
     width: 26,
   },
   label: {
-    fontSize: 10,
+    fontSize: FONT_SIZE.xs,
     fontWeight: '500',
     letterSpacing: 0.3,
   },
@@ -117,7 +118,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 2,
     flex: 1,
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     paddingHorizontal: 10,
     paddingVertical: 8,
   },

--- a/app/components/modals/MultiCurrencyFields.js
+++ b/app/components/modals/MultiCurrencyFields.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Text, TextInput, StyleSheet, Keyboard } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
-import { SPACING } from '../../styles/designTokens';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
 import * as Currency from '../../services/currency';
 
@@ -126,18 +126,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.xs,
   },
   currencyInfoText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
   currencyLabel: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     minWidth: 40,
   },
   disabledInput: {
     opacity: 0.5,
   },
   inputLabel: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     minWidth: 120,
   },
   inputRow: {
@@ -147,17 +147,17 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.sm,
   },
   rateInfo: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginBottom: SPACING.sm,
     marginTop: SPACING.xs,
     paddingHorizontal: SPACING.xs,
     textAlign: 'center',
   },
   smallInput: {
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
     flex: 1,
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     paddingHorizontal: SPACING.md,
     paddingVertical: SPACING.sm,
   },

--- a/app/components/operations/CurrencyPickerModal.js
+++ b/app/components/operations/CurrencyPickerModal.js
@@ -6,6 +6,7 @@ import currencies from '../../../assets/currencies.json';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import { getTopSourceCurrencies } from '../../services/OperationsDB';
 import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../../styles/designTokens';
+import { MODAL_TITLE } from '../../styles/componentStyles';
 
 const alphabeticalList = Object.entries(currencies).map(([code, data]) => ({
   code,
@@ -199,8 +200,7 @@ const styles = StyleSheet.create({
     width: 28,
   },
   title: {
-    fontSize: FONT_SIZE.lg,
-    fontWeight: '600',
+    ...MODAL_TITLE,
   },
 });
 

--- a/app/components/operations/DescriptionSuggestionRow.js
+++ b/app/components/operations/DescriptionSuggestionRow.js
@@ -6,6 +6,7 @@ import { SPACING, FONT_SIZE, BORDER_RADIUS, DURATION } from '../../styles/design
 import { useSwipeNavigationGesture } from '../../contexts/SwipeNavigationContext';
 import { displayLabel } from '../../utils/labelUtils';
 import { motionDuration } from '../../utils/reducedMotion';
+import { CHIP, CHIP_TEXT } from '../../styles/componentStyles';
 
 const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
   // Entry polish only (rise into place). Like UndoSnackbar, this row is
@@ -78,12 +79,7 @@ const DescriptionSuggestionRow = ({ chips, colors, onApply, onDismiss }) => {
 };
 
 const styles = StyleSheet.create({
-  chip: {
-    borderRadius: BORDER_RADIUS.lg,
-    borderWidth: 1,
-    paddingHorizontal: SPACING.md,
-    paddingVertical: SPACING.xs,
-  },
+  chip: CHIP,
   chipRow: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -93,10 +89,7 @@ const styles = StyleSheet.create({
   chipScroll: {
     flex: 1,
   },
-  chipText: {
-    fontSize: FONT_SIZE.sm,
-    fontWeight: '500',
-  },
+  chipText: CHIP_TEXT,
   container: {
     paddingBottom: SPACING.md,
     paddingTop: SPACING.sm,

--- a/app/components/operations/LabelInput.js
+++ b/app/components/operations/LabelInput.js
@@ -12,6 +12,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../../styles/designTokens';
 import { parseLabels, serializeLabels, addLabel, removeLabel, hasLabel, displayLabel } from '../../utils/labelUtils';
+import { CHIP, CHIP_TEXT } from '../../styles/componentStyles';
 
 const MAX_SUGGESTION_CHIPS = 8;
 
@@ -260,18 +261,11 @@ LabelInput.propTypes = {
 
 const styles = StyleSheet.create({
   chip: {
-    alignItems: 'center',
-    borderRadius: 14,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: SPACING.xs,
+    ...CHIP,
     maxWidth: '100%',
-    paddingHorizontal: SPACING.md,
-    paddingVertical: SPACING.xs,
   },
   chipText: {
-    fontSize: FONT_SIZE.sm,
-    fontWeight: '500',
+    ...CHIP_TEXT,
     maxWidth: 220,
   },
   chipsContent: {
@@ -301,19 +295,13 @@ const styles = StyleSheet.create({
   input: {
     flexGrow: 1,
     flexShrink: 1,
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     minWidth: 80,
     paddingVertical: SPACING.xs,
   },
   suggestionChip: {
-    alignItems: 'center',
-    borderRadius: 14,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 3,
+    ...CHIP,
     marginRight: SPACING.xs,
-    paddingHorizontal: SPACING.md,
-    paddingVertical: SPACING.xs,
   },
   suggestionText: {
     fontSize: FONT_SIZE.sm,

--- a/app/components/operations/NotificationBindingCard.js
+++ b/app/components/operations/NotificationBindingCard.js
@@ -16,7 +16,8 @@ import { canSaveSuggestion } from '../../hooks/usePendingOperationSuggestions';
 import { getCategoryDisplayName } from '../../utils/categoryUtils';
 import { normalizeMerchantLabel } from '../../utils/labelUtils';
 import * as Currency from '../../services/currency';
-import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
+import { BUTTON_COMPACT, BUTTON_TEXT, SECTION_LABEL } from '../../styles/componentStyles';
 
 // "Jun 28" for an ISO YYYY-MM-DD date, localized to the app's language. The
 // T00:00:00 anchors the bare string to local midnight (a bare date parses as UTC
@@ -206,7 +207,7 @@ const NotificationBindingCard = ({
       {/* Pinned outside the scroll body so Save (and any error) is always
           reachable without scrolling the form. */}
       {saveError ? (
-        <Text style={[styles.errorText, { color: colors.delete || '#c0392b' }]} numberOfLines={2}>
+        <Text style={[styles.errorText, { color: colors.destructive }]} numberOfLines={2}>
           {t('bank_notifications_save_error')
             || 'Couldn’t add this operation. Check the account and try again.'}
         </Text>
@@ -261,21 +262,11 @@ const styles = StyleSheet.create({
   accountPicker: {
     marginTop: SPACING.xs,
   },
-  actionButton: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.sm,
-    justifyContent: 'center',
-    minHeight: 44,
-    paddingHorizontal: SPACING.lg,
-    paddingVertical: SPACING.xs + 2,
-  },
+  actionButton: BUTTON_COMPACT,
   actionButtonPrimary: {
     minWidth: 88,
   },
-  actionLabel: {
-    fontSize: 13,
-    fontWeight: '600',
-  },
+  actionLabel: BUTTON_TEXT,
   actionLabelPrimary: {
     color: '#ffffff',
   },
@@ -319,21 +310,19 @@ const styles = StyleSheet.create({
     marginRight: SPACING.sm,
   },
   conversionText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontStyle: 'italic',
     marginTop: 2,
   },
   errorText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
     paddingHorizontal: SPACING.md,
     paddingTop: SPACING.xs,
   },
   fieldLabel: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.6,
-    marginBottom: 4,
+    ...SECTION_LABEL,
+    marginBottom: SPACING.xs,
     marginTop: SPACING.sm,
   },
   merchant: {
@@ -351,12 +340,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     flexShrink: 1,
-    gap: 4,
+    gap: SPACING.xs,
     marginBottom: SPACING.xs,
     marginTop: SPACING.sm,
   },
   selectedCategoryText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '600',
   },
   sourceLabel: {

--- a/app/components/operations/NotificationBindingStack.js
+++ b/app/components/operations/NotificationBindingStack.js
@@ -4,6 +4,7 @@ import { View, Text, StyleSheet, Animated, Easing } from 'react-native';
 import NotificationBindingCard from './NotificationBindingCard';
 import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
 import { motionDuration } from '../../utils/reducedMotion';
+import { BADGE, BADGE_TEXT } from '../../styles/componentStyles';
 
 // At most this many cards render as deck layers; the rest are summed up in the
 // "+N" badge and surface as the front cards drain.
@@ -199,19 +200,15 @@ NotificationBindingStack.propTypes = {
 
 const styles = StyleSheet.create({
   overflowBadge: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.sm,
+    ...BADGE,
     minWidth: 26,
-    paddingHorizontal: 5,
-    paddingVertical: 1,
     position: 'absolute',
     right: SPACING.lg + (MAX_DECK - 1) * EDGE_INSET,
     top: -2,
   },
   overflowBadgeText: {
+    ...BADGE_TEXT,
     color: '#ffffff',
-    fontSize: 11,
-    fontWeight: '700',
   },
   overlay: {
     bottom: 0,

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -128,7 +128,7 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
     ],
   };
 
-  const deleteColor = colors.delete || colors.expense || '#d32f2f';
+  const deleteColor = colors.destructive;
 
   // Transfers feed no chart, so the hide/show action would be a no-op for them.
   // Balance adjustments DO get it: they have no editable form, which makes this

--- a/app/components/operations/OperationFormFields.js
+++ b/app/components/operations/OperationFormFields.js
@@ -19,12 +19,8 @@ import currencies from '../../../assets/currencies.json';
 
 const getCurrencySymbol = (code) => currencies[code]?.symbol || code;
 
-// Red outline used to flash a field that failed validation on a QuickAdd attempt.
-const FLASH_ERROR_COLOR = '#ef4444';
-
 import { hasOperation as checkHasOperation, evaluateExpression } from '../../utils/calculatorUtils';
-import { SPACING, BORDER_RADIUS } from '../../styles/layout';
-import { FONT_SIZE } from '../../styles/designTokens';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 /**
  * OperationFormFields Component
@@ -124,8 +120,9 @@ const OperationFormFields = memo(({
     return () => clearTimeout(timer);
   }, [flashError?.field, flashError?.token]);
 
-  const chipBorderColor = flashingField === 'category' ? FLASH_ERROR_COLOR : colors.border;
-  const toAccountChipBorderColor = flashingField === 'toAccount' ? FLASH_ERROR_COLOR : colors.border;
+  // Red outline flashed on the field that failed validation on a QuickAdd attempt.
+  const chipBorderColor = flashingField === 'category' ? colors.destructive : colors.border;
+  const toAccountChipBorderColor = flashingField === 'toAccount' ? colors.destructive : colors.border;
 
   // Inline "All categories" browser state — replaces the bottom-sheet picker in
   // QuickAdd. We render the category hierarchy in-place using chips that look
@@ -257,10 +254,10 @@ const OperationFormFields = memo(({
   // Per-field border overrides — flash red when that field is the one that
   // failed validation, otherwise fall back to the normal group border.
   const accountBorderStyle = flashingField === 'account'
-    ? { borderColor: FLASH_ERROR_COLOR }
+    ? { borderColor: colors.destructive }
     : groupBorderStyle;
   const toAccountBorderStyle = flashingField === 'toAccount'
-    ? { borderColor: FLASH_ERROR_COLOR }
+    ? { borderColor: colors.destructive }
     : groupBorderStyle;
 
   const disabledStyle = useMemo(() =>
@@ -1005,13 +1002,13 @@ OperationFormFields.propTypes = {
 
 const styles = StyleSheet.create({
   accountBalanceText: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   accountRows: {
     gap: SPACING.xs,
   },
   accountShortcutBalance: {
-    fontSize: 10,
+    fontSize: FONT_SIZE.xs,
     textAlign: 'center',
   },
   accountShortcutButton: {
@@ -1111,12 +1108,12 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.xs,
   },
   formInputText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
   hiddenBalance: {
     backgroundColor: 'rgba(120, 120, 120, 0.25)',
-    borderRadius: 4,
+    borderRadius: BORDER_RADIUS.sm,
     height: 12,
     width: 64,
   },
@@ -1139,7 +1136,7 @@ const styles = StyleSheet.create({
     opacity: 0.35,
   },
   placeholderDot: {
-    borderRadius: 9,
+    borderRadius: BORDER_RADIUS.pill,
     height: 18,
     width: 18,
   },
@@ -1165,7 +1162,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.sm,
   },
   typeButtonText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
   typeSelector: {

--- a/app/components/operations/OperationLocationRow.js
+++ b/app/components/operations/OperationLocationRow.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
-import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 /**
  * OperationLocationRow — compact inline row for an operation's attached location.
@@ -113,7 +113,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.sm,
   },
   text: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
   },
 });
 

--- a/app/components/operations/OperationsList.js
+++ b/app/components/operations/OperationsList.js
@@ -6,7 +6,8 @@ import DateSeparator from './DateSeparator';
 import OperationListItem from './OperationListItem';
 import OperationsListPlaceholder from './OperationsListPlaceholder';
 import currencies from '../../../assets/currencies.json';
-import { SPACING, BORDER_RADIUS, HEIGHTS } from '../../styles/designTokens';
+import { BORDER_RADIUS, FONT_SIZE, HEIGHTS, SPACING } from '../../styles/designTokens';
+import EmptyState from '../EmptyState';
 
 /**
  * Get currency symbol from currency code
@@ -428,12 +429,12 @@ const OperationsList = forwardRef(({
         initialLoading ? (
           <OperationsListPlaceholder colors={colors} />
         ) : (
-          <View style={styles.emptyContainer}>
-            <Icon name="cash-multiple" size={64} color={colors.mutedText} />
-            <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-              {t('no_operations')}
-            </Text>
-          </View>
+          <EmptyState
+            icon="cash-multiple"
+            iconSize={64}
+            message={t('no_operations')}
+            style={styles.emptyContainer}
+          />
         )
       }
       contentContainerStyle={
@@ -530,17 +531,11 @@ const styles = StyleSheet.create({
     marginHorizontal: SPACING.lg,
   },
   emptyContainer: {
-    alignItems: 'center',
     flex: 1,
-    justifyContent: 'center',
     paddingTop: 80,
   },
   emptyList: {
     flex: 1,
-  },
-  emptyText: {
-    fontSize: 16,
-    marginTop: SPACING.lg,
   },
   groupContainer: {},
   itemWrapper: {
@@ -558,7 +553,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.xl,
   },
   loadingMoreText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     marginTop: SPACING.sm,
   },
 });

--- a/app/components/operations/OperationsListPlaceholder.js
+++ b/app/components/operations/OperationsListPlaceholder.js
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
     marginBottom: SPACING.sm,
   },
   iconCircle: {
-    borderRadius: 11,
+    borderRadius: BORDER_RADIUS.pill,
     height: 22,
     marginRight: SPACING.md,
     width: 22,

--- a/app/components/operations/PickerModal.js
+++ b/app/components/operations/PickerModal.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import CategoryGridSelector from '../CategoryGridSelector';
 import AccountGridSelector from '../AccountGridSelector';
-import { SPACING } from '../../styles/designTokens';
+import { FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 /**
  * Unified picker modal for account and category selection.
@@ -113,7 +113,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
   },
   closeButtonText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '600',
   },
   gridContent: {

--- a/app/components/operations/QuickAddForm.js
+++ b/app/components/operations/QuickAddForm.js
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { View, StyleSheet } from 'react-native';
 import OperationFormFields from './OperationFormFields';
-import { SPACING, BORDER_RADIUS } from '../../styles/layout';
+import { SPACING, BORDER_RADIUS } from '../../styles/designTokens';
 
 /**
  * QuickAddForm Component

--- a/app/components/operations/SplitOperationModal.js
+++ b/app/components/operations/SplitOperationModal.js
@@ -20,6 +20,7 @@ import { motionDuration } from '../../utils/reducedMotion';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import CategoryGridSelector from '../CategoryGridSelector';
 import useKeyboardOffset from '../../hooks/useKeyboardOffset';
+import { BUTTON, BUTTON_TEXT, MODAL_TITLE } from '../../styles/componentStyles';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -220,7 +221,7 @@ export default function SplitOperationModal({
 
                 {/* Error Message */}
                 {error ? (
-                  <Text style={styles.errorText} testID="error-message">{error}</Text>
+                  <Text style={[styles.errorText, { color: colors.destructive }]} testID="error-message">{error}</Text>
                 ) : null}
 
                 {/* Action Buttons */}
@@ -300,22 +301,16 @@ export default function SplitOperationModal({
 
 const styles = StyleSheet.create({
   button: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
+    ...BUTTON,
     flex: 1,
     marginHorizontal: SPACING.xs,
-    minHeight: HEIGHTS.input,
-    paddingVertical: SPACING.md,
   },
   buttonRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginTop: SPACING.lg,
   },
-  buttonText: {
-    fontSize: FONT_SIZE.base,
-    fontWeight: '500',
-  },
+  buttonText: BUTTON_TEXT,
   closeButton: {
     alignItems: 'center',
     alignSelf: 'center',
@@ -331,7 +326,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   errorText: {
-    color: '#ff6b6b',
     fontSize: FONT_SIZE.sm,
     marginTop: SPACING.sm,
   },
@@ -371,8 +365,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   modalTitle: {
-    fontSize: FONT_SIZE.xl,
-    fontWeight: 'bold',
+    ...MODAL_TITLE,
     marginBottom: SPACING.md,
     textAlign: 'center',
   },

--- a/app/components/search/ExpandableFilters.js
+++ b/app/components/search/ExpandableFilters.js
@@ -5,6 +5,8 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import PropTypes from 'prop-types';
 import { formatDate } from '../../services/BalanceHistoryDB';
 import currencies from '../../../assets/currencies.json';
+import { CHIP, CHIP_TEXT, SECTION_LABEL } from '../../styles/componentStyles';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 const ExpandableFilters = ({
   filters,
@@ -388,18 +390,18 @@ ExpandableFilters.propTypes = {
 
 const styles = StyleSheet.create({
   amountCurrencyHint: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
     marginRight: 6,
   },
   amountInputField: {
     flex: 1,
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     paddingVertical: 9,
   },
   amountInputWrap: {
     alignItems: 'center',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
     flex: 1,
     flexDirection: 'row',
@@ -408,34 +410,23 @@ const styles = StyleSheet.create({
   amountRangeContainer: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 12,
+    gap: SPACING.md,
   },
   amountRangeSeparator: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
   },
-  chip: {
-    alignItems: 'center',
-    borderRadius: 16,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 5,
-    paddingHorizontal: 12,
-    paddingVertical: 5,
-  },
+  chip: CHIP,
   chipContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: 6,
   },
-  chipText: {
-    fontSize: 13,
-    fontWeight: '500',
-  },
+  chipText: CHIP_TEXT,
   clearDateButton: {
     marginTop: 7,
   },
   clearDateButtonText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
   container: {
@@ -443,20 +434,20 @@ const styles = StyleSheet.create({
   },
   dateInput: {
     alignItems: 'center',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
     flex: 1,
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     paddingHorizontal: 12,
     paddingVertical: 9,
   },
   dateInputText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
   },
   dateRangeContainer: {
     flexDirection: 'row',
-    gap: 12,
+    gap: SPACING.md,
   },
   footer: {
     alignItems: 'center',
@@ -482,7 +473,7 @@ const styles = StyleSheet.create({
     opacity: 0.4,
   },
   footerButtonText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   footerCount: {
@@ -513,11 +504,8 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
   },
   sectionLabel: {
-    fontSize: 11,
-    fontWeight: '600',
-    letterSpacing: 0.5,
-    marginBottom: 6,
-    textTransform: 'uppercase',
+    ...SECTION_LABEL,
+    marginBottom: SPACING.xs,
   },
   sectionLast: {
     marginBottom: 0,

--- a/app/components/search/FilterBadge.js
+++ b/app/components/search/FilterBadge.js
@@ -1,16 +1,26 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
+import { BADGE, BADGE_TEXT } from '../../styles/componentStyles';
 
-const FilterBadge = ({ count = 0, colors }) => {
+/**
+ * The small round count that rides on the corner of an icon — active filters on
+ * the search button, and the same thing on the collapsed search pill.
+ *
+ * `testID` and `style` are props because SearchBar renders two of these (the
+ * collapsed pill and the open row's filter button) and its tests address them
+ * separately. Before that they were not props, so SearchBar carried its own
+ * byte-identical copy of the badge instead of rendering this one.
+ */
+const FilterBadge = ({ count = 0, colors, testID = 'filter-badge', style }) => {
   if (!count || count === 0) {
     return null;
   }
 
   return (
     <View
-      testID="filter-badge"
-      style={[styles.badge, { backgroundColor: colors.primary }]}
+      testID={testID}
+      style={[styles.badge, { backgroundColor: colors.primary }, style]}
     >
       <Text style={styles.badgeText}>{count}</Text>
     </View>
@@ -22,24 +32,21 @@ FilterBadge.propTypes = {
   colors: PropTypes.shape({
     primary: PropTypes.string.isRequired,
   }).isRequired,
+  testID: PropTypes.string,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 };
 
 const styles = StyleSheet.create({
   badge: {
-    alignItems: 'center',
-    borderRadius: 9,
-    height: 18,
-    justifyContent: 'center',
-    minWidth: 18,
-    paddingHorizontal: 4,
+    ...BADGE,
+    // Overlaps the icon it counts for, rather than sitting beside it.
     position: 'absolute',
     right: -4,
     top: -4,
   },
   badgeText: {
+    ...BADGE_TEXT,
     color: '#fff',
-    fontSize: 11,
-    fontWeight: '700',
   },
 });
 

--- a/app/components/search/FilterChipStrip.js
+++ b/app/components/search/FilterChipStrip.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
-import { HORIZONTAL_PADDING } from '../../styles/layout';
+import { HORIZONTAL_PADDING } from '../../styles/designTokens';
+import { CHIP, CHIP_TEXT } from '../../styles/componentStyles';
 
 const formatDateLabel = (dateRange) => {
   const { startDate, endDate } = dateRange;
@@ -124,19 +125,8 @@ FilterChipStrip.propTypes = {
 };
 
 const styles = StyleSheet.create({
-  chip: {
-    alignItems: 'center',
-    borderRadius: 14,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 5,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  chipText: {
-    fontSize: 12,
-    fontWeight: '500',
-  },
+  chip: CHIP,
+  chipText: CHIP_TEXT,
   container: {
     borderBottomWidth: 1,
   },

--- a/app/components/search/SearchBar.js
+++ b/app/components/search/SearchBar.js
@@ -3,7 +3,8 @@ import { View, TextInput, TouchableOpacity, StyleSheet, Text, Keyboard, Platform
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
-import { HORIZONTAL_PADDING, SPACING } from '../../styles/layout';
+import { FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../../styles/designTokens';
+import FilterBadge from './FilterBadge';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -155,11 +156,7 @@ const SearchBar = ({
             >
               <View style={styles.iconWrapper}>
                 <Icon name="magnify" size={18} color={colors.text} />
-                {filterCount > 0 && (
-                  <View testID="filter-count-badge-collapsed" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
-                    <Text style={styles.filterBadgeText}>{filterCount}</Text>
-                  </View>
-                )}
+                <FilterBadge count={filterCount} colors={colors} testID="filter-count-badge-collapsed" />
               </View>
               <Text style={[styles.collapsedLabel, { color: colors.mutedText }]} numberOfLines={1}>
                 {t('search')}
@@ -199,11 +196,7 @@ const SearchBar = ({
                 >
                   <View style={styles.filterButtonContent}>
                     <Icon name="filter-variant" size={22} color={filterCount > 0 ? colors.primary : colors.text} />
-                    {filterCount > 0 && (
-                      <View testID="filter-count-badge" style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
-                        <Text style={styles.filterBadgeText}>{filterCount}</Text>
-                      </View>
-                    )}
+                    <FilterBadge count={filterCount} colors={colors} testID="filter-count-badge" />
                   </View>
                 </TouchableOpacity>
                 <TouchableOpacity
@@ -249,7 +242,7 @@ const styles = StyleSheet.create({
     width: 96, // 44 + 44 + 8
   },
   collapsedLabel: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
   },
   // Fills the holder so a tap anywhere on the resting pill opens search,
   // with the icon + label centered inside.
@@ -269,22 +262,6 @@ const styles = StyleSheet.create({
   contentHolder: {
     flexDirection: 'row',
     height: '100%',
-  },
-  filterBadge: {
-    alignItems: 'center',
-    borderRadius: 9,
-    height: 18,
-    justifyContent: 'center',
-    minWidth: 18,
-    paddingHorizontal: 4,
-    position: 'absolute',
-    right: -4,
-    top: -4,
-  },
-  filterBadgeText: {
-    color: '#fff',
-    fontSize: 11,
-    fontWeight: '700',
   },
   filterButtonContent: {
     position: 'relative',
@@ -328,7 +305,7 @@ const styles = StyleSheet.create({
   },
   searchInput: {
     flex: 1,
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     height: '100%',
     paddingVertical: 0,
   },

--- a/app/components/search/SearchOverlay.js
+++ b/app/components/search/SearchOverlay.js
@@ -5,7 +5,7 @@ import {
 } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
 import PropTypes from 'prop-types';
-import { HORIZONTAL_PADDING } from '../../styles/layout';
+import { HORIZONTAL_PADDING } from '../../styles/designTokens';
 import ExpandableFilters from './ExpandableFilters';
 import { useOperationsData } from '../../contexts/OperationsDataContext';
 import { useOperationsActions } from '../../contexts/OperationsActionsContext';

--- a/app/contexts/ThemeColorsContext.js
+++ b/app/contexts/ThemeColorsContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useThemeConfig } from './ThemeConfigContext';
+import { DESTRUCTIVE } from '../styles/semanticColors';
 
 const ThemeColorsContext = createContext();
 
@@ -24,14 +25,25 @@ const lightTheme = {
     inputBackground: '#fff',
     inputBorder: '#cccccc',
     calcButtonBackground: '#ffffff',
-    danger: 'red',
-    // Budget-row signal colours. Real hex (unlike `danger`, a bare CSS keyword)
-    // because a plan row tints its background with these at a low alpha, which
-    // needs an appendable hex channel. `overspend` means "past the target" — the
-    // one status a plan row states in colour.
+    // The one red. Every "this went wrong" or "this destroys something" in the
+    // app resolves here: validation text, delete affordances, error banners,
+    // Paper's `error` role. It used to be nine different reds — `danger` was the
+    // bare CSS keyword `red` (#f00, which no other colour in either palette came
+    // near), and eight more were hardcoded at their call sites, four of them
+    // hardcoding the *dark* red so it rendered unchanged on the light theme.
+    destructive: DESTRUCTIVE.light,
+    // Aliases kept because both names are load-bearing across the app and its
+    // tests. They are the same colour now, which is the point: `danger` (a
+    // negative signal) and `delete` (a destructive act) never wanted to differ.
+    danger: DESTRUCTIVE.light,
+    delete: DESTRUCTIVE.light,
+    error: DESTRUCTIVE.light,
+    // Budget-row signal colours. Separate from `destructive` on purpose: these
+    // are a plan row's *status*, not an error, and a row tints its background
+    // with them at a low alpha — which needs an appendable hex channel.
+    // `overspend` means "past the target".
     warning: '#C77700',
     overspend: '#C62828',
-    delete: '#d9534f',
     selected: '#a8d0f5',
     altRow: '#ffffff', // Added for alternating rows
     expense: '#5a3030',
@@ -69,12 +81,16 @@ const darkTheme = {
     inputBackground: '#333333',
     inputBorder: '#555555',
     calcButtonBackground: '#1e1e1e',
-    danger: 'red',
+    // See lightTheme note. Lifted off the light-theme red so it holds contrast
+    // against a near-black surface.
+    destructive: DESTRUCTIVE.dark,
+    danger: DESTRUCTIVE.dark,
+    delete: DESTRUCTIVE.dark,
+    error: DESTRUCTIVE.dark,
     // See lightTheme note. Lifted for legibility as a tint on a near-black
     // surface.
     warning: '#F2A93B',
     overspend: '#FF6B6B',
-    delete: '#ff6b6b',
     selected: '#003a7a',
     altRow: '#1a1a1a', // Added for alternating rows
     expense: '#e6cccc',

--- a/app/modals/CategoryModal.js
+++ b/app/modals/CategoryModal.js
@@ -23,14 +23,14 @@ import IconPicker from '../components/IconPicker';
 import ModalShell from '../components/ModalShell';
 import { makeModalStyles, modalSharedStyles } from '../styles/modalStyles';
 import PropTypes from 'prop-types';
-import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 
 export default function CategoryModal({ visible, onClose, category, isNew }) {
   const { colors } = useThemeColors();
   const { paperInputTheme } = makeModalStyles(colors);
   const themed = useMemo(() => ({
-    pickerItemText: { color: colors.text, fontSize: 18 },
-    parentText: { color: colors.text, fontSize: 18, marginLeft: 12 },
+    pickerItemText: { color: colors.text, fontSize: FONT_SIZE.lg },
+    parentText: { color: colors.text, fontSize: FONT_SIZE.lg, marginLeft: 12 },
   }), [colors]);
   const { t } = useLocalization();
   const { showDialog } = useDialog();
@@ -261,7 +261,7 @@ export default function CategoryModal({ visible, onClose, category, isNew }) {
           </Text>
         </Pressable>
 
-        {errors.general && <Text style={styles.error}>{errors.general}</Text>}
+        {errors.general && <Text style={[styles.error, { color: colors.destructive }]}>{errors.general}</Text>}
 
         {/* In-sheet animated picker panel — slides in from the right */}
         {activePicker && (
@@ -385,8 +385,7 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   error: {
-    color: '#ff6b6b',
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginBottom: SPACING.sm,
   },
   iconPickerButton: {

--- a/app/modals/ImportProgressModal.js
+++ b/app/modals/ImportProgressModal.js
@@ -5,6 +5,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import * as Updates from 'expo-updates';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useImportProgress } from '../contexts/ImportProgressContext';
+import { BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 
 export default function ImportProgressModal() {
   const { colors } = useThemeColors();
@@ -244,7 +245,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0,
   },
   modalContainer: {
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     margin: 20,
     maxHeight: '80%',
     padding: 24,
@@ -258,7 +259,7 @@ const styles = StyleSheet.create({
     width: 24,
   },
   stepIconPlaceholder: {
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.pill,
     borderWidth: 2,
     height: 24,
     marginRight: 12,
@@ -283,7 +284,7 @@ const styles = StyleSheet.create({
     paddingBottom: 8,
   },
   subtitle: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     textAlign: 'center',
   },
   title: {

--- a/app/modals/OperationModal.js
+++ b/app/modals/OperationModal.js
@@ -29,7 +29,7 @@ import { getDistinctLabels, getLabelsNearLocation } from '../services/Operations
 import useOperationLocation from '../hooks/useOperationLocation';
 import * as Currency from '../services/currency';
 import { formatDate } from '../services/BalanceHistoryDB';
-import { SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import { SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 import currencies from '../../assets/currencies.json';
 import { hasOperation, evaluateExpression } from '../utils/calculatorUtils';
 import useOperationForm from '../hooks/useOperationForm';
@@ -659,7 +659,7 @@ export default function OperationModal({
           </View>
         )}
 
-        {errors.general && <Text style={styles.error}>{errors.general}</Text>}
+        {errors.general && <Text style={[styles.error, { color: colors.destructive }]}>{errors.general}</Text>}
       </ModalShell>
 
       {/* Split Operation Modal */}
@@ -751,19 +751,18 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.md,
   },
   closeButtonText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '600',
   },
   disabledInput: {
     opacity: 0.6,
   },
   error: {
-    color: '#ff6b6b',
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginBottom: SPACING.sm,
   },
   excludeAvgHint: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   excludeAvgLabel: {
     marginBottom: 2,
@@ -820,7 +819,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.sm,
   },
   splitButtonText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
 

--- a/app/modals/UpdateAvailableModal.js
+++ b/app/modals/UpdateAvailableModal.js
@@ -5,8 +5,9 @@ import { Text, Divider } from 'react-native-paper';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
-import { SPACING, BORDER_RADIUS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../styles/designTokens';
 import { parseReleaseNotes, formatReleaseDateTime } from '../components/UpdateContentPanel';
+import { BUTTON, MODAL_TITLE } from '../styles/componentStyles';
 
 // Picks the release-note entry describing the version we're prompting the user to install.
 // Prefers the entry whose version matches the latest release; otherwise falls back to the
@@ -187,12 +188,9 @@ const styles = StyleSheet.create({
     paddingTop: SPACING.md,
   },
   button: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
+    ...BUTTON,
     flexDirection: 'row',
     gap: SPACING.xs,
-    height: 46,
-    justifyContent: 'center',
   },
   card: {
     borderRadius: BORDER_RADIUS.lg,
@@ -217,7 +215,7 @@ const styles = StyleSheet.create({
     marginTop: SPACING.md,
   },
   emptyNotes: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     lineHeight: 20,
     paddingHorizontal: SPACING.lg,
     paddingTop: SPACING.md,
@@ -292,9 +290,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.lg,
   },
   title: {
-    fontSize: 17,
-    fontWeight: '700',
-    letterSpacing: -0.1,
+    ...MODAL_TITLE,
   },
   updateButton: {
     flex: 1,

--- a/app/navigation/SimpleTabs.js
+++ b/app/navigation/SimpleTabs.js
@@ -44,6 +44,7 @@ import { SwipeNavigationGestureProvider } from '../contexts/SwipeNavigationConte
 import Header from '../components/Header';
 import SettingsScreen from '../screens/SettingsScreen';
 import { appEvents, EVENTS } from '../services/eventEmitter';
+import { BORDER_RADIUS } from '../styles/designTokens';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
@@ -707,7 +708,7 @@ const styles = StyleSheet.create({
   },
   floatingBar: {
     alignSelf: 'center',
-    borderRadius: 28,
+    borderRadius: BORDER_RADIUS.xl,
     borderWidth: 1,
     marginBottom: 12,
     overflow: 'hidden',

--- a/app/screens/AccountsScreen.js
+++ b/app/screens/AccountsScreen.js
@@ -14,7 +14,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeConfig } from '../contexts/ThemeConfigContext';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useDisplaySettings } from '../contexts/DisplaySettingsContext';
-import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS, HEIGHTS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HEIGHTS, HORIZONTAL_PADDING, SPACING, TOP_CONTENT_SPACING } from '../styles/designTokens';
 import { useAccountsData } from '../contexts/AccountsDataContext';
 import { useAccountsActions } from '../contexts/AccountsActionsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
@@ -25,6 +25,7 @@ import { computeNetWorthSummary, getOperationsByDateRange } from '../services/Op
 import { appEvents, EVENTS } from '../services/eventEmitter';
 import { parseCardMasks, serializeCardMasks, cardMaskLast4 } from '../utils/cardMask';
 import currencies from '../../assets/currencies.json';
+import { CARD_SURFACE } from '../styles/componentStyles';
 
 // Alias for use as a prop default: a `currencies = currencies` destructuring
 // default would shadow the import and throw (TDZ), so default to this instead.
@@ -1359,7 +1360,7 @@ const styles = StyleSheet.create({
     textAlign: 'right',
   },
   accountCurrencyLabel: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     letterSpacing: 0.2,
     marginTop: 2,
   },
@@ -1394,8 +1395,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   accountsCard: {
-    borderRadius: 16,
-    borderWidth: 1,
+    ...CARD_SURFACE,
     marginHorizontal: SPACING.lg,
     marginTop: SPACING.sm,
     overflow: 'hidden',
@@ -1409,7 +1409,7 @@ const styles = StyleSheet.create({
     gap: SPACING.sm,
   },
   cardMaskHint: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 4,
   },
   cardMaskInput: {
@@ -1434,7 +1434,7 @@ const styles = StyleSheet.create({
   },
   cardMaskValue: {
     flex: 1,
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
   },
   centeredBodyMedium: {
     marginBottom: SPACING.lg,
@@ -1503,7 +1503,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.md,
   },
   currencyPanelItemText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
   },
   currencyPanelTitle: {
     fontSize: 17,
@@ -1531,7 +1531,7 @@ const styles = StyleSheet.create({
   },
   formFooterBtn: {
     alignItems: 'center',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
     flex: 1,
     height: 44,
@@ -1560,7 +1560,7 @@ const styles = StyleSheet.create({
   formPanelFooter: {
     borderTopWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     paddingHorizontal: 12,
     paddingTop: 12,
   },
@@ -1580,7 +1580,7 @@ const styles = StyleSheet.create({
   },
   formPanelTitle: {
     flex: 1,
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: '600',
     textAlign: 'center',
   },
@@ -1599,7 +1599,7 @@ const styles = StyleSheet.create({
     marginTop: SPACING.sm,
   },
   monthlyChangeText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontVariant: ['tabular-nums'],
     fontWeight: '500',
     letterSpacing: -0.1,
@@ -1612,15 +1612,14 @@ const styles = StyleSheet.create({
     marginTop: SPACING.xs,
   },
   netWorthCard: {
-    borderRadius: 16,
-    borderWidth: 1,
+    ...CARD_SURFACE,
     marginHorizontal: SPACING.lg,
     marginTop: SPACING.sm,
     padding: SPACING.xl,
   },
   netWorthConvertToggle: {
     alignItems: 'center',
-    borderRadius: 16,
+    borderRadius: BORDER_RADIUS.pill,
     borderWidth: 1,
     height: 32,
     justifyContent: 'center',
@@ -1638,12 +1637,12 @@ const styles = StyleSheet.create({
   netWorthWarningRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     marginTop: SPACING.sm,
   },
   netWorthWarningText: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   pickerCloseButton: {
     marginTop: SPACING.sm,
@@ -1661,11 +1660,11 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.md,
   },
   pickerOptionText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
   },
   roundingOption: {
     alignItems: 'center',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     flex: 1,
     paddingVertical: 10,
   },
@@ -1680,7 +1679,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     borderWidth: 1,
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
     marginTop: 4,
     padding: 4,
   },
@@ -1688,7 +1687,7 @@ const styles = StyleSheet.create({
     paddingBottom: 180,
   },
   settingHint: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 2,
   },
   settingItem: {
@@ -1716,7 +1715,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   showHiddenButton: {
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     borderWidth: 1,
     marginHorizontal: SPACING.lg,
     marginTop: SPACING.sm,
@@ -1731,7 +1730,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.md,
   },
   showHiddenText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
 });

--- a/app/screens/BudgetScreen.js
+++ b/app/screens/BudgetScreen.js
@@ -13,7 +13,7 @@ import MonthlyPlanSection from '../components/budgets/MonthlyPlanSection';
 import AddFAB from '../components/AddFAB';
 import LoadingView from '../components/LoadingView';
 import * as Currency from '../services/currency';
-import { SPACING } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../styles/designTokens';
 import { currentMonthKey, addMonths, formatMonthLabel } from '../utils/monthUtils';
 import { TIMING_ENTER } from '../utils/motion';
 
@@ -411,7 +411,7 @@ const styles = StyleSheet.create({
   },
   convertToggle: {
     alignItems: 'center',
-    borderRadius: 14,
+    borderRadius: BORDER_RADIUS.pill,
     borderWidth: 1,
     height: 28,
     justifyContent: 'center',
@@ -419,7 +419,7 @@ const styles = StyleSheet.create({
   },
   currencyChip: {
     alignItems: 'center',
-    borderRadius: 14,
+    borderRadius: BORDER_RADIUS.pill,
     borderWidth: 1,
     flexDirection: 'row',
     gap: 2,
@@ -439,7 +439,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   heroLabel: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   heroRow: {
     alignItems: 'flex-end',
@@ -448,12 +448,12 @@ const styles = StyleSheet.create({
     marginTop: SPACING.sm,
   },
   heroTotals: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontVariant: ['tabular-nums'],
     marginTop: 2,
   },
   heroValue: {
-    fontSize: 24,
+    fontSize: FONT_SIZE.xxl,
     fontVariant: ['tabular-nums'],
     fontWeight: '700',
     letterSpacing: -0.5,

--- a/app/screens/CategoriesScreen.js
+++ b/app/screens/CategoriesScreen.js
@@ -16,7 +16,7 @@ import { Text, TouchableRipple, TextInput as PaperTextInput } from 'react-native
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS } from '../styles/designTokens';
+import { TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS, FONT_SIZE } from '../styles/designTokens';
 import { DURATION_ENTER, DURATION_EXIT } from '../utils/motion';
 import { motionDuration } from '../utils/reducedMotion';
 import AddFAB from '../components/AddFAB';
@@ -41,8 +41,8 @@ const CategoriesScreen = ({ onBackStateChange }) => {
   const insets = useSafeAreaInsets();
   const { paperInputTheme } = makeModalStyles(colors);
   const themed = useMemo(() => ({
-    pickerItemText: { color: colors.text, fontSize: 18 },
-    parentText: { color: colors.text, fontSize: 18, marginLeft: 12 },
+    pickerItemText: { color: colors.text, fontSize: FONT_SIZE.lg },
+    parentText: { color: colors.text, fontSize: FONT_SIZE.lg, marginLeft: 12 },
     saveButtonText: { color: '#fff' },
     cancelButtonText: { color: colors.text },
   }), [colors]);
@@ -380,7 +380,7 @@ const CategoriesScreen = ({ onBackStateChange }) => {
             </Text>
             {!formIsNew ? (
               <TouchableOpacity onPress={handleDelete} style={styles.formPanelBack} accessibilityRole="button" accessibilityLabel={t('delete_category')}>
-                <Icon name="trash-can-outline" size={22} color={colors.delete || '#ef4444'} />
+                <Icon name="trash-can-outline" size={22} color={colors.destructive} />
               </TouchableOpacity>
             ) : (
               <View style={styles.formPanelBack} />
@@ -471,7 +471,7 @@ const CategoriesScreen = ({ onBackStateChange }) => {
             </Pressable>
 
             {formErrors.general && (
-              <Text style={styles.errorText}>{formErrors.general}</Text>
+              <Text style={[styles.errorText, { color: colors.destructive }]}>{formErrors.general}</Text>
             )}
           </ScrollView>
 
@@ -622,7 +622,7 @@ const styles = StyleSheet.create({
     gap: 2,
   },
   backLabel: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '500',
   },
   container: {
@@ -636,8 +636,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   errorText: {
-    color: '#ff6b6b',
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginBottom: SPACING.sm,
   },
   folderBadge: {
@@ -648,7 +647,7 @@ const styles = StyleSheet.create({
   // Form footer buttons
   formFooterBtn: {
     alignItems: 'center',
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
     borderWidth: 1,
     flex: 1,
     height: 44,
@@ -675,7 +674,7 @@ const styles = StyleSheet.create({
   formPanelFooter: {
     borderTopWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     paddingHorizontal: 12,
     paddingTop: 12,
   },
@@ -695,7 +694,7 @@ const styles = StyleSheet.create({
   },
   formPanelTitle: {
     flex: 1,
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: '600',
     textAlign: 'center',
   },
@@ -710,7 +709,7 @@ const styles = StyleSheet.create({
     width: (Dimensions.get('window').width - SPACING.sm * 2 - SPACING.xs * 2 * 3) / 3,
   },
   gridCellName: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     fontWeight: '500',
     textAlign: 'center',
   },

--- a/app/screens/GraphsScreen.js
+++ b/app/screens/GraphsScreen.js
@@ -6,7 +6,7 @@ import WheelPicker from '@quidone/react-native-wheel-picker';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useAccountsData } from '../contexts/AccountsDataContext';
-import { TOP_CONTENT_SPACING } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, SPACING, TOP_CONTENT_SPACING } from '../styles/designTokens';
 import { getAvailableMonths, getUnconvertibleCurrencies } from '../services/OperationsDB';
 import { getAllCategories } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
@@ -26,6 +26,7 @@ import useExpenseData from '../hooks/useExpenseData';
 import useIncomeData from '../hooks/useIncomeData';
 import useCategoryOperations from '../hooks/useCategoryOperations';
 import useBalanceHistory from '../hooks/useBalanceHistory';
+import { CARD_SURFACE } from '../styles/componentStyles';
 
 const CARD_HEADER_HEIGHT = 56;
 const MAX_CHART_HEIGHT = 500;
@@ -997,23 +998,23 @@ const styles = StyleSheet.create({
   },
   convertWarning: {
     alignItems: 'center',
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     borderWidth: 1,
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     marginBottom: 12,
     paddingHorizontal: 12,
     paddingVertical: 8,
   },
   convertWarningText: {
     flex: 1,
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
   },
   fabToggle: {
     // A compact badge tucked into the currency wheel's bottom-right corner —
     // rendered after the wheel with higher elevation/zIndex so it sits on top.
     alignItems: 'center',
-    borderRadius: 16,
+    borderRadius: BORDER_RADIUS.pill,
     borderWidth: 1,
     bottom: 104,
     elevation: 12,
@@ -1029,8 +1030,7 @@ const styles = StyleSheet.create({
     zIndex: 2,
   },
   fabWheel: {
-    borderRadius: 16,
-    borderWidth: 1,
+    ...CARD_SURFACE,
     bottom: 116,
     elevation: 8,
     overflow: 'hidden',
@@ -1041,7 +1041,7 @@ const styles = StyleSheet.create({
     shadowRadius: 8,
   },
   fabWheelLeft: {
-    borderRadius: 40,
+    borderRadius: BORDER_RADIUS.pill,
     right: 152,
     width: 80,
   },
@@ -1068,9 +1068,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   summaryPanel: {
-    borderRadius: 16,
-    borderWidth: 1,
-    marginBottom: 16,
+    ...CARD_SURFACE,
+    marginBottom: SPACING.lg,
     overflow: 'hidden',
   },
   tabDivider: {
@@ -1101,10 +1100,10 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   wheelItemText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
   },
   wheelOverlayItem: {
-    borderRadius: 8,
+    borderRadius: BORDER_RADIUS.md,
   },
 });
 

--- a/app/screens/LanguageSelectionScreen.js
+++ b/app/screens/LanguageSelectionScreen.js
@@ -18,7 +18,7 @@ import frTranslations from '../../assets/i18n/fr.json';
 import zhTranslations from '../../assets/i18n/zh.json';
 import deTranslations from '../../assets/i18n/de.json';
 import hyTranslations from '../../assets/i18n/hy.json';
-import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, TOP_CONTENT_SPACING } from '../styles/designTokens';
 
 // This is the only screen in the app a user sees exactly once, and it is where
 // the whole motion budget for first-run lives: everywhere else in Penny is a
@@ -166,14 +166,14 @@ const styles = StyleSheet.create({
   checkmark: {
     alignItems: 'center',
     backgroundColor: '#2196f3',
-    borderRadius: 14,
+    borderRadius: BORDER_RADIUS.pill,
     height: 28,
     justifyContent: 'center',
     width: 28,
   },
   checkmarkText: {
     color: '#ffffff',
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: 'bold',
   },
   container: {
@@ -189,7 +189,7 @@ const styles = StyleSheet.create({
   continueButton: {
     alignItems: 'center',
     backgroundColor: '#2196f3',
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     justifyContent: 'center',
     padding: 16,
   },
@@ -198,7 +198,7 @@ const styles = StyleSheet.create({
   },
   continueButtonText: {
     color: '#ffffff',
-    fontSize: 18,
+    fontSize: FONT_SIZE.lg,
     fontWeight: '600',
   },
   continueButtonTextDisabled: {
@@ -216,7 +216,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#f5f5f5',
     borderColor: '#f5f5f5',
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.lg,
     borderWidth: 2,
     flexDirection: 'row',
     marginBottom: 16,
@@ -228,14 +228,14 @@ const styles = StyleSheet.create({
   },
   languageEnglishName: {
     color: '#666666',
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
   },
   languageEnglishNameSelected: {
     color: '#1976d2',
   },
   languageName: {
     color: '#1a1a1a',
-    fontSize: 20,
+    fontSize: FONT_SIZE.xl,
     fontWeight: '600',
     marginBottom: 4,
   },
@@ -255,7 +255,7 @@ const styles = StyleSheet.create({
   },
   subtitle: {
     color: '#666666',
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     marginBottom: 48,
     textAlign: 'center',
   },

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -5,7 +5,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useThemeColors } from '../contexts/ThemeColorsContext';
-import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS, HEIGHTS } from '../styles/layout';
+import { TOP_CONTENT_SPACING, HORIZONTAL_PADDING, SPACING, BORDER_RADIUS, HEIGHTS } from '../styles/designTokens';
 import { useLocalization } from '../contexts/LocalizationContext';
 import { useDialog } from '../contexts/DialogContext';
 import { useOperationsData } from '../contexts/OperationsDataContext';

--- a/app/screens/SettingsScreen.js
+++ b/app/screens/SettingsScreen.js
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 // eslint-disable-next-line react-native/split-platform-components
 import { View, StyleSheet, TouchableOpacity, ScrollView, FlatList, Linking, ActivityIndicator, BackHandler, AppState, ToastAndroid } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
-import { HORIZONTAL_PADDING, SPACING, BORDER_RADIUS } from '../styles/layout';
+import { BORDER_RADIUS, FONT_SIZE, HORIZONTAL_PADDING, SPACING } from '../styles/designTokens';
+import { DESTRUCTIVE } from '../styles/semanticColors';
 import { Text, Divider, TouchableRipple, Menu } from 'react-native-paper';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -42,6 +43,8 @@ import NotificationFiltersContentPanel from '../components/NotificationFiltersCo
 import NotificationBindingsContentPanel from '../components/NotificationBindingsContentPanel';
 import AccountsScreen from './AccountsScreen';
 import CategoriesScreen from './CategoriesScreen';
+import { BADGE, BADGE_TEXT, CHIP, CHIP_TEXT, SECTION_LABEL } from '../styles/componentStyles';
+import EmptyState from '../components/EmptyState';
 
 const SHEETS_STEPS = [
   { id: 'auth', label: 'Signing in to Google' },
@@ -57,8 +60,10 @@ const SHEETS_IMPORT_STEPS = [
   { id: 'parse', label: 'Reading sheet data' },
 ];
 
+// Log severity is a categorical scale, fixed across both themes like
+// chartPalette — only its red is pinned to the app's one red.
 const LOG_LEVEL_COLORS = {
-  error: '#e53935',
+  error: DESTRUCTIVE.light,
   warn: '#fb8c00',
   info: '#1e88e5',
   debug: '#757575',
@@ -71,9 +76,6 @@ const LOG_FILTERS = ['all', 'error', 'warn', 'info', 'debug'];
 const SELECTED_BADGE_BG = 'rgba(255,255,255,0.3)';
 
 const SPRING_CONFIG = { mass: 1, damping: 20, stiffness: 200 };
-
-// Red used for the inline "location permission denied" hint under the toggle row.
-const ERROR_TEXT_COLOR = '#e53935';
 
 /**
  * A settings row with an animated on/off switch. Extracted so the three toggle
@@ -99,7 +101,7 @@ const SettingToggleRow = ({ icon, label, hint, value, onToggle, hintError = fals
           <Ionicons name={icon} size={22} color={colors.text} />
           <View style={styles.settingsRowText}>
             <Text style={[styles.settingsRowLabel, { color: colors.text }]}>{label}</Text>
-            <Text style={[styles.settingsRowValue, { color: hintError ? ERROR_TEXT_COLOR : colors.mutedText }]}>
+            <Text style={[styles.settingsRowValue, { color: hintError ? colors.destructive : colors.mutedText }]}>
               {hint}
             </Text>
           </View>
@@ -940,7 +942,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 <Text style={[styles.backupConfirmButtonText, { color: colors.mutedText }]}>{t('cancel') || 'Cancel'}</Text>
               </TouchableOpacity>
               <TouchableOpacity onPress={() => handleConfirmDeleteLocalBackup(item.uri)} style={styles.backupConfirmButton}>
-                <Text style={styles.backupConfirmButtonDestructiveText}>{t('delete') || 'Delete'}</Text>
+                <Text style={[styles.backupConfirmButtonDestructiveText, { color: colors.destructive }]}>{t('delete') || 'Delete'}</Text>
               </TouchableOpacity>
             </>
           ) : (
@@ -949,7 +951,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 <Ionicons name="refresh-outline" size={20} color={colors.primary} />
               </TouchableOpacity>
               <TouchableOpacity onPress={() => handleDeleteLocalBackup(item.uri)} style={styles.backupActionButton}>
-                <Ionicons name="trash-outline" size={18} color="#c44" />
+                <Ionicons name="trash-outline" size={18} color={colors.destructive} />
               </TouchableOpacity>
             </>
           )}
@@ -1330,18 +1332,18 @@ export default function SettingsScreen({ setSubPanelActive }) {
                       {step.status === 'pending' && <Ionicons name="ellipse-outline" size={22} color={colors.mutedText} />}
                       {step.status === 'in_progress' && <ActivityIndicator size="small" color={colors.primary} />}
                       {step.status === 'completed' && <Ionicons name="checkmark-circle" size={22} color="#4caf50" />}
-                      {step.status === 'error' && <Ionicons name="close-circle" size={22} color="#c44" />}
+                      {step.status === 'error' && <Ionicons name="close-circle" size={22} color={colors.destructive} />}
                     </View>
                     <Text style={[
                       styles.sheetsProgressStepLabel,
-                      step.status === 'error' ? styles.sheetsProgressStepLabelError :
+                      step.status === 'error' ? { color: colors.destructive } :
                         { color: step.status === 'pending' ? colors.mutedText : colors.text },
                     ]}>
                       {step.label}
                     </Text>
                   </View>
                 ))}
-                {sheetsError && <Text style={styles.sheetsErrorText}>{sheetsError}</Text>}
+                {sheetsError && <Text style={[styles.sheetsErrorText, { color: colors.destructive }]}>{sheetsError}</Text>}
                 {sheetsSuccessUrl && (
                   <TouchableOpacity
                     onPress={() => Linking.openURL(sheetsSuccessUrl)}
@@ -1358,14 +1360,14 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
             {activeSubPanel === 'reset' && (
               <View style={styles.confirmContent}>
-                <Ionicons name="warning-outline" size={48} color="#c44" style={styles.confirmWarningIcon} />
+                <Ionicons name="warning-outline" size={48} color={colors.destructive} style={styles.confirmWarningIcon} />
                 <Text style={[styles.confirmText, { color: colors.text }]}>
                   {t('reset_database_confirm') || 'Are you sure you want to reset the database? This will delete all data and create default accounts.'}
                 </Text>
                 <TouchableRipple
                   onPress={confirmResetDatabase}
                   disabled={resetInProgress}
-                  style={[styles.confirmButtonDestructive, resetInProgress && styles.confirmButtonBusy]}
+                  style={[styles.confirmButtonDestructive, { backgroundColor: colors.destructive }, resetInProgress && styles.confirmButtonBusy]}
                 >
                   {resetInProgress ? (
                     <View style={styles.confirmButtonBusyRow}>
@@ -1437,7 +1439,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 </TouchableRipple>
                 {sheetsImportError && importStep === 'source' && (
                   <View style={styles.sheetsSetupCta}>
-                    <Text testID="settings-import-no-spreadsheet" style={styles.sheetsImportErrorInline}>
+                    <Text testID="settings-import-no-spreadsheet" style={[styles.sheetsImportErrorInline, { color: colors.destructive }]}>
                       {sheetsImportError}
                     </Text>
                     <TouchableRipple
@@ -1459,9 +1461,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
             {activeSubPanel === 'import' && importStep === 'local-list' && (
               backupsLoading ? (
-                <View style={styles.emptyContainer}>
-                  <Text style={[styles.emptyText, { color: colors.mutedText }]}>{'Loading...'}</Text>
-                </View>
+                <EmptyState message={'Loading...'} style={styles.emptyContainer} />
               ) : (
                 <FlatList
                   data={storedBackups}
@@ -1473,9 +1473,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                     { paddingBottom: scrollBottomInset },
                   ]}
                   ListEmptyComponent={
-                    <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                      {t('local_backups_empty') || 'No local backups yet'}
-                    </Text>
+                    <EmptyState message={t('local_backups_empty') || 'No local backups yet'} />
                   }
                 />
               )
@@ -1483,11 +1481,11 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
             {activeSubPanel === 'import' && importStep === 'confirm-file' && (
               <View style={styles.confirmContent}>
-                <Ionicons name="warning-outline" size={48} color="#c44" style={styles.confirmWarningIcon} />
+                <Ionicons name="warning-outline" size={48} color={colors.destructive} style={styles.confirmWarningIcon} />
                 <Text style={[styles.confirmText, { color: colors.text }]}>
                   {t('restore_confirm') || 'Are you sure you want to restore from backup? This will replace all current data.'}
                 </Text>
-                <TouchableRipple testID="confirm-import-file-btn" onPress={confirmImportBackup} style={styles.confirmButtonDestructive}>
+                <TouchableRipple testID="confirm-import-file-btn" onPress={confirmImportBackup} style={[styles.confirmButtonDestructive, { backgroundColor: colors.destructive }]}>
                   <Text style={styles.confirmButtonText}>{t('restore_database') || 'Restore'}</Text>
                 </TouchableRipple>
               </View>
@@ -1495,7 +1493,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
 
             {activeSubPanel === 'import' && importStep === 'confirm-local' && (
               <View style={styles.confirmContent}>
-                <Ionicons name="warning-outline" size={48} color="#c44" style={styles.confirmWarningIcon} />
+                <Ionicons name="warning-outline" size={48} color={colors.destructive} style={styles.confirmWarningIcon} />
                 {importSelectedBackup && (
                   <Text style={[styles.confirmText, { color: colors.mutedText }]}>
                     {formatBackupLabel(importSelectedBackup.filename)}
@@ -1504,7 +1502,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                 <Text style={[styles.confirmText, { color: colors.text }]}>
                   {t('restore_confirm') || 'Are you sure you want to restore from backup? This will replace all current data.'}
                 </Text>
-                <TouchableRipple onPress={confirmRestoreLocalBackup} style={styles.confirmButtonDestructive}>
+                <TouchableRipple onPress={confirmRestoreLocalBackup} style={[styles.confirmButtonDestructive, { backgroundColor: colors.destructive }]}>
                   <Text style={styles.confirmButtonText}>{t('restore_database') || 'Restore'}</Text>
                 </TouchableRipple>
               </View>
@@ -1518,18 +1516,18 @@ export default function SettingsScreen({ setSubPanelActive }) {
                       {step.status === 'pending' && <Ionicons name="ellipse-outline" size={22} color={colors.mutedText} />}
                       {step.status === 'in_progress' && <ActivityIndicator size="small" color={colors.primary} />}
                       {step.status === 'completed' && <Ionicons name="checkmark-circle" size={22} color="#4caf50" />}
-                      {step.status === 'error' && <Ionicons name="close-circle" size={22} color="#c44" />}
+                      {step.status === 'error' && <Ionicons name="close-circle" size={22} color={colors.destructive} />}
                     </View>
                     <Text style={[
                       styles.sheetsProgressStepLabel,
-                      step.status === 'error' ? styles.sheetsProgressStepLabelError :
+                      step.status === 'error' ? { color: colors.destructive } :
                         { color: step.status === 'pending' ? colors.mutedText : colors.text },
                     ]}>
                       {step.label}
                     </Text>
                   </View>
                 ))}
-                {sheetsImportError && <Text style={styles.sheetsErrorText}>{sheetsImportError}</Text>}
+                {sheetsImportError && <Text style={[styles.sheetsErrorText, { color: colors.destructive }]}>{sheetsImportError}</Text>}
               </View>
             )}
 
@@ -1595,9 +1593,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                   windowSize={5}
                   contentContainerStyle={entries.length === 0 && styles.emptyContainer}
                   ListEmptyComponent={
-                    <Text style={[styles.emptyText, { color: colors.mutedText }]}>
-                      {t('no_logs') || 'No logs yet'}
-                    </Text>
+                    <EmptyState message={t('no_logs') || 'No logs yet'} />
                   }
                 />
 
@@ -1612,7 +1608,7 @@ export default function SettingsScreen({ setSubPanelActive }) {
                   </TouchableOpacity>
                   <TouchableOpacity onPress={handleClearLogs} style={styles.logsActionButton}>
                     <Ionicons name="trash-outline" size={20} color={LOG_LEVEL_COLORS.error} />
-                    <Text style={[styles.logsActionText, styles.clearLogsText]}>
+                    <Text style={[styles.logsActionText, { color: colors.destructive }]}>
                       {t('clear_logs') || 'Clear Logs'}
                     </Text>
                   </TouchableOpacity>
@@ -1852,8 +1848,8 @@ export default function SettingsScreen({ setSubPanelActive }) {
         <TouchableRipple onPress={() => openSubPanel('reset')} style={styles.settingsRow}>
           <View style={styles.settingsRowContent}>
             <View style={styles.settingsRowLeft}>
-              <Ionicons name="trash-outline" size={22} color="#c44" />
-              <Text style={[styles.settingsRowLabel, styles.destructiveText]}>{t('reset_database') || 'Reset Database'}</Text>
+              <Ionicons name="trash-outline" size={22} color={colors.destructive} />
+              <Text style={[styles.settingsRowLabel, { color: colors.destructive }]}>{t('reset_database') || 'Reset Database'}</Text>
             </View>
           </View>
         </TouchableRipple>
@@ -1878,12 +1874,11 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
   },
   backupConfirmButtonDestructiveText: {
-    color: '#c44',
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   backupConfirmButtonText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   backupItem: {
@@ -1897,7 +1892,7 @@ const styles = StyleSheet.create({
   backupItemActions: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
   },
   backupItemLabel: {
     fontSize: 15,
@@ -1909,14 +1904,11 @@ const styles = StyleSheet.create({
     gap: SPACING.md,
   },
   backupItemMeta: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: 2,
   },
   backupItemText: {
     flex: 1,
-  },
-  clearLogsText: {
-    color: '#e53935',
   },
   confirmButtonBusy: {
     opacity: 0.85,
@@ -1928,7 +1920,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   confirmButtonDestructive: {
-    backgroundColor: '#c44',
     borderRadius: BORDER_RADIUS.md,
     marginTop: SPACING.xl,
     paddingHorizontal: SPACING.xl,
@@ -1936,7 +1927,7 @@ const styles = StyleSheet.create({
   },
   confirmButtonText: {
     color: '#fff',
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '600',
     textAlign: 'center',
   },
@@ -1958,50 +1949,22 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  destructiveText: {
-    color: '#c44',
-  },
   divider: {
     marginVertical: SPACING.xs,
   },
   emptyContainer: {
-    alignItems: 'center',
     flex: 1,
-    justifyContent: 'center',
   },
-  emptyText: {
-    fontSize: 14,
-  },
-  filterChip: {
-    alignItems: 'center',
-    borderRadius: 16,
-    borderWidth: 1,
-    flexDirection: 'row',
-    gap: 5,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-  },
-  filterChipBadge: {
-    alignItems: 'center',
-    borderRadius: 8,
-    justifyContent: 'center',
-    minWidth: 16,
-    paddingHorizontal: 4,
-  },
-  filterChipBadgeText: {
-    fontSize: 10,
-    fontWeight: '700',
-  },
-  filterChipText: {
-    fontSize: 12,
-    fontWeight: '600',
-  },
+  filterChip: CHIP,
+  filterChipBadge: BADGE,
+  filterChipBadgeText: BADGE_TEXT,
+  filterChipText: CHIP_TEXT,
   filterChipTextSelected: {
     color: '#fff',
   },
   filterRow: {
     flexDirection: 'row',
-    gap: 8,
+    gap: SPACING.sm,
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.sm,
   },
@@ -2009,7 +1972,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   formatDescription: {
-    fontSize: 12,
+    fontSize: FONT_SIZE.sm,
     marginTop: SPACING.xs,
   },
   formatItemRow: {
@@ -2035,7 +1998,7 @@ const styles = StyleSheet.create({
     paddingVertical: SPACING.lg,
   },
   listItemText: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
   },
   logEntry: {
     borderBottomWidth: StyleSheet.hairlineWidth,
@@ -2072,14 +2035,14 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   logsActionText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   resetSpacer: {
     height: SPACING.sm,
   },
   sectionLabel: {
-    letterSpacing: 0.5,
+    ...SECTION_LABEL,
     paddingHorizontal: HORIZONTAL_PADDING,
     paddingVertical: SPACING.sm,
   },
@@ -2100,7 +2063,7 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   settingsRowLabel: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
   },
   settingsRowLeft: {
     alignItems: 'center',
@@ -2117,15 +2080,13 @@ const styles = StyleSheet.create({
     marginTop: 2,
   },
   sheetsErrorText: {
-    color: '#c44',
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     lineHeight: 20,
     marginTop: SPACING.lg,
     textAlign: 'center',
   },
   sheetsImportErrorInline: {
-    color: '#c44',
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     lineHeight: 20,
     marginBottom: 8,
     marginHorizontal: 16,
@@ -2142,7 +2103,7 @@ const styles = StyleSheet.create({
   },
   sheetsOpenButtonText: {
     color: '#fff',
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '600',
   },
   sheetsProgressContent: {
@@ -2165,9 +2126,6 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 15,
   },
-  sheetsProgressStepLabelError: {
-    color: '#c44',
-  },
   sheetsSetupCta: {
     marginTop: SPACING.sm,
   },
@@ -2185,7 +2143,7 @@ const styles = StyleSheet.create({
     gap: SPACING.sm,
   },
   sheetsSetupCtaText: {
-    fontSize: 14,
+    fontSize: FONT_SIZE.md,
     fontWeight: '600',
   },
   subPanelBody: {
@@ -2228,14 +2186,14 @@ const styles = StyleSheet.create({
   },
   switchThumb: {
     backgroundColor: '#fff',
-    borderRadius: 10,
+    borderRadius: BORDER_RADIUS.pill,
     elevation: 2,
     height: 20,
     position: 'absolute',
     width: 20,
   },
   switchTrack: {
-    borderRadius: 12,
+    borderRadius: BORDER_RADIUS.pill,
     height: 24,
     justifyContent: 'center',
     width: 44,
@@ -2246,7 +2204,7 @@ const styles = StyleSheet.create({
   updateRowRight: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: 4,
+    gap: SPACING.xs,
   },
   updateRowSpinner: {
     marginLeft: 2,

--- a/app/styles/componentStyles.js
+++ b/app/styles/componentStyles.js
@@ -1,0 +1,136 @@
+// app/styles/componentStyles.js
+import { StyleSheet } from 'react-native';
+import {
+  BORDER_RADIUS,
+  FONT_SIZE,
+  FONT_WEIGHT,
+  HEIGHTS,
+  SPACING,
+} from './designTokens';
+
+/**
+ * Shared *composite* styles — the recurring UI elements that were each being
+ * re-specified per file.
+ *
+ * designTokens.js holds the scalars (a spacing step, a radius, a font size).
+ * This file holds the handful of small elements that are assembled from those
+ * scalars the same way everywhere: a card surface, an eyebrow label, a modal
+ * title, a button, a count badge. Before this file each of those existed in
+ * four or five slightly different versions — chips at five radii, cards at two
+ * radii and two border widths, eyebrow labels at four weight/tracking pairs.
+ *
+ * Colors are not included: they depend on the active theme and are applied
+ * inline by the host from ThemeColorsContext.
+ */
+
+/**
+ * Card surface — the bordered container that holds a chunk of content: a graph
+ * card, a plan section, a notification rule.
+ *
+ * Border is hairline rather than 1px. At 1px a card outline competes with the
+ * content it is supposed to be grouping; the whole job here is separation, and
+ * hairline is the least ink that still does it.
+ */
+export const CARD_SURFACE = {
+  borderRadius: BORDER_RADIUS.lg,
+  borderWidth: StyleSheet.hairlineWidth,
+};
+
+/**
+ * Pill chip — filter chips, label chips, suggestion chips, the drill-down back
+ * chip. Fully rounded via `pill` rather than a hand-computed half-height: every
+ * one of these was already trying to be a pill (radius 12/14/16/20 against a
+ * 26-30px height), each arriving at it by a different guess.
+ */
+export const CHIP = {
+  alignItems: 'center',
+  borderRadius: BORDER_RADIUS.pill,
+  borderWidth: 1,
+  flexDirection: 'row',
+  gap: SPACING.xs,
+  paddingHorizontal: SPACING.md,
+  paddingVertical: SPACING.xs,
+};
+
+export const CHIP_TEXT = {
+  fontSize: FONT_SIZE.sm,
+  fontWeight: FONT_WEIGHT.medium,
+};
+
+/**
+ * Eyebrow / overline label — the small uppercase text that names a group of
+ * fields or a section of a panel.
+ */
+export const SECTION_LABEL = {
+  fontSize: FONT_SIZE.xs,
+  fontWeight: FONT_WEIGHT.semibold,
+  letterSpacing: 0.8,
+  textTransform: 'uppercase',
+};
+
+/**
+ * Section heading — a real heading that titles a block of content, as opposed
+ * to the eyebrow above. Bigger and sentence-weight rather than tracked-out.
+ */
+export const SECTION_HEADING = {
+  fontSize: FONT_SIZE.md,
+  fontWeight: FONT_WEIGHT.bold,
+  textTransform: 'uppercase',
+};
+
+/**
+ * Modal / bottom-sheet title. Negative tracking because at this size and weight
+ * the default spacing reads loose against the sheet's tight top padding.
+ */
+export const MODAL_TITLE = {
+  fontSize: FONT_SIZE.lg,
+  fontWeight: FONT_WEIGHT.bold,
+  letterSpacing: -0.3,
+};
+
+/**
+ * Button that owns its own line — a modal's Save, a dialog's confirm.
+ */
+export const BUTTON = {
+  alignItems: 'center',
+  borderRadius: BORDER_RADIUS.md,
+  justifyContent: 'center',
+  minHeight: HEIGHTS.input,
+  paddingHorizontal: SPACING.lg,
+};
+
+/**
+ * Button that sits inside a row of other content — a card's inline action.
+ */
+export const BUTTON_COMPACT = {
+  alignItems: 'center',
+  borderRadius: BORDER_RADIUS.md,
+  justifyContent: 'center',
+  minHeight: HEIGHTS.buttonCompact,
+  paddingHorizontal: SPACING.md,
+};
+
+export const BUTTON_TEXT = {
+  fontSize: FONT_SIZE.md,
+  fontWeight: FONT_WEIGHT.semibold,
+};
+
+/**
+ * Count badge — the small round counter on a filter button or a rule card.
+ */
+export const BADGE = {
+  alignItems: 'center',
+  borderRadius: BORDER_RADIUS.pill,
+  justifyContent: 'center',
+  // Both minimums, not just minWidth: with only a width floor a single-digit
+  // count collapses to the line height of its own text and the badge stops
+  // being round. Equal floors give a circle at one digit and a pill past that.
+  minHeight: HEIGHTS.badge,
+  minWidth: HEIGHTS.badge,
+  paddingHorizontal: SPACING.xs,
+};
+
+export const BADGE_TEXT = {
+  fontSize: FONT_SIZE.xs,
+  fontWeight: FONT_WEIGHT.bold,
+};

--- a/app/styles/designTokens.js
+++ b/app/styles/designTokens.js
@@ -56,8 +56,16 @@ export const HEIGHTS = {
   input: 48,           // All text inputs, pickers, buttons (min touch target)
   listItem: 48,        // ALL list item rows (accounts, operations, categories)
   calculator: 44,      // Calculator buttons (compact, intentional)
+  // A button that sits inside a row of content rather than owning its own line
+  // — a card's "Save", an inline "Apply". Below `input` on purpose: a 48px
+  // button inside a 12px-padded card reads as the card's primary act rather
+  // than as one control among several. Still at Android's touch floor.
+  buttonCompact: 44,
   fab: 56,             // Floating action button
   tabBar: 80,          // Bottom tab bar (includes 24px bottom padding)
+  // Count badge (filter count, unread count). Fully round via BORDER_RADIUS.pill
+  // rather than a hand-computed half-height.
+  badge: 18,
 };
 
 // ============ TYPOGRAPHY ============

--- a/app/styles/layout.js
+++ b/app/styles/layout.js
@@ -1,12 +1,29 @@
 /**
  * Shared layout constants for consistent spacing across screens
  *
- * DEPRECATED: These values are now defined in designTokens.js
- * This file re-exports them for backward compatibility
- *
- * New code should import directly from designTokens.js:
+ * DEPRECATED: These values are now defined in designTokens.js. Nothing under
+ * `app/` imports this module any more — import from designTokens.js directly:
  * import { SPACING, HORIZONTAL_PADDING, TOP_CONTENT_SPACING } from '../styles/designTokens';
+ *
+ * The re-export list below is a full mirror rather than the five names it used
+ * to carry. A partial mirror is a trap: `import { FONT_SIZE } from './layout'`
+ * is valid JS, passes lint, and silently yields `undefined` — which then reads
+ * as `undefined.sm` at StyleSheet build time, i.e. a crash at import, in a file
+ * that looks correct.
  */
 
 // Re-export from design tokens for backward compatibility
-export { HORIZONTAL_PADDING, TOP_CONTENT_SPACING, SPACING, BORDER_RADIUS, HEIGHTS } from './designTokens';
+export {
+  HORIZONTAL_PADDING,
+  TOP_CONTENT_SPACING,
+  SPACING,
+  BORDER_RADIUS,
+  HEIGHTS,
+  FONT_SIZE,
+  FONT_WEIGHT,
+  ICON_SIZE,
+  ELEVATION,
+  OPACITY,
+  DURATION,
+  Z_INDEX,
+} from './designTokens';

--- a/app/styles/modalStyles.js
+++ b/app/styles/modalStyles.js
@@ -1,6 +1,8 @@
 // app/styles/modalStyles.js
 import { StyleSheet } from 'react-native';
 import { SPACING, BORDER_RADIUS } from './designTokens';
+import { SECTION_LABEL } from './componentStyles';
+import { FONT_SIZE } from '../styles/designTokens';
 
 /**
  * Static styles shared across all modal form content.
@@ -9,9 +11,7 @@ import { SPACING, BORDER_RADIUS } from './designTokens';
 export const modalSharedStyles = StyleSheet.create({
   // Small-caps label rendered above each input or picker row
   fieldLabel: {
-    fontSize: 10,
-    fontWeight: '600',
-    letterSpacing: 0.8,
+    ...SECTION_LABEL,
     marginBottom: 2,
     marginTop: SPACING.sm,
   },
@@ -32,7 +32,7 @@ export const modalSharedStyles = StyleSheet.create({
   },
   // Selected value text inside a picker row
   pickerRowValue: {
-    fontSize: 16,
+    fontSize: FONT_SIZE.base,
     fontWeight: '500',
   },
   // Spacing below PaperTextInput

--- a/app/styles/semanticColors.js
+++ b/app/styles/semanticColors.js
@@ -1,0 +1,27 @@
+// app/styles/semanticColors.js
+/**
+ * Scheme-keyed semantic colours, as plain values.
+ *
+ * This is a leaf module — it imports nothing. ThemeColorsContext builds its
+ * palettes from it, and the few consumers that cannot read a React context
+ * import it directly:
+ *
+ *  - ErrorBoundary renders *because* the tree below it threw, so it must not
+ *    depend on a provider that lives in that tree.
+ *  - StyleSheets built at module scope, which run before any provider mounts.
+ *
+ * Everything else reads `colors.destructive` from ThemeColorsContext.
+ */
+
+/**
+ * The one red. Every "this went wrong" or "this destroys something" resolves
+ * here: validation text, delete affordances, error banners, Paper's `error`
+ * role. The dark value is lifted off the light one to hold contrast against a
+ * near-black surface — which is exactly the distinction the call sites that
+ * hardcoded `#ff6b6b` were losing, since they rendered the dark red on both
+ * schemes.
+ */
+export const DESTRUCTIVE = {
+  light: '#d9534f',
+  dark: '#ff6b6b',
+};


### PR DESCRIPTION
## Summary

Every UI element that repeats across screens had drifted into four or five slightly different versions — chips at five corner radii, cards at two radii and two border widths, eyebrow labels at four weight/tracking pairs, empty states at two font sizes, and nine different destructive reds. This collapses each of them onto a single definition in a new `app/styles/componentStyles.js`, and points the remaining scalar literals at `app/styles/designTokens.js`.

No behaviour changes — this is presentation only. The visible differences are the intended ones: elements that were *almost* the same are now exactly the same.

## Changes

- **app/styles/componentStyles.js** (new) — composite styles for the recurring elements: `CARD_SURFACE`, `CHIP`/`CHIP_TEXT`, `BADGE`/`BADGE_TEXT`, `BUTTON`/`BUTTON_COMPACT`/`BUTTON_TEXT`, `SECTION_LABEL`, `SECTION_HEADING`, `MODAL_TITLE`. Hosts spread these and add their own layout alongside.
- **app/styles/semanticColors.js** (new) — the destructive red per scheme, as a leaf module so `ErrorBoundary` can use it without depending on a provider inside the tree it exists to catch.
- **app/contexts/ThemeColorsContext.js** — adds `colors.destructive`, with `danger`/`delete`/`error` as aliases of it. `danger` was the bare CSS keyword `red` (#f00, which no other colour in either palette came near); `colors.error` was referenced by `modalStyles.js` but never defined.
- **Chips** — `FilterChipStrip`, `ExpandableFilters`, `LabelInput` (×2), `DescriptionSuggestionRow`, `CategoryBackChip`, `SettingsScreen` log filter: radii 8/12/14/16/20 → one `CHIP`. All six were already pill-shaped at their given heights; each had hand-computed a different half-height, so `BORDER_RADIUS.pill` renders them the same and removes the magic numbers.
- **Cards** — `OperationsHeatmapCard`, `CategorySpendingCard`, `BalanceHistoryCard`, `MonthlyPlanSection`, `GraphsScreen` (summary panel, FAB wheel), `AccountsScreen` (accounts + net-worth cards), `HeatmapMapModal`, and the four notification panels: a radius-16/1px family and a radius-8/hairline family → one `CARD_SURFACE`. 16 was not on the radius scale at all.
- **Destructive red** — `MaterialDialog`, `OperationActionMenu`, `Calculator`, `OperationFormFields`, `ErrorBoundary`, `BalanceHistoryCalendarView`, `SplitOperationModal`, `CategoryModal`, `OperationModal`, `CategoriesScreen`, `SettingsScreen` (which held two different reds on its own), `NotificationBindingsContentPanel`, `NotificationBindingCard`: nine hardcoded reds → `colors.destructive`. Four of them hardcoded `#ff6b6b`, the *dark*-theme red, so error text rendered in the dark red on the light theme. `Calculator` and `OperationFormFields` each held a module-level `FLASH_ERROR_COLOR` whose comment noted it mirrored the other's.
- **app/components/EmptyState.js** — gains `fill` (an inline empty state must not `flexGrow`) and `iconSet` (the notification panels draw from Ionicons) so every host can use it instead of forking it. Adopted by `OperationsList`, `CategorySpendingCard`, `ExpensePieChart`, `IncomePieChart`, `HeatmapMapModal`, `MonthlyPlanSection`, `BudgetPlanLineModal`, `SettingsScreen` (×3) and the three notification panels — eleven hand-rolled blocks removed.
- **Section labels / modal titles** — four eyebrow treatments → `SECTION_LABEL`, one heading → `SECTION_HEADING`, five modal-title treatments → `MODAL_TITLE`, across `modalStyles`, the notification panels, `ExpandableFilters`, `CategorySpendingCard`, `SettingsScreen`, both budget modals, `ModalShell`, `ModalHeader`, `UpdateAvailableModal`, `CurrencyPickerModal`, `IconPicker`, `SplitOperationModal`.
- **app/components/search/FilterBadge.js + SearchBar.js** — the two files held byte-identical badge styles. `SearchBar` now renders `FilterBadge`, which gained `testID`/`style` props (it renders two, and its tests address them separately).
- **Scalar literals** — `borderRadius` literals 87 → 19, `fontSize` literals 275 → 86, replaced by the token that already held that exact value. Separately, a radius that was half its element's own fixed height (16 sites: switch thumbs and tracks, dots, circular buttons, rails) is now `BORDER_RADIUS.pill`, which clamps to the same value and cannot drift when the height changes.
- **app/styles/layout.js** — every `app/` import repointed at `designTokens.js`. The shim re-exported only five of designTokens' names, so `import { FONT_SIZE } from './layout'` was valid JS, passed lint, and silently yielded `undefined` — surfacing as `undefined.sm` at StyleSheet build time. It is now a full mirror so the trap cannot recur.
- **CLAUDE.md** — documents the new `styles/` layout and adds a "Shared Element Styles" convention section alongside the existing Category/Account Selection rules.
- **__tests__/components/graphs/SpendingPredictionCard.test.js** — the card fell back to a hardcoded `#ff4444` when `colors.expense` was absent, a red that is not the expense colour in either palette. Both real palettes always define `expense`; the card now just reads it, and the test asserts it renders without inventing a colour rather than asserting the stray red.

**Not included:** ~73 text elements still sit at off-scale sizes (30 at 15px, 22 at 11px, 21 at 13px, 4 at 17px). Snapping those changes readable text size across the Budget, Graphs and notification screens, so it wants design intent and on-device review rather than a mechanical substitution — worth a follow-up.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 181 suites / 5194 tests pass (same as the pre-change baseline).
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

Not smoke-tested on a device. The diff is presentation-only, but it does touch every screen, so `/verify-pr` or `/screenshots` before merge would be worthwhile — particularly the light theme, where the four `#ff6b6b` error-text sites change colour, and the Graphs tab, where card radius moves 16 → 12.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no string changes)
- [x] Linked the related issue with `Closes #NNN` below — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_013rFGxwghF4sDd7728JTe4t)_