### PR TITLE
feat(graphs): remember the balance chart's comparison line

### DIFF
--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { act, render, fireEvent, waitFor } from '@testing-library/react-native';
 import BalanceHistoryCard, {
   computeBalanceChart,
   computeYearBalanceChart,
@@ -20,6 +20,22 @@ jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
     hideBalances: false,
   })),
 }));
+
+// Mock PreferencesDB — the card remembers its comparison-line mode there.
+jest.mock('../../app/services/PreferencesDB', () => ({
+  PREF_KEYS: { BALANCE_CHART_COMPARISON: 'balance_chart_comparison' },
+  getPreference: jest.fn(() => Promise.resolve(null)),
+  setPreference: jest.fn(() => Promise.resolve()),
+}));
+
+const { getPreference, setPreference, PREF_KEYS } = require('../../app/services/PreferencesDB');
+
+beforeEach(() => {
+  getPreference.mockReset();
+  getPreference.mockResolvedValue(null);
+  setPreference.mockReset();
+  setPreference.mockResolvedValue(undefined);
+});
 
 // victory-native (CartesianChart → testID "cartesian-chart", Line → testID
 // "vn-line") and @shopify/react-native-skia are virtually mocked in jest.setup.js.
@@ -2321,6 +2337,69 @@ describe('BalanceHistoryCard', () => {
       await fireEvent.press(getByTestId('calendar-toggle-btn'));
 
       await waitFor(() => expect(queryByTestId('third-line-toggle-btn')).toBeNull());
+    });
+
+    describe('persistence across restarts', () => {
+      it('persists the picked mode so the next launch can restore it', async () => {
+        const { getByTestId } = await renderCard();
+
+        await fireEvent.press(getByTestId('third-line-toggle-btn'));
+
+        await waitFor(() => expect(setPreference).toHaveBeenCalledWith(
+          PREF_KEYS.BALANCE_CHART_COMPARISON,
+          'yearAvg',
+        ));
+      });
+
+      it('restores the stored mode instead of the prev-month default', async () => {
+        getPreference.mockResolvedValue('yearAvg');
+
+        const { getByText, queryByText } = await renderCard();
+
+        await waitFor(() => expect(getByText('Year avg')).toBeTruthy());
+        expect(queryByText('Prev Month')).toBeNull();
+      });
+
+      it('restores "none", leaving the chart without a comparison line', async () => {
+        getPreference.mockResolvedValue('none');
+
+        const { container, queryByText } = await renderCard();
+
+        await waitFor(() => expect(queryByText('Prev Month')).toBeNull());
+        expect(queryByText('Year avg')).toBeNull();
+        // actual + zero baseline only
+        expect(container.queryAll(n => n.props.testID === 'vn-line')).toHaveLength(2);
+      });
+
+      it('falls back to the default when the stored mode is unknown', async () => {
+        getPreference.mockResolvedValue('someRetiredMode');
+
+        const { getByText } = await renderCard();
+
+        await waitFor(() => expect(getByText('Prev Month')).toBeTruthy());
+      });
+
+      it('survives a failed read without breaking the toggle', async () => {
+        getPreference.mockRejectedValue(new Error('db closed'));
+
+        const { getByTestId, getByText } = await renderCard();
+
+        expect(getByText('Prev Month')).toBeTruthy();
+        await fireEvent.press(getByTestId('third-line-toggle-btn'));
+        await waitFor(() => expect(getByText('Year avg')).toBeTruthy());
+      });
+
+      it('keeps a tap that lands before the stored mode arrives', async () => {
+        let resolveRead;
+        getPreference.mockReturnValue(new Promise((resolve) => { resolveRead = resolve; }));
+
+        const { getByTestId, getByText } = await renderCard();
+
+        await fireEvent.press(getByTestId('third-line-toggle-btn'));
+        await act(async () => { resolveRead('none'); });
+
+        expect(getByText('Year avg')).toBeTruthy();
+      });
     });
 
     it('builds a yearAvg series and legend values in yearAvg mode', () => {

--- a/__tests__/components/BalanceHistoryCard.test.js
+++ b/__tests__/components/BalanceHistoryCard.test.js
@@ -21,20 +21,20 @@ jest.mock('../../app/contexts/DisplaySettingsContext', () => ({
   })),
 }));
 
-// Mock PreferencesDB — the card remembers its comparison-line mode there.
+// Mock PreferencesDB — the card remembers its comparison-line modes there.
 jest.mock('../../app/services/PreferencesDB', () => ({
   PREF_KEYS: { BALANCE_CHART_COMPARISON: 'balance_chart_comparison' },
-  getPreference: jest.fn(() => Promise.resolve(null)),
-  setPreference: jest.fn(() => Promise.resolve()),
+  getJsonPreference: jest.fn(() => Promise.resolve(null)),
+  setJsonPreference: jest.fn(() => Promise.resolve()),
 }));
 
-const { getPreference, setPreference, PREF_KEYS } = require('../../app/services/PreferencesDB');
+const { getJsonPreference, setJsonPreference, PREF_KEYS } = require('../../app/services/PreferencesDB');
 
 beforeEach(() => {
-  getPreference.mockReset();
-  getPreference.mockResolvedValue(null);
-  setPreference.mockReset();
-  setPreference.mockResolvedValue(undefined);
+  getJsonPreference.mockReset();
+  getJsonPreference.mockResolvedValue(null);
+  setJsonPreference.mockReset();
+  setJsonPreference.mockResolvedValue(undefined);
 });
 
 // victory-native (CartesianChart → testID "cartesian-chart", Line → testID
@@ -2345,14 +2345,14 @@ describe('BalanceHistoryCard', () => {
 
         await fireEvent.press(getByTestId('third-line-toggle-btn'));
 
-        await waitFor(() => expect(setPreference).toHaveBeenCalledWith(
+        await waitFor(() => expect(setJsonPreference).toHaveBeenCalledWith(
           PREF_KEYS.BALANCE_CHART_COMPARISON,
-          'yearAvg',
+          { month: 'yearAvg', year: 'prevYear' },
         ));
       });
 
       it('restores the stored mode instead of the prev-month default', async () => {
-        getPreference.mockResolvedValue('yearAvg');
+        getJsonPreference.mockResolvedValue({ month: 'yearAvg' });
 
         const { getByText, queryByText } = await renderCard();
 
@@ -2361,7 +2361,7 @@ describe('BalanceHistoryCard', () => {
       });
 
       it('restores "none", leaving the chart without a comparison line', async () => {
-        getPreference.mockResolvedValue('none');
+        getJsonPreference.mockResolvedValue({ month: 'none' });
 
         const { container, queryByText } = await renderCard();
 
@@ -2372,7 +2372,15 @@ describe('BalanceHistoryCard', () => {
       });
 
       it('falls back to the default when the stored mode is unknown', async () => {
-        getPreference.mockResolvedValue('someRetiredMode');
+        getJsonPreference.mockResolvedValue({ month: 'someRetiredMode' });
+
+        const { getByText } = await renderCard();
+
+        await waitFor(() => expect(getByText('Prev Month')).toBeTruthy());
+      });
+
+      it('ignores a stored value that is not the expected shape', async () => {
+        getJsonPreference.mockResolvedValue('yearAvg');
 
         const { getByText } = await renderCard();
 
@@ -2380,7 +2388,7 @@ describe('BalanceHistoryCard', () => {
       });
 
       it('survives a failed read without breaking the toggle', async () => {
-        getPreference.mockRejectedValue(new Error('db closed'));
+        getJsonPreference.mockRejectedValue(new Error('db closed'));
 
         const { getByTestId, getByText } = await renderCard();
 
@@ -2391,14 +2399,58 @@ describe('BalanceHistoryCard', () => {
 
       it('keeps a tap that lands before the stored mode arrives', async () => {
         let resolveRead;
-        getPreference.mockReturnValue(new Promise((resolve) => { resolveRead = resolve; }));
+        getJsonPreference.mockReturnValue(new Promise((resolve) => { resolveRead = resolve; }));
 
         const { getByTestId, getByText } = await renderCard();
 
         await fireEvent.press(getByTestId('third-line-toggle-btn'));
-        await act(async () => { resolveRead('none'); });
+        await act(async () => { resolveRead({ month: 'none' }); });
 
         expect(getByText('Year avg')).toBeTruthy();
+      });
+
+      it('does not let a year-view tap overwrite the month view\'s remembered mode', async () => {
+        getJsonPreference.mockResolvedValue({ month: 'yearAvg', year: 'prevYear' });
+
+        const { getByTestId, getByText, rerender } = await renderCard();
+        await waitFor(() => expect(getByText('Year avg')).toBeTruthy());
+
+        // Switch to the year view and turn its comparison off.
+        const yearProps = {
+          colors: mockColors,
+          t: mockT,
+          selectedAccount: 'acc1',
+          onAccountChange: jest.fn(),
+          accountItems: mockAccountItems,
+          loadingBalanceHistory: false,
+          balanceHistoryData: { ...thirdLineData, prevYear: [900, 890, 880, 870, 860, 850, 840] },
+          selectedYear: 2024,
+          selectedMonth: null,
+          accounts: mockAccounts,
+          isCurrentMonth: false,
+          spendingPrediction: null,
+          balanceHistoryTableData: [],
+          editingBalanceValue: '',
+          onEditingBalanceValueChange: jest.fn(),
+          onEditBalance: jest.fn(),
+          onCancelEdit: jest.fn(),
+          onSaveBalance: jest.fn(),
+          onDeleteBalance: jest.fn(),
+          onShowCalendar: jest.fn(),
+        };
+        await rerender(<BalanceHistoryCard {...yearProps} />);
+        await waitFor(() => expect(getByText('Prev Year')).toBeTruthy());
+        await fireEvent.press(getByTestId('third-line-toggle-btn'));
+
+        // The month slot is untouched, both on disk...
+        await waitFor(() => expect(setJsonPreference).toHaveBeenCalledWith(
+          PREF_KEYS.BALANCE_CHART_COMPARISON,
+          { month: 'yearAvg', year: 'none' },
+        ));
+
+        // ...and on screen when the reader comes back to the month view.
+        await rerender(<BalanceHistoryCard {...yearProps} selectedMonth={0} balanceHistoryData={thirdLineData} />);
+        await waitFor(() => expect(getByText('Year avg')).toBeTruthy());
       });
     });
 

--- a/__tests__/services/PreferencesDB.test.js
+++ b/__tests__/services/PreferencesDB.test.js
@@ -72,6 +72,7 @@ describe('PreferencesDB', () => {
         'SHOW_ACCOUNTS_TAB',
         'SHOW_BUDGET_TAB',
         'BUDGET_EXPANDED_GROUPS',
+        'BALANCE_CHART_COMPARISON',
         'GOOGLE_SHEETS_SPREADSHEET_ID',
         'DEFAULT_ACCOUNT_ID',
         'BANK_NOTIFICATIONS_ENABLED',

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -22,7 +22,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import SimplePicker from '../SimplePicker';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
-import { getPreference, setPreference, PREF_KEYS } from '../../services/PreferencesDB';
+import { getJsonPreference, setJsonPreference, PREF_KEYS } from '../../services/PreferencesDB';
 import { balanceLineColors } from '../../styles/chartPalette';
 import BalanceHistoryCalendarView from './BalanceHistoryCalendarView';
 import { MONTH_ABBREVIATIONS } from './monthLabels';
@@ -160,13 +160,25 @@ export const YEAR_THIRD_LINE_MODES = ['prevYear', 'none'];
 export const thirdLineModesFor = (granularity) =>
   (granularity === 'year' ? YEAR_THIRD_LINE_MODES : THIRD_LINE_MODES);
 
-// The mode the card opens in when nothing has been remembered yet.
-export const DEFAULT_THIRD_LINE_MODE = 'prevMonth';
+// The mode each view opens in when nothing has been remembered for it yet.
+export const defaultThirdLineMode = (granularity) => thirdLineModesFor(granularity)[0];
 
-// A stored mode is only honoured if it is still one this build knows about — a
-// value left behind by an older release must not blank the comparison line.
-export const isThirdLineMode = (mode) =>
-  THIRD_LINE_MODES.includes(mode) || YEAR_THIRD_LINE_MODES.includes(mode);
+// The two views remember their comparison lines separately: they do not offer
+// the same modes, and the one mode they share ('none') would otherwise let a
+// single tap in the year view permanently blank the month view's line.
+export const THIRD_LINE_GRANULARITIES = ['month', 'year'];
+
+// A stored mode is only honoured if the view it was stored for still offers it —
+// a value left behind by an older release must not blank the comparison line.
+export const parseStoredThirdLines = (stored) => {
+  const parsed = {};
+  if (!stored || typeof stored !== 'object') return parsed;
+  THIRD_LINE_GRANULARITIES.forEach((granularity) => {
+    const mode = stored[granularity];
+    if (thirdLineModesFor(granularity).includes(mode)) parsed[granularity] = mode;
+  });
+  return parsed;
+};
 
 export const nextThirdLineMode = (mode, granularity = 'month') => {
   const modes = thirdLineModesFor(granularity);
@@ -883,11 +895,14 @@ const BalanceHistoryCard = ({
   // calendar left open across a period switch would otherwise strand the user in
   // a month grid with no way back to the chart.
   const [showCalendar, setShowCalendar] = useState(false);
-  // Which comparison line rides along with the actual balance: last month, the
-  // 12-month median, or nothing at all (the year view offers last year / nothing).
-  // Persisted, so the choice survives a restart — a reader who turned the
-  // comparison off does not have to turn it off again every launch.
-  const [thirdLine, setThirdLineState] = useState(DEFAULT_THIRD_LINE_MODE);
+  // Which comparison line rides along with the actual balance, per view: the
+  // month view offers last month / the 12-month median / nothing, the year view
+  // last year / nothing. Kept apart and persisted separately, so a tap in one
+  // view never rewrites the other's choice and both survive a restart.
+  const [thirdLines, setThirdLines] = useState(() => ({
+    month: defaultThirdLineMode('month'),
+    year: defaultThirdLineMode('year'),
+  }));
   // The burndown norm ("plain avg") is a second opinion on the same month, not a
   // reading of it — off by default so the chart opens with just the actual line,
   // and switched on from the header when the reader wants the comparison.
@@ -895,30 +910,41 @@ const BalanceHistoryCard = ({
   const [contentHeight, setContentHeight] = useState(340);
   // Day currently under the finger while scrubbing the chart (null when idle).
   const [scrubDay, setScrubDay] = useState(null);
-  // Set once the reader picks a mode by hand. A tap that beats the stored-value
-  // read must win it — restoring afterwards would silently undo their choice.
-  const thirdLinePickedRef = useRef(false);
-  // Restore the remembered comparison mode. The card renders the default until
+  // Views the reader has already picked a mode for by hand. A tap that beats the
+  // stored-value read must win it for that view — restoring over it afterwards
+  // would silently undo the choice they just made.
+  const thirdLinePickedRef = useRef({});
+  // Restore the remembered comparison modes. The card renders the defaults until
   // this resolves; the read is a single indexed row, so the swap lands well
   // before the balance history itself finishes loading.
   useEffect(() => {
     let cancelled = false;
-    getPreference(PREF_KEYS.BALANCE_CHART_COMPARISON, null)
+    getJsonPreference(PREF_KEYS.BALANCE_CHART_COMPARISON, null)
       .then((stored) => {
-        if (cancelled || thirdLinePickedRef.current || !isThirdLineMode(stored)) return;
-        setThirdLineState(stored);
+        if (cancelled) return;
+        const restored = parseStoredThirdLines(stored);
+        setThirdLines((prev) => {
+          const next = { ...prev };
+          Object.entries(restored).forEach(([granularity, mode]) => {
+            if (!thirdLinePickedRef.current[granularity]) next[granularity] = mode;
+          });
+          return next;
+        });
       })
       .catch(() => {});
     return () => { cancelled = true; };
   }, []);
 
-  const setThirdLine = useCallback((mode) => {
-    thirdLinePickedRef.current = true;
-    setThirdLineState(mode);
+  const setThirdLineFor = useCallback((granularity, mode) => {
+    thirdLinePickedRef.current[granularity] = true;
+    // Both views are written every time, so the stored row always holds the pair
+    // rather than only whichever one was last touched.
+    const next = { ...thirdLines, [granularity]: mode };
+    setThirdLines(next);
     // Fire-and-forget: a failed write costs the reader the next restart's
     // default, never the tap they just made.
-    setPreference(PREF_KEYS.BALANCE_CHART_COMPARISON, mode).catch(() => {});
-  }, []);
+    setJsonPreference(PREF_KEYS.BALANCE_CHART_COMPARISON, next).catch(() => {});
+  }, [thirdLines]);
 
   // Comparison-line steps for the current mode — the legend dots below read from
   // the same object, so a swatch can never drift from the line it stands for.
@@ -929,10 +955,11 @@ const BalanceHistoryCard = ({
   const isYearView = selectedMonth === null;
   const granularity = isYearView ? 'year' : 'month';
   const calendarVisible = showCalendar && !isYearView;
-  // The mode is kept across a period switch when it still exists there, and
-  // otherwise falls back to that period's first mode — switching to the year view
-  // must not leave a stale 'yearAvg' selected and no line drawn.
+  // Each period reads its own remembered mode; the fallback still guards a value
+  // that period no longer offers, so a stale 'yearAvg' can never leave the year
+  // view with nothing drawn.
   const thirdLineModes = thirdLineModesFor(granularity);
+  const thirdLine = thirdLines[granularity];
   const effectiveThirdLine = thirdLineModes.includes(thirdLine) ? thirdLine : thirdLineModes[0];
 
   const selectedAccountData = accounts.find(acc => acc.id === selectedAccount);
@@ -1087,7 +1114,7 @@ const BalanceHistoryCard = ({
           <TouchableOpacity
             testID="third-line-toggle-btn"
             style={[styles.calendarToggleBtn, { backgroundColor: colors.surface }]}
-            onPress={() => setThirdLine(nextThirdLineMode(effectiveThirdLine, granularity))}
+            onPress={() => setThirdLineFor(granularity, nextThirdLineMode(effectiveThirdLine, granularity))}
             activeOpacity={0.7}
             accessibilityRole="button"
             accessibilityLabel={thirdLineLabel}

--- a/app/components/graphs/BalanceHistoryCard.js
+++ b/app/components/graphs/BalanceHistoryCard.js
@@ -22,6 +22,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import SimplePicker from '../SimplePicker';
 import currencies from '../../../assets/currencies.json';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+import { getPreference, setPreference, PREF_KEYS } from '../../services/PreferencesDB';
 import { balanceLineColors } from '../../styles/chartPalette';
 import BalanceHistoryCalendarView from './BalanceHistoryCalendarView';
 import { MONTH_ABBREVIATIONS } from './monthLabels';
@@ -158,6 +159,14 @@ export const YEAR_THIRD_LINE_MODES = ['prevYear', 'none'];
 
 export const thirdLineModesFor = (granularity) =>
   (granularity === 'year' ? YEAR_THIRD_LINE_MODES : THIRD_LINE_MODES);
+
+// The mode the card opens in when nothing has been remembered yet.
+export const DEFAULT_THIRD_LINE_MODE = 'prevMonth';
+
+// A stored mode is only honoured if it is still one this build knows about — a
+// value left behind by an older release must not blank the comparison line.
+export const isThirdLineMode = (mode) =>
+  THIRD_LINE_MODES.includes(mode) || YEAR_THIRD_LINE_MODES.includes(mode);
 
 export const nextThirdLineMode = (mode, granularity = 'month') => {
   const modes = thirdLineModesFor(granularity);
@@ -876,7 +885,9 @@ const BalanceHistoryCard = ({
   const [showCalendar, setShowCalendar] = useState(false);
   // Which comparison line rides along with the actual balance: last month, the
   // 12-month median, or nothing at all (the year view offers last year / nothing).
-  const [thirdLine, setThirdLine] = useState('prevMonth');
+  // Persisted, so the choice survives a restart — a reader who turned the
+  // comparison off does not have to turn it off again every launch.
+  const [thirdLine, setThirdLineState] = useState(DEFAULT_THIRD_LINE_MODE);
   // The burndown norm ("plain avg") is a second opinion on the same month, not a
   // reading of it — off by default so the chart opens with just the actual line,
   // and switched on from the header when the reader wants the comparison.
@@ -884,6 +895,31 @@ const BalanceHistoryCard = ({
   const [contentHeight, setContentHeight] = useState(340);
   // Day currently under the finger while scrubbing the chart (null when idle).
   const [scrubDay, setScrubDay] = useState(null);
+  // Set once the reader picks a mode by hand. A tap that beats the stored-value
+  // read must win it — restoring afterwards would silently undo their choice.
+  const thirdLinePickedRef = useRef(false);
+  // Restore the remembered comparison mode. The card renders the default until
+  // this resolves; the read is a single indexed row, so the swap lands well
+  // before the balance history itself finishes loading.
+  useEffect(() => {
+    let cancelled = false;
+    getPreference(PREF_KEYS.BALANCE_CHART_COMPARISON, null)
+      .then((stored) => {
+        if (cancelled || thirdLinePickedRef.current || !isThirdLineMode(stored)) return;
+        setThirdLineState(stored);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const setThirdLine = useCallback((mode) => {
+    thirdLinePickedRef.current = true;
+    setThirdLineState(mode);
+    // Fire-and-forget: a failed write costs the reader the next restart's
+    // default, never the tap they just made.
+    setPreference(PREF_KEYS.BALANCE_CHART_COMPARISON, mode).catch(() => {});
+  }, []);
+
   // Comparison-line steps for the current mode — the legend dots below read from
   // the same object, so a swatch can never drift from the line it stands for.
   const chartLineColors = useMemo(() => balanceLineColors(colors), [colors]);

--- a/app/services/PreferencesDB.js
+++ b/app/services/PreferencesDB.js
@@ -20,6 +20,10 @@ export const PREF_KEYS = {
   // JSON array of group ids. Absent means every envelope is folded, which is
   // the default a plan opens in.
   BUDGET_EXPANDED_GROUPS: 'budget_expanded_groups',
+  // Which comparison line the balance chart draws alongside the actual balance
+  // ('prevMonth' | 'yearAvg' | 'prevYear' | 'none'). Remembered across restarts
+  // so the reader's choice of baseline survives leaving the Graphs tab.
+  BALANCE_CHART_COMPARISON: 'balance_chart_comparison',
   GOOGLE_SHEETS_SPREADSHEET_ID: 'google_sheets_spreadsheet_id',
   DEFAULT_ACCOUNT_ID: 'default_account_id',
   // Bank-notification processing


### PR DESCRIPTION
## Summary

The balance chart's comparison-line toggle (prev month → year avg → none, and prev year → none in the year view) was component state only, so it reset to "prev month" on every launch. A reader who had turned the comparison off had to turn it off again each time the app started. The picked mode is now persisted and restored on mount, kept per view so the two views cannot overwrite each other's choice.

## Changes

- **app/components/graphs/BalanceHistoryCard.js** — the comparison mode is now held per view (`{ month, year }`), hydrated from PreferencesDB on mount and written back on every toggle press. A tap writes only the slot for the view that was tapped, so turning the comparison off in the year view no longer rewrites the month view's remembered choice — `'none'` is a valid mode in both, which made that clobbering silent and (once persisted) permanent. Each slot is validated against the modes its own view offers, so a value left behind by an older release falls back to that view's default rather than blanking the line. The existing `effectiveThirdLine` fallback is kept as a guard for exactly that case.
- **app/services/PreferencesDB.js** — new `PREF_KEYS.BALANCE_CHART_COMPARISON` (`balance_chart_comparison`), stored as JSON.
- **__tests__/components/BalanceHistoryCard.test.js** — mock PreferencesDB; 8 new cases covering persist-on-press, restore, restoring `none`, unknown-mode fallback, a malformed stored value, a failed read, the tap-beats-read race, and a regression test that a year-view tap leaves the month view's mode intact both on disk and on screen.
- **__tests__/services/PreferencesDB.test.js** — add the new key to the expected `PREF_KEYS` list.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 189 suites / 5426 tests pass, 0 failed.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a, no new strings (the existing `prev_month` / `year_avg` / `prev_year` / `comparison_none` labels are reused)
- [x] Linked the related issue with `Closes #NNN` below — n/a