### PR TITLE
feat(graphs): city-level default zoom for the heatmap, no pinch-end jump

### DIFF
--- a/__tests__/components/OperationsHeatmapCard.test.js
+++ b/__tests__/components/OperationsHeatmapCard.test.js
@@ -10,6 +10,8 @@ import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import OperationsHeatmapCard from '../../app/components/graphs/OperationsHeatmapCard';
 import { getOperationCoordinates } from '../../app/services/OperationsDB';
 import { pruneTileCache } from '../../app/services/MapTileCache';
+import { ensureLocationPermission, getCurrentLocation } from '../../app/services/LocationService';
+import { useDisplaySettings } from '../../app/contexts/DisplaySettingsContext';
 
 jest.mock('../../app/services/OperationsDB', () => ({
   getOperationCoordinates: jest.fn(),
@@ -18,6 +20,17 @@ jest.mock('../../app/services/OperationsDB', () => ({
 jest.mock('../../app/services/MapTileCache', () => ({
   getTileUri: jest.fn().mockResolvedValue(null),
   pruneTileCache: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../app/services/LocationService', () => ({
+  ensureLocationPermission: jest.fn(),
+  getCurrentLocation: jest.fn(),
+}));
+
+// The modal reads the attach-location opt-in from DisplaySettingsContext
+// itself; mock the hook so each test controls the preference directly.
+jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
+  useDisplaySettings: jest.fn(),
 }));
 
 const press = async (element) => {
@@ -53,6 +66,10 @@ describe('OperationsHeatmapCard', () => {
     getOperationCoordinates.mockResolvedValue([
       { latitude: 40.1772, longitude: 44.5035 },
     ]);
+    // Location feature off by default; individual tests opt in.
+    useDisplaySettings.mockReturnValue({ attachLocation: false });
+    ensureLocationPermission.mockResolvedValue({ granted: true, canAskAgain: true });
+    getCurrentLocation.mockResolvedValue({ latitude: '40.1772', longitude: '44.5035' });
   });
 
   it('renders the collapsed row without touching the DB or the tile cache', async () => {
@@ -111,6 +128,33 @@ describe('OperationsHeatmapCard', () => {
     await waitFor(() => {
       expect(getByText('graphs_map_no_locations')).toBeTruthy();
     });
+  });
+
+  it('does not touch geolocation while the attach-location opt-in is off', async () => {
+    const { getByTestId } = await render(<OperationsHeatmapCard {...defaultProps} />);
+    await press(getByTestId('operations-heatmap-card'));
+    await waitFor(() => expect(getOperationCoordinates).toHaveBeenCalled());
+    expect(ensureLocationPermission).not.toHaveBeenCalled();
+    expect(getCurrentLocation).not.toHaveBeenCalled();
+  });
+
+  it('centers on the device location when the opt-in is on', async () => {
+    useDisplaySettings.mockReturnValue({ attachLocation: true });
+    const { getByTestId } = await render(<OperationsHeatmapCard {...defaultProps} />);
+    await press(getByTestId('operations-heatmap-card'));
+    await waitFor(() => {
+      expect(ensureLocationPermission).toHaveBeenCalledTimes(1);
+      expect(getCurrentLocation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not fetch a fix when the location permission is denied', async () => {
+    useDisplaySettings.mockReturnValue({ attachLocation: true });
+    ensureLocationPermission.mockResolvedValue({ granted: false, canAskAgain: false });
+    const { getByTestId } = await render(<OperationsHeatmapCard {...defaultProps} />);
+    await press(getByTestId('operations-heatmap-card'));
+    await waitFor(() => expect(ensureLocationPermission).toHaveBeenCalled());
+    expect(getCurrentLocation).not.toHaveBeenCalled();
   });
 
   it('closes the map and unmounts it entirely', async () => {

--- a/app/components/graphs/HeatmapMapModal.js
+++ b/app/components/graphs/HeatmapMapModal.js
@@ -15,6 +15,8 @@ import { Canvas, Circle, Group, BlurMask } from '@shopify/react-native-skia';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getOperationCoordinates } from '../../services/OperationsDB';
 import { getTileUri, pruneTileCache } from '../../services/MapTileCache';
+import { ensureLocationPermission, getCurrentLocation } from '../../services/LocationService';
+import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 import { formatDate } from '../../services/BalanceHistoryDB';
 import {
   visibleTiles,
@@ -29,6 +31,10 @@ import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 // Fallback view when there is nothing to fit — the whole world.
 const WORLD_REGION = { latitude: 20, longitude: 0, zoom: 2 };
+
+// Default camera when the device location is available: the user's current
+// city. Zoom 12 spans roughly a city and its districts on a phone screen.
+const CITY_ZOOM = 12;
 
 // Heat blob look. Density comes from overlap: each operation is one
 // semi-transparent blob, so clusters saturate toward opaque. The color is
@@ -97,6 +103,8 @@ const HeatmapMapModal = ({
   periodLabel,
 }) => {
   const insets = useSafeAreaInsets();
+  // No provider in isolated renders (tests) — undefined reads as feature off.
+  const { attachLocation } = useDisplaySettings() ?? {};
   const [allTime, setAllTime] = useState(false);
   const [points, setPoints] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -110,11 +118,41 @@ const HeatmapMapModal = ({
   sizeRef.current = size;
   // Set when a new point set arrives; consumed once the viewport is measured.
   const fitPendingRef = useRef(false);
+  // True once the user pans/zooms — from then on nothing may move the camera
+  // out from under them (a late GPS fix, a scope-toggle refit).
+  const interactedRef = useRef(false);
+  // True once the camera was parked on the device's city. Scope toggles then
+  // only swap the points underneath it instead of refitting.
+  const locationAppliedRef = useRef(false);
 
   // Housekeeping once per opening, off the critical path.
   useEffect(() => {
     if (visible) pruneTileCache();
   }, [visible]);
+
+  // Default camera: the user's current city (CITY_ZOOM around the device
+  // location). Gated on the attach-location opt-in — the map must not surface
+  // a permission prompt for users who kept geolocation off (their heatmap is
+  // empty anyway; for opted-in users the permission is already granted and
+  // this is silent). The fix can take seconds, so it lands as an override of
+  // the points-fit — unless the user has already started moving the map.
+  useEffect(() => {
+    if (!visible || !attachLocation) return;
+    let cancelled = false;
+    (async () => {
+      const { granted } = await ensureLocationPermission();
+      if (!granted || cancelled) return;
+      const fix = await getCurrentLocation();
+      if (cancelled || !fix) return;
+      const latitude = parseFloat(fix.latitude);
+      const longitude = parseFloat(fix.longitude);
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return;
+      if (interactedRef.current) return;
+      locationAppliedRef.current = true;
+      setRegion({ latitude, longitude, zoom: CITY_ZOOM });
+    })();
+    return () => { cancelled = true; };
+  }, [visible, attachLocation]);
 
   useEffect(() => {
     if (!visible) return;
@@ -151,9 +189,12 @@ const HeatmapMapModal = ({
 
   // Fit the loaded points once the viewport is measured (and again on every
   // scope switch). Runs as an effect because layout and data race each other.
+  // Skipped once the camera belongs to the device-city view or to the user's
+  // own gestures — a reload then only swaps the points underneath.
   useEffect(() => {
     if (!fitPendingRef.current || !size.width || !size.height || loading) return;
     fitPendingRef.current = false;
+    if (locationAppliedRef.current || interactedRef.current) return;
     setRegion(fitBounds(points, size.width, size.height) ?? WORLD_REGION);
   }, [points, size, loading]);
 
@@ -189,6 +230,7 @@ const HeatmapMapModal = ({
       .runOnJS(true)
       .maxPointers(1)
       .onStart(() => {
+        interactedRef.current = true;
         panLast.current = { x: 0, y: 0 };
       })
       .onUpdate((e) => {
@@ -201,6 +243,7 @@ const HeatmapMapModal = ({
     const pinch = Gesture.Pinch()
       .runOnJS(true)
       .onStart((e) => {
+        interactedRef.current = true;
         const { width, height } = sizeRef.current;
         pinchLast.current = {
           scale: 1,

--- a/app/components/graphs/HeatmapMapModal.js
+++ b/app/components/graphs/HeatmapMapModal.js
@@ -174,7 +174,15 @@ const HeatmapMapModal = ({
   // region (no touch-down snapshots), so gesture hand-offs — lifting to one
   // finger mid-pinch, adding a second finger mid-pan — never jump.
   const panLast = useRef({ x: 0, y: 0 });
-  const pinchLast = useRef({ scale: 1, fx: 0, fy: 0 });
+  const pinchLast = useRef({ scale: 1, fx: 0, fy: 0, pointers: 2 });
+
+  // A finger landing or lifting mid-gesture TELEPORTS the pinch centroid
+  // toward the remaining/added finger — that is not the user dragging, and
+  // treating it as a focal delta threw the map sideways at the end of every
+  // pinch (fingers never lift in the same frame). Any single-event focal move
+  // beyond this many px is such a teleport: re-anchor instead of translating.
+  // A real drag at 60 Hz stays far below it (48 px/frame ≈ 2900 px/s).
+  const FOCAL_TELEPORT_PX = 48;
 
   const composedGesture = useMemo(() => {
     const pan = Gesture.Pan()
@@ -198,6 +206,7 @@ const HeatmapMapModal = ({
           scale: 1,
           fx: e.focalX ?? width / 2,
           fy: e.focalY ?? height / 2,
+          pointers: e.numberOfPointers ?? 2,
         };
       })
       .onUpdate((e) => {
@@ -206,12 +215,24 @@ const HeatmapMapModal = ({
         const last = pinchLast.current;
         const fx = e.focalX ?? last.fx;
         const fy = e.focalY ?? last.fy;
+        const pointers = e.numberOfPointers ?? last.pointers;
+        // Centroid teleport (finger count changed, or the focal jumped
+        // farther than a finger can move in one frame): re-baseline both the
+        // focal point and the scale on the new configuration and apply
+        // nothing — the next event's deltas are trustworthy again.
+        const teleported = pointers !== last.pointers ||
+          Math.abs(fx - last.fx) > FOCAL_TELEPORT_PX ||
+          Math.abs(fy - last.fy) > FOCAL_TELEPORT_PX;
+        if (teleported) {
+          pinchLast.current = { scale: e.scale, fx, fy, pointers };
+          return;
+        }
         // Two-finger pan: how far the pinch centroid moved since last event.
         let next = translateRegion(regionRef.current, fx - last.fx, fy - last.fy);
         // Zoom by the scale delta, anchored on the current focal point.
         const factor = e.scale / (last.scale || 1);
         next = scaleRegion(next, factor, fx, fy, width, height);
-        pinchLast.current = { scale: e.scale, fx, fy };
+        pinchLast.current = { scale: e.scale, fx, fy, pointers };
         setRegion(next);
       });
     return Gesture.Simultaneous(pan, pinch);


### PR DESCRIPTION
## Summary

Two heatmap camera improvements. Opening the map now parks the camera on the device's current city (zoom 12) instead of fitting all points — the first view is the streets you actually spend on, not a continent-wide fit. And ending a pinch no longer throws the map sideways: fingers never leave the screen in the same frame, so the gesture's focal centroid teleports toward the finger still touching, and the handler was applying that teleport as a phantom two-finger drag.

## Changes

- **app/components/graphs/HeatmapMapModal.js**
  - Default camera: on open, resolve the device location (via the existing `LocationService`) and center at `CITY_ZOOM = 12`. Gated on the attach-location opt-in — users who kept geolocation off get no permission prompt (their heatmap is empty anyway) and keep the old fit-to-points behavior; falls back to fit-to-points on denied permission, timeout, or no fix.
  - The GPS fix is asynchronous, so it lands as a camera override — unless the user already started panning/zooming (`interactedRef`), in which case nothing may move the camera out from under them. The same guard now also suppresses scope-toggle refits after any interaction.
  - Pinch-end jump: detect the centroid teleport (the event's `numberOfPointers` changed, or the focal point moved farther in one event than a finger can in one frame — 48 px) and re-baseline the focal/scale reference instead of applying the phantom delta. Deliberate two-finger drags and zooms are unaffected.
- **__tests__/components/OperationsHeatmapCard.test.js** — new cases: no geolocation touch while the opt-in is off, permission + fix requested once when on, no fix fetch on denied permission.

## Testing

- `npm test` — 182 suites / 5244 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no string changes)
- [ ] Linked the related issue with `Closes #NNN` below — n/a (follow-up to #1518/#1520)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXk4LiCaVP4t1QJyKRZNtg