### PR TITLE
fix(graphs): default the spending trend to the current month

### DIFF
--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import CategorySpendingCard, { formatPctTick, formatYTick } from '../../../app/components/graphs/CategorySpendingCard';
+import CategorySpendingCard, { formatPctTick, formatYTick, resolveScrubIndex } from '../../../app/components/graphs/CategorySpendingCard';
 import useCategoryMonthlySpending from '../../../app/hooks/useCategoryMonthlySpending';
 
 // Mock the hook
@@ -783,6 +783,64 @@ describe('CategorySpendingCard', () => {
         expect(formatPctTick(33.333)).toBe('33%');
         expect(formatPctTick('66.7')).toBe('67%');
       });
+    });
+  });
+
+  // `useAnimatedReaction` is a no-op under the Jest reanimated mock, so the
+  // scrub reaction is only reachable through its exported worklet.
+  describe('resolveScrubIndex', () => {
+    const COUNT = 12;
+
+    it('ignores the mount-time run, so the current month keeps the selection', () => {
+      // useAnimatedReaction fires once on creation with previous === null and
+      // the press state still at its x=0 initial value.
+      expect(resolveScrubIndex({ active: false, x: 0 }, null, COUNT)).toBe(-1);
+    });
+
+    it('ignores every reading taken with the finger up', () => {
+      expect(resolveScrubIndex({ active: false, x: 7 }, { active: true, x: 3 }, COUNT)).toBe(-1);
+    });
+
+    it('reports the pressed month once the finger goes down', () => {
+      expect(resolveScrubIndex({ active: true, x: 5 }, { active: false, x: 0 }, COUNT)).toBe(5);
+    });
+
+    it('reports the leftmost month even though x never left its initial 0', () => {
+      expect(resolveScrubIndex({ active: true, x: 0 }, { active: false, x: 0 }, COUNT)).toBe(0);
+    });
+
+    it('re-reports nothing while a drag stays inside one month', () => {
+      expect(resolveScrubIndex({ active: true, x: 5 }, { active: true, x: 5 }, COUNT)).toBe(-1);
+    });
+
+    it('follows a drag across months', () => {
+      expect(resolveScrubIndex({ active: true, x: 6 }, { active: true, x: 5 }, COUNT)).toBe(6);
+    });
+
+    it('snaps a fractional press position to the nearest month', () => {
+      expect(resolveScrubIndex({ active: true, x: 4.4 }, { active: true, x: 3 }, COUNT)).toBe(4);
+      expect(resolveScrubIndex({ active: true, x: 4.6 }, { active: true, x: 3 }, COUNT)).toBe(5);
+    });
+
+    it('drops positions dragged off either end of the chart', () => {
+      expect(resolveScrubIndex({ active: true, x: -1 }, { active: true, x: 0 }, COUNT)).toBe(-1);
+      expect(resolveScrubIndex({ active: true, x: 12 }, { active: true, x: 11 }, COUNT)).toBe(-1);
+    });
+  });
+
+  describe('Regression Tests', () => {
+    // Guards the resting default only — the reaction that used to override it at
+    // mount is stubbed out here, and is covered by `resolveScrubIndex` above.
+    it('defaults the selection to the current month, not the oldest of the 12', async () => {
+      const { getByText, queryByText } = await render(
+        <CategorySpendingCard {...defaultProps} />,
+      );
+
+      // Last entry of the 12-month window is the current month; its total is 200.
+      expect(getByText('$200.00')).toBeTruthy();
+      expect(getByText('this_month')).toBeTruthy();
+      // The oldest month's total (100) must not be what the card is showing.
+      expect(queryByText('$100.00')).toBeNull();
     });
   });
 });

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -51,6 +51,33 @@ export const formatYTick = (value) => {
 
 export const formatPctTick = (value) => `${Math.round(Number(value))}%`;
 
+/**
+ * Which month a chart-press reaction should scrub to, or -1 for "leave the
+ * selection alone".
+ *
+ * The press state starts at x=0 and `useAnimatedReaction` runs its reaction
+ * once at mount — so reading x alone made the card select the *oldest* month
+ * the moment the chart appeared, silently overriding the "current month"
+ * default. Gating on `active` ignores that initial run; the finger has to be
+ * down for a press to mean anything.
+ *
+ * The x-only equality check is kept *inside* an active drag, so scrubbing
+ * across a month re-reports it at most once. It deliberately does not span the
+ * inactive→active edge: without that, pressing the leftmost bar first (x is
+ * already 0) would report nothing at all.
+ *
+ * Exported because `useAnimatedReaction`'s reaction is a worklet under Jest's
+ * no-op mock, so this is the only reachable seam for testing it.
+ */
+export const resolveScrubIndex = (current, previous, count) => {
+  'worklet';
+  if (!current.active) return -1;
+  if (previous && previous.active && current.x === previous.x) return -1;
+  const index = Math.round(current.x);
+  if (index < 0 || index >= count) return -1;
+  return index;
+};
+
 // "Nice" y-axis step so ticks land on round numbers.
 const niceStepFor = (max) => {
   const raw = max / 5;
@@ -143,11 +170,10 @@ const SpendingBarChart = ({
   );
 
   useAnimatedReaction(
-    () => pressState.x.value.value,
+    () => ({ active: pressState.isActive.value, x: pressState.x.value.value }),
     (current, previous) => {
-      if (current === previous) return;
-      const index = Math.round(current);
-      if (index >= 0 && index < count) {
+      const index = resolveScrubIndex(current, previous, count);
+      if (index >= 0) {
         runOnJS(onBarPress)(index);
       }
     },


### PR DESCRIPTION
## Summary

The 12-month spending trend opened with the **oldest** month of the window selected — highlighted, and its total shown beside the card title — instead of the current month. The card does compute its resting selection as the last month in the window, but the chart-press reaction overrode it the instant the chart mounted: `useAnimatedReaction` runs its reaction once at registration with `previous === null` while the press state still holds its initial `x: 0`, and the reaction only compared x against the previous x. `0 !== null` counted as a press on the leftmost bar, with no finger ever having touched the chart.

## Changes

- **app/components/graphs/CategorySpendingCard.js** — gate the chart-press reaction on `pressState.isActive` so only a real press scrubs the selection; the mount-time run is now ignored and the current month keeps the default. The x-equality check that de-dupes a drag within one month is kept, but scoped to an active drag: letting it span the inactive→active edge would make the leftmost bar unselectable, since its x is already the initial `0`. The decision moves into an exported `resolveScrubIndex` worklet, because the reaction itself is a no-op under the Jest reanimated mock and that is the only seam a test can reach.
- **__tests__/components/graphs/CategorySpendingCard.test.js** — 8 cases over `resolveScrubIndex` (mount-time run ignored, finger-up readings ignored, first press reported including on the leftmost bar, drags de-duped within a month and followed across months, fractional positions snapped, off-chart positions dropped), plus a regression test that the card rests on the current month's total rather than the oldest month's.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 189 suites / 5435 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.
- Verified against `victory-native@41.26.0` source that `useChartPressState`'s `state.isActive` is a `SharedValue<boolean>`, and against `react-native-reanimated@4.3.1` that the mapper already extracts it as an input (`extractInputs` recurses into plain objects), so the reaction still fires on press-down.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a, no new strings
- [x] Linked the related issue with `Closes #NNN` below — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqW8PJUNLj7M9rBfBFVp5a)_