### PR TITLE
fix(graphs): keep tile instances alive across heatmap zoom-level hand-off

### DIFF
--- a/app/components/graphs/HeatmapMapModal.js
+++ b/app/components/graphs/HeatmapMapModal.js
@@ -319,6 +319,19 @@ const HeatmapMapModal = ({
     [region, size, underlayZoom],
   );
 
+  // ONE flat keyed list, underlay first so the current level draws on top.
+  // Rendering the two layers as separate arrays remounted every tile on a
+  // level crossing: React reconciles keys only within one array, so a tile
+  // moving from the current level into the underlay lost its component — and
+  // with it the native Image's already-decoded bitmap. The re-decode left
+  // both layers transparent for a frame or two: the residual black flash.
+  // In a single list the key survives the role change, the instance (and its
+  // decoded bitmap) persists, and only its position/size props update.
+  const renderTiles = useMemo(
+    () => [...underlayTiles, ...tiles],
+    [underlayTiles, tiles],
+  );
+
   // Once the camera has been still for a beat, warm the ADJACENT zoom levels
   // of the current viewport (one level in — the likely next pinch — first,
   // then one level out). By the time the user crosses a level its tiles are
@@ -374,18 +387,7 @@ const HeatmapMapModal = ({
           <View style={styles.mapArea} onLayout={handleLayout}>
             <GestureDetector gesture={composedGesture}>
               <View style={styles.mapSurface} collapsable={false} testID="heatmap-map-surface">
-                {underlayTiles.map((tile) => (
-                  <MapTile
-                    key={tile.key}
-                    z={tile.z}
-                    x={tile.x}
-                    y={tile.y}
-                    screenX={tile.screenX}
-                    screenY={tile.screenY}
-                    size={tile.size}
-                  />
-                ))}
-                {tiles.map((tile) => (
+                {renderTiles.map((tile) => (
                   <MapTile
                     key={tile.key}
                     z={tile.z}


### PR DESCRIPTION
## Summary

Brief black flashes still showed during heatmap zoom after #1534. Root cause: the underlay was rendered as a *second array* of tiles, and React reconciles keys only within one array — so on a zoom-level crossing, the tiles moving from the current level into the underlay lost their components, and with them the native Image's already-decoded bitmap. The re-decode left both layers transparent for a frame or two.

## Changes

- **app/components/graphs/HeatmapMapModal.js** — render both tile layers as one flat keyed list (underlay first, so the current level draws on top). A tile's key now survives the role change (current level → underlay), the component instance and its decoded bitmap persist, and only position/size props update — the level that was just on screen stays continuously painted while the new level streams in over it.

## Testing

- `npm test` — 189 suites / 5412 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no string changes)
- [ ] Linked the related issue with `Closes #NNN` below — n/a (follow-up to #1534/#1536)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXk4LiCaVP4t1QJyKRZNtg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXk4LiCaVP4t1QJyKRZNtg)_