### PR TITLE
feat(graphs): scroll the spending trend through the whole history

### DIFF
--- a/__tests__/components/graphs/CategorySpendingCard.test.js
+++ b/__tests__/components/graphs/CategorySpendingCard.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import CategorySpendingCard, { formatPctTick, formatYTick, resolveScrubIndex } from '../../../app/components/graphs/CategorySpendingCard';
+import CategorySpendingCard, { formatPctTick, formatYTick, resolveScrollTarget, resolveTapIndex } from '../../../app/components/graphs/CategorySpendingCard';
 import useCategoryMonthlySpending from '../../../app/hooks/useCategoryMonthlySpending';
 
 // Mock the hook
@@ -100,7 +100,7 @@ describe('CategorySpendingCard', () => {
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(getByTestId('cartesian-chart')).toBeTruthy();
+      expect(getByTestId('spending-chart-canvas')).toBeTruthy();
       expect(getAllByTestId('vn-bar').length).toBeGreaterThan(0);
     });
 
@@ -133,7 +133,7 @@ describe('CategorySpendingCard', () => {
       );
 
       expect(getByText('no_spending_data')).toBeTruthy();
-      expect(queryByTestId('cartesian-chart')).toBeFalsy();
+      expect(queryByTestId('spending-chart-canvas')).toBeFalsy();
     });
 
     it('renders null when no parent expense categories', async () => {
@@ -397,7 +397,7 @@ describe('CategorySpendingCard', () => {
         <CategorySpendingCard {...defaultProps} />,
       );
 
-      expect(getByTestId('cartesian-chart')).toBeTruthy();
+      expect(getByTestId('spending-chart-canvas')).toBeTruthy();
     });
   });
 
@@ -786,45 +786,101 @@ describe('CategorySpendingCard', () => {
     });
   });
 
-  // `useAnimatedReaction` is a no-op under the Jest reanimated mock, so the
-  // scrub reaction is only reachable through its exported worklet.
-  describe('resolveScrubIndex', () => {
+  // The tap gesture's callback is a worklet under the gesture-handler mock, so
+  // the hit test is only reachable through its exported helper.
+  describe('resolveTapIndex', () => {
+    const PITCH = 48;
     const COUNT = 12;
 
-    it('ignores the mount-time run, so the current month keeps the selection', () => {
-      // useAnimatedReaction fires once on creation with previous === null and
-      // the press state still at its x=0 initial value.
-      expect(resolveScrubIndex({ active: false, x: 0 }, null, COUNT)).toBe(-1);
+    it('maps a tap to the month whose slot it landed in', () => {
+      expect(resolveTapIndex(0, PITCH, COUNT)).toBe(0);
+      expect(resolveTapIndex(47, PITCH, COUNT)).toBe(0);
+      expect(resolveTapIndex(48, PITCH, COUNT)).toBe(1);
+      expect(resolveTapIndex(263, PITCH, COUNT)).toBe(5);
     });
 
-    it('ignores every reading taken with the finger up', () => {
-      expect(resolveScrubIndex({ active: false, x: 7 }, { active: true, x: 3 }, COUNT)).toBe(-1);
+    it('reaches the newest month at the far edge of the content', () => {
+      // Regression: the newest month used to sit half a bar off the canvas, so
+      // the right-hand end of the content had to be reachable.
+      expect(resolveTapIndex(PITCH * COUNT - 1, PITCH, COUNT)).toBe(COUNT - 1);
     });
 
-    it('reports the pressed month once the finger goes down', () => {
-      expect(resolveScrubIndex({ active: true, x: 5 }, { active: false, x: 0 }, COUNT)).toBe(5);
+    it('drops taps that fall outside the plotted months', () => {
+      expect(resolveTapIndex(-1, PITCH, COUNT)).toBe(-1);
+      expect(resolveTapIndex(PITCH * COUNT, PITCH, COUNT)).toBe(-1);
     });
 
-    it('reports the leftmost month even though x never left its initial 0', () => {
-      expect(resolveScrubIndex({ active: true, x: 0 }, { active: false, x: 0 }, COUNT)).toBe(0);
+    it('drops taps when there is nothing laid out yet', () => {
+      expect(resolveTapIndex(10, 0, COUNT)).toBe(-1);
+      expect(resolveTapIndex(10, PITCH, 0)).toBe(-1);
+    });
+  });
+
+  describe('resolveScrollTarget', () => {
+    it('opens on the current month by parking at the far right', () => {
+      // Regression: the card used to squeeze twelve months into one screen; now
+      // that they scroll, opening at offset 0 would show the oldest month.
+      expect(resolveScrollTarget({ mode: 'end' }, 576, 296)).toBe(280);
     });
 
-    it('re-reports nothing while a drag stays inside one month', () => {
-      expect(resolveScrubIndex({ active: true, x: 5 }, { active: true, x: 5 }, COUNT)).toBe(-1);
+    it('has nowhere to go when the months already fit', () => {
+      expect(resolveScrollTarget({ mode: 'end' }, 296, 296)).toBe(0);
     });
 
-    it('follows a drag across months', () => {
-      expect(resolveScrubIndex({ active: true, x: 6 }, { active: true, x: 5 }, COUNT)).toBe(6);
+    it('keeps a zoom anchor inside the scrollable range', () => {
+      expect(resolveScrollTarget({ mode: 'x', x: 120 }, 576, 296)).toBe(120);
+      expect(resolveScrollTarget({ mode: 'x', x: -40 }, 576, 296)).toBe(0);
+      expect(resolveScrollTarget({ mode: 'x', x: 9999 }, 576, 296)).toBe(280);
     });
 
-    it('snaps a fractional press position to the nearest month', () => {
-      expect(resolveScrubIndex({ active: true, x: 4.4 }, { active: true, x: 3 }, COUNT)).toBe(4);
-      expect(resolveScrubIndex({ active: true, x: 4.6 }, { active: true, x: 3 }, COUNT)).toBe(5);
+    it('waits for the content to be measured', () => {
+      expect(resolveScrollTarget({ mode: 'end' }, 0, 296)).toBeNull();
+      expect(resolveScrollTarget(null, 576, 296)).toBeNull();
+    });
+  });
+
+  describe('Horizontal scrolling', () => {
+    it('scrolls the months and pins the scale beside them', async () => {
+      const { getByTestId } = await render(
+        <CategorySpendingCard {...defaultProps} />,
+      );
+
+      // The scale lives on its own canvas outside the scroller, so it stays
+      // readable however far back the months are scrolled.
+      expect(getByTestId('spending-chart-axis')).toBeTruthy();
+      expect(getByTestId('spending-chart-scroll').props.horizontal).toBe(true);
     });
 
-    it('drops positions dragged off either end of the chart', () => {
-      expect(resolveScrubIndex({ active: true, x: -1 }, { active: true, x: 0 }, COUNT)).toBe(-1);
-      expect(resolveScrubIndex({ active: true, x: 12 }, { active: true, x: 11 }, COUNT)).toBe(-1);
+    it('replays the opening scroll on both content size and layout', async () => {
+      // Whichever of the two lands last is the one that can actually move the
+      // scroller, so both have to be wired up.
+      const { getByTestId } = await render(
+        <CategorySpendingCard {...defaultProps} />,
+      );
+
+      const scroller = getByTestId('spending-chart-scroll');
+      expect(scroller.props.onContentSizeChange).toEqual(expect.any(Function));
+      expect(scroller.props.onLayout).toEqual(expect.any(Function));
+
+      await fireEvent(scroller, 'layout', { nativeEvent: { layout: { width: 300, height: 116 } } });
+      await fireEvent(scroller, 'contentSizeChange', 900, 116);
+    });
+
+    it('lays the months out wider than the card so the newest one fits', async () => {
+      const { getByTestId } = await render(
+        <CategorySpendingCard {...defaultProps} />,
+      );
+
+      const canvas = getByTestId('spending-chart-canvas');
+      const style = Array.isArray(canvas.props.style)
+        ? Object.assign({}, ...canvas.props.style)
+        : canvas.props.style;
+
+      // 12 months at the default 48px pitch, or the viewport when that is wider
+      // — a phone gets the scrolling layout, a tablet-width card still fills.
+      const { width: screenWidth } = require('react-native').Dimensions.get('window');
+      const viewport = screenWidth - 64 - 34;
+      expect(style.width).toBeCloseTo(Math.max(12 * 48, viewport), 5);
     });
   });
 

--- a/__tests__/hooks/useCategoryMonthlySpending.test.js
+++ b/__tests__/hooks/useCategoryMonthlySpending.test.js
@@ -1,12 +1,13 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
-import useCategoryMonthlySpending, { ALL_EXPENSE_CATEGORIES } from '../../app/hooks/useCategoryMonthlySpending';
+import useCategoryMonthlySpending, { ALL_EXPENSE_CATEGORIES, buildMonthWindow } from '../../app/hooks/useCategoryMonthlySpending';
 import * as OperationsDB from '../../app/services/OperationsDB';
 import * as CategoriesDB from '../../app/services/CategoriesDB';
 import { appEvents, EVENTS } from '../../app/services/eventEmitter';
 
 // Mock the services
 jest.mock('../../app/services/OperationsDB', () => ({
-  getLast12MonthsSpendingByCategories: jest.fn(),
+  getMonthlySpendingHistoryByCategories: jest.fn(),
+  getEarliestExpenseMonth: jest.fn(),
 }));
 
 jest.mock('../../app/services/CategoriesDB', () => ({
@@ -36,6 +37,8 @@ describe('useCategoryMonthlySpending', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    // No history by default: the window falls back to the rolling 12 months.
+    OperationsDB.getEarliestExpenseMonth.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -46,7 +49,7 @@ describe('useCategoryMonthlySpending', () => {
     it('should initialize with loading=true and empty data', async () => {
       // Use a pending promise so effects never complete, keeping loading=true
       CategoriesDB.getAllDescendants.mockReturnValue(new Promise(() => {}));
-      OperationsDB.getLast12MonthsSpendingByCategories.mockReturnValue(new Promise(() => {}));
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockReturnValue(new Promise(() => {}));
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -71,7 +74,7 @@ describe('useCategoryMonthlySpending', () => {
       ];
 
       CategoriesDB.getAllDescendants.mockResolvedValue(mockDescendants);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue(mockSpending);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue(mockSpending);
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -92,7 +95,7 @@ describe('useCategoryMonthlySpending', () => {
 
     it('should return 0 for months with no spending', async () => {
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -115,7 +118,7 @@ describe('useCategoryMonthlySpending', () => {
       ];
 
       CategoriesDB.getAllDescendants.mockResolvedValue(mockDescendants);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -126,15 +129,16 @@ describe('useCategoryMonthlySpending', () => {
       });
 
       // Should include selected category + descendants
-      expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+      expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
         mockCurrency,
         [mockCategoryId, 'cat-groceries', 'cat-restaurants'],
         false,
+        expect.stringMatching(/^\d{4}-\d{2}$/),
       );
     });
 
     it('should query every expense without a category filter for ALL_EXPENSE_CATEGORIES', async () => {
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, ALL_EXPENSE_CATEGORIES, mockCategories),
@@ -145,27 +149,29 @@ describe('useCategoryMonthlySpending', () => {
       });
 
       // null = no category filter at all, so uncategorised expenses count too
-      expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+      expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
         mockCurrency,
         null,
         false,
+        expect.stringMatching(/^\d{4}-\d{2}$/),
       );
       expect(CategoriesDB.getAllDescendants).not.toHaveBeenCalled();
     });
 
     it('should filter by selected currency', async () => {
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       await renderHook(() =>
         useCategoryMonthlySpending('EUR', mockCategoryId, mockCategories),
       );
 
       await waitFor(() => {
-        expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+        expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
           'EUR',
           [mockCategoryId],
           false,
+          expect.stringMatching(/^\d{4}-\d{2}$/),
         );
       });
     });
@@ -182,7 +188,7 @@ describe('useCategoryMonthlySpending', () => {
         mockSpending.push({ yearMonth, total: 100 + i * 50 });
       }
 
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue(mockSpending);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue(mockSpending);
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -198,10 +204,100 @@ describe('useCategoryMonthlySpending', () => {
     });
   });
 
+  describe('History window', () => {
+    it('reaches back to the first expense ever recorded', async () => {
+      CategoriesDB.getAllDescendants.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
+      const now = new Date();
+      const start = new Date(now.getFullYear() - 2, now.getMonth(), 1);
+      const startYearMonth = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`;
+      OperationsDB.getEarliestExpenseMonth.mockResolvedValue(startYearMonth);
+
+      const { result } = await renderHook(() =>
+        useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Two years back, inclusive of both ends.
+      expect(result.current.monthlyData).toHaveLength(25);
+      expect(result.current.monthlyData[0].yearMonth).toBe(startYearMonth);
+      // The query is bounded by the same month the window starts at, so no
+      // spending can land outside a bar.
+      expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
+        mockCurrency,
+        [mockCategoryId],
+        false,
+        startYearMonth,
+      );
+    });
+
+    it('does not shrink below a year for a brand-new ledger', async () => {
+      CategoriesDB.getAllDescendants.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
+      const now = new Date();
+      const start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      OperationsDB.getEarliestExpenseMonth.mockResolvedValue(
+        `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}`,
+      );
+
+      const { result } = await renderHook(() =>
+        useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.monthlyData).toHaveLength(12);
+    });
+  });
+
+  describe('buildMonthWindow', () => {
+    const june2025 = new Date(2025, 5, 15);
+
+    it('ends on the current month', () => {
+      const months = buildMonthWindow(null, june2025);
+      expect(months[months.length - 1]).toEqual({ yearMonth: '2025-06', year: 2025, month: 5 });
+    });
+
+    it('runs the last 12 months when there is no history', () => {
+      const months = buildMonthWindow(null, june2025);
+      expect(months).toHaveLength(12);
+      expect(months[0].yearMonth).toBe('2024-07');
+    });
+
+    it('crosses year boundaries without skipping a month', () => {
+      const months = buildMonthWindow('2023-11', june2025);
+      expect(months).toHaveLength(20);
+      expect(months.slice(0, 4).map(m => m.yearMonth)).toEqual([
+        '2023-11', '2023-12', '2024-01', '2024-02',
+      ]);
+      expect(months[2]).toEqual({ yearMonth: '2024-01', year: 2024, month: 0 });
+    });
+
+    it('pads a start inside the 12-month floor back out to a year', () => {
+      const months = buildMonthWindow('2024-11', june2025);
+      expect(months).toHaveLength(12);
+      expect(months[0].yearMonth).toBe('2024-07');
+    });
+
+    it('caps a nonsense start date instead of building thousands of columns', () => {
+      const months = buildMonthWindow('1600-01', june2025);
+      expect(months).toHaveLength(240);
+    });
+
+    it('ignores an unparseable start date', () => {
+      expect(buildMonthWindow('not-a-month', june2025)).toHaveLength(12);
+    });
+  });
+
   describe('Event Handling', () => {
     it('should subscribe to OPERATION_CHANGED event', async () => {
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -218,7 +314,7 @@ describe('useCategoryMonthlySpending', () => {
       appEvents.on.mockReturnValue(unsubscribe);
 
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { unmount } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -233,7 +329,7 @@ describe('useCategoryMonthlySpending', () => {
   describe('Edge Cases', () => {
     it('should handle empty categories array', async () => {
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, []),
@@ -256,7 +352,7 @@ describe('useCategoryMonthlySpending', () => {
       });
 
       expect(result.current.monthlyData).toEqual([]);
-      expect(OperationsDB.getLast12MonthsSpendingByCategories).not.toHaveBeenCalled();
+      expect(OperationsDB.getMonthlySpendingHistoryByCategories).not.toHaveBeenCalled();
     });
 
     it('should handle empty currency', async () => {
@@ -269,7 +365,7 @@ describe('useCategoryMonthlySpending', () => {
       });
 
       expect(result.current.monthlyData).toEqual([]);
-      expect(OperationsDB.getLast12MonthsSpendingByCategories).not.toHaveBeenCalled();
+      expect(OperationsDB.getMonthlySpendingHistoryByCategories).not.toHaveBeenCalled();
     });
 
     it('should handle database errors gracefully', async () => {
@@ -294,7 +390,7 @@ describe('useCategoryMonthlySpending', () => {
   describe('loadData function', () => {
     it('should expose loadData function for manual refresh', async () => {
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { result } = await renderHook(() =>
         useCategoryMonthlySpending(mockCurrency, mockCategoryId, mockCategories),
@@ -312,14 +408,14 @@ describe('useCategoryMonthlySpending', () => {
       });
 
       // Should have been called at least twice (initial + manual)
-      expect(OperationsDB.getLast12MonthsSpendingByCategories.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(OperationsDB.getMonthlySpendingHistoryByCategories.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 
   describe('Dependency Changes', () => {
     it('should reload data when currency changes', async () => {
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { rerender } = await renderHook(
         ({ currency }) => useCategoryMonthlySpending(currency, mockCategoryId, mockCategories),
@@ -327,31 +423,33 @@ describe('useCategoryMonthlySpending', () => {
       );
 
       await waitFor(() => {
-        expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+        expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
           'USD',
           [mockCategoryId],
           false,
+          expect.stringMatching(/^\d{4}-\d{2}$/),
         );
       });
 
       jest.clearAllMocks();
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       rerender({ currency: 'EUR' });
 
       await waitFor(() => {
-        expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+        expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
           'EUR',
           [mockCategoryId],
           false,
+          expect.stringMatching(/^\d{4}-\d{2}$/),
         );
       });
     });
 
     it('should reload data when categoryId changes', async () => {
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       const { rerender } = await renderHook(
         ({ categoryId }) => useCategoryMonthlySpending(mockCurrency, categoryId, mockCategories),
@@ -359,24 +457,26 @@ describe('useCategoryMonthlySpending', () => {
       );
 
       await waitFor(() => {
-        expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+        expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
           mockCurrency,
           ['cat-food'],
           false,
+          expect.stringMatching(/^\d{4}-\d{2}$/),
         );
       });
 
       jest.clearAllMocks();
       CategoriesDB.getAllDescendants.mockResolvedValue([]);
-      OperationsDB.getLast12MonthsSpendingByCategories.mockResolvedValue([]);
+      OperationsDB.getMonthlySpendingHistoryByCategories.mockResolvedValue([]);
 
       rerender({ categoryId: 'cat-transport' });
 
       await waitFor(() => {
-        expect(OperationsDB.getLast12MonthsSpendingByCategories).toHaveBeenCalledWith(
+        expect(OperationsDB.getMonthlySpendingHistoryByCategories).toHaveBeenCalledWith(
           mockCurrency,
           ['cat-transport'],
           false,
+          expect.stringMatching(/^\d{4}-\d{2}$/),
         );
       });
     });

--- a/__tests__/services/OperationsDB.test.js
+++ b/__tests__/services/OperationsDB.test.js
@@ -1067,7 +1067,8 @@ describe('OperationsDB Service', () => {
       ['getIncomeByCategoryAndCurrency', () => OperationsDB.getIncomeByCategoryAndCurrency('USD', '2025-12-01', '2025-12-31')],
       ['getOperationsByCategoryAndCurrency', () => OperationsDB.getOperationsByCategoryAndCurrency('cat1', 'USD', '2025-12-01', '2025-12-31')],
       ['getMonthlySpendingByCategories', () => OperationsDB.getMonthlySpendingByCategories('USD', 2025, ['cat1'])],
-      ['getLast12MonthsSpendingByCategories', () => OperationsDB.getLast12MonthsSpendingByCategories('USD', ['cat1'])],
+      ['getMonthlySpendingHistoryByCategories', () => OperationsDB.getMonthlySpendingHistoryByCategories('USD', ['cat1'])],
+      ['getEarliestExpenseMonth', () => OperationsDB.getEarliestExpenseMonth()],
       ['getSpendingByCategory', () => OperationsDB.getSpendingByCategory('2025-12-01', '2025-12-31')],
       ['getIncomeByCategory', () => OperationsDB.getIncomeByCategory('2025-12-01', '2025-12-31')],
     ])('%s filters out operations hidden from the charts', async (_name, run) => {
@@ -1252,7 +1253,7 @@ describe('OperationsDB Service', () => {
           { year_month: '2025-12', amount: 50, currency: 'EUR' },   // 55
         ]);
 
-        const result = await OperationsDB.getLast12MonthsSpendingByCategories('USD', ['cat1'], true);
+        const result = await OperationsDB.getMonthlySpendingHistoryByCategories('USD', ['cat1'], true);
 
         const sql = queryAll.mock.calls[0][0];
         expect(sql).not.toContain('a.currency = ?');
@@ -3641,11 +3642,11 @@ describe('OperationsDB Service', () => {
     });
   });
 
-  describe('getLast12MonthsSpendingByCategories', () => {
+  describe('getMonthlySpendingHistoryByCategories', () => {
     it('filters by the given category ids', async () => {
       queryAll.mockResolvedValue([]);
 
-      await OperationsDB.getLast12MonthsSpendingByCategories('USD', ['cat-food', 'cat-groceries']);
+      await OperationsDB.getMonthlySpendingHistoryByCategories('USD', ['cat-food', 'cat-groceries']);
 
       const [sql, params] = queryAll.mock.calls[0];
       expect(sql).toContain('o.category_id IN (?,?)');
@@ -3655,7 +3656,7 @@ describe('OperationsDB Service', () => {
     it('drops the category filter entirely when categoryIds is null', async () => {
       queryAll.mockResolvedValue([]);
 
-      await OperationsDB.getLast12MonthsSpendingByCategories('USD', null);
+      await OperationsDB.getMonthlySpendingHistoryByCategories('USD', null);
 
       const [sql, params] = queryAll.mock.calls[0];
       expect(sql).not.toContain('category_id');
@@ -3669,7 +3670,7 @@ describe('OperationsDB Service', () => {
         { year_month: '2026-06', amount: '3', currency: 'USD' },
       ]);
 
-      const result = await OperationsDB.getLast12MonthsSpendingByCategories('USD', null);
+      const result = await OperationsDB.getMonthlySpendingHistoryByCategories('USD', null);
 
       expect(result).toEqual([
         { yearMonth: '2026-06', total: '3' },
@@ -3680,10 +3681,54 @@ describe('OperationsDB Service', () => {
     it('returns an empty result for an empty category list without querying', async () => {
       queryAll.mockResolvedValue([]);
 
-      const result = await OperationsDB.getLast12MonthsSpendingByCategories('USD', []);
+      const result = await OperationsDB.getMonthlySpendingHistoryByCategories('USD', []);
 
       expect(result).toEqual([]);
       expect(queryAll).not.toHaveBeenCalled();
+    });
+
+    it('starts at the given month so the chart can reach back past a year', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getMonthlySpendingHistoryByCategories('USD', null, false, '2019-03');
+
+      const [, params] = queryAll.mock.calls[0];
+      expect(params[1]).toBe('2019-03-01');
+    });
+
+    it('falls back to the rolling 12-month window when no start month is given', async () => {
+      queryAll.mockResolvedValue([]);
+
+      await OperationsDB.getMonthlySpendingHistoryByCategories('USD', null);
+
+      const now = new Date();
+      const start = new Date(now.getFullYear(), now.getMonth() - 11, 1);
+      const [, params] = queryAll.mock.calls[0];
+      expect(params[1]).toBe(
+        `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-01`,
+      );
+    });
+  });
+
+  describe('getEarliestExpenseMonth', () => {
+    it('returns the month of the oldest chart-visible expense', async () => {
+      queryAll.mockResolvedValue([{ year_month: '2021-04' }]);
+
+      const result = await OperationsDB.getEarliestExpenseMonth();
+
+      const [sql] = queryAll.mock.calls[0];
+      expect(sql).toContain("o.type = 'expense'");
+      // No category or currency filter: both trend series have to be built over
+      // the same window or they cannot be compared month against month.
+      expect(sql).not.toContain('category_id');
+      expect(sql).not.toContain('a.currency = ?');
+      expect(result).toBe('2021-04');
+    });
+
+    it('returns null when there are no expenses at all', async () => {
+      queryAll.mockResolvedValue([{ year_month: null }]);
+
+      expect(await OperationsDB.getEarliestExpenseMonth()).toBeNull();
     });
   });
 });

--- a/app/components/graphs/CategorySpendingCard.js
+++ b/app/components/graphs/CategorySpendingCard.js
@@ -1,9 +1,10 @@
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useRef, useState, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Dimensions, TouchableOpacity, Modal, ScrollView } from 'react-native';
 import PropTypes from 'prop-types';
-import { CartesianChart, Bar, BarGroup, StackedBar, useChartPressState } from 'victory-native';
+import { CartesianChart, Bar, BarGroup, StackedBar } from 'victory-native';
 import { matchFont, Paint, RoundedRect } from '@shopify/react-native-skia';
-import { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
+import { runOnJS } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import currencies from '../../../assets/currencies.json';
 import useCategoryMonthlySpending, { ALL_EXPENSE_CATEGORIES } from '../../hooks/useCategoryMonthlySpending';
@@ -12,6 +13,7 @@ import { comparisonSeriesColor } from '../../styles/chartPalette';
 import { MONTH_ABBREVIATIONS } from './monthLabels';
 import ModalBlurOverlay from '../ModalBlurOverlay';
 import { useDisplaySettings } from '../../contexts/DisplaySettingsContext';
+import { useSwipeNavigationGesture } from '../../contexts/SwipeNavigationContext';
 import { CARD_SURFACE, SECTION_LABEL } from '../../styles/componentStyles';
 import EmptyState from '../EmptyState';
 
@@ -35,12 +37,60 @@ const BAR_ANIMATION = { type: 'spring' };
 // border: a stroke in the surface colour reads as breathing room, an outline
 // reads as one more piece of chrome. 2px total (1px either side of the seam).
 const STACK_GAP = 2;
-// Press state key sets must match the chart's yKeys, so the canvas remounts
-// (via `key`) whenever the vs-series is added or removed.
-const PRESS_INIT_SINGLE = { x: 0, y: { amount: 0 } };
-const PRESS_INIT_VS = { x: 0, y: { primary: 0, vs: 0 } };
 // TalkBack can still step through months now that the RN hit slots are gone.
 const ACCESSIBILITY_ACTIONS = [{ name: 'increment' }, { name: 'decrement' }];
+
+// The history is as long as the user's, so months are laid out at a fixed pitch
+// and scrolled through rather than squeezed into the card. 48px leaves a 24px
+// bar with 24px of air — the width at which twelve months stopped fitting.
+const DEFAULT_MONTH_WIDTH = 48;
+const MIN_MONTH_WIDTH = 24;
+const MAX_MONTH_WIDTH = 96;
+// Gutter for the pinned y-axis. It sits outside the scroller, so the scale stays
+// readable however far back the user has scrolled.
+const Y_AXIS_WIDTH = 34;
+// The axis canvas draws no series — it exists only to place the y labels, and
+// borrows the plot geometry from the same Victory layout code as the real chart.
+const AXIS_GUIDE_DATA = [{ x: 0, amount: 0 }];
+const AXIS_GUIDE_KEYS = ['amount'];
+const AXIS_GUIDE_PADDING = { left: 0, right: 0, top: TOP_PADDING };
+const renderNothing = () => null;
+// Labels are drawn beside the pinned axis instead, but the space they would take
+// still has to be reserved so both canvases resolve the same plot height.
+const hideYLabel = () => '';
+const spacerXLabel = () => 'Ja';
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+/**
+ * Where the scroller should sit for a pending move, or null while there is
+ * nothing to move to (no move queued, or the content not measured yet).
+ *
+ * `{ mode: 'end' }` is "open on the current month" — the newest month is the
+ * last one laid out, so the card's resting position is the far right rather
+ * than the twelve-month-old left edge.
+ */
+export const resolveScrollTarget = (pending, contentWidth, viewportWidth) => {
+  if (!pending || !(contentWidth > 0)) return null;
+  const maxX = Math.max(0, contentWidth - viewportWidth);
+  return pending.mode === 'end' ? maxX : clamp(pending.x, 0, maxX);
+};
+
+/**
+ * Which month a tap at `x` (in scroll-content pixels) landed on, or -1 when it
+ * fell outside the plotted months.
+ *
+ * Months are laid out at a fixed pitch with half a slot of domain padding at
+ * either end, so a bar's slot is exactly `[i * pitch, (i + 1) * pitch)` and the
+ * hit test is a division — no Skia hit region, no RN overlay per bar.
+ */
+export const resolveTapIndex = (x, monthWidth, count) => {
+  'worklet';
+  if (!(monthWidth > 0) || count <= 0) return -1;
+  const index = Math.floor(x / monthWidth);
+  if (index < 0 || index >= count) return -1;
+  return index;
+};
 
 export const formatYTick = (value) => {
   const num = Number(value);
@@ -50,33 +100,6 @@ export const formatYTick = (value) => {
 };
 
 export const formatPctTick = (value) => `${Math.round(Number(value))}%`;
-
-/**
- * Which month a chart-press reaction should scrub to, or -1 for "leave the
- * selection alone".
- *
- * The press state starts at x=0 and `useAnimatedReaction` runs its reaction
- * once at mount — so reading x alone made the card select the *oldest* month
- * the moment the chart appeared, silently overriding the "current month"
- * default. Gating on `active` ignores that initial run; the finger has to be
- * down for a press to mean anything.
- *
- * The x-only equality check is kept *inside* an active drag, so scrubbing
- * across a month re-reports it at most once. It deliberately does not span the
- * inactive→active edge: without that, pressing the leftmost bar first (x is
- * already 0) would report nothing at all.
- *
- * Exported because `useAnimatedReaction`'s reaction is a worklet under Jest's
- * no-op mock, so this is the only reachable seam for testing it.
- */
-export const resolveScrubIndex = (current, previous, count) => {
-  'worklet';
-  if (!current.active) return -1;
-  if (previous && previous.active && current.x === previous.x) return -1;
-  const index = Math.round(current.x);
-  if (index < 0 || index >= count) return -1;
-  return index;
-};
 
 // "Nice" y-axis step so ticks land on round numbers.
 const niceStepFor = (max) => {
@@ -99,9 +122,14 @@ const niceStepFor = (max) => {
  *  - grouped: <BarGroup> with primary + vs bars side by side per month
  *  - stacked: <StackedBar> over 100%-normalized shares of primary vs vs
  *
- * Axes are drawn by Victory on the Skia canvas (xAxis/yAxis/frame). Month selection
- * runs through `useChartPressState`, so dragging across the chart scrubs months on
- * the UI thread; the selected month is marked by a translucent column highlight.
+ * The months are laid out at a fixed pitch inside a horizontal scroller and the
+ * y-axis is pinned beside it, so the window opens on the current month and the
+ * whole history is a swipe away instead of twelve bars fighting for one screen.
+ *
+ * Gestures, in the order a finger resolves them: a tap selects the month it
+ * landed on, a horizontal drag scrolls the months (and blocks the screen-swipe
+ * navigation for as long as it can scroll), and a pinch re-pitches the months so
+ * more or fewer fit at once.
  */
 const SpendingBarChart = ({
   data,
@@ -163,21 +191,128 @@ const SpendingBarChart = ({
     }
   }, []);
 
-  // Dragging across the canvas scrubs the selected month. x values are the month
-  // indices themselves, so the pressed x rounds straight to a data index.
-  const { state: pressState } = useChartPressState(
-    hasVs ? PRESS_INIT_VS : PRESS_INIT_SINGLE,
+  // --- Horizontal layout -------------------------------------------------
+  // `monthWidth` is the pitch the user has pinched to; the pitch actually drawn
+  // never goes below "fill the viewport", so a three-month history still spans
+  // the card instead of huddling on the left.
+  const [monthWidth, setMonthWidth] = useState(DEFAULT_MONTH_WIDTH);
+  const viewportWidth = Math.max(width - Y_AXIS_WIDTH, 1);
+  const fillWidth = viewportWidth / Math.max(count, 1);
+  const pitch = Math.max(monthWidth, fillWidth);
+  const contentWidth = pitch * count;
+
+  const scrollRef = useRef(null);
+  const scrollXRef = useRef(0);
+  // Offset to move to once the scroller can act on it — the content has to be
+  // measured before an offset into it means anything.
+  const pendingScrollRef = useRef({ mode: 'end' });
+  const measuredContentRef = useRef(0);
+  const layoutReadyRef = useRef(false);
+  const monthWidthRef = useRef(monthWidth);
+  const pinchBaseRef = useRef(monthWidth);
+
+  // A longer (or shorter) history is a different chart — open it on the current
+  // month, the same way the card opens on mount.
+  const prevCountRef = useRef(count);
+  if (prevCountRef.current !== count) {
+    prevCountRef.current = count;
+    pendingScrollRef.current = { mode: 'end' };
+  }
+
+  const handleScroll = useCallback((event) => {
+    scrollXRef.current = event.nativeEvent.contentOffset.x;
+  }, []);
+
+  // Content size and layout arrive in either order, and a scrollTo issued before
+  // both is dropped — so the move is replayed on each until one sticks.
+  const flushPendingScroll = useCallback(() => {
+    const x = resolveScrollTarget(
+      pendingScrollRef.current,
+      measuredContentRef.current,
+      viewportWidth,
+    );
+    if (x == null) return;
+    scrollRef.current?.scrollTo({ x, y: 0, animated: false });
+    scrollXRef.current = x;
+    if (layoutReadyRef.current) pendingScrollRef.current = null;
+  }, [viewportWidth]);
+
+  const handleContentSizeChange = useCallback((newContentWidth) => {
+    measuredContentRef.current = newContentWidth;
+    flushPendingScroll();
+  }, [flushPendingScroll]);
+
+  const handleLayout = useCallback(() => {
+    layoutReadyRef.current = true;
+    flushPendingScroll();
+  }, [flushPendingScroll]);
+
+  const scrollIndexIntoView = useCallback((index) => {
+    const target = index * pitch + pitch / 2 - viewportWidth / 2;
+    scrollRef.current?.scrollTo({
+      x: clamp(target, 0, Math.max(0, contentWidth - viewportWidth)),
+      y: 0,
+      animated: true,
+    });
+  }, [pitch, viewportWidth, contentWidth]);
+
+  const beginPinch = useCallback(() => {
+    pinchBaseRef.current = monthWidthRef.current;
+  }, []);
+
+  const applyPinch = useCallback((scale) => {
+    const next = clamp(
+      Math.round(pinchBaseRef.current * scale),
+      MIN_MONTH_WIDTH,
+      MAX_MONTH_WIDTH,
+    );
+    const current = monthWidthRef.current;
+    if (next === current) return;
+    // Zoom around the middle of what is on screen, so the months the user is
+    // looking at are the ones that stay put.
+    const from = Math.max(current, fillWidth);
+    const to = Math.max(next, fillWidth);
+    const centreMonths = (scrollXRef.current + viewportWidth / 2) / from;
+    pendingScrollRef.current = { mode: 'x', x: centreMonths * to - viewportWidth / 2 };
+    monthWidthRef.current = next;
+    setMonthWidth(next);
+  }, [fillWidth, viewportWidth]);
+
+  // --- Gestures ----------------------------------------------------------
+  // The screen-swipe Pan owns horizontal drags everywhere else on the tab; the
+  // native scroller claims them over the chart for as long as it has room left.
+  const swipeGesture = useSwipeNavigationGesture();
+  const scrollGesture = useMemo(() => {
+    const native = Gesture.Native();
+    return swipeGesture ? native.blocksExternalGesture(swipeGesture) : native;
+  }, [swipeGesture]);
+
+  const pinchGesture = useMemo(
+    () => Gesture.Pinch()
+      .onStart(() => {
+        runOnJS(beginPinch)();
+      })
+      .onUpdate((event) => {
+        runOnJS(applyPinch)(event.scale);
+      }),
+    [beginPinch, applyPinch],
   );
 
-  useAnimatedReaction(
-    () => ({ active: pressState.isActive.value, x: pressState.x.value.value }),
-    (current, previous) => {
-      const index = resolveScrubIndex(current, previous, count);
+  const containerGesture = useMemo(
+    () => Gesture.Simultaneous(scrollGesture, pinchGesture),
+    [scrollGesture, pinchGesture],
+  );
+
+  // Tap coordinates are relative to the scrolled content, which is exactly the
+  // space the month pitch is measured in.
+  const tapGesture = useMemo(
+    () => Gesture.Tap().onEnd((event) => {
+      const index = resolveTapIndex(event.x, pitch, count);
       if (index >= 0) {
         runOnJS(onBarPress)(index);
       }
-    },
-    [count, onBarPress],
+    }),
+    [pitch, count, onBarPress],
   );
 
   const handleAccessibilityAction = useCallback(
@@ -186,8 +321,9 @@ const SpendingBarChart = ({
       const base = selectedIndex == null ? count - 1 : selectedIndex;
       const next = Math.min(count - 1, Math.max(0, base + step));
       onBarPress(next);
+      scrollIndexIntoView(next);
     },
-    [count, selectedIndex, onBarPress],
+    [count, selectedIndex, onBarPress, scrollIndexIntoView],
   );
 
   // Translucent column behind the selected month — replaces the old dashed RN
@@ -283,6 +419,28 @@ const SpendingBarChart = ({
     ? monthAbbreviations[data[selectedIndex].month]
     : '';
 
+  // Half a slot of padding at either end puts every bar in the middle of its own
+  // slot — which is what keeps the newest month clear of the right edge, and what
+  // makes a tap's slot arithmetic exact.
+  const domainPadding = useMemo(
+    () => ({ left: pitch / 2, right: pitch / 2, top: TOP_PADDING }),
+    [pitch],
+  );
+
+  const formatYLabel = isStacked ? formatPctTick : formatYTick;
+
+  // Twelve months no longer fit in one window, so a bare "Ja" cannot say which
+  // January it is. Each January carries its year, where the pitch has room.
+  const formatXLabel = useCallback((value) => {
+    const item = data[Math.round(value)];
+    if (!item) return '';
+    const abbreviation = monthAbbreviations[item.month] ?? '';
+    if (item.month === 0 && pitch >= 34) {
+      return `${abbreviation}'${String(item.year).slice(2)}`;
+    }
+    return abbreviation;
+  }, [data, monthAbbreviations, pitch]);
+
   return (
     <View
       style={[styles.chartWrap, { width }]}
@@ -292,34 +450,89 @@ const SpendingBarChart = ({
       accessibilityActions={ACCESSIBILITY_ACTIONS}
       onAccessibilityAction={handleAccessibilityAction}
     >
-      <View style={styles.chartCanvas}>
-        <CartesianChart
-          data={chartData}
-          xKey="x"
-          yKeys={yKeys}
-          domain={domain}
-          domainPadding={{ left: 6, right: 6, top: TOP_PADDING }}
-          chartPressState={pressState}
-          xAxis={{
-            font: axisFont,
-            lineWidth: 0,
-            labelColor: colors.mutedText,
-            tickCount: count,
-            formatXLabel: (value) => monthAbbreviations[data[Math.round(value)]?.month] ?? '',
-          }}
-          yAxis={[{
-            font: axisFont,
-            lineColor: colors.border,
-            labelColor: colors.mutedText,
-            tickCount: 5,
-            formatYLabel: isStacked ? formatPctTick : formatYTick,
-            // Solid hairline: a dashed grid reads as a threshold or a projection
-            // when all it is is the grid.
-          }]}
-          frame={{ lineWidth: 0 }}
-        >
-          {renderChart}
-        </CartesianChart>
+      <View style={styles.chartRow}>
+        {/* Pinned scale. Its own canvas, sharing the height, y-domain and x-label
+            metrics of the scrolling one so Victory resolves both plots to the
+            same vertical geometry and the labels line up with the gridlines. */}
+        <View style={styles.axisColumn} pointerEvents="none" testID="spending-chart-axis">
+          <CartesianChart
+            data={AXIS_GUIDE_DATA}
+            xKey="x"
+            yKeys={AXIS_GUIDE_KEYS}
+            domain={domain}
+            domainPadding={AXIS_GUIDE_PADDING}
+            xAxis={{
+              font: axisFont,
+              lineWidth: 0,
+              // Reserves the month-label strip without drawing over it.
+              labelColor: colors.altRow,
+              tickCount: 2,
+              formatXLabel: spacerXLabel,
+            }}
+            yAxis={[{
+              font: axisFont,
+              lineWidth: 0,
+              labelColor: colors.mutedText,
+              tickCount: 5,
+              formatYLabel,
+            }]}
+            frame={{ lineWidth: 0 }}
+          >
+            {renderNothing}
+          </CartesianChart>
+        </View>
+
+        <GestureDetector gesture={containerGesture}>
+          <ScrollView
+            ref={scrollRef}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            scrollEventThrottle={16}
+            onScroll={handleScroll}
+            onContentSizeChange={handleContentSizeChange}
+            onLayout={handleLayout}
+            style={styles.scrollArea}
+            testID="spending-chart-scroll"
+          >
+            <GestureDetector gesture={tapGesture}>
+              <View
+                style={[styles.chartCanvas, { width: contentWidth }]}
+                testID="spending-chart-canvas"
+              >
+                <CartesianChart
+                  data={chartData}
+                  xKey="x"
+                  yKeys={yKeys}
+                  domain={domain}
+                  domainPadding={domainPadding}
+                  xAxis={{
+                    font: axisFont,
+                    lineWidth: 0,
+                    labelColor: colors.mutedText,
+                    tickCount: count,
+                    formatXLabel,
+                  }}
+                  yAxis={[{
+                    font: axisFont,
+                    lineColor: colors.border,
+                    labelColor: colors.mutedText,
+                    tickCount: 5,
+                    // The labels live on the pinned axis; suppressing them here
+                    // also gives up the gutter Victory would reserve for them,
+                    // so the plot starts at the canvas edge and a month's slot
+                    // is exactly one pitch wide.
+                    formatYLabel: hideYLabel,
+                    // Solid hairline: a dashed grid reads as a threshold or a
+                    // projection when all it is is the grid.
+                  }]}
+                  frame={{ lineWidth: 0 }}
+                >
+                  {renderChart}
+                </CartesianChart>
+              </View>
+            </GestureDetector>
+          </ScrollView>
+        </GestureDetector>
       </View>
     </View>
   );
@@ -676,9 +889,9 @@ const CategorySpendingCard = ({
         />
       ) : (
         <SpendingBarChart
-          // Remount when the vs-series appears/disappears: the chart press state
-          // is keyed by series and cannot change shape in place.
-          key={hasVsData ? 'vs' : 'single'}
+          // No remount when the vs-series appears or disappears: the press state
+          // that used to be keyed by series is gone, and holding the mount keeps
+          // the zoom and scroll position the user has arrived at.
           data={monthlyData}
           vsData={hasVsData ? vsMonthlyData : null}
           stacked={showStackedBar && hasVsData}
@@ -695,7 +908,11 @@ const CategorySpendingCard = ({
 
 SpendingBarChart.propTypes = {
   colors: PropTypes.object.isRequired,
-  data: PropTypes.arrayOf(PropTypes.shape({ total: PropTypes.number, month: PropTypes.number })).isRequired,
+  data: PropTypes.arrayOf(PropTypes.shape({
+    month: PropTypes.number,
+    total: PropTypes.number,
+    year: PropTypes.number,
+  })).isRequired,
   monthAbbreviations: PropTypes.arrayOf(PropTypes.string).isRequired,
   onBarPress: PropTypes.func.isRequired,
   selectedIndex: PropTypes.number,
@@ -719,6 +936,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: 5,
+  },
+  axisColumn: {
+    height: CHART_HEIGHT,
+    width: Y_AXIS_WIDTH,
   },
   card: {
     ...CARD_SURFACE,
@@ -747,6 +968,9 @@ const styles = StyleSheet.create({
   },
   chartCanvas: {
     height: CHART_HEIGHT,
+  },
+  chartRow: {
+    flexDirection: 'row',
   },
   chartWrap: {
     marginTop: 12,
@@ -811,6 +1035,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     borderBottomWidth: 1,
     flexDirection: 'row',
+  },
+  scrollArea: {
+    flex: 1,
   },
   sectionLabel: SECTION_LABEL,
   seriesDot: {

--- a/app/hooks/useCategoryMonthlySpending.js
+++ b/app/hooks/useCategoryMonthlySpending.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
-import { getLast12MonthsSpendingByCategories } from '../services/OperationsDB';
+import { getEarliestExpenseMonth, getMonthlySpendingHistoryByCategories } from '../services/OperationsDB';
 import * as Currency from '../services/currency';
 import { getAllDescendants } from '../services/CategoriesDB';
 import { appEvents, EVENTS } from '../services/eventEmitter';
@@ -11,9 +11,51 @@ import { appEvents, EVENTS } from '../services/eventEmitter';
  */
 export const ALL_EXPENSE_CATEGORIES = 'all';
 
+// The window never gets shorter than a year, however new the ledger is: a
+// three-bar chart says less about a spending habit than three bars and nine
+// blanks do.
+const MIN_MONTHS = 12;
+// A guard against a nonsense date (a typo'd year, a bad import) turning into a
+// chart with thousands of columns.
+const MAX_MONTHS = 240;
+
+/**
+ * Every month from `startYearMonth` (or 12 months back, whichever is earlier)
+ * through the current one.
+ *
+ * Computed per call (not memoized at mount) so the window follows a month
+ * rollover during a long-lived session — the DB query recomputes its end from
+ * "now" too, and the two must agree or the newest month's spending maps to
+ * nothing.
+ */
+export const buildMonthWindow = (startYearMonth, now = new Date()) => {
+  const currentIndex = now.getFullYear() * 12 + now.getMonth();
+  let startIndex = currentIndex - (MIN_MONTHS - 1);
+
+  if (startYearMonth) {
+    const [year, month] = startYearMonth.split('-').map(Number);
+    if (Number.isFinite(year) && Number.isFinite(month)) {
+      startIndex = Math.min(startIndex, year * 12 + (month - 1));
+    }
+  }
+  startIndex = Math.max(startIndex, currentIndex - (MAX_MONTHS - 1));
+
+  const months = [];
+  for (let index = startIndex; index <= currentIndex; index++) {
+    const year = Math.floor(index / 12);
+    const month = index % 12; // 0-11
+    months.push({
+      yearMonth: `${year}-${String(month + 1).padStart(2, '0')}`,
+      year,
+      month,
+    });
+  }
+  return months;
+};
+
 /**
  * Custom hook for loading monthly spending data for a specific category
- * Shows the last 12 months (rolling window)
+ * Covers every month back to the first expense ever recorded (at least 12)
  * Includes all descendant categories in the totals
  * @param {string} selectedCurrency - Currency code
  * @param {string|null} selectedCategoryId - Category ID to show spending for,
@@ -23,25 +65,6 @@ export const ALL_EXPENSE_CATEGORIES = 'all';
 const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, categories, convertAllCurrencies = false) => {
   const [monthlyData, setMonthlyData] = useState([]);
   const [loading, setLoading] = useState(false);
-
-  // Generate the last 12 months as YYYY-MM strings. Computed per call (not
-  // memoized at mount) so the window follows a month rollover during a
-  // long-lived session — the DB query recomputes its window from "now" too,
-  // and the two must agree or the newest month's spending maps to nothing.
-  const getLast12Months = () => {
-    const months = [];
-    const now = new Date();
-    for (let i = 11; i >= 0; i--) {
-      const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
-      const yearMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-      months.push({
-        yearMonth,
-        year: date.getFullYear(),
-        month: date.getMonth(), // 0-11
-      });
-    }
-    return months;
-  };
 
   // Load monthly spending data
   const loadData = useCallback(async () => {
@@ -63,11 +86,16 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
         categoryIds = [selectedCategoryId, ...descendants.map(d => d.id)];
       }
 
-      // Get last 12 months spending data
-      const spending = await getLast12MonthsSpendingByCategories(
+      // The window is the ledger's own history, so the chart can be scrolled
+      // back to the first expense instead of stopping a year ago.
+      const earliestMonth = await getEarliestExpenseMonth();
+      const monthWindow = buildMonthWindow(earliestMonth);
+
+      const spending = await getMonthlySpendingHistoryByCategories(
         selectedCurrency,
         categoryIds,
         convertAllCurrencies,
+        monthWindow[0].yearMonth,
       );
 
       // Create a map of yearMonth to total for easy lookup
@@ -76,17 +104,17 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
         spendingMap.set(item.yearMonth, item.total);
       });
 
-      // Build array of 12 months (fill 0 for missing months)
+      // Fill 0 for months with no spending.
       // totals arrive as Decimal-safe strings from the DB layer; convert to float here
       // since chart components need numeric values for bar height arithmetic.
-      const fullYearData = getLast12Months().map(monthInfo => ({
+      const windowData = monthWindow.map(monthInfo => ({
         yearMonth: monthInfo.yearMonth,
         year: monthInfo.year,
         month: monthInfo.month,
         total: parseFloat(spendingMap.get(monthInfo.yearMonth) || '0') || 0,
       }));
 
-      setMonthlyData(fullYearData);
+      setMonthlyData(windowData);
     } catch (error) {
       console.error('Failed to load category monthly spending:', error);
       setMonthlyData([]);
@@ -95,7 +123,7 @@ const useCategoryMonthlySpending = (selectedCurrency, selectedCategoryId, catego
     }
   }, [selectedCurrency, selectedCategoryId, convertAllCurrencies]);
 
-  // Calculate total yearly spending using Decimal-safe addition before the final float conversion
+  // Total across the whole loaded window using Decimal-safe addition before the final float conversion
   const totalYearlySpending = useMemo(() => {
     const total = monthlyData.reduce(
       (sum, item) => Currency.add(sum, String(item.total || '0')),

--- a/app/services/OperationsDB.js
+++ b/app/services/OperationsDB.js
@@ -2204,7 +2204,36 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
 };
 
 /**
- * Get spending by categories for the last 12 months (rolling)
+ * First month that holds a chart-visible expense, across every account and
+ * category.
+ *
+ * Deliberately unfiltered: the spending-trend card runs two of these series side
+ * by side, and they can only be compared month against month if both are built
+ * over the same window. A per-category earliest month would give the two series
+ * different lengths.
+ *
+ * @returns {Promise<string|null>} 'YYYY-MM', or null when there are no expenses
+ */
+export const getEarliestExpenseMonth = async () => {
+  try {
+    const rows = await queryAll(
+      `SELECT strftime('%Y-%m', MIN(o.date)) as year_month
+       FROM operations o
+       JOIN accounts a ON o.account_id = a.id
+       WHERE o.type = 'expense'
+         AND ${chartVisibleSql()}`,
+      [],
+    );
+    return rows?.[0]?.year_month || null;
+  } catch (error) {
+    console.error('Failed to get earliest expense month:', error);
+    throw error;
+  }
+};
+
+/**
+ * Get spending by categories per month, from `startYearMonth` (inclusive) to the
+ * current month.
  * @param {string} currency - Currency code
  * @param {Array<string>|null} categoryIds - Category IDs to include, or `null`
  *   for every expense (uncategorised operations included). An empty array still
@@ -2212,9 +2241,11 @@ export const getMonthlySpendingByCategories = async (currency, year, categoryIds
  * @param {boolean} [convertAll=false] - When true, include operations from every
  *   currency and convert amounts to `currency` at the current exchange rate.
  *   Past months are converted at today's rate too (a single "current rate" view).
+ * @param {string|null} [startYearMonth=null] - 'YYYY-MM' lower bound; defaults to
+ *   the 12-month rolling window when omitted.
  * @returns {Promise<Array<{yearMonth: string, total: string}>>} Array of {yearMonth: 'YYYY-MM', total as Decimal-safe string}
  */
-export const getLast12MonthsSpendingByCategories = async (currency, categoryIds, convertAll = false) => {
+export const getMonthlySpendingHistoryByCategories = async (currency, categoryIds, convertAll = false, startYearMonth = null) => {
   try {
     const allCategories = categoryIds === null;
 
@@ -2224,10 +2255,11 @@ export const getLast12MonthsSpendingByCategories = async (currency, categoryIds,
 
     const placeholders = allCategories ? '' : categoryIds.map(() => '?').join(',');
 
-    // Calculate date 12 months ago from today
     const now = new Date();
-    const startDate = new Date(now.getFullYear(), now.getMonth() - 11, 1);
-    const startDateStr = `${startDate.getFullYear()}-${String(startDate.getMonth() + 1).padStart(2, '0')}-01`;
+    const defaultStart = new Date(now.getFullYear(), now.getMonth() - 11, 1);
+    const startDateStr = startYearMonth
+      ? `${startYearMonth}-01`
+      : `${defaultStart.getFullYear()}-${String(defaultStart.getMonth() + 1).padStart(2, '0')}-01`;
     const endDateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-31`;
 
     // When converting, keep the account currency per row so each amount can be
@@ -2277,7 +2309,7 @@ export const getLast12MonthsSpendingByCategories = async (currency, categoryIds,
       .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
       .map(([yearMonth, total]) => ({ yearMonth, total }));
   } catch (error) {
-    console.error('Failed to get last 12 months spending by categories:', error);
+    console.error('Failed to get monthly spending history by categories:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary

The spending-trend card squeezed twelve months into one card width, so the bars did not fit horizontally — the current month sat clipped against the right edge and the month labels ran into each other. The months are now laid out at a fixed pitch inside a horizontal scroller that opens on the current month, and the window reaches back to the first expense ever recorded instead of stopping twelve months ago.

## Changes

- **app/components/graphs/CategorySpendingCard.js** — months are drawn at a fixed 48px pitch (pinchable between 24px and 96px) inside a horizontal `ScrollView`; half a slot of domain padding at either end centres every bar in its own slot, which is what keeps the newest bar clear of the right edge. The scroller opens at its far right, so the current month is what the card shows at rest. Gestures follow the layout: a tap selects the month it landed on (`resolveTapIndex`), a horizontal drag scrolls the months and blocks the screen-swipe navigation while it can still scroll, and a pinch re-pitches the months so more or fewer fit at once, anchored on the middle of the viewport. The drag-to-scrub chart press state is gone, since a drag now scrolls. The y-axis moved onto its own pinned canvas beside the scroller so the scale stays readable however far back the user has scrolled — both canvases share the height, y-domain and x-label metrics, so Victory resolves them to the same plot geometry and the labels line up with the gridlines. January labels now carry their year (`Ja'25`), which a multi-year window needs. The chart no longer remounts when a vs-series is added, so zoom and scroll position survive it.
- **app/hooks/useCategoryMonthlySpending.js** — the window is built from the first recorded expense through the current month (`buildMonthWindow`), with a 12-month floor for a new ledger and a 240-month cap against a nonsense date.
- **app/services/OperationsDB.js** — new `getEarliestExpenseMonth()`, deliberately unfiltered so the primary and comparison series are always built over the same window; `getLast12MonthsSpendingByCategories` becomes `getMonthlySpendingHistoryByCategories(currency, categoryIds, convertAll, startYearMonth)`, still defaulting to the rolling 12 months when no start month is given.
- **__tests__/** — tap hit-testing, resting scroll position, the pinned axis and scroller structure, the content width, the month-window builder (year crossings, floor, cap, unparseable input) and the two new/renamed DB functions.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 189 suites / 5451 tests pass.
- `npx eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0` — clean.
- Not run on a device: the two-canvas axis alignment and the tap/scroll/pinch gesture arbitration are worth a look on hardware.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a (no new strings; month abbreviations are deliberately unlocalised, see `monthLabels.js`)
- [x] Linked the related issue with `Closes #NNN` below — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn85NQ6btE9dW4yWjxWRBW)_