### PR TITLE
fix(graphs): no background flash when the heatmap crosses a zoom level

### DIFF
--- a/__tests__/services/MapTileCache.test.js
+++ b/__tests__/services/MapTileCache.test.js
@@ -18,6 +18,7 @@ jest.mock('expo-file-system/legacy', () => ({
 
 import {
   getTileUri,
+  getResolvedTileUri,
   pruneTileCache,
   tileUrl,
   tilePath,
@@ -136,6 +137,34 @@ describe('MapTileCache', () => {
       expect(a).toBe(tilePath(10, 13, 14));
       expect(b).toBe(tilePath(10, 13, 14));
       expect(FileSystem.downloadAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getResolvedTileUri (synchronous session cache)', () => {
+    it('returns null for a tile no getTileUri call has resolved yet', () => {
+      expect(getResolvedTileUri(15, 1, 1)).toBeNull();
+    });
+
+    it('remembers a fresh disk hit', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue(fileInfo(60_000));
+      await getTileUri(15, 2, 2);
+      expect(getResolvedTileUri(15, 2, 2)).toBe(tilePath(15, 2, 2));
+    });
+
+    it('remembers a downloaded tile', async () => {
+      await getTileUri(15, 3, 3);
+      expect(getResolvedTileUri(15, 3, 3)).toBe(tilePath(15, 3, 3));
+    });
+
+    it('remembers a stale fallback but not a total failure', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue(fileInfo(TILE_TTL_MS + 60_000));
+      FileSystem.downloadAsync.mockRejectedValue(new Error('offline'));
+      await getTileUri(15, 4, 4);
+      expect(getResolvedTileUri(15, 4, 4)).toBe(tilePath(15, 4, 4));
+
+      FileSystem.getInfoAsync.mockResolvedValue(MISSING);
+      await getTileUri(15, 5, 5);
+      expect(getResolvedTileUri(15, 5, 5)).toBeNull();
     });
   });
 

--- a/__tests__/utils/mapProjection.test.js
+++ b/__tests__/utils/mapProjection.test.js
@@ -229,5 +229,19 @@ describe('mapProjection', () => {
       const keys = new Set(tiles.map(tl => tl.key));
       expect(keys.size).toBe(tiles.length);
     });
+
+    it('honors a forced tile level and rescales accordingly', () => {
+      // Region at zoom 13 rendered from level 12 tiles (the underlay case):
+      // tiles come from z12 drawn at double size, covering the viewport.
+      const region = { latitude: 40, longitude: 44, zoom: 13 };
+      const tiles = visibleTiles(region, 400, 800, 12);
+      expect(tiles.length).toBeGreaterThan(0);
+      expect(tiles.every(tl => tl.z === 12)).toBe(true);
+      expect(tiles[0].size).toBeCloseTo(TILE_SIZE * 2);
+      const minX = Math.min(...tiles.map(tl => tl.screenX));
+      const maxX = Math.max(...tiles.map(tl => tl.screenX + tl.size));
+      expect(minX).toBeLessThanOrEqual(0);
+      expect(maxX).toBeGreaterThanOrEqual(400);
+    });
   });
 });

--- a/app/components/graphs/HeatmapMapModal.js
+++ b/app/components/graphs/HeatmapMapModal.js
@@ -14,7 +14,7 @@ import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-g
 import { Canvas, Circle, Group, BlurMask } from '@shopify/react-native-skia';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getOperationCoordinates } from '../../services/OperationsDB';
-import { getTileUri, pruneTileCache } from '../../services/MapTileCache';
+import { getTileUri, getResolvedTileUri, pruneTileCache } from '../../services/MapTileCache';
 import { ensureLocationPermission, getCurrentLocation } from '../../services/LocationService';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 import { formatDate } from '../../services/BalanceHistoryDB';
@@ -48,18 +48,21 @@ const MAX_HEAT_POINTS = 4000;
 const HEAT_MARGIN = HEAT_RADIUS + HEAT_BLUR;
 
 /**
- * One raster tile. Resolves its cached-or-downloaded file URI lazily; renders
- * nothing (theme background shows through) until the tile is available.
- * Memoized so panning only re-renders position styles, not the resolution.
+ * One raster tile. A tile some earlier render already resolved paints on its
+ * very first frame (synchronous session cache); anything else resolves
+ * lazily and renders nothing until then. Memoized so panning only re-renders
+ * position styles, not the resolution.
  */
 const MapTile = React.memo(function MapTile({ z, x, y, screenX, screenY, size }) {
-  const [uri, setUri] = useState(null);
+  const [uri, setUri] = useState(() => getResolvedTileUri(z, x, y));
   useEffect(() => {
+    if (uri) return undefined;
     let cancelled = false;
     getTileUri(z, x, y).then((resolved) => {
       if (!cancelled && resolved) setUri(resolved);
     }).catch(() => {});
     return () => { cancelled = true; };
+    // `uri` is deliberately not a dependency: once set it never changes.
   }, [z, x, y]);
 
   if (!uri) return null;
@@ -286,6 +289,28 @@ const HeatmapMapModal = ({
     [region, size],
   );
 
+  // Underlay: while zooming across an integer tile level, the level being
+  // LEFT keeps rendering (rescaled live) beneath the new one. Its tiles all
+  // sit in the synchronous session cache — they were just on screen — so the
+  // hand-off never flashes bare background while the new level streams in.
+  // Never rendered more than one level apart: a wider gap means the camera
+  // jumped (fit, city default), where a 4×-blown underlay would look broken.
+  const currentTileZoom = tiles.length > 0 ? tiles[0].z : null;
+  const tileZoomRef = useRef(null);
+  const underZoomRef = useRef(null);
+  if (currentTileZoom !== null && currentTileZoom !== tileZoomRef.current) {
+    underZoomRef.current = tileZoomRef.current;
+    tileZoomRef.current = currentTileZoom;
+  }
+  const underlayZoom =
+    underZoomRef.current !== null && Math.abs(currentTileZoom - underZoomRef.current) === 1
+      ? underZoomRef.current
+      : null;
+  const underlayTiles = useMemo(
+    () => (underlayZoom === null ? [] : visibleTiles(region, size.width, size.height, underlayZoom)),
+    [region, size, underlayZoom],
+  );
+
   const heatPoints = useMemo(() => {
     if (!size.width || !size.height) return [];
     const projected = [];
@@ -316,6 +341,17 @@ const HeatmapMapModal = ({
           <View style={styles.mapArea} onLayout={handleLayout}>
             <GestureDetector gesture={composedGesture}>
               <View style={styles.mapSurface} collapsable={false} testID="heatmap-map-surface">
+                {underlayTiles.map((tile) => (
+                  <MapTile
+                    key={tile.key}
+                    z={tile.z}
+                    x={tile.x}
+                    y={tile.y}
+                    screenX={tile.screenX}
+                    screenY={tile.screenY}
+                    size={tile.size}
+                  />
+                ))}
                 {tiles.map((tile) => (
                   <MapTile
                     key={tile.key}

--- a/app/services/MapTileCache.js
+++ b/app/services/MapTileCache.js
@@ -35,6 +35,25 @@ export const tilePath = (z, x, y) => `${TILE_CACHE_DIR}${z}_${x}_${y}.png`;
 // tile again before its first download resolves.
 const inFlight = new Map();
 
+// URIs that already resolved this session, readable SYNCHRONOUSLY. A tile
+// component initializing from here paints on its very first frame — without
+// this, crossing a zoom level remounts every tile empty for the async round
+// trip to disk and the map flashes bare background.
+const resolvedUris = new Map();
+
+const rememberResolved = (z, x, y, uri) => {
+  resolvedUris.set(`${z}/${x}/${y}`, uri);
+  return uri;
+};
+
+/**
+ * Synchronous lookup of a tile URI that some earlier getTileUri call already
+ * resolved. Returns null for tiles not yet seen this session — the caller
+ * then falls back to the async path.
+ */
+export const getResolvedTileUri = (z, x, y) =>
+  resolvedUris.get(`${z}/${x}/${y}`) ?? null;
+
 const downloadTile = async (z, x, y, path) => {
   await FileSystem.makeDirectoryAsync(TILE_CACHE_DIR, { intermediates: true });
   const tmpPath = `${path}.tmp`;
@@ -66,7 +85,7 @@ export const getTileUri = async (z, x, y) => {
     cached = await FileSystem.getInfoAsync(path);
     if (cached.exists) {
       const ageMs = Date.now() - cached.modificationTime * 1000;
-      if (ageMs < TILE_TTL_MS) return path;
+      if (ageMs < TILE_TTL_MS) return rememberResolved(z, x, y, path);
     }
   } catch {
     cached = null;
@@ -83,10 +102,10 @@ export const getTileUri = async (z, x, y) => {
   }
 
   try {
-    return await inFlight.get(path);
+    return rememberResolved(z, x, y, await inFlight.get(path));
   } catch {
     // Refresh failed — fall back to the expired copy when there is one.
-    return cached?.exists ? path : null;
+    return cached?.exists ? rememberResolved(z, x, y, path) : null;
   }
 };
 

--- a/app/utils/mapProjection.js
+++ b/app/utils/mapProjection.js
@@ -151,12 +151,17 @@ export const fitBounds = (points, width, height, padding = 48) => {
  * length. X wraps around the antimeridian (the fetch coordinate is `x`,
  * already wrapped); Y outside the world is skipped.
  *
+ * `tileZoomOverride` forces a specific integer tile level instead of the
+ * nearest one — the map renders the level it is LEAVING as an underlay while
+ * the new level's tiles stream in, so crossing levels never flashes bare
+ * background.
+ *
  * @returns {Array<{key: string, z: number, x: number, y: number,
  *                  screenX: number, screenY: number, size: number}>}
  */
-export const visibleTiles = (region, width, height) => {
+export const visibleTiles = (region, width, height, tileZoomOverride = null) => {
   if (!width || !height) return [];
-  const tileZoom = Math.round(clampZoom(region.zoom));
+  const tileZoom = tileZoomOverride ?? Math.round(clampZoom(region.zoom));
   const scale = Math.pow(2, region.zoom - tileZoom);
   const scaledTile = TILE_SIZE * scale;
   const tileCount = Math.pow(2, tileZoom);


### PR DESCRIPTION
## Summary

Zooming the operations heatmap flashed the bare theme background (black on the dark theme) for a split second. Crossing the midpoint between integer zoom levels swaps the entire tile set: every tile component remounted empty and resolved its file URI asynchronously, so for a few frames nothing was drawn.

## Changes

- **app/services/MapTileCache.js** — new synchronous in-memory map of tile URIs already resolved this session (`getResolvedTileUri`); every successful `getTileUri` path (fresh hit, download, stale fallback) registers into it.
- **app/components/graphs/HeatmapMapModal.js** — a remounting tile initializes from the synchronous cache and paints on its very first frame. While zooming across a level, the level being *left* keeps rendering (rescaled live) as an underlay beneath the new one — its tiles were just on screen, so the hand-off never shows bare background while the new level streams in. The underlay is capped at one level of separation, so a camera jump (fit, city default) doesn't draw a 4×-blown blur.
- **app/utils/mapProjection.js** — `visibleTiles` gains an optional `tileZoomOverride` to render a specific level for the underlay.
- **__tests__/** — new cases: forced tile level rescaling in the projection; the synchronous cache remembering fresh hits, downloads and stale fallbacks but not total failures.

## Testing

- `npm test` — 182 suites / 5249 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no string changes)
- [ ] Linked the related issue with `Closes #NNN` below — n/a (follow-up to #1531)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXk4LiCaVP4t1QJyKRZNtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXk4LiCaVP4t1QJyKRZNtg)_