### PR TITLE
perf(graphs): prefetch adjacent zoom levels on the heatmap

### DIFF
--- a/__tests__/services/MapTileCache.test.js
+++ b/__tests__/services/MapTileCache.test.js
@@ -19,6 +19,7 @@ jest.mock('expo-file-system/legacy', () => ({
 import {
   getTileUri,
   getResolvedTileUri,
+  prefetchTiles,
   pruneTileCache,
   tileUrl,
   tilePath,
@@ -165,6 +166,39 @@ describe('MapTileCache', () => {
       FileSystem.getInfoAsync.mockResolvedValue(MISSING);
       await getTileUri(15, 5, 5);
       expect(getResolvedTileUri(15, 5, 5)).toBeNull();
+    });
+  });
+
+  describe('prefetchTiles', () => {
+    it('warms every tile in the batch through getTileUri', async () => {
+      await prefetchTiles([
+        { z: 16, x: 1, y: 1 },
+        { z: 16, x: 2, y: 1 },
+        { z: 16, x: 3, y: 1 },
+      ]);
+      expect(FileSystem.downloadAsync).toHaveBeenCalledTimes(3);
+      // Prefetched tiles land in the synchronous session cache like any other.
+      expect(getResolvedTileUri(16, 2, 1)).toBe(tilePath(16, 2, 1));
+    });
+
+    it('skips the network entirely for tiles already fresh on disk', async () => {
+      FileSystem.getInfoAsync.mockResolvedValue(fileInfo(60_000));
+      await prefetchTiles([{ z: 16, x: 4, y: 4 }, { z: 16, x: 5, y: 5 }]);
+      expect(FileSystem.downloadAsync).not.toHaveBeenCalled();
+    });
+
+    it('swallows per-tile failures and still settles', async () => {
+      FileSystem.downloadAsync.mockRejectedValue(new Error('offline'));
+      await expect(prefetchTiles([
+        { z: 16, x: 6, y: 6 },
+        { z: 16, x: 7, y: 7 },
+      ])).resolves.toBeUndefined();
+    });
+
+    it('tolerates an empty or missing batch', async () => {
+      await expect(prefetchTiles([])).resolves.toBeUndefined();
+      await expect(prefetchTiles()).resolves.toBeUndefined();
+      expect(FileSystem.downloadAsync).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/graphs/HeatmapMapModal.js
+++ b/app/components/graphs/HeatmapMapModal.js
@@ -14,7 +14,7 @@ import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-g
 import { Canvas, Circle, Group, BlurMask } from '@shopify/react-native-skia';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getOperationCoordinates } from '../../services/OperationsDB';
-import { getTileUri, getResolvedTileUri, pruneTileCache } from '../../services/MapTileCache';
+import { getTileUri, getResolvedTileUri, prefetchTiles, pruneTileCache } from '../../services/MapTileCache';
 import { ensureLocationPermission, getCurrentLocation } from '../../services/LocationService';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
 import { formatDate } from '../../services/BalanceHistoryDB';
@@ -24,6 +24,8 @@ import {
   fitBounds,
   translateRegion,
   scaleRegion,
+  MIN_ZOOM,
+  MAX_ZOOM,
 } from '../../utils/mapProjection';
 import EmptyState from '../EmptyState';
 import { CARD_SURFACE } from '../../styles/componentStyles';
@@ -46,6 +48,12 @@ const HEAT_COLOR = 'rgba(233, 30, 99, 0.35)';
 const MAX_HEAT_POINTS = 4000;
 // Blobs just off-screen still bleed their blur into view, so keep a margin.
 const HEAT_MARGIN = HEAT_RADIUS + HEAT_BLUR;
+
+// Adjacent-zoom-level prefetch: fire only after the camera has been still
+// this long (every move resets the timer), and never more than this many
+// tiles per settle — one level in of a phone viewport is ~40–60 tiles.
+const PREFETCH_DEBOUNCE_MS = 400;
+const PREFETCH_MAX_TILES = 48;
 
 /**
  * One raster tile. A tile some earlier render already resolved paints on its
@@ -310,6 +318,31 @@ const HeatmapMapModal = ({
     () => (underlayZoom === null ? [] : visibleTiles(region, size.width, size.height, underlayZoom)),
     [region, size, underlayZoom],
   );
+
+  // Once the camera has been still for a beat, warm the ADJACENT zoom levels
+  // of the current viewport (one level in — the likely next pinch — first,
+  // then one level out). By the time the user crosses a level its tiles are
+  // already on disk and in the synchronous session cache, so the hand-off is
+  // seamless. Every camera move resets the debounce, so nothing is fetched
+  // mid-gesture; the cap and getTileUri's dedup/cache keep this well within
+  // polite use of the OSM tile server (a settled viewport re-fetches nothing).
+  useEffect(() => {
+    if (tiles.length === 0) return undefined;
+    const timer = setTimeout(() => {
+      const { width, height } = sizeRef.current;
+      const currentRegion = regionRef.current;
+      const z = tiles[0].z;
+      const targets = [];
+      if (z + 1 <= MAX_ZOOM) {
+        targets.push(...visibleTiles(currentRegion, width, height, z + 1));
+      }
+      if (z - 1 >= MIN_ZOOM) {
+        targets.push(...visibleTiles(currentRegion, width, height, z - 1));
+      }
+      prefetchTiles(targets.slice(0, PREFETCH_MAX_TILES));
+    }, PREFETCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [tiles]);
 
   const heatPoints = useMemo(() => {
     if (!size.width || !size.height) return [];

--- a/app/services/MapTileCache.js
+++ b/app/services/MapTileCache.js
@@ -109,6 +109,39 @@ export const getTileUri = async (z, x, y) => {
   }
 };
 
+// Prefetch runs at most this many downloads at once — a background warm-up
+// must not saturate the connection the visible tiles are loading on, nor
+// hammer the OSM server.
+const PREFETCH_CONCURRENCY = 4;
+
+/**
+ * Fire-and-forget warm-up of tiles the user is likely to need next (e.g. the
+ * adjacent zoom levels of the current viewport). Each tile goes through
+ * getTileUri, so the disk cache, TTL, in-flight dedup and the synchronous
+ * session map all apply — tiles already cached cost no network at all.
+ * Failures are swallowed per tile: a prefetch must never surface an error.
+ *
+ * @param {Array<{z: number, x: number, y: number}>} tiles
+ * @returns {Promise<void>} resolves when the whole batch settled
+ */
+export const prefetchTiles = async (tiles) => {
+  const queue = [...(tiles || [])];
+  if (queue.length === 0) return;
+  const worker = async () => {
+    while (queue.length > 0) {
+      const tile = queue.shift();
+      try {
+        await getTileUri(tile.z, tile.x, tile.y);
+      } catch {
+        // Ignore — getTileUri already degrades to null, this is belt-and-braces.
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(PREFETCH_CONCURRENCY, queue.length) }, worker),
+  );
+};
+
 /**
  * Delete tiles older than TILE_PRUNE_AGE_MS. Fire-and-forget housekeeping —
  * callers do not await the per-file deletes' outcome and errors are swallowed:


### PR DESCRIPTION
## Summary

Follow-up to #1534: instead of only masking the zoom-level hand-off with the underlay, warm the adjacent levels ahead of time. Once the camera has been still for 400 ms, the tiles of the current viewport one zoom level in (the likely next pinch — fetched first) and one level out are prefetched — by the time the user crosses a level, its tiles are already on disk and in the synchronous session cache, so the hand-off is seamless.

## Changes

- **app/services/MapTileCache.js** — new `prefetchTiles(tiles)`: fire-and-forget warm-up running at most 4 downloads at a time; every tile goes through `getTileUri`, so the disk cache, TTL, in-flight dedup and the synchronous session map all apply, and per-tile failures are swallowed.
- **app/components/graphs/HeatmapMapModal.js** — debounced effect (400 ms after the camera settles; every move resets the timer, so nothing is fetched mid-gesture) computes the adjacent levels' viewport tiles via `visibleTiles(..., zoomOverride)` and prefetches them, capped at 48 tiles per settle. A settled viewport whose neighbors are already cached re-fetches nothing — polite to the OSM tile server by construction.
- **__tests__/services/MapTileCache.test.js** — prefetch cases: warms every tile in the batch (and registers them in the session cache), skips the network for fresh disk hits, swallows per-tile failures, tolerates empty batches.

## Testing

- `npm test` — 182 suites / 5253 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no string changes)
- [ ] Linked the related issue with `Closes #NNN` below — n/a (follow-up to #1534)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXk4LiCaVP4t1QJyKRZNtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXk4LiCaVP4t1QJyKRZNtg)_