### PR TITLE
feat(budgets): lead rows with fill percentage and fold envelopes

### DIFF
--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -39,6 +39,15 @@ jest.mock('../../../app/contexts/BudgetPlansContext', () => ({
   useBudgetPlans: () => mockPlans,
 }));
 
+// Which envelopes are unfolded is UI state, kept in the app's preferences.
+const mockGetJsonPreference = jest.fn(async () => null);
+const mockSetJsonPreference = jest.fn(async () => {});
+jest.mock('../../../app/services/PreferencesDB', () => ({
+  PREF_KEYS: { BUDGET_EXPANDED_GROUPS: 'budget_expanded_groups' },
+  getJsonPreference: (...args) => mockGetJsonPreference(...args),
+  setJsonPreference: (...args) => mockSetJsonPreference(...args),
+}));
+
 // Stub the line editor modal: dedicated tests cover its internals. Here it just
 // exposes buttons to drive the section's save/income handlers.
 let capturedModalProps = null;
@@ -263,9 +272,25 @@ const moveLine = async (getByTestId, lineId, direction) => {
   });
 };
 
+// Envelopes are folded by default, so a test that wants to see a group's
+// children has to open it the way a user does.
+const expandGroup = async (getByTestId, groupId) => {
+  await act(async () => {
+    fireEvent.press(getByTestId(`plan-group-${groupId}`));
+  });
+};
+
+const longPressGroup = async (getByTestId, groupId) => {
+  await act(async () => {
+    fireEvent(getByTestId(`plan-group-${groupId}`), 'longPress');
+  });
+};
+
 describe('MonthlyPlanSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Nothing stored: every envelope starts folded.
+    mockGetJsonPreference.mockResolvedValue(null);
     capturedModalProps = null;
   });
 
@@ -383,42 +408,51 @@ describe('MonthlyPlanSection', () => {
       setPlanWithStatus();
       const { getByTestId, getByText, queryByText } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
-      // The row leads with what is LEFT — the figure a person acts on — and
-      // carries the actual/target pair below it as the context for that figure.
-      // Compact magnitudes on both: a row is scanned, not audited.
-      expect(getByTestId('plan-line-primary-l1')).toHaveTextContent('150');
+      // The row leads with HOW FULL the budget is — a normalized figure, so a
+      // column of them can be scanned down — and carries the actual/target pair
+      // below it as the exact context for that figure.
+      expect(getByTestId('plan-line-primary-l1')).toHaveTextContent('50%');
       expect(getByText('150 / 300')).toBeTruthy();
-      // The labelled forms are gone: "remaining" is the headline figure now, the
-      // "50%" badge is the bar's length, and "over budget by 50" restated a
-      // subtraction the pair already shows while making an overspent row two
-      // lines tall when every other row was one.
+      // The labelled forms are gone: the percentage is the headline figure now,
+      // and "over budget by 50" restated a subtraction the pair already shows
+      // while making an overspent row two lines tall when every other row was
+      // one.
       expect(queryByText('remaining_budget: 150.00')).toBeNull();
-      expect(queryByText('50%')).toBeNull();
       expect(queryByText('over_budget_by 50')).toBeNull();
       // The overspent row says so with the segment past the target mark.
       expect(getByTestId('plan-line-bar-l2')).toBeTruthy();
       expect(getByTestId('plan-line-bar-l2-over')).toBeTruthy();
     });
 
-    it('keeps the headline figure equal to the pair it sits under', async () => {
+    it('keeps the headline figure derived from the pair it sits under', async () => {
       // The status is computed from the plan's stored amount while the row's
       // target comes from the host's converted one. They normally agree, but a
       // rounding step apart on a converted line — or a status a beat behind a
-      // just-saved edit — used to put a headline on the row that did not equal
-      // target minus actual, which is arithmetic the reader can watch fail.
+      // just-saved edit — used to put a headline on the row that did not follow
+      // from the pair, which is arithmetic the reader can watch fail.
       setPlanWithStatus({
         ...STATUS,
         lines: [
-          { lineId: 'l1', broken: false, amount: '299.50', actual: '150.00', remaining: '149.50', percentage: 50, isExceeded: false, status: 'safe' },
+          { lineId: 'l1', broken: false, amount: '299.50', actual: '150.00', remaining: '149.50', percentage: 87, isExceeded: false, status: 'safe' },
           ...STATUS.lines.slice(1),
         ],
       });
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
-      // 300 − 150, from the two figures actually printed — not the status's own
-      // 149.50, which belongs to a target this row never shows.
-      expect(getByTestId('plan-line-primary-l1')).toHaveTextContent('150');
+      // 150 of 300, from the two figures actually printed — not the status's own
+      // percentage, which belongs to a target this row never shows.
+      expect(getByTestId('plan-line-primary-l1')).toHaveTextContent('50%');
       expect(getByTestId('plan-line-pair-l1')).toHaveTextContent('150 / 300');
+    });
+
+    it('states an overspent line as more than 100 per cent', async () => {
+      // 250 of 200. The headline keeps counting past the target rather than
+      // saturating — "over" and "three times over" are different news.
+      setPlanWithStatus();
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l2')).toBeTruthy());
+      expect(getByTestId('plan-line-primary-l2')).toHaveTextContent('125%');
+      expect(flatColor(getByTestId('plan-line-primary-l2'))).toBe(COLORS.overspend);
     });
 
     it('shows actual income against expected income in the header', async () => {
@@ -1205,9 +1239,9 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-bar-l-over')).toBeTruthy());
       expect(barOverColor(getByTestId, 'l-over')).toBe(COLORS.overspend);
-      // And the headline figure goes negative in the same colour — the row's
-      // "you have this much left" is now "you are this much past".
-      expect(getByTestId('plan-line-primary-l-over')).toHaveTextContent('-40');
+      // And the headline figure passes 100% in the same colour — the row's
+      // "this budget is this full" is now "this budget is past full".
+      expect(getByTestId('plan-line-primary-l-over')).toHaveTextContent('140%');
       expect(flatColor(getByTestId('plan-line-primary-l-over'))).toBe(COLORS.overspend);
     });
 
@@ -1482,6 +1516,7 @@ describe('MonthlyPlanSection', () => {
       });
       const { getByTestId, queryByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+      await expandGroup(getByTestId, 'g1');
 
       // Derived budget: 300 + 120, formatted compactly like every other figure.
       expect(getByTestId('plan-group-g1')).toHaveTextContent(/420/);
@@ -1537,7 +1572,9 @@ describe('MonthlyPlanSection', () => {
       expect(queryByTestId('plan-group-g1')).toBeNull();
     });
 
-    it('opens the group editor when the group row is tapped', async () => {
+    it('opens the group editor from the long-press sheet', async () => {
+      // Editing moved off the tap, which folds the envelope now — the sheet is
+      // where every other whole-row action already lived.
       setPlans({
         plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
         lines: groupedLines(),
@@ -1545,9 +1582,107 @@ describe('MonthlyPlanSection', () => {
       });
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
-      await act(async () => { fireEvent.press(getByTestId('plan-group-g1')); });
+      await longPressGroup(getByTestId, 'g1');
+      await act(async () => { lastDialogAction('edit_group').onPress(); });
       await waitFor(() => expect(getByTestId('plan-group-modal')).toBeTruthy());
       expect(getByTestId('plan-group-name').props.value).toBe('Car');
+    });
+
+    describe('Folding', () => {
+      const planWithGroup = () => setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [GROUP],
+      });
+
+      it('folds every envelope by default, keeping the header and its figures', async () => {
+        // The header carries the whole budget — its figure, its actual, its bar
+        // — so the rows under it are detail, and a plan of five envelopes was
+        // forty rows of scrolling for five numbers.
+        planWithGroup();
+        const { getByTestId, queryByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+        expect(queryByTestId('plan-line-l-fuel')).toBeNull();
+        expect(queryByTestId('plan-line-l-parking')).toBeNull();
+        expect(getByTestId('plan-group-g1')).toHaveTextContent(/420/);
+        // An ungrouped line belongs to no envelope, so nothing folds it away.
+        expect(getByTestId('plan-line-l-loose')).toBeTruthy();
+      });
+
+      it('unfolds and refolds an envelope on tap', async () => {
+        planWithGroup();
+        const { getByTestId, queryByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+
+        await expandGroup(getByTestId, 'g1');
+        expect(getByTestId('plan-line-l-fuel')).toBeTruthy();
+        expect(getByTestId('plan-line-l-parking')).toBeTruthy();
+
+        await expandGroup(getByTestId, 'g1');
+        expect(queryByTestId('plan-line-l-fuel')).toBeNull();
+      });
+
+      it('says which state it is in on the folder glyph and to a screen reader', async () => {
+        planWithGroup();
+        const { getByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+        expect(getByTestId('plan-group-folder-g1')).toHaveTextContent('folder');
+        expect(getByTestId('plan-group-g1').props.accessibilityState.expanded).toBe(false);
+        expect(getByTestId('plan-group-g1').props.accessibilityHint).toBe('expand_group');
+
+        await expandGroup(getByTestId, 'g1');
+        expect(getByTestId('plan-group-folder-g1')).toHaveTextContent('folder-open');
+        expect(getByTestId('plan-group-g1').props.accessibilityState.expanded).toBe(true);
+        expect(getByTestId('plan-group-g1').props.accessibilityHint).toBe('collapse_group');
+      });
+
+      it('remembers which envelopes were left open', async () => {
+        planWithGroup();
+        const { getByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+        await expandGroup(getByTestId, 'g1');
+        expect(mockSetJsonPreference).toHaveBeenLastCalledWith('budget_expanded_groups', ['g1']);
+
+        await expandGroup(getByTestId, 'g1');
+        expect(mockSetJsonPreference).toHaveBeenLastCalledWith('budget_expanded_groups', []);
+      });
+
+      it('restores a stored open envelope on load', async () => {
+        planWithGroup();
+        mockGetJsonPreference.mockResolvedValue(['g1']);
+        const { getByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-line-l-fuel')).toBeTruthy());
+        expect(getByTestId('plan-group-g1').props.accessibilityState.expanded).toBe(true);
+      });
+
+      it('writes nothing back before the stored state has been read', async () => {
+        // The initial (empty) set must never race the read and clobber it.
+        planWithGroup();
+        const { getByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+        expect(mockSetJsonPreference).not.toHaveBeenCalled();
+      });
+
+      it('does not undo a tap that landed while the stored state was loading', async () => {
+        planWithGroup();
+        let resolveStored;
+        mockGetJsonPreference.mockReturnValue(new Promise((resolve) => { resolveStored = resolve; }));
+        const { getByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+        await expandGroup(getByTestId, 'g1');
+        // The stored state says "everything folded" and arrives second — the
+        // tap is the newer statement of the two.
+        await act(async () => { resolveStored([]); });
+        expect(getByTestId('plan-line-l-fuel')).toBeTruthy();
+      });
+
+      it('keeps everything folded when the stored preference is unusable', async () => {
+        planWithGroup();
+        mockGetJsonPreference.mockResolvedValue('not-an-array');
+        const { getByTestId, queryByTestId } = await renderSection();
+        await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+        expect(queryByTestId('plan-line-l-fuel')).toBeNull();
+      });
     });
 
     it('carries the picked group through to the saved line', async () => {

--- a/__tests__/services/PreferencesDB.test.js
+++ b/__tests__/services/PreferencesDB.test.js
@@ -71,6 +71,7 @@ describe('PreferencesDB', () => {
         'ATTACH_LOCATION',
         'SHOW_ACCOUNTS_TAB',
         'SHOW_BUDGET_TAB',
+        'BUDGET_EXPANDED_GROUPS',
         'GOOGLE_SHEETS_SPREADSHEET_ID',
         'DEFAULT_ACCOUNT_ID',
         'BANK_NOTIFICATIONS_ENABLED',

--- a/__tests__/services/currency.test.js
+++ b/__tests__/services/currency.test.js
@@ -164,6 +164,52 @@ describe('Currency Service', () => {
     });
   });
 
+  describe('formatFillPercent', () => {
+    it('states how much of a target has been used', async () => {
+      expect(Currency.formatFillPercent('0', '300')).toBe('0%');
+      expect(Currency.formatFillPercent('150', '300')).toBe('50%');
+      expect(Currency.formatFillPercent('300', '300')).toBe('100%');
+    });
+
+    it('keeps counting past the target instead of saturating', async () => {
+      // A budget row's headline has to distinguish barely over from three times
+      // over — clamping at 100% is what the old background wash did.
+      expect(Currency.formatFillPercent('250', '200')).toBe('125%');
+      expect(Currency.formatFillPercent('696', '200')).toBe('348%');
+    });
+
+    it('rounds to whole percent', async () => {
+      expect(Currency.formatFillPercent('1', '3')).toBe('33%');
+      expect(Currency.formatFillPercent('2', '3')).toBe('67%');
+    });
+
+    it('never prints 100% for a figure that is not exactly at the target', async () => {
+      // Rounding alone would put "100%" on a row under its target and on a row
+      // over it, disagreeing with the colour that switches at exactly that
+      // point. Those land either side instead.
+      expect(Currency.formatFillPercent('99.6', '100')).toBe('99%');
+      expect(Currency.formatFillPercent('100.4', '100')).toBe('101%');
+      expect(Currency.formatFillPercent('100', '100')).toBe('100%');
+    });
+
+    it('has no percentage to state for a non-positive target', async () => {
+      expect(Currency.formatFillPercent('50', '0')).toBeNull();
+      expect(Currency.formatFillPercent('50', null)).toBeNull();
+      expect(Currency.formatFillPercent('50', '-100')).toBeNull();
+    });
+
+    it('keeps the sign of an actual below zero', async () => {
+      // Refunds can outweigh spending in a category, which is a real state and
+      // reads as a negative fill rather than as an empty budget.
+      expect(Currency.formatFillPercent('-30', '300')).toBe('-10%');
+    });
+
+    it('handles invalid actuals gracefully', async () => {
+      expect(Currency.formatFillPercent(null, '300')).toBe('0%');
+      expect(Currency.formatFillPercent('invalid', '300')).toBe('0%');
+    });
+  });
+
   describe('toCents', () => {
     it('converts string amounts to cents correctly', async () => {
       expect(Currency.toCents('10.50')).toBe(1050);

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -9,6 +9,7 @@ import { useLocalization } from '../../contexts/LocalizationContext';
 import { useDialog } from '../../contexts/DialogContext';
 import { useBudgetPlans } from '../../contexts/BudgetPlansContext';
 import * as Currency from '../../services/currency';
+import { PREF_KEYS, getJsonPreference, setJsonPreference } from '../../services/PreferencesDB';
 import usePlanLineAmounts from '../../hooks/usePlanLineAmounts';
 import { FONT_SIZE, SPACING } from '../../styles/designTokens';
 import { envelopeHue } from '../../styles/envelopePalette';
@@ -101,6 +102,16 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   // them from separate effects would let the list render a group's children under
   // a header that has not arrived yet.
   const [groups, setGroups] = useState([]);
+  // Which envelopes are OPEN. Everything not in here is folded, which is the
+  // default state of a plan on first load: an envelope's header carries the
+  // whole budget (its own figure, its actual and its bar), so the six rows under
+  // it are detail, and a plan of five envelopes was forty rows of scrolling for
+  // five numbers. Persisted, because folding a group is a statement about how
+  // the person reads their plan and it would be tedious to restate on every
+  // visit — it is UI state though, not plan data, so it goes to the app's
+  // preferences rather than into the plan's own tables (and never into a
+  // backup's budget rows).
+  const [expandedGroupIds, setExpandedGroupIds] = useState(() => new Set());
   const [modal, setModal] = useState(CLOSED_MODAL);
   const [groupModal, setGroupModal] = useState(CLOSED_GROUP_MODAL);
   const [busy, setBusy] = useState(false);
@@ -242,6 +253,41 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     })();
     return () => { cancelled = true; };
   }, [month, getLinesForMonth, getLineGroups]);
+
+  // Restore which envelopes were left open. Groups are global rather than
+  // month-scoped, so this is loaded once and survives month navigation — an
+  // envelope the user opened stays open as they page through the year, which is
+  // how they were reading it in the first place. A missing or unparseable
+  // preference simply leaves everything folded, the default.
+  //
+  // `foldStateSettled` marks the point where what is on screen becomes the
+  // authoritative fold state — either because the stored one has been read, or
+  // because the user folded something themselves. Before that nothing is
+  // written back, so the empty initial set can never overwrite a stored one by
+  // racing the read; after it, nothing is restored over.
+  const foldStateSettled = useRef(false);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const stored = await getJsonPreference(PREF_KEYS.BUDGET_EXPANDED_GROUPS, null);
+      // A tap that landed while the read was in flight is the newer of the two
+      // statements; restoring over it would undo what the user just did.
+      if (cancelled || foldStateSettled.current) return;
+      if (Array.isArray(stored)) setExpandedGroupIds(new Set(stored));
+      foldStateSettled.current = true;
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Fire-and-forget: the fold has already happened on screen by the time the
+  // write lands, and a preference that fails to save is not worth interrupting
+  // the user over — it costs one tap next time.
+  useEffect(() => {
+    if (!foldStateSettled.current) return;
+    setJsonPreference(PREF_KEYS.BUDGET_EXPANDED_GROUPS, [...expandedGroupIds]).catch((error) => {
+      console.warn('Failed to persist expanded budget groups:', error);
+    });
+  }, [expandedGroupIds]);
 
   // Income lines declare the expected income; the rest allocate it. Recurring
   // (global template) lines and this month's one-off lines are edited and
@@ -770,6 +816,24 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     }
   }, [groupViews, reorderLineGroups, reloadLines]);
 
+  // Tapping an envelope folds or unfolds it. Editing it is the long-press
+  // sheet's first item — the tap can only mean one thing, and on a row whose
+  // children are the thing being hidden, folding is the thing it should mean.
+  //
+  // The write is the effect below, not part of this updater: an updater that
+  // saves is an updater React may not call twice, and the fold has already
+  // happened on screen either way.
+  const toggleGroup = useCallback((group) => {
+    // The user has now said what they want folded, so the restore above must
+    // not land on top of it and this state is worth writing back.
+    foldStateSettled.current = true;
+    setExpandedGroupIds((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(group.id)) next.add(group.id);
+      return next;
+    });
+  }, []);
+
   const openEditGroup = useCallback((group) => setGroupModal({ visible: true, group }), []);
   const closeGroupModal = useCallback(() => setGroupModal(CLOSED_GROUP_MODAL), []);
 
@@ -988,6 +1052,9 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
           // colour. See envelopePalette for why colour identifies an envelope
           // here rather than flagging a status.
           const hue = envelopeHue(groupIndex);
+          // Folded is the default, so an envelope shows its children only once
+          // the user has said to — see `expandedGroupIds`.
+          const expanded = expandedGroupIds.has(view.group.id);
           return (
             <React.Fragment key={view.group.id}>
               <PlanGroupRow
@@ -1002,14 +1069,15 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
                 planCurrency={planCurrency}
                 colors={colors}
                 t={t}
+                collapsed={!expanded}
                 onMove={moveGroup}
-                onPress={openEditGroup}
+                onToggle={toggleGroup}
                 onLongPress={handleLongPressGroup}
               />
-              {view.recurring.map((line, index) => renderLine(
+              {expanded && view.recurring.map((line, index) => renderLine(
                 line, index, view.recurring, groupMovers.get(`${view.group.id}|r`), true, hue,
               ))}
-              {view.oneOff.map((line, index) => renderLine(
+              {expanded && view.oneOff.map((line, index) => renderLine(
                 line, index, view.oneOff, groupMovers.get(`${view.group.id}|o`), true, hue,
               ))}
             </React.Fragment>

--- a/app/components/budgets/PlanGroupRow.js
+++ b/app/components/budgets/PlanGroupRow.js
@@ -29,6 +29,13 @@ const FILL_ALPHA = '99'; // ~60%
  * because it IS a budget — the thing the person actually tracks when they say
  * "we spend 50k on the car". Its children sit beneath it, joined to it by the
  * rail that starts here and continues down their left edge.
+ *
+ * And because the header IS the budget, it is also what the person usually
+ * wants to read: a tap folds the children away, and the envelopes stay folded
+ * by default. A plan of five envelopes with six lines each is forty rows to
+ * scroll for five figures. Editing the envelope moved to the long-press sheet
+ * (where every other whole-row action already lives) so that the tap can mean
+ * one thing — the sheet's first item is still Edit group.
  */
 const PlanGroupRow = memo(function PlanGroupRow({
   group,
@@ -42,8 +49,9 @@ const PlanGroupRow = memo(function PlanGroupRow({
   colors,
   t,
   listLength,
+  collapsed = true,
   onMove = null,
-  onPress,
+  onToggle,
   onLongPress,
 }) {
   const isUnconvertible = status?.status === 'unconvertible';
@@ -54,11 +62,13 @@ const PlanGroupRow = memo(function PlanGroupRow({
   const ratio = tracked ? status.percentage / 100 : 0;
 
   const target = status?.amount ?? displayAmount;
-  // Leads with what is left, like a line does — an envelope is the level most
-  // people actually budget at, so it is the level where "can I still spend
-  // here?" gets asked most often. Subtracted from the pair's own two figures
-  // rather than read off `status.remaining`, for the reason PlanLineRow does the
-  // same: the three numbers on the row have to add up to each other.
+  // Leads with how full the envelope is, like a line does — and it has to be
+  // the same figure as a line's, because an envelope sits directly above its
+  // children: a header stating one kind of number over rows stating another is
+  // a column that cannot be read down. Both the percentage and the remaining
+  // that colours the row come from the pair's own two figures rather than from
+  // `status.percentage` / `status.remaining`, for the reason PlanLineRow does
+  // the same: the numbers on the row have to follow from each other.
   const showPair = tracked && target != null;
   let primaryText;
   let pairText = null;
@@ -67,7 +77,9 @@ const PlanGroupRow = memo(function PlanGroupRow({
     primaryText = CONVERTING_PLACEHOLDER;
   } else if (showPair) {
     remaining = Currency.subtract(target, status.actual, planCurrency);
-    primaryText = Currency.formatCompact(remaining);
+    // A zero budget has no percentage to state — see PlanLineRow.
+    primaryText = Currency.formatFillPercent(status.actual, target)
+      ?? Currency.formatCompact(remaining);
     pairText = `${Currency.formatCompact(status.actual)} / ${Currency.formatCompact(target)}`;
   } else {
     primaryText = Currency.formatCompact(target);
@@ -88,10 +100,15 @@ const PlanGroupRow = memo(function PlanGroupRow({
   return (
     <Pressable
       style={styles.groupRow}
-      onPress={() => onPress(group)}
+      onPress={() => onToggle(group)}
       onLongPress={() => onLongPress(group, index, listLength, onMove)}
       accessibilityRole="button"
-      accessibilityLabel={`${t('edit_group')}: ${group.label}, ${primaryText}${pairText ? `, ${pairText}` : ''}, ${childCount} ${t('allocations')}`}
+      // Names the envelope and its figures; what the tap DOES is the hint, and
+      // whether it is open is the state — a label that said "Edit group" was
+      // both wrong (the tap folds now) and the wrong place to say it.
+      accessibilityLabel={`${group.label}, ${primaryText}${pairText ? `, ${pairText}` : ''}, ${childCount} ${t('allocations')}`}
+      accessibilityHint={collapsed ? t('expand_group') : t('collapse_group')}
+      accessibilityState={{ expanded: !collapsed }}
       testID={`plan-group-${group.id}`}
     >
       {/* The head of the rail that runs down this envelope's children. At full
@@ -105,8 +122,20 @@ const PlanGroupRow = memo(function PlanGroupRow({
         <View style={styles.groupTop}>
           {/* The envelope's colour, on the one glyph that means "envelope". Two
               places carry it and no more — this and the rail — so the palette
-              identifies without becoming decoration. */}
-          <Icon name="folder" size={20} color={envelopeColor} />
+              identifies without becoming decoration.
+              It is also the disclosure state, open or shut. A separate chevron
+              would have to go somewhere, and both places it could go are
+              columns this screen aligns deliberately: to its left it pushes the
+              folder past the icon column its own children sit in (the indent
+              inverts), and to the right of the amount it pulls the header's
+              figure out of the column every row's figure shares. A folder that
+              is open when its contents are showing costs neither. */}
+          <Icon
+            name={collapsed ? 'folder' : 'folder-open'}
+            size={20}
+            color={envelopeColor}
+            testID={`plan-group-folder-${group.id}`}
+          />
           <View style={styles.groupBody}>
             <Text style={[styles.groupName, { color: colors.text }]} numberOfLines={1}>
               {group.label}
@@ -197,8 +226,9 @@ PlanGroupRow.propTypes = {
   planCurrency: PropTypes.string.isRequired,
   colors: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
+  collapsed: PropTypes.bool,
   onMove: PropTypes.func,
-  onPress: PropTypes.func.isRequired,
+  onToggle: PropTypes.func.isRequired,
   onLongPress: PropTypes.func.isRequired,
 };
 

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -99,26 +99,34 @@ const PlanLineRow = memo(function PlanLineRow({
   const showMeter = tracked && (!executed || status.isExceeded);
   const ratio = tracked ? status.percentage / 100 : 0;
 
-  // The row leads with what is LEFT, not with what was spent.
+  // The row leads with HOW FULL the budget is, as a percentage.
   //
-  // It used to print `actual / target` and nothing else, which made the reader
-  // do the subtraction on every row — and the subtraction is the whole question
-  // ("can I still spend here?"). The pair stays, one step down in the hierarchy,
-  // because it is the context for that figure: 0 left of 5K and 0 left of 100K
-  // are not the same situation.
+  // It used to lead with what was left, and before that with `actual / target`
+  // alone. The pair alone made the reader do arithmetic on every row; the
+  // remaining amount answered that arithmetic but only in isolation — 2K left
+  // is most of a 2.5K budget and a rounding error on a 200K one, so a column of
+  // remainders could not be scanned down, which is the one thing a column is
+  // for. A percentage is already normalized, so the rows compare to each other
+  // and to the bar beside them. The exact figures stay one step down in the
+  // hierarchy as the pair, and in full in the editor one tap away.
   //
-  // Compact magnitudes, not exact figures: a row is scanned, not audited, and
-  // the exact amounts are one tap away in the editor. No currency code either —
-  // the screen shows one currency, and the header states which. An unconvertible
-  // line is the exception on both counts: with no rate there is nothing to
-  // convert, so it keeps its stored figure in full and says what unit that is.
-  // Derived from the very figures the pair prints rather than read off
-  // `status.remaining`, so the three numbers on the row always agree. The status
-  // is computed from the plan's own stored amount while `displayAmount` is the
-  // host's converted one; they normally match, but when they do not (a rounding
-  // step apart on a converted line, a status a beat behind a just-saved edit) a
-  // headline that does not equal target minus actual is worse than either input
-  // — it is arithmetic the reader can see failing.
+  // Unbounded above on purpose: past the target it keeps counting (125%, 348%)
+  // rather than saturating, exactly like the bar's overspend segment.
+  //
+  // Both the percentage and the remaining that colours the row are derived from
+  // the very figures the pair prints, rather than read off `status.percentage` /
+  // `status.remaining`, so every number on the row agrees with every other. The
+  // status is computed from the plan's own stored amount while `displayAmount`
+  // is the host's converted one; they normally match, but when they do not (a
+  // rounding step apart on a converted line, a status a beat behind a just-saved
+  // edit) a headline that does not follow from the pair under it is arithmetic
+  // the reader can watch fail.
+  //
+  // A row with no actual to compare against — no status yet, or an unconvertible
+  // line — has no fill to state, so it falls back to printing its target. An
+  // unconvertible one keeps its stored figure in full and says what unit that
+  // is, because with no rate a labelled foreign number is honest and an
+  // unlabelled one is not.
   const showPair = showMeter && status.actual != null && displayAmount != null;
   let primaryText;
   let pairText = null;
@@ -129,7 +137,10 @@ const PlanLineRow = memo(function PlanLineRow({
     primaryText = CONVERTING_PLACEHOLDER;
   } else if (showPair) {
     remaining = Currency.subtract(displayAmount, status.actual, planCurrency);
-    primaryText = Currency.formatCompact(remaining);
+    // A zero target has no percentage (nothing to be a fraction of), so such a
+    // row says what is left instead of printing a meaningless 0%.
+    primaryText = Currency.formatFillPercent(status.actual, displayAmount)
+      ?? Currency.formatCompact(remaining);
     pairText = `${Currency.formatCompact(status.actual)} / ${Currency.formatCompact(displayAmount)}`;
   } else {
     primaryText = Currency.formatCompact(displayAmount);

--- a/app/services/PreferencesDB.js
+++ b/app/services/PreferencesDB.js
@@ -16,6 +16,10 @@ export const PREF_KEYS = {
   // Global toggle: show the Budget tab in the bottom navigation. Defaults on
   // (unlike Accounts) because budgets are reachable from nowhere else.
   SHOW_BUDGET_TAB: 'show_budget_tab',
+  // Which budget envelopes (line groups) are unfolded on the Budgets tab, as a
+  // JSON array of group ids. Absent means every envelope is folded, which is
+  // the default a plan opens in.
+  BUDGET_EXPANDED_GROUPS: 'budget_expanded_groups',
   GOOGLE_SHEETS_SPREADSHEET_ID: 'google_sheets_spreadsheet_id',
   DEFAULT_ACCOUNT_ID: 'default_account_id',
   // Bank-notification processing

--- a/app/services/currency.js
+++ b/app/services/currency.js
@@ -159,6 +159,41 @@ export const formatCompact = (amount) => {
   return `${sign}${magnitude.toFixed(0)}`;
 };
 
+/**
+ * How much of a target an actual figure covers, as a whole-number percentage:
+ * 150 of 300 → "50%", 250 of 200 → "125%".
+ *
+ * For the headline figure of a budget row, which answers "how full is this
+ * budget?" — so it is deliberately unbounded above: past the target it keeps
+ * counting (348%) rather than saturating at 100%, because "over" and "three
+ * times over" are not the same news.
+ *
+ * Whole percent, with one exception: a value that is near but not exactly at
+ * the target never prints "100%". 99.6% would round up to a figure that says
+ * the budget is exactly used, and 100.4% would round down to one that says it
+ * is not over — and the row's colour, which switches at the target, would then
+ * disagree with its own number. Those two land on 99% and 101% instead, so
+ * "100%" means precisely at target and "over 100" means over.
+ *
+ * @param {Decimal|string|number} actual - What has been spent.
+ * @param {Decimal|string|number} target - What was budgeted.
+ * @returns {string|null} Percentage string, or null when the target is not a
+ *   positive figure and there is therefore no fraction of it to state.
+ */
+export const formatFillPercent = (actual, target) => {
+  const targetDecimal = toDecimal(target);
+  if (!targetDecimal.isFinite() || targetDecimal.lessThanOrEqualTo(0)) {
+    return null;
+  }
+
+  const exact = toDecimal(actual).dividedBy(targetDecimal).times(100);
+  let rounded = exact.toDecimalPlaces(0, Decimal.ROUND_HALF_UP);
+  if (rounded.equals(100) && !exact.equals(100)) {
+    rounded = new Decimal(exact.lessThan(100) ? 99 : 101);
+  }
+  return `${rounded.toFixed(0)}%`;
+};
+
 // Maps a rounding-mode name to the decimal.js rounding constant applied when
 // dividing the amount by the step. Amounts are non-negative magnitudes here, so
 // ROUND_UP/ROUND_DOWN (away from / toward zero) behave as ceil/floor.

--- a/assets/i18n/de.json
+++ b/assets/i18n/de.json
@@ -601,6 +601,8 @@
   "group_name": "Gruppenname",
   "group_name_required": "Ein Gruppenname ist erforderlich",
   "edit_group": "Gruppe bearbeiten",
+  "expand_group": "Gruppe ausklappen",
+  "collapse_group": "Gruppe einklappen",
   "delete_group": "Gruppe löschen",
   "delete_group_confirm": "Diese Gruppe löschen? Ihre Posten bleiben erhalten und sind danach einfach ohne Gruppe.",
   "custom_group_budget": "Eigenes Budget",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -604,6 +604,8 @@
   "group_name": "Group name",
   "group_name_required": "A group name is required",
   "edit_group": "Edit group",
+  "expand_group": "Expand group",
+  "collapse_group": "Collapse group",
   "delete_group": "Delete group",
   "delete_group_confirm": "Delete this group? Its allocations are kept — they simply become ungrouped.",
   "custom_group_budget": "Custom budget",

--- a/assets/i18n/es.json
+++ b/assets/i18n/es.json
@@ -601,6 +601,8 @@
   "group_name": "Nombre del grupo",
   "group_name_required": "El nombre del grupo es obligatorio",
   "edit_group": "Editar grupo",
+  "expand_group": "Expandir grupo",
+  "collapse_group": "Contraer grupo",
   "delete_group": "Eliminar grupo",
   "delete_group_confirm": "¿Eliminar este grupo? Sus asignaciones se conservan y quedan sin grupo.",
   "custom_group_budget": "Presupuesto propio",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -601,6 +601,8 @@
   "group_name": "Nom du groupe",
   "group_name_required": "Le nom du groupe est obligatoire",
   "edit_group": "Modifier le groupe",
+  "expand_group": "Développer le groupe",
+  "collapse_group": "Réduire le groupe",
   "delete_group": "Supprimer le groupe",
   "delete_group_confirm": "Supprimer ce groupe ? Ses lignes sont conservées et se retrouvent simplement sans groupe.",
   "custom_group_budget": "Budget personnalisé",

--- a/assets/i18n/hy.json
+++ b/assets/i18n/hy.json
@@ -601,6 +601,8 @@
   "group_name": "Խմբի անվանումը",
   "group_name_required": "Խմբի անվանումը պարտադիր է",
   "edit_group": "Խմբագրել խումբը",
+  "expand_group": "Բացել խումբը",
+  "collapse_group": "Ծալել խումբը",
   "delete_group": "Ջնջել խումբը",
   "delete_group_confirm": "Ջնջե՞լ այս խումբը։ Դրա հոդվածները կմնան և պարզապես դուրս կգան խմբից։",
   "custom_group_budget": "Սեփական բյուջե",

--- a/assets/i18n/it.json
+++ b/assets/i18n/it.json
@@ -601,6 +601,8 @@
   "group_name": "Nome del gruppo",
   "group_name_required": "Il nome del gruppo è obbligatorio",
   "edit_group": "Modifica gruppo",
+  "expand_group": "Espandi gruppo",
+  "collapse_group": "Comprimi gruppo",
   "delete_group": "Elimina gruppo",
   "delete_group_confirm": "Eliminare questo gruppo? Le sue voci restano e tornano semplicemente senza gruppo.",
   "custom_group_budget": "Budget personalizzato",

--- a/assets/i18n/ja.json
+++ b/assets/i18n/ja.json
@@ -601,6 +601,8 @@
   "group_name": "グループ名",
   "group_name_required": "グループ名を入力してください",
   "edit_group": "グループを編集",
+  "expand_group": "グループを展開",
+  "collapse_group": "グループを折りたたむ",
   "delete_group": "グループを削除",
   "delete_group_confirm": "このグループを削除しますか？中の項目は残り、グループなしになります。",
   "custom_group_budget": "予算を手動で設定",

--- a/assets/i18n/ko.json
+++ b/assets/i18n/ko.json
@@ -601,6 +601,8 @@
   "group_name": "그룹 이름",
   "group_name_required": "그룹 이름을 입력하세요",
   "edit_group": "그룹 편집",
+  "expand_group": "그룹 펼치기",
+  "collapse_group": "그룹 접기",
   "delete_group": "그룹 삭제",
   "delete_group_confirm": "이 그룹을 삭제할까요? 안의 항목은 유지되며 그룹만 해제됩니다.",
   "custom_group_budget": "예산 직접 설정",

--- a/assets/i18n/pt.json
+++ b/assets/i18n/pt.json
@@ -601,6 +601,8 @@
   "group_name": "Nome do grupo",
   "group_name_required": "O nome do grupo é obrigatório",
   "edit_group": "Editar grupo",
+  "expand_group": "Expandir grupo",
+  "collapse_group": "Recolher grupo",
   "delete_group": "Excluir grupo",
   "delete_group_confirm": "Excluir este grupo? As alocações são mantidas e apenas ficam sem grupo.",
   "custom_group_budget": "Orçamento personalizado",

--- a/assets/i18n/ru.json
+++ b/assets/i18n/ru.json
@@ -604,6 +604,8 @@
   "group_name": "Название группы",
   "group_name_required": "Укажите название группы",
   "edit_group": "Изменить группу",
+  "expand_group": "Раскрыть группу",
+  "collapse_group": "Свернуть группу",
   "delete_group": "Удалить группу",
   "delete_group_confirm": "Удалить эту группу? Её статьи останутся и просто выйдут из группы.",
   "custom_group_budget": "Свой бюджет группы",

--- a/assets/i18n/zh.json
+++ b/assets/i18n/zh.json
@@ -601,6 +601,8 @@
   "group_name": "分组名称",
   "group_name_required": "请填写分组名称",
   "edit_group": "编辑分组",
+  "expand_group": "展开分组",
+  "collapse_group": "收起分组",
   "delete_group": "删除分组",
   "delete_group_confirm": "删除该分组？其中的预算条目会保留，只是不再属于任何分组。",
   "custom_group_budget": "自定义预算",


### PR DESCRIPTION
## Summary

A budget row's headline figure is now **how full the budget is** (50%, 125%, 348%) instead of how much is left — a remaining amount only means something next to its own target, so a column of them could not be scanned down. Past the target the percentage keeps counting rather than saturating, matching the bar's overspend segment. Separately, **envelope (group) rows now fold**: they start folded, a tap opens or closes one, and the open set is remembered; editing an envelope moved to the long-press sheet so the tap means one thing.

## Changes

- **app/services/currency.js** — new `formatFillPercent(actual, target)`: whole-percent fill, unbounded above, `null` for a non-positive target. Never rounds to exactly `100%` for a figure that is not at the target (99.6% → `99%`, 100.4% → `101%`), which would otherwise contradict the colour that switches there.
- **app/components/budgets/PlanLineRow.js** — headline is the fill percentage, derived from the same two figures the `actual / target` pair under it prints (not from `status.percentage`), so every number on the row follows from the others. Falls back to the remaining amount when the target is zero; unconvertible / status-less rows are unchanged.
- **app/components/budgets/PlanGroupRow.js** — same headline figure, since an envelope header sits directly above its children. Takes `collapsed` + `onToggle` in place of `onPress`; the folder glyph is the disclosure state (`folder` / `folder-open`), and the row reports `accessibilityState.expanded` with an expand/collapse hint. A separate chevron could only go where it would break either the icon column or the amount column.
- **app/components/budgets/MonthlyPlanSection.js** — owns `expandedGroupIds` (empty = all folded, the default), renders a group's children only when open, restores the set from preferences on mount and writes it back on change. Nothing is written before the read completes, and a tap that lands mid-read wins over the stored value.
- **app/services/PreferencesDB.js** — new `BUDGET_EXPANDED_GROUPS` key (JSON array of group ids).
- **assets/i18n/\*.json** — add `expand_group` / `collapse_group` for all 11 languages.
- **__tests__/** — percentage assertions for line rows (including >100% overspend), a `formatFillPercent` suite, and folding coverage: default folded, tap to open/close, glyph + a11y state, persistence, restore, the mid-read race, and an unusable stored value.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/ --silent` — 182 suites / 5260 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.
- Not run on a device.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files
- [ ] Linked the related issue with `Closes #NNN` below — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiqKFkY7kKxFQ7bo7emCd3)_