### PR TITLE
feat(budgets): lift the pressed row on long press instead of a dialog

### DIFF
--- a/__tests__/components/RowActionMenu.test.js
+++ b/__tests__/components/RowActionMenu.test.js
@@ -1,0 +1,143 @@
+/**
+ * Tests for RowActionMenu — the long-press context menu shared by every list row
+ * that offers whole-row actions (operations, budget lines, budget envelopes).
+ *
+ * The operation-specific action list is covered in OperationActionMenu.test.js;
+ * what is tested here is the generic frame: an arbitrary action list, the lifted
+ * copy of the pressed row, and how the bar grows when the actions outnumber one
+ * row's worth.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import RowActionMenu, { panelRows } from '../../app/components/RowActionMenu';
+import {
+  OverlayHostProvider,
+  OverlayOutlet,
+} from '../../app/contexts/OverlayHostContext';
+
+const colors = {
+  surface: '#fff',
+  border: '#ddd',
+  text: '#000',
+  primary: '#007AFF',
+  mutedText: '#888',
+  destructive: '#d32f2f',
+};
+
+const makeMenu = () => ({
+  layout: { x: 16, y: 200, width: 320, height: 48 },
+  row: <Text>Groceries</Text>,
+});
+
+const makeActions = (count) => Array.from({ length: count }, (_, i) => ({
+  key: `a${i}`,
+  icon: 'pencil',
+  label: `action ${i}`,
+  onPress: jest.fn(),
+}));
+
+const harnessStyles = StyleSheet.create({ fill: { flex: 1 } });
+
+// Mirrors App.js: the menu renders inside the (blurred) content view, its overlay
+// lands in the outlet next to it — one shared parent, one coordinate space.
+const tree = (props) => (
+  <OverlayHostProvider>
+    <View style={harnessStyles.fill}>
+      <View style={harnessStyles.fill}>
+        <RowActionMenu {...props} />
+      </View>
+      <OverlayOutlet />
+    </View>
+  </OverlayHostProvider>
+);
+
+const renderMenu = (props) => render(tree({
+  colors, onClose: jest.fn(), testIDPrefix: 'row-action', ...props,
+}));
+
+describe('RowActionMenu', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders nothing when there is no menu', async () => {
+    const { queryByTestId } = await renderMenu({ menu: null, actions: makeActions(2) });
+    await waitFor(() => expect(queryByTestId('overlay-outlet')).toBeNull());
+  });
+
+  it('renders nothing when the row has no actions to offer', async () => {
+    const { queryByTestId } = await renderMenu({ menu: makeMenu(), actions: [] });
+    await waitFor(() => expect(queryByTestId('row-action-menu-backdrop')).toBeNull());
+  });
+
+  it('names each action button after its key, under the host prefix', async () => {
+    const actions = makeActions(3);
+    const { getByTestId } = await renderMenu({ menu: makeMenu(), actions });
+    await waitFor(() => expect(getByTestId('row-action-a0')).toBeTruthy());
+
+    fireEvent.press(getByTestId('row-action-a2'));
+    expect(actions[2].onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('lifts a copy of the pressed row to the position it was measured at', async () => {
+    const { getByText, getByTestId } = await renderMenu({ menu: makeMenu(), actions: makeActions(2) });
+    await waitFor(() => expect(getByTestId('overlay-outlet')).toBeTruthy());
+
+    const clone = getByText('Groceries').parent;
+    expect(StyleSheet.flatten(clone.props.style)).toMatchObject({ top: 200, left: 16, width: 320 });
+  });
+
+  describe('Action bar layout', () => {
+    // Past four across the labels stop being readable at a row's width, so a
+    // longer list stacks — and the two rows are balanced rather than leaving one
+    // button alone at double width.
+    it.each([
+      [1, 1], [4, 1], [5, 2], [6, 2], [8, 2],
+    ])('lays %i actions out over %i row(s)', (count, rows) => {
+      expect(panelRows(count)).toBe(rows);
+    });
+
+    it('gives the bar the height of the rows it needs', async () => {
+      const oneRow = await renderMenu({ menu: makeMenu(), actions: makeActions(4) });
+      const twoRows = await renderMenu({ menu: makeMenu(), actions: makeActions(6) });
+      await waitFor(() => expect(oneRow.getByTestId('row-action-a0')).toBeTruthy());
+
+      const heightOf = (queries, key) => {
+        // The panel is the action button's grandparent (button → row → panel).
+        const panel = queries.getByTestId(key).parent.parent;
+        return StyleSheet.flatten(panel.props.style).height;
+      };
+      expect(heightOf(twoRows, 'row-action-a0')).toBe(2 * heightOf(oneRow, 'row-action-a0'));
+    });
+  });
+
+  describe('Tone', () => {
+    it('draws a destructive action in the destructive colour, label included', async () => {
+      const actions = [
+        { key: 'edit', icon: 'pencil', label: 'edit', onPress: jest.fn() },
+        { key: 'delete', icon: 'trash-can-outline', label: 'delete', destructive: true, onPress: jest.fn() },
+      ];
+      const { getByTestId, getByText } = await renderMenu({ menu: makeMenu(), actions });
+      await waitFor(() => expect(getByTestId('row-action-delete')).toBeTruthy());
+
+      expect(StyleSheet.flatten(getByText('delete').props.style).color).toBe(colors.destructive);
+      expect(StyleSheet.flatten(getByText('edit').props.style).color).toBe(colors.text);
+    });
+  });
+
+  it('prefers the full phrase for a screen reader when the label was shortened', async () => {
+    const actions = [{
+      key: 'delete', icon: 'trash-can-outline', label: 'delete', a11yLabel: 'delete_group', onPress: jest.fn(),
+    }];
+    const { getByLabelText } = await renderMenu({ menu: makeMenu(), actions });
+    await waitFor(() => expect(getByLabelText('delete_group')).toBeTruthy());
+  });
+
+  it('dismisses when the backdrop is pressed', async () => {
+    const onClose = jest.fn();
+    const { getByTestId } = await renderMenu({ menu: makeMenu(), actions: makeActions(2), onClose });
+    await waitFor(() => expect(getByTestId('row-action-menu-backdrop')).toBeTruthy());
+
+    fireEvent.press(getByTestId('row-action-menu-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/RowActionMenu.test.js
+++ b/__tests__/components/RowActionMenu.test.js
@@ -8,9 +8,9 @@
  * row's worth.
  */
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { BackHandler, StyleSheet, Text, View } from 'react-native';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import RowActionMenu, { panelRows } from '../../app/components/RowActionMenu';
+import RowActionMenu from '../../app/components/RowActionMenu';
 import {
   OverlayHostProvider,
   OverlayOutlet,
@@ -88,14 +88,7 @@ describe('RowActionMenu', () => {
 
   describe('Action bar layout', () => {
     // Past four across the labels stop being readable at a row's width, so a
-    // longer list stacks — and the two rows are balanced rather than leaving one
-    // button alone at double width.
-    it.each([
-      [1, 1], [4, 1], [5, 2], [6, 2], [8, 2],
-    ])('lays %i actions out over %i row(s)', (count, rows) => {
-      expect(panelRows(count)).toBe(rows);
-    });
-
+    // longer list stacks into a second row and the bar grows to match.
     it('gives the bar the height of the rows it needs', async () => {
       const oneRow = await renderMenu({ menu: makeMenu(), actions: makeActions(4) });
       const twoRows = await renderMenu({ menu: makeMenu(), actions: makeActions(6) });
@@ -114,7 +107,7 @@ describe('RowActionMenu', () => {
     it('draws a destructive action in the destructive colour, label included', async () => {
       const actions = [
         { key: 'edit', icon: 'pencil', label: 'edit', onPress: jest.fn() },
-        { key: 'delete', icon: 'trash-can-outline', label: 'delete', destructive: true, onPress: jest.fn() },
+        { key: 'delete', icon: 'trash-can-outline', label: 'delete', tone: 'destructive', onPress: jest.fn() },
       ];
       const { getByTestId, getByText } = await renderMenu({ menu: makeMenu(), actions });
       await waitFor(() => expect(getByTestId('row-action-delete')).toBeTruthy());
@@ -132,12 +125,80 @@ describe('RowActionMenu', () => {
     await waitFor(() => expect(getByLabelText('delete_group')).toBeTruthy());
   });
 
-  it('dismisses when the backdrop is pressed', async () => {
-    const onClose = jest.fn();
-    const { getByTestId } = await renderMenu({ menu: makeMenu(), actions: makeActions(2), onClose });
-    await waitFor(() => expect(getByTestId('row-action-menu-backdrop')).toBeTruthy());
+  describe('Dismissal', () => {
+    it('dismisses when the backdrop is pressed', async () => {
+      const onClose = jest.fn();
+      const { getByTestId } = await renderMenu({ menu: makeMenu(), actions: makeActions(2), onClose });
+      await waitFor(() => expect(getByTestId('row-action-menu-backdrop')).toBeTruthy());
 
-    fireEvent.press(getByTestId('row-action-menu-backdrop'));
-    expect(onClose).toHaveBeenCalledTimes(1);
+      fireEvent.press(getByTestId('row-action-menu-backdrop'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    // Dismissing belongs to the menu, not to each host's handlers: every action
+    // either opens something or asks for a confirmation, and a bar left covering
+    // the screen over a dialog was the failure mode this closes off.
+    it('dismisses itself before running the chosen action', async () => {
+      const order = [];
+      const onClose = jest.fn(() => order.push('close'));
+      const actions = [{
+        key: 'edit', icon: 'pencil', label: 'edit', onPress: () => order.push('action'),
+      }];
+      const { getByTestId } = await renderMenu({ menu: makeMenu(), actions, onClose });
+      await waitFor(() => expect(getByTestId('row-action-edit')).toBeTruthy());
+
+      fireEvent.press(getByTestId('row-action-edit'));
+      expect(order).toEqual(['close', 'action']);
+    });
+
+    it('unmounts the overlay when the menu closes', async () => {
+      const props = { menu: makeMenu(), actions: makeActions(2), colors, onClose: jest.fn(), testIDPrefix: 'row-action' };
+      const { queryByTestId, rerender } = await renderMenu(props);
+      await waitFor(() => expect(queryByTestId('row-action-menu-backdrop')).toBeTruthy());
+
+      rerender(tree({ ...props, menu: null }));
+
+      await waitFor(() => expect(queryByTestId('row-action-menu-backdrop')).toBeNull());
+    });
+  });
+
+  describe('Overlay placement', () => {
+    it('mounts the overlay into the outlet, not in place', async () => {
+      const { getByTestId } = await renderMenu({ menu: makeMenu(), actions: makeActions(2) });
+      const outlet = await waitFor(() => getByTestId('overlay-outlet'));
+      // Walking up from the backdrop must reach the outlet: that is what proves the
+      // content and the menu live under one shared ancestor.
+      let node = getByTestId('row-action-menu-backdrop').parent;
+      let found = false;
+      while (node) {
+        if (node === outlet) { found = true; break; }
+        node = node.parent;
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe('Regression Tests', () => {
+    // Without a Modal window there is no onRequestClose, so back has to be wired by
+    // hand — otherwise the hardware back button would leave the screen with the menu
+    // still up.
+    it('closes on hardware back while open', async () => {
+      const onClose = jest.fn();
+      const spy = jest.spyOn(BackHandler, 'addEventListener');
+      await renderMenu({ menu: makeMenu(), actions: makeActions(2), onClose });
+
+      await waitFor(() => expect(spy).toHaveBeenCalledWith('hardwareBackPress', expect.any(Function)));
+      const handler = spy.mock.calls.at(-1)[1];
+      expect(handler()).toBe(true);
+      expect(onClose).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+
+    it('does not intercept hardware back while closed', async () => {
+      const spy = jest.spyOn(BackHandler, 'addEventListener');
+      await renderMenu({ menu: null, actions: makeActions(2) });
+      await waitFor(() => expect(spy).not.toHaveBeenCalled());
+      spy.mockRestore();
+    });
   });
 });

--- a/__tests__/components/budgets/MonthlyPlanSection.test.js
+++ b/__tests__/components/budgets/MonthlyPlanSection.test.js
@@ -2,8 +2,9 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import MonthlyPlanSection from '../../../app/components/budgets/MonthlyPlanSection';
+import { OverlayHostProvider, OverlayOutlet } from '../../../app/contexts/OverlayHostContext';
 
 const COLORS = {
   background: '#111318',
@@ -210,15 +211,23 @@ const TEMPLATE_LINE = {
   hasTemplate: true, lastExecutedMonth: null,
 };
 
+// Mirrors App.js: the section renders inside the (blurred) content view, and the
+// long-press action menu it opens lands in the overlay outlet beside it. Without
+// the outlet the menu would mount nowhere at all.
 const renderSection = (ref, extraProps = {}) => render(
-  <MonthlyPlanSection
-    ref={ref}
-    currency="USD"
-    expenseCategories={EXPENSE_CATEGORIES}
-    incomeCategories={INCOME_CATEGORIES}
-    accounts={ACCOUNTS}
-    {...extraProps}
-  />,
+  <OverlayHostProvider>
+    <View>
+      <MonthlyPlanSection
+        ref={ref}
+        currency="USD"
+        expenseCategories={EXPENSE_CATEGORIES}
+        incomeCategories={INCOME_CATEGORIES}
+        accounts={ACCOUNTS}
+        {...extraProps}
+      />
+    </View>
+    <OverlayOutlet />
+  </OverlayHostProvider>,
 );
 
 const flatColor = (node) => StyleSheet.flatten(node.props.style)?.color;
@@ -238,22 +247,11 @@ const openEditor = async (ref, kind = 'expense') => {
 };
 
 // Reordering moved off the rows (a chevron pair on every one) and into the
-// long-press action sheet. `t` is the identity function here, so an action's
-// text is its translation key.
-const lastDialogAction = (key) => {
-  const calls = mockShowDialog.mock.calls;
-  const buttons = calls[calls.length - 1][2];
-  const action = buttons.find(b => b.text === key);
-  if (!action) {
-    throw new Error(`No "${key}" action in the last dialog: ${buttons.map(b => b.text).join(', ')}`);
-  }
-  return action;
-};
+// long-press action menu, which lifts the pressed row above a blurred backdrop
+// and floats an icon bar over it. Each action is a button in that bar.
+const menuAction = (getByTestId, key) => getByTestId(`plan-action-${key}`);
 
-const hasDialogAction = (key) => {
-  const calls = mockShowDialog.mock.calls;
-  return calls[calls.length - 1][2].some(b => b.text === key);
-};
+const hasMenuAction = (queryByTestId, key) => queryByTestId(`plan-action-${key}`) !== null;
 
 // Always act()-wrapped: several tests here long-press a row while its own
 // reorder/save round trip is still in flight, and firing an event outside act()
@@ -268,7 +266,7 @@ const longPressLine = async (getByTestId, lineId) => {
 const moveLine = async (getByTestId, lineId, direction) => {
   await longPressLine(getByTestId, lineId);
   await act(async () => {
-    lastDialogAction(direction === -1 ? 'move_up' : 'move_down').onPress();
+    fireEvent.press(menuAction(getByTestId, direction === -1 ? 'move-up' : 'move-down'));
   });
 };
 
@@ -1018,14 +1016,14 @@ describe('MonthlyPlanSection', () => {
       mockPlans.reorderRecurringLines = jest.fn(
         () => new Promise((resolve) => { releaseReorder = resolve; }),
       );
-      const { getByTestId } = await renderSection();
+      const { getByTestId, queryByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-line-l-a')).toBeTruthy());
-      // Before the move: l-a is first, so its action sheet offers only "down".
-      // (The sheet omits a move that has nowhere to land — it used to be a pair
+      // Before the move: l-a is first, so its action bar offers only "down".
+      // (The bar omits a move that has nowhere to land — it used to be a pair
       // of chevrons whose disabled state said the same thing.)
       await longPressLine(getByTestId, 'l-a');
-      expect(hasDialogAction('move_up')).toBe(false);
-      expect(hasDialogAction('move_down')).toBe(true);
+      expect(hasMenuAction(queryByTestId, 'move-up')).toBe(false);
+      expect(hasMenuAction(queryByTestId, 'move-down')).toBe(true);
 
       await moveLine(getByTestId, 'l-a', 1);
 
@@ -1034,8 +1032,8 @@ describe('MonthlyPlanSection', () => {
       // order below can have changed is the optimistic setLines() call that
       // happens BEFORE that await.
       await longPressLine(getByTestId, 'l-a');
-      expect(hasDialogAction('move_up')).toBe(true);
-      expect(hasDialogAction('move_down')).toBe(false);
+      expect(hasMenuAction(queryByTestId, 'move-up')).toBe(true);
+      expect(hasMenuAction(queryByTestId, 'move-down')).toBe(false);
 
       await act(async () => { releaseReorder(); });
     });
@@ -1065,19 +1063,14 @@ describe('MonthlyPlanSection', () => {
 
       // Two taps in immediate succession (same JS task, before either resolves)
       // — a state-only guard would not catch this; only a synchronous ref does.
-      // The action is grabbed once and fired twice, which is what a real double
-      // tap on one sheet button does; re-opening the sheet in between would
-      // instead exercise the sheet's own bounds check.
-      // Two taps in immediate succession (same JS task, before either resolves)
-      // — a state-only guard would not catch this; only a synchronous ref does.
-      // The action is grabbed once and fired twice, which is what a real double
-      // tap on one sheet button does; re-opening the sheet in between would
-      // instead exercise the sheet's own bounds check.
+      // The button is grabbed once and pressed twice, which is what a real
+      // double tap on one action does; re-opening the menu in between would
+      // instead exercise the menu's own bounds check.
       await longPressLine(getByTestId, 'l-a');
-      const moveDown = lastDialogAction('move_down');
+      const moveDown = menuAction(getByTestId, 'move-down');
       await act(async () => {
-        moveDown.onPress();
-        moveDown.onPress();
+        fireEvent.press(moveDown);
+        fireEvent.press(moveDown);
       });
 
       await waitFor(() => expect(mockPlans.getLinesForMonth).toHaveBeenCalledTimes(2)); // mount + one reconcile
@@ -1098,10 +1091,10 @@ describe('MonthlyPlanSection', () => {
       await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
 
       await longPressLine(getByTestId, 'l1');
-      const moveDown = lastDialogAction('move_down');
+      const moveDown = menuAction(getByTestId, 'move-down');
       await act(async () => {
-        moveDown.onPress();
-        moveDown.onPress();
+        fireEvent.press(moveDown);
+        fireEvent.press(moveDown);
       });
 
       await waitFor(() => expect(mockPlans.getLinesForMonth).toHaveBeenCalledTimes(2));
@@ -1488,6 +1481,142 @@ describe('MonthlyPlanSection', () => {
       expect(getByTestId('plan-income-total')).toHaveTextContent(/150 \/ 220 USD/);
     });
   });
+  describe('Long-press action menu', () => {
+    // Long-pressing a budget used to open a "Select an action" dialog listing the
+    // row's name — the same actions, one step removed from the thing they act on.
+    // The row is now lifted above a blurred backdrop with an icon bar floating
+    // over it, exactly as an operation row already behaved.
+    const LINE = {
+      id: 'l1', planId: 'p1', amount: '100', label: 'Books', comment: null, kind: 'expense',
+      categoryId: 'cat1', toAccountId: null, sortOrder: 0, isBroken: false, isRecurring: false,
+      currency: 'USD',
+    };
+    const withLine = (line = LINE) => setPlans({
+      plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '1000' }],
+      lines: [line],
+    });
+
+    it('opens the action bar instead of a dialog, and offers no move for a lone row', async () => {
+      withLine();
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+
+      await longPressLine(getByTestId, 'l1');
+
+      expect(getByTestId('plan-action-menu-backdrop')).toBeTruthy();
+      expect(getByTestId('plan-action-edit')).toBeTruthy();
+      expect(getByTestId('plan-action-delete')).toBeTruthy();
+      // A single line has nowhere to move to, so neither move action is offered.
+      expect(hasMenuAction(queryByTestId, 'move-up')).toBe(false);
+      expect(hasMenuAction(queryByTestId, 'move-down')).toBe(false);
+      expect(mockShowDialog).not.toHaveBeenCalled();
+    });
+
+    it('opens the line editor from the menu', async () => {
+      withLine();
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+      await longPressLine(getByTestId, 'l1');
+
+      await act(async () => { fireEvent.press(menuAction(getByTestId, 'edit')); });
+
+      await waitFor(() => expect(getByTestId('mock-line-modal')).toBeTruthy());
+      expect(capturedModalProps.line.id).toBe('l1');
+    });
+
+    it('dismisses the menu once an action has run', async () => {
+      withLine();
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+      await longPressLine(getByTestId, 'l1');
+
+      await act(async () => { fireEvent.press(menuAction(getByTestId, 'edit')); });
+
+      expect(queryByTestId('plan-action-menu-backdrop')).toBeNull();
+    });
+
+    it('dismisses on a backdrop tap without acting', async () => {
+      withLine();
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+      await longPressLine(getByTestId, 'l1');
+
+      await act(async () => { fireEvent.press(getByTestId('plan-action-menu-backdrop')); });
+
+      expect(queryByTestId('plan-action-menu-backdrop')).toBeNull();
+      expect(queryByTestId('mock-line-modal')).toBeNull();
+      expect(mockPlans.deleteLine).not.toHaveBeenCalled();
+    });
+
+    it('still confirms before deleting a line', async () => {
+      withLine();
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+      await longPressLine(getByTestId, 'l1');
+
+      await act(async () => { fireEvent.press(menuAction(getByTestId, 'delete')); });
+
+      expect(mockShowDialog).toHaveBeenCalledWith(
+        'delete_allocation', 'delete_allocation_confirm', expect.anything(),
+      );
+      expect(mockPlans.deleteLine).not.toHaveBeenCalled();
+      const confirm = mockShowDialog.mock.calls.at(-1)[2].find(b => b.style === 'destructive');
+      await act(async () => { confirm.onPress(); });
+      expect(mockPlans.deleteLine).toHaveBeenCalledWith('l1');
+    });
+
+    it('offers execute and mark-done for a template line, and runs the execution', async () => {
+      setPlans({ plans: [], lines: [TEMPLATE_LINE] });
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l-tpl')).toBeTruthy());
+      await longPressLine(getByTestId, 'l-tpl');
+
+      expect(getByTestId('plan-action-done')).toBeTruthy();
+      expect(hasMenuAction(queryByTestId, 'undo')).toBe(false);
+      await act(async () => { fireEvent.press(menuAction(getByTestId, 'execute')); });
+
+      await waitFor(() => expect(mockPlans.executeLine).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'l-tpl' }), 'Rent',
+      ));
+    });
+
+    it('offers undo instead once the template has been executed this month', async () => {
+      setPlans({ plans: [], lines: [{ ...TEMPLATE_LINE, lastExecutedMonth: THIS_MONTH }] });
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l-tpl')).toBeTruthy());
+      await longPressLine(getByTestId, 'l-tpl');
+
+      expect(hasMenuAction(queryByTestId, 'execute')).toBe(false);
+      await act(async () => { fireEvent.press(menuAction(getByTestId, 'undo')); });
+
+      await waitFor(() => expect(mockPlans.unmarkLineExecuted).toHaveBeenCalledWith('l-tpl'));
+    });
+
+    it('offers no execution actions for a month other than the current one', async () => {
+      setPlans({ plans: [], lines: [TEMPLATE_LINE] });
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l-tpl')).toBeTruthy());
+      await act(async () => { fireEvent.press(getByTestId('plan-next-month')); });
+
+      await longPressLine(getByTestId, 'l-tpl');
+
+      expect(hasMenuAction(queryByTestId, 'execute')).toBe(false);
+      expect(hasMenuAction(queryByTestId, 'done')).toBe(false);
+      expect(getByTestId('plan-action-edit')).toBeTruthy();
+    });
+
+    it('names the shortened labels in full for a screen reader', async () => {
+      withLine();
+      const { getByTestId, getByLabelText } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-line-l1')).toBeTruthy());
+      await longPressLine(getByTestId, 'l1');
+
+      // The bar has room for one word per button; the phrase goes to the label.
+      expect(getByLabelText('edit_allocation')).toBeTruthy();
+      expect(getByLabelText('delete_allocation')).toBeTruthy();
+    });
+  });
+
   describe('Line groups (migration 0022)', () => {
     const GROUP = { id: 'g1', label: 'Car', amount: null, currency: null, sortOrder: 0, isDerived: true };
     const groupedLines = () => ([
@@ -1572,8 +1701,8 @@ describe('MonthlyPlanSection', () => {
       expect(queryByTestId('plan-group-g1')).toBeNull();
     });
 
-    it('opens the group editor from the long-press sheet', async () => {
-      // Editing moved off the tap, which folds the envelope now — the sheet is
+    it('opens the group editor from the long-press action menu', async () => {
+      // Editing moved off the tap, which folds the envelope now — the menu is
       // where every other whole-row action already lived.
       setPlans({
         plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
@@ -1583,9 +1712,44 @@ describe('MonthlyPlanSection', () => {
       const { getByTestId } = await renderSection();
       await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
       await longPressGroup(getByTestId, 'g1');
-      await act(async () => { lastDialogAction('edit_group').onPress(); });
+      await act(async () => { fireEvent.press(menuAction(getByTestId, 'edit')); });
       await waitFor(() => expect(getByTestId('plan-group-modal')).toBeTruthy());
       expect(getByTestId('plan-group-name').props.value).toBe('Car');
+    });
+
+    it('confirms before deleting a group from the action menu', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [GROUP],
+      });
+      const { getByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+      await longPressGroup(getByTestId, 'g1');
+
+      await act(async () => { fireEvent.press(menuAction(getByTestId, 'delete')); });
+
+      expect(mockShowDialog).toHaveBeenCalledWith(
+        'delete_group', 'delete_group_confirm', expect.anything(),
+      );
+      expect(mockPlans.deleteLineGroup).not.toHaveBeenCalled();
+      const confirm = mockShowDialog.mock.calls.at(-1)[2].find(b => b.style === 'destructive');
+      await act(async () => { confirm.onPress(); });
+      expect(mockPlans.deleteLineGroup).toHaveBeenCalledWith('g1');
+    });
+
+    it('offers no move actions to an only envelope', async () => {
+      setPlans({
+        plans: [{ id: 'p1', month: THIS_MONTH, currency: 'USD', expectedIncome: '0' }],
+        lines: groupedLines(),
+        groups: [GROUP],
+      });
+      const { getByTestId, queryByTestId } = await renderSection();
+      await waitFor(() => expect(getByTestId('plan-group-g1')).toBeTruthy());
+      await longPressGroup(getByTestId, 'g1');
+
+      expect(hasMenuAction(queryByTestId, 'move-up')).toBe(false);
+      expect(hasMenuAction(queryByTestId, 'move-down')).toBe(false);
     });
 
     describe('Folding', () => {

--- a/__tests__/components/operations/OperationActionMenu.test.js
+++ b/__tests__/components/operations/OperationActionMenu.test.js
@@ -1,10 +1,13 @@
 /**
- * Tests for OperationActionMenu — the long-press context menu shown over an
- * operation row (Edit / Repeat / hide-from-charts / Delete on a lifted, blurred
- * backdrop).
+ * Tests for OperationActionMenu — the ACTION LIST an operation row offers on long
+ * press (Edit / Repeat / hide-from-charts / Delete).
+ *
+ * The presentation those actions arrive in — the lifted copy of the row, the
+ * blurred backdrop, dismissal, hardware back — belongs to RowActionMenu and is
+ * covered in __tests__/components/RowActionMenu.test.js.
  */
 import React from 'react';
-import { BackHandler, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import OperationActionMenu from '../../../app/components/operations/OperationActionMenu';
 import {
@@ -59,13 +62,6 @@ const renderMenu = (props) => render(tree(props));
 
 describe('OperationActionMenu', () => {
   beforeEach(() => jest.clearAllMocks());
-
-  it('renders nothing when menu is null', async () => {
-    const { queryByTestId } = await renderMenu({ menu: null, ...baseProps() });
-    await waitFor(() => expect(queryByTestId('overlay-outlet')).toBeNull());
-    expect(queryByTestId('operation-action-edit')).toBeNull();
-    expect(queryByTestId('operation-action-menu-backdrop')).toBeNull();
-  });
 
   it('renders the action buttons and the lifted row when open', async () => {
     const { getByTestId, getByText } = await renderMenu({ menu: makeMenu(), ...baseProps() });
@@ -124,73 +120,16 @@ describe('OperationActionMenu', () => {
     });
   });
 
-  it('dismisses when the backdrop is pressed', async () => {
-    const props = baseProps();
-    const { getByTestId } = await renderMenu({ menu: makeMenu(), ...props });
-    await waitFor(() => expect(getByTestId('operation-action-menu-backdrop')).toBeTruthy());
-    fireEvent.press(getByTestId('operation-action-menu-backdrop'));
-    expect(props.onClose).toHaveBeenCalledTimes(1);
-  });
+  // The reason this component's frame left <Modal> behind: a Modal is a separate
+  // native window, so a row measured in app coordinates and redrawn inside it drifts
+  // by whatever the two origins disagree on. That, and the hardware-back wiring it
+  // forced, are RowActionMenu's now — what stays here is that an operation's row
+  // reaches the overlay at all.
+  it('lifts the pressed row into the overlay layer', async () => {
+    const { getByTestId, getByText } = await renderMenu({ menu: makeMenu(), ...baseProps() });
+    await waitFor(() => expect(getByTestId('overlay-outlet')).toBeTruthy());
 
-  describe('Overlay placement', () => {
-    // The reason this component left <Modal> behind: a Modal is a separate native
-    // window, so a row measured in app coordinates and redrawn inside it drifts by
-    // whatever the two origins disagree on. The overlay shares a parent with the
-    // content, so `layout.y` addresses the same pixel on both sides.
-    it('draws the lifted clone at the measured row position', async () => {
-      const { getByTestId, getByText } = await renderMenu({ menu: makeMenu(), ...baseProps() });
-      await waitFor(() => expect(getByTestId('overlay-outlet')).toBeTruthy());
-
-      const clone = getByText('Groceries').parent;
-      expect(StyleSheet.flatten(clone.props.style)).toMatchObject({ top: 200, left: 16, width: 320 });
-    });
-
-    it('mounts the overlay into the outlet, not in place', async () => {
-      const { getByTestId } = await renderMenu({ menu: makeMenu(), ...baseProps() });
-      const outlet = await waitFor(() => getByTestId('overlay-outlet'));
-      // Walking up from the backdrop must reach the outlet: that is what proves the
-      // content and the menu live under one shared ancestor.
-      let node = getByTestId('operation-action-menu-backdrop').parent;
-      let found = false;
-      while (node) {
-        if (node === outlet) { found = true; break; }
-        node = node.parent;
-      }
-      expect(found).toBe(true);
-    });
-
-    it('unmounts the overlay when the menu closes', async () => {
-      const props = baseProps();
-      const { queryByTestId, rerender } = await renderMenu({ menu: makeMenu(), ...props });
-      await waitFor(() => expect(queryByTestId('operation-action-menu-backdrop')).toBeTruthy());
-
-      rerender(tree({ menu: null, ...props }));
-
-      await waitFor(() => expect(queryByTestId('operation-action-menu-backdrop')).toBeNull());
-    });
-  });
-
-  describe('Regression Tests', () => {
-    // Without a Modal window there is no onRequestClose, so back has to be wired by
-    // hand — otherwise the hardware back button would leave the screen with the menu
-    // still up.
-    it('closes on hardware back while open', async () => {
-      const props = baseProps();
-      const spy = jest.spyOn(BackHandler, 'addEventListener');
-      await renderMenu({ menu: makeMenu(), ...props });
-
-      await waitFor(() => expect(spy).toHaveBeenCalledWith('hardwareBackPress', expect.any(Function)));
-      const handler = spy.mock.calls.at(-1)[1];
-      expect(handler()).toBe(true);
-      expect(props.onClose).toHaveBeenCalledTimes(1);
-      spy.mockRestore();
-    });
-
-    it('does not intercept hardware back while closed', async () => {
-      const spy = jest.spyOn(BackHandler, 'addEventListener');
-      await renderMenu({ menu: null, ...baseProps() });
-      await waitFor(() => expect(spy).not.toHaveBeenCalled());
-      spy.mockRestore();
-    });
+    const clone = getByText('Groceries').parent;
+    expect(StyleSheet.flatten(clone.props.style)).toMatchObject({ top: 200, left: 16, width: 320 });
   });
 });

--- a/app/components/RowActionMenu.js
+++ b/app/components/RowActionMenu.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BackHandler, View, Text, Pressable, StyleSheet, Animated, Dimensions } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
@@ -21,8 +21,23 @@ const MAX_PER_ROW = 4;
  * is needed the two are balanced (5 actions read 3 + 2, not 4 + 1) so no single
  * button ends up alone at double width.
  */
-export const panelRows = (count) => Math.max(1, Math.ceil(count / MAX_PER_ROW));
+const panelRows = (count) => Math.max(1, Math.ceil(count / MAX_PER_ROW));
 const perRow = (count) => Math.ceil(count / panelRows(count));
+
+// A closed menu's action list, as one shared value: hosts derive their actions
+// from the pressed row, and a fresh `[]` per render would miss this component's
+// memo on every render of a screen whose menu isn't even open.
+export const NO_ACTIONS = [];
+
+// Icon and label colour per tone. `default` is the accent; `muted` marks an
+// action that undoes or hides rather than does; `destructive` is the one red on
+// the bar, and it carries the label too so the button reads as dangerous at a
+// glance rather than only under its glyph.
+const TONES = {
+  default: (colors) => ({ icon: colors.primary, text: colors.text }),
+  muted: (colors) => ({ icon: colors.mutedText, text: colors.text }),
+  destructive: (colors) => ({ icon: colors.destructive, text: colors.destructive }),
+};
 
 /**
  * The long-press context menu shared by every list row that offers whole-row
@@ -43,11 +58,16 @@ const perRow = (count) => Math.ceil(count / panelRows(count));
  * the same thing on both sides and the clone always lands on the row.
  *
  * The host owns visibility and the action list: pass a `menu` object to open, `null`
- * to close, and the `actions` the pressed row supports. Entrance is animated; closing
- * unmounts immediately (a snappy dismiss is the expected feel for a context menu, and
- * keeping no internal open/close state avoids setState-in-effect churn).
+ * to close, and the `actions` the pressed row supports. Choosing an action dismisses
+ * the menu before it runs — that is this component's job, not each host's, because
+ * every action either opens something or asks for a confirmation, and a menu left
+ * covering the screen over a dialog is the failure mode.
+ *
+ * Entrance is animated; closing unmounts immediately (a snappy dismiss is the
+ * expected feel for a context menu, and keeping no internal open/close state avoids
+ * setState-in-effect churn).
  */
-export default function RowActionMenu({ menu, actions, colors, onClose, testIDPrefix }) {
+function RowActionMenu({ menu, actions, colors, onClose, testIDPrefix }) {
   const insets = useSafeAreaInsets();
   const progress = useRef(new Animated.Value(0)).current;
   // Height of the overlay layer itself, not of the screen: the layer is the box the
@@ -62,10 +82,10 @@ export default function RowActionMenu({ menu, actions, colors, onClose, testIDPr
   }, []);
 
   // Open-ness rather than the `menu` object itself drives both effects below: a
-  // host that rebuilds the object on every render (because the lifted copy tracks
-  // live data) would otherwise re-subscribe to back and restart the entrance
+  // host whose lifted copy tracks live data rebuilds that object while the menu
+  // is up, and keying off it would re-subscribe to back and restart the entrance
   // spring mid-animation.
-  const isOpen = !!menu;
+  const isOpen = !!menu && actions.length > 0;
 
   // The overlay is not a native window, so the hardware back button is ours to handle.
   useEffect(() => {
@@ -96,57 +116,60 @@ export default function RowActionMenu({ menu, actions, colors, onClose, testIDPr
     }
   }, [isOpen, progress]);
 
-  if (!menu || actions.length === 0) return null;
-
-  const { layout, row } = menu;
+  const layout = menu?.layout ?? null;
   const panelHeight = panelRows(actions.length) * PANEL_ROW_HEIGHT;
-  // A percentage rather than flex: it keeps the buttons of a wrapped second row in
-  // the same columns as the first one's, instead of stretching to fill it.
-  const buttonWidth = `${100 / perRow(actions.length)}%`;
 
   // Where the floating icon bar goes. Prefer above the row; fall back to below.
   // Both edges are bounded so the bar never lands under the status bar / notch
   // or under the bottom inset (tab bar / gesture area) for a near-edge row.
-  let panelTop;
-  let panelPlacedAbove = true;
-  if (layout) {
+  const { panelTop, panelPlacedAbove } = useMemo(() => {
+    if (!layout) {
+      // No measurement (rare): center the bar on screen.
+      return { panelTop: layerHeight / 2 - panelHeight / 2, panelPlacedAbove: false };
+    }
     const topLimit = insets.top + SPACING.sm;
     const bottomLimit = layerHeight - insets.bottom - SPACING.sm - panelHeight;
     const above = layout.y - GAP - panelHeight;
     const below = layout.y + layout.height + GAP;
-    if (above >= topLimit) {
-      panelTop = above;
-    } else if (below <= bottomLimit) {
-      panelTop = below;
-      panelPlacedAbove = false;
-    } else {
-      // Neither side fully clears an inset — clamp into the visible area.
-      panelTop = Math.max(topLimit, Math.min(above, bottomLimit));
-    }
-  } else {
-    // No measurement (rare): center the bar on screen.
-    panelTop = layerHeight / 2 - panelHeight / 2;
-    panelPlacedAbove = false;
-  }
+    if (above >= topLimit) return { panelTop: above, panelPlacedAbove: true };
+    if (below <= bottomLimit) return { panelTop: below, panelPlacedAbove: false };
+    // Neither side fully clears an inset — clamp into the visible area.
+    return {
+      panelTop: Math.max(topLimit, Math.min(above, bottomLimit)),
+      panelPlacedAbove: true,
+    };
+  }, [layout, panelHeight, layerHeight, insets.top, insets.bottom]);
 
-  const backdropStyle = { opacity: progress };
-  const cloneStyle = {
-    opacity: progress,
-    transform: [
-      { scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.97, 1] }) },
-    ],
-  };
-  const panelStyle = {
-    opacity: progress,
-    transform: [
-      {
-        translateY: progress.interpolate({
-          inputRange: [0, 1],
-          outputRange: [panelPlacedAbove ? SPACING.sm : -SPACING.sm, 0],
-        }),
-      },
-    ],
-  };
+  // Built once per placement rather than per render: each `interpolate` call
+  // creates a native animation node, and rebuilding them while the entrance
+  // spring is running tears down and re-creates the node graph under the clone.
+  const { backdropStyle, cloneStyle, panelStyle } = useMemo(() => ({
+    backdropStyle: { opacity: progress },
+    cloneStyle: {
+      opacity: progress,
+      transform: [
+        { scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.97, 1] }) },
+      ],
+    },
+    panelStyle: {
+      opacity: progress,
+      transform: [
+        {
+          translateY: progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [panelPlacedAbove ? SPACING.sm : -SPACING.sm, 0],
+          }),
+        },
+      ],
+    },
+  }), [progress, panelPlacedAbove]);
+
+  if (!isOpen) return null;
+
+  const { row } = menu;
+  // A percentage rather than flex: it keeps the buttons of a wrapped second row in
+  // the same columns as the first one's, instead of stretching to fill it.
+  const buttonWidth = `${100 / perRow(actions.length)}%`;
 
   return (
     <>
@@ -199,18 +222,15 @@ export default function RowActionMenu({ menu, actions, colors, onClose, testIDPr
                 : { left: SPACING.lg, right: SPACING.lg },
             ]}
           >
-            <Pressable style={styles.panelRow} onPress={() => {}}>
+            <Pressable style={styles.panelRow} onPress={swallowTap}>
               {actions.map((action) => (
                 <ActionButton
                   key={action.key}
-                  testID={action.testID || `${testIDPrefix}-${action.key}`}
-                  icon={action.icon}
-                  label={action.label}
-                  a11yLabel={action.a11yLabel}
-                  color={action.destructive ? colors.destructive : (action.muted ? colors.mutedText : colors.primary)}
-                  textColor={action.destructive ? colors.destructive : colors.text}
+                  testID={`${testIDPrefix}-${action.key}`}
+                  action={action}
+                  colors={colors}
                   width={buttonWidth}
-                  onPress={action.onPress}
+                  onClose={onClose}
                 />
               ))}
             </Pressable>
@@ -221,47 +241,49 @@ export default function RowActionMenu({ menu, actions, colors, onClose, testIDPr
   );
 }
 
-function ActionButton({ testID, icon, label, a11yLabel, color, textColor, width, onPress }) {
+const swallowTap = () => {};
+
+function ActionButton({ testID, action, colors, width, onClose }) {
+  const { icon: iconColor, text: textColor } = (TONES[action.tone] || TONES.default)(colors);
+  const handlePress = () => {
+    onClose();
+    action.onPress();
+  };
   return (
     <Pressable
       testID={testID}
-      onPress={onPress}
+      onPress={handlePress}
       style={({ pressed }) => [styles.actionButton, { width }, pressed && styles.actionButtonPressed]}
       accessibilityRole="button"
-      accessibilityLabel={a11yLabel || label}
+      accessibilityLabel={action.a11yLabel || action.label}
     >
-      <Icon name={icon} size={ICON_SIZE.md} color={color} />
+      <Icon name={action.icon} size={ICON_SIZE.md} color={iconColor} />
       <Text style={[styles.actionLabel, { color: textColor }]} numberOfLines={1}>
-        {label}
+        {action.label}
       </Text>
     </Pressable>
   );
 }
 
-ActionButton.propTypes = {
-  testID: PropTypes.string,
-  icon: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  a11yLabel: PropTypes.string,
-  color: PropTypes.string.isRequired,
-  textColor: PropTypes.string.isRequired,
-  width: PropTypes.string.isRequired,
-  onPress: PropTypes.func.isRequired,
-};
-
-export const actionShape = PropTypes.shape({
-  // Identifies the action and, unless `testID` says otherwise, names its testID.
+const actionShape = PropTypes.shape({
+  // Identifies the action and names its testID under the host's prefix.
   key: PropTypes.string.isRequired,
   icon: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   // The full phrase, for screen readers, when the visible label had to be shortened
   // to fit beside its siblings.
   a11yLabel: PropTypes.string,
-  destructive: PropTypes.bool,
-  muted: PropTypes.bool,
-  testID: PropTypes.string,
+  tone: PropTypes.oneOf(Object.keys(TONES)),
   onPress: PropTypes.func.isRequired,
 });
+
+ActionButton.propTypes = {
+  testID: PropTypes.string,
+  action: actionShape.isRequired,
+  colors: PropTypes.object.isRequired,
+  width: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
 
 RowActionMenu.propTypes = {
   menu: PropTypes.shape({
@@ -278,6 +300,12 @@ RowActionMenu.propTypes = {
   onClose: PropTypes.func.isRequired,
   testIDPrefix: PropTypes.string.isRequired,
 };
+
+// Memoized because it renders through OverlayPortal, whose effect re-mounts the
+// overlay slot whenever its children change identity — one host render would
+// otherwise cost a second pass over the whole clone-and-panel subtree. Hosts keep
+// `menu` and `actions` stable (see NO_ACTIONS) for this to hold.
+export default memo(RowActionMenu);
 
 const styles = StyleSheet.create({
   actionButton: {

--- a/app/components/RowActionMenu.js
+++ b/app/components/RowActionMenu.js
@@ -1,0 +1,338 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { BackHandler, View, Text, Pressable, StyleSheet, Animated, Dimensions } from 'react-native';
+import PropTypes from 'prop-types';
+import Icon from '@expo/vector-icons/MaterialCommunityIcons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import ModalBlurOverlay from './ModalBlurOverlay';
+import { OverlayPortal } from '../contexts/OverlayHostContext';
+import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../styles/designTokens';
+import { isReduceMotionEnabled } from '../utils/reducedMotion';
+
+// Height of one row of action buttons; a menu with more actions than fit across
+// the row stacks a second one (see `panelRows`), so the reserved height — which
+// decides whether the bar fits above the pressed row — follows the count.
+const PANEL_ROW_HEIGHT = 68;
+const GAP = 10;
+// Past four across, the labels stop being readable at a row's width.
+const MAX_PER_ROW = 4;
+
+/**
+ * How the actions are laid out: at most MAX_PER_ROW across, and when a second row
+ * is needed the two are balanced (5 actions read 3 + 2, not 4 + 1) so no single
+ * button ends up alone at double width.
+ */
+export const panelRows = (count) => Math.max(1, Math.ceil(count / MAX_PER_ROW));
+const perRow = (count) => Math.ceil(count / panelRows(count));
+
+/**
+ * The long-press context menu shared by every list row that offers whole-row
+ * actions (operations, budget lines, budget envelopes).
+ *
+ * Instead of a plain "choose action" dialog, the pressed row is lifted above a
+ * blurred backdrop (a static clone rendered at its measured position) and a compact
+ * icon bar floats just above (or below) it. Tapping the backdrop or pressing back
+ * dismisses it. The row stays visible and in place, so the actions are attached to
+ * something the user can still see rather than to a title in a dialog.
+ *
+ * The clone is drawn in the app-wide overlay layer (OverlayPortal), NOT in a core
+ * `<Modal>`. That is the whole trick: a Modal is a separate native window, so a row
+ * measured in the app's coordinates and re-drawn inside that window drifts by
+ * whatever the two origins disagree on — a status bar's worth of offset on
+ * edge-to-edge Android, which is exactly what made the row visibly jump on long
+ * press. The overlay shares a parent with the content it covers, so `layout.y` means
+ * the same thing on both sides and the clone always lands on the row.
+ *
+ * The host owns visibility and the action list: pass a `menu` object to open, `null`
+ * to close, and the `actions` the pressed row supports. Entrance is animated; closing
+ * unmounts immediately (a snappy dismiss is the expected feel for a context menu, and
+ * keeping no internal open/close state avoids setState-in-effect churn).
+ */
+export default function RowActionMenu({ menu, actions, colors, onClose, testIDPrefix }) {
+  const insets = useSafeAreaInsets();
+  const progress = useRef(new Animated.Value(0)).current;
+  // Height of the overlay layer itself, not of the screen: the layer is the box the
+  // panel is being placed in, so clamping against anything else re-introduces the
+  // guesswork this component just got rid of. Seeded from window height for the
+  // first frame, corrected by the first onLayout.
+  const [layerHeight, setLayerHeight] = useState(() => Dimensions.get('window').height);
+
+  const handleLayerLayout = useCallback((e) => {
+    const { height } = e.nativeEvent.layout;
+    setLayerHeight((prev) => (height > 0 && height !== prev ? height : prev));
+  }, []);
+
+  // Open-ness rather than the `menu` object itself drives both effects below: a
+  // host that rebuilds the object on every render (because the lifted copy tracks
+  // live data) would otherwise re-subscribe to back and restart the entrance
+  // spring mid-animation.
+  const isOpen = !!menu;
+
+  // The overlay is not a native window, so the hardware back button is ours to handle.
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onClose();
+      return true;
+    });
+    return () => sub.remove();
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Under the OS "Remove animations" setting the menu is simply present: the
+      // lift is what carries the meaning here, and there is no fade left to keep
+      // once it is gone (`progress` drives the backdrop and the clone together).
+      if (isReduceMotionEnabled()) {
+        progress.setValue(1);
+        return;
+      }
+      progress.setValue(0);
+      Animated.spring(progress, {
+        toValue: 1,
+        useNativeDriver: true,
+        speed: 18,
+        bounciness: 6,
+      }).start();
+    }
+  }, [isOpen, progress]);
+
+  if (!menu || actions.length === 0) return null;
+
+  const { layout, row } = menu;
+  const panelHeight = panelRows(actions.length) * PANEL_ROW_HEIGHT;
+  // A percentage rather than flex: it keeps the buttons of a wrapped second row in
+  // the same columns as the first one's, instead of stretching to fill it.
+  const buttonWidth = `${100 / perRow(actions.length)}%`;
+
+  // Where the floating icon bar goes. Prefer above the row; fall back to below.
+  // Both edges are bounded so the bar never lands under the status bar / notch
+  // or under the bottom inset (tab bar / gesture area) for a near-edge row.
+  let panelTop;
+  let panelPlacedAbove = true;
+  if (layout) {
+    const topLimit = insets.top + SPACING.sm;
+    const bottomLimit = layerHeight - insets.bottom - SPACING.sm - panelHeight;
+    const above = layout.y - GAP - panelHeight;
+    const below = layout.y + layout.height + GAP;
+    if (above >= topLimit) {
+      panelTop = above;
+    } else if (below <= bottomLimit) {
+      panelTop = below;
+      panelPlacedAbove = false;
+    } else {
+      // Neither side fully clears an inset — clamp into the visible area.
+      panelTop = Math.max(topLimit, Math.min(above, bottomLimit));
+    }
+  } else {
+    // No measurement (rare): center the bar on screen.
+    panelTop = layerHeight / 2 - panelHeight / 2;
+    panelPlacedAbove = false;
+  }
+
+  const backdropStyle = { opacity: progress };
+  const cloneStyle = {
+    opacity: progress,
+    transform: [
+      { scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.97, 1] }) },
+    ],
+  };
+  const panelStyle = {
+    opacity: progress,
+    transform: [
+      {
+        translateY: progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [panelPlacedAbove ? SPACING.sm : -SPACING.sm, 0],
+        }),
+      },
+    ],
+  };
+
+  return (
+    <>
+      <ModalBlurOverlay />
+      <OverlayPortal>
+        <Pressable
+          testID={`${testIDPrefix}-menu-backdrop`}
+          style={styles.fill}
+          onPress={onClose}
+          onLayout={handleLayerLayout}
+        >
+          <Animated.View style={[styles.backdrop, backdropStyle]} pointerEvents="none" />
+
+          {/* Lifted clone of the pressed row */}
+          {layout && row && (
+            <Animated.View
+              pointerEvents="none"
+              style={[
+                styles.clone,
+                cloneStyle,
+                {
+                  top: layout.y,
+                  left: layout.x,
+                  width: layout.width,
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                },
+              ]}
+            >
+              {row}
+            </Animated.View>
+          )}
+
+          {/* Floating icon action bar. Wrapped in a non-press-through Pressable so
+              taps on the bar don't fall through to the dismiss backdrop. */}
+          <Animated.View
+            style={[
+              styles.panel,
+              panelStyle,
+              {
+                top: panelTop,
+                height: panelHeight,
+                backgroundColor: colors.surface,
+                borderColor: colors.border,
+              },
+              // Anchored to the row when it was measured; otherwise inset from both
+              // edges of the layer, which needs no width arithmetic at all.
+              layout
+                ? { left: layout.x, width: layout.width }
+                : { left: SPACING.lg, right: SPACING.lg },
+            ]}
+          >
+            <Pressable style={styles.panelRow} onPress={() => {}}>
+              {actions.map((action) => (
+                <ActionButton
+                  key={action.key}
+                  testID={action.testID || `${testIDPrefix}-${action.key}`}
+                  icon={action.icon}
+                  label={action.label}
+                  a11yLabel={action.a11yLabel}
+                  color={action.destructive ? colors.destructive : (action.muted ? colors.mutedText : colors.primary)}
+                  textColor={action.destructive ? colors.destructive : colors.text}
+                  width={buttonWidth}
+                  onPress={action.onPress}
+                />
+              ))}
+            </Pressable>
+          </Animated.View>
+        </Pressable>
+      </OverlayPortal>
+    </>
+  );
+}
+
+function ActionButton({ testID, icon, label, a11yLabel, color, textColor, width, onPress }) {
+  return (
+    <Pressable
+      testID={testID}
+      onPress={onPress}
+      style={({ pressed }) => [styles.actionButton, { width }, pressed && styles.actionButtonPressed]}
+      accessibilityRole="button"
+      accessibilityLabel={a11yLabel || label}
+    >
+      <Icon name={icon} size={ICON_SIZE.md} color={color} />
+      <Text style={[styles.actionLabel, { color: textColor }]} numberOfLines={1}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+ActionButton.propTypes = {
+  testID: PropTypes.string,
+  icon: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  a11yLabel: PropTypes.string,
+  color: PropTypes.string.isRequired,
+  textColor: PropTypes.string.isRequired,
+  width: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+export const actionShape = PropTypes.shape({
+  // Identifies the action and, unless `testID` says otherwise, names its testID.
+  key: PropTypes.string.isRequired,
+  icon: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  // The full phrase, for screen readers, when the visible label had to be shortened
+  // to fit beside its siblings.
+  a11yLabel: PropTypes.string,
+  destructive: PropTypes.bool,
+  muted: PropTypes.bool,
+  testID: PropTypes.string,
+  onPress: PropTypes.func.isRequired,
+});
+
+RowActionMenu.propTypes = {
+  menu: PropTypes.shape({
+    layout: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+    }),
+    row: PropTypes.node,
+  }),
+  actions: PropTypes.arrayOf(actionShape).isRequired,
+  colors: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  testIDPrefix: PropTypes.string.isRequired,
+};
+
+const styles = StyleSheet.create({
+  actionButton: {
+    alignItems: 'center',
+    borderRadius: BORDER_RADIUS.md,
+    gap: SPACING.xs,
+    height: PANEL_ROW_HEIGHT,
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.xs,
+  },
+  actionButtonPressed: {
+    opacity: 0.55,
+  },
+  actionLabel: {
+    fontSize: FONT_SIZE.sm,
+    fontWeight: '600',
+  },
+  backdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  clone: {
+    borderRadius: BORDER_RADIUS.md,
+    borderWidth: 1,
+    elevation: 8,
+    overflow: 'hidden',
+    position: 'absolute',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 10,
+  },
+  fill: {
+    flex: 1,
+  },
+  panel: {
+    borderRadius: BORDER_RADIUS.lg,
+    borderWidth: 1,
+    elevation: 10,
+    position: 'absolute',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 12,
+  },
+  panelRow: {
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    paddingHorizontal: SPACING.sm,
+  },
+});

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -17,14 +17,16 @@ import BudgetPlanLineModal from './BudgetPlanLineModal';
 import BudgetLineGroupModal from './BudgetLineGroupModal';
 import PlanLineRow from './PlanLineRow';
 import PlanGroupRow from './PlanGroupRow';
-import RowActionMenu from '../RowActionMenu';
+import RowActionMenu, { NO_ACTIONS } from '../RowActionMenu';
 import { currentMonthKey, addMonths, formatMonthLabel } from '../../utils/monthUtils';
 import { CARD_SURFACE, SECTION_HEADING } from '../../styles/componentStyles';
 import EmptyState from '../EmptyState';
 
 const CLOSED_MODAL = { visible: false, line: null, kind: 'expense' };
 const CLOSED_GROUP_MODAL = { visible: false, group: null };
-const NOOP = () => {};
+// The "list" a lifted copy belongs to: it stands alone, so its length is 1 and
+// its index is 0 — a constant rather than a fresh array per press.
+const SINGLE_ROW = { length: 1 };
 
 // Key under which a group's own (override) amount rides along in the shared
 // conversion map — see the `amountSources` memo. Groups and lines have separate
@@ -733,7 +735,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     }
     return groups
       .filter(group => childrenByGroup.has(group.id))
-      .map((group) => {
+      .map((group, groupIndex) => {
         const children = childrenByGroup.get(group.id);
         // The derived figure the group shows until (and unless) the async status
         // lands: the same sum, from the same converted amounts the rows print.
@@ -750,6 +752,12 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
           oneOff: children.filter(l => !l.isRecurring),
           displayAmount: group.isDerived ? derived : (override ?? null),
           derived,
+          // Assigned by position, and carried on the view so the header, every
+          // child row and the copy the action menu lifts all read one value —
+          // deriving it a second time at any of those sites is how one envelope
+          // ends up rendering in two colours. See envelopePalette for why colour
+          // identifies an envelope here rather than flagging a status.
+          hue: envelopeHue(groupIndex),
         };
       });
   }, [groups, allocationLines, isGrouped, amountById, planCurrency]);
@@ -887,7 +895,14 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
 
   // Shared row renderer for every block — each list moves independently (own
   // sort_order sequence), so `list` and `onMove` are passed in per block.
-  const renderLine = useCallback((line, index, list, onMove, indented = false, envelopeColor = null) => {
+  //
+  // `lifted` renders the static copy the action menu floats over the row: same
+  // row, no handlers and no swipe actions (the bar above it offers those), under
+  // its own testID namespace. It goes through this renderer rather than a second
+  // hand-written <PlanLineRow> so the copy cannot drift from the row it covers.
+  const renderLine = useCallback((line, index, list, onMove, {
+    indented = false, envelopeColor = null, lifted = false,
+  } = {}) => {
     const executed = line.lastExecutedMonth === month;
     return (
       <PlanLineRow
@@ -905,13 +920,14 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         colors={colors}
         t={t}
         executed={executed}
-        canExecute={line.hasTemplate && isCurrentMonth && !executed}
-        canUndo={line.hasTemplate && isCurrentMonth && executed}
+        canExecute={!lifted && line.hasTemplate && isCurrentMonth && !executed}
+        canUndo={!lifted && line.hasTemplate && isCurrentMonth && executed}
         showProgress={line.kind !== 'income'}
         listLength={list.length}
-        onMove={onMove}
-        onPress={openEditLine}
-        onLongPress={handleLongPressLine}
+        lifted={lifted}
+        onMove={lifted ? null : onMove}
+        onPress={lifted ? undefined : openEditLine}
+        onLongPress={lifted ? undefined : handleLongPressLine}
         onExecute={handleExecute}
         onMarkExecuted={handleMarkExecuted}
         onUndo={handleUndoExecuted}
@@ -921,24 +937,32 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     openEditLine, handleLongPressLine, lineDisplayName, lineIcon, handleExecute,
     handleMarkExecuted, handleUndoExecuted]);
 
+  // Same idea for an envelope header: one renderer for the list and for the copy.
+  const renderGroupRow = useCallback((view, index, lifted = false) => (
+    <PlanGroupRow
+      group={view.group}
+      index={index}
+      listLength={groupViews.length}
+      status={groupStatusById.get(view.group.id) || null}
+      displayAmount={view.displayAmount}
+      converting={converting}
+      childCount={view.children.length}
+      envelopeColor={view.hue}
+      planCurrency={planCurrency}
+      colors={colors}
+      t={t}
+      collapsed={!expandedGroupIds.has(view.group.id)}
+      lifted={lifted}
+      onMove={lifted ? null : moveGroup}
+      onToggle={lifted ? undefined : toggleGroup}
+      onLongPress={lifted ? undefined : handleLongPressGroup}
+    />
+  ), [groupViews.length, groupStatusById, converting, planCurrency, colors, t,
+    expandedGroupIds, moveGroup, toggleGroup, handleLongPressGroup]);
+
   const hasAnyLines = lines.length > 0;
 
   /* ── Long-press action menu ──────────────────────────────────────────────── */
-
-  // Which envelope (if any) each row belongs to, by colour. The render loop below
-  // assigns a hue per group position; the lifted copy of a row has to be handed
-  // the same one, or a child row would lose the rail that says which envelope it
-  // is in the moment it is picked up.
-  const envelopeHues = useMemo(() => {
-    const byGroup = new Map();
-    const byLine = new Map();
-    groupViews.forEach((view, groupIndex) => {
-      const hue = envelopeHue(groupIndex);
-      byGroup.set(view.group.id, hue);
-      for (const child of view.children) byLine.set(child.id, hue);
-    });
-    return { byGroup, byLine };
-  }, [groupViews]);
 
   const closeActionMenu = useCallback(() => setActionMenu(null), []);
 
@@ -948,78 +972,29 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   const menuRow = useMemo(() => {
     if (!actionMenu) return null;
     if (actionMenu.type === 'group') {
-      const view = groupViews.find(v => v.group.id === actionMenu.group.id);
-      if (!view) return null;
-      return (
-        // PlanGroupRow carries its own top margin — it is what separates one
-        // envelope from the row above it in the list. Inside the lifted copy
-        // there is nothing to separate from, and the margin would push the copy
-        // that far below the row it is supposed to cover.
-        <View style={styles.cloneOffset}>
-          <PlanGroupRow
-            group={view.group}
-            index={0}
-            listLength={1}
-            status={groupStatusById.get(view.group.id) || null}
-            displayAmount={view.displayAmount}
-            converting={converting}
-            childCount={view.children.length}
-            envelopeColor={envelopeHues.byGroup.get(view.group.id)}
-            planCurrency={planCurrency}
-            colors={colors}
-            t={t}
-            collapsed={!expandedGroupIds.has(view.group.id)}
-            onToggle={NOOP}
-            onLongPress={NOOP}
-            testIDPrefix="plan-group-lifted"
-          />
-        </View>
-      );
+      const index = groupViews.findIndex(v => v.group.id === actionMenu.group.id);
+      return index < 0 ? null : renderGroupRow(groupViews[index], index, true);
     }
     const { line } = actionMenu;
-    const hue = envelopeHues.byLine.get(line.id) ?? null;
-    return (
-      <PlanLineRow
-        line={line}
-        index={0}
-        listLength={1}
-        indented={!!hue}
-        envelopeColor={hue}
-        name={lineDisplayName(line)}
-        icon={lineIcon(line)}
-        status={lineStatusById.get(line.id) || null}
-        planCurrency={planCurrency}
-        displayAmount={amountById.get(line.id) ?? null}
-        converting={converting}
-        colors={colors}
-        t={t}
-        executed={line.lastExecutedMonth === month}
-        showProgress={line.kind !== 'income'}
-        // No canExecute/canUndo: the copy is not swipeable, and the actions it
-        // would carry are exactly the ones the bar above it now offers.
-        onPress={NOOP}
-        onLongPress={NOOP}
-        testIDPrefix="plan-line-lifted"
-      />
-    );
-  }, [actionMenu, groupViews, groupStatusById, envelopeHues, expandedGroupIds, lineStatusById,
-    amountById, converting, planCurrency, colors, t, month, lineDisplayName, lineIcon]);
+    // A child row keeps the rail that says which envelope it is in — without it
+    // the copy would read as a loose allocation the moment it is picked up.
+    const hue = groupViews.find(v => v.children.some(c => c.id === line.id))?.hue ?? null;
+    return renderLine(line, 0, SINGLE_ROW, null, {
+      indented: !!hue, envelopeColor: hue, lifted: true,
+    });
+  }, [actionMenu, groupViews, renderGroupRow, renderLine]);
 
-  // Stable while the menu is open (the entrance animation keys off this object),
-  // so it is rebuilt only when the pressed row or its copy actually changes.
+  // Memoized because RowActionMenu is memoized: it draws through an overlay portal
+  // that re-mounts its slot whenever the children change identity, and this
+  // section re-renders on every conversion result while the menu is up.
   const menu = useMemo(
     () => (actionMenu ? { layout: actionMenu.layout, row: menuRow } : null),
     [actionMenu, menuRow],
   );
 
   const menuActions = useMemo(() => {
-    if (!actionMenu) return [];
-    // Every action dismisses the menu first: it covers the screen, and each of
-    // these either opens an editor, moves the row or asks for a confirmation.
-    const run = (action) => () => {
-      setActionMenu(null);
-      action();
-    };
+    // Dismissing is RowActionMenu's job, not each action's — see its docblock.
+    if (!actionMenu) return NO_ACTIONS;
     const { index, listLength, onMove } = actionMenu;
     const moveActions = [];
     if (onMove) {
@@ -1027,12 +1002,12 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
       // action that silently does nothing.
       if (index > 0) {
         moveActions.push({
-          key: 'move-up', icon: 'arrow-up', label: t('move_up'), onPress: run(() => onMove(index, -1)),
+          key: 'move-up', icon: 'arrow-up', label: t('move_up'), onPress: () => onMove(index, -1),
         });
       }
       if (index < listLength - 1) {
         moveActions.push({
-          key: 'move-down', icon: 'arrow-down', label: t('move_down'), onPress: run(() => onMove(index, 1)),
+          key: 'move-down', icon: 'arrow-down', label: t('move_down'), onPress: () => onMove(index, 1),
         });
       }
     }
@@ -1043,7 +1018,7 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
         // The bar has room for a word per button, so the buttons say what they do
         // and the screen reader gets what they do it to.
         {
-          key: 'edit', icon: 'pencil', label: t('edit'), a11yLabel: t('edit_group'), onPress: run(() => openEditGroup(group)),
+          key: 'edit', icon: 'pencil', label: t('edit'), a11yLabel: t('edit_group'), onPress: () => openEditGroup(group),
         },
         ...moveActions,
         {
@@ -1051,8 +1026,8 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
           icon: 'trash-can-outline',
           label: t('delete'),
           a11yLabel: t('delete_group'),
-          destructive: true,
-          onPress: run(() => confirmDeleteGroup(group)),
+          tone: 'destructive',
+          onPress: () => confirmDeleteGroup(group),
         },
       ];
     }
@@ -1070,33 +1045,33 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
           icon: 'undo',
           label: t('undo'),
           a11yLabel: t('undo_execution'),
-          muted: true,
-          onPress: run(() => handleUndoExecuted(line)),
+          tone: 'muted',
+          onPress: () => handleUndoExecuted(line),
         });
       } else {
         executionActions.push(
-          { key: 'execute', icon: 'play', label: t('execute'), onPress: run(() => handleExecute(line)) },
+          { key: 'execute', icon: 'play', label: t('execute'), onPress: () => handleExecute(line) },
           {
             key: 'done',
             icon: 'check-bold',
             label: t('done'),
             a11yLabel: t('mark_as_executed'),
-            onPress: run(() => handleMarkExecuted(line)),
+            onPress: () => handleMarkExecuted(line),
           },
         );
       }
     }
     return [
       ...executionActions,
-      { key: 'edit', icon: 'pencil', label: t('edit'), a11yLabel: t('edit_allocation'), onPress: run(() => openEditLine(line)) },
+      { key: 'edit', icon: 'pencil', label: t('edit'), a11yLabel: t('edit_allocation'), onPress: () => openEditLine(line) },
       ...moveActions,
       {
         key: 'delete',
         icon: 'trash-can-outline',
         label: t('delete'),
         a11yLabel: t('delete_allocation'),
-        destructive: true,
-        onPress: run(() => confirmDeleteLine(line)),
+        tone: 'destructive',
+        onPress: () => confirmDeleteLine(line),
       },
     ];
   }, [actionMenu, t, month, isCurrentMonth, openEditGroup, confirmDeleteGroup, openEditLine,
@@ -1186,39 +1161,20 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
             recurring line next to a one-off one — so it sits above the loose
             ones rather than among them. */}
         {groupViews.map((view, groupIndex) => {
-          // Assigned by position, and handed to the header and every child so
-          // one envelope reads as one object: the folder glyph, the rail beside
-          // the header and the rail beside each row below it are all the same
-          // colour. See envelopePalette for why colour identifies an envelope
-          // here rather than flagging a status.
-          const hue = envelopeHue(groupIndex);
           // Folded is the default, so an envelope shows its children only once
           // the user has said to — see `expandedGroupIds`.
           const expanded = expandedGroupIds.has(view.group.id);
+          // The envelope's colour is carried on the view (see groupViews), so the
+          // header, its children and the lifted copy all read the same one.
+          const childOptions = { indented: true, envelopeColor: view.hue };
           return (
             <React.Fragment key={view.group.id}>
-              <PlanGroupRow
-                group={view.group}
-                index={groupIndex}
-                listLength={groupViews.length}
-                status={groupStatusById.get(view.group.id) || null}
-                displayAmount={view.displayAmount}
-                converting={converting}
-                childCount={view.children.length}
-                envelopeColor={hue}
-                planCurrency={planCurrency}
-                colors={colors}
-                t={t}
-                collapsed={!expanded}
-                onMove={moveGroup}
-                onToggle={toggleGroup}
-                onLongPress={handleLongPressGroup}
-              />
+              {renderGroupRow(view, groupIndex)}
               {expanded && view.recurring.map((line, index) => renderLine(
-                line, index, view.recurring, groupMovers.get(`${view.group.id}|r`), true, hue,
+                line, index, view.recurring, groupMovers.get(`${view.group.id}|r`), childOptions,
               ))}
               {expanded && view.oneOff.map((line, index) => renderLine(
-                line, index, view.oneOff, groupMovers.get(`${view.group.id}|o`), true, hue,
+                line, index, view.oneOff, groupMovers.get(`${view.group.id}|o`), childOptions,
               ))}
             </React.Fragment>
           );
@@ -1395,10 +1351,6 @@ const styles = StyleSheet.create({
     ...CARD_SURFACE,
     marginBottom: SPACING.md,
     padding: SPACING.md,
-  },
-  cloneOffset: {
-    // Cancels PlanGroupRow's own top margin inside the lifted copy — see menuRow.
-    marginTop: -SPACING.sm,
   },
   convertWarning: {
     alignItems: 'center',

--- a/app/components/budgets/MonthlyPlanSection.js
+++ b/app/components/budgets/MonthlyPlanSection.js
@@ -17,12 +17,14 @@ import BudgetPlanLineModal from './BudgetPlanLineModal';
 import BudgetLineGroupModal from './BudgetLineGroupModal';
 import PlanLineRow from './PlanLineRow';
 import PlanGroupRow from './PlanGroupRow';
+import RowActionMenu from '../RowActionMenu';
 import { currentMonthKey, addMonths, formatMonthLabel } from '../../utils/monthUtils';
 import { CARD_SURFACE, SECTION_HEADING } from '../../styles/componentStyles';
 import EmptyState from '../EmptyState';
 
 const CLOSED_MODAL = { visible: false, line: null, kind: 'expense' };
 const CLOSED_GROUP_MODAL = { visible: false, group: null };
+const NOOP = () => {};
 
 // Key under which a group's own (override) amount rides along in the shared
 // conversion map — see the `amountSources` memo. Groups and lines have separate
@@ -114,6 +116,11 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
   const [expandedGroupIds, setExpandedGroupIds] = useState(() => new Set());
   const [modal, setModal] = useState(CLOSED_MODAL);
   const [groupModal, setGroupModal] = useState(CLOSED_GROUP_MODAL);
+  // The long-press action menu: which row was pressed, where it sits on screen,
+  // and what its move handler is. Null when closed. The actions themselves are
+  // derived from it below rather than stored, so a menu left open across a
+  // reload never offers an action against a stale row.
+  const [actionMenu, setActionMenu] = useState(null);
   const [busy, setBusy] = useState(false);
   // Synchronous double-tap guard (Fix 3, adversarial review round 2): `busy`
   // (React state) only reflects reality AFTER a re-render commits, so two taps
@@ -645,51 +652,19 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     runExecutionAction(() => unmarkLineExecuted(line.id), 'marked_as_pending')
   ), [runExecutionAction, unmarkLineExecuted]);
 
-  // `context` carries the line's position in its own block plus that block's move
-  // handler — reordering used to be a pair of chevrons on every row, which cost
-  // 40dp of horizontal space next to the amount on all of them and took one tap
-  // per position moved. It lives here now, where it is out of the way until asked
-  // for and sits next to the other whole-row actions.
-  const handleLongPressLine = useCallback((line, index, listLength, onMove) => {
-    const executed = line.lastExecutedMonth === month;
-    const executionActions = [];
-    if (line.hasTemplate && isCurrentMonth) {
-      if (executed) {
-        // `undo_execution`, not the bare `undo`: in several languages (Russian
-        // among them) "Undo" and "Cancel" collapse into near-identical words,
-        // and this sheet shows both right next to each other.
-        executionActions.push({ text: t('undo_execution'), onPress: () => handleUndoExecuted(line) });
-      } else {
-        executionActions.push(
-          { text: t('execute'), onPress: () => handleExecute(line) },
-          { text: t('mark_as_executed'), onPress: () => handleMarkExecuted(line) },
-        );
-      }
-    }
-    const moveActions = [];
-    if (onMove) {
-      // Offered only where the move can actually land, so the sheet never shows
-      // an action that silently does nothing.
-      if (index > 0) {
-        moveActions.push({ text: t('move_up'), onPress: () => onMove(index, -1) });
-      }
-      if (index < listLength - 1) {
-        moveActions.push({ text: t('move_down'), onPress: () => onMove(index, 1) });
-      }
-    }
-    showDialog(
-      t('select_action'),
-      lineDisplayName(line),
-      [
-        ...executionActions,
-        { text: t('edit'), onPress: () => openEditLine(line) },
-        ...moveActions,
-        { text: t('delete'), style: 'destructive', onPress: () => confirmDeleteLine(line) },
-        { text: t('cancel'), style: 'cancel' },
-      ],
-    );
-  }, [month, isCurrentMonth, t, showDialog, handleExecute, handleMarkExecuted, handleUndoExecuted,
-    openEditLine, confirmDeleteLine, lineDisplayName]);
+  // Long-pressing a row lifts it above a blurred backdrop and floats an icon bar
+  // over it (RowActionMenu) instead of naming it in a dialog title — the row
+  // itself says which budget the actions apply to, and it stays where the user
+  // was already looking.
+  //
+  // `index`/`listLength`/`onMove` carry the row's position in its own block plus
+  // that block's move handler — reordering used to be a pair of chevrons on every
+  // row, which cost 40dp of horizontal space next to the amount on all of them
+  // and took one tap per position moved. It lives in the menu now, where it is
+  // out of the way until asked for and sits next to the other whole-row actions.
+  const handleLongPressLine = useCallback((line, index, listLength, onMove, layout) => {
+    setActionMenu({ type: 'line', line, index, listLength, onMove, layout });
+  }, []);
 
   /* ── Reordering ──────────────────────────────────────────────────────────── */
 
@@ -882,34 +857,20 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     return created;
   }, [addLineGroup, groups.length]);
 
-  const handleLongPressGroup = useCallback((group, index, listLength, onMove) => {
-    const moveActions = [];
-    if (onMove) {
-      if (index > 0) moveActions.push({ text: t('move_up'), onPress: () => onMove(index, -1) });
-      if (index < listLength - 1) moveActions.push({ text: t('move_down'), onPress: () => onMove(index, 1) });
-    }
+  const confirmDeleteGroup = useCallback((group) => {
     showDialog(
-      t('select_action'),
-      group.label,
+      t('delete_group'),
+      t('delete_group_confirm'),
       [
-        { text: t('edit_group'), onPress: () => openEditGroup(group) },
-        ...moveActions,
-        {
-          text: t('delete_group'),
-          style: 'destructive',
-          onPress: () => showDialog(
-            t('delete_group'),
-            t('delete_group_confirm'),
-            [
-              { text: t('cancel'), style: 'cancel' },
-              { text: t('delete'), style: 'destructive', onPress: () => handleDeleteGroup(group.id) },
-            ],
-          ),
-        },
         { text: t('cancel'), style: 'cancel' },
+        { text: t('delete'), style: 'destructive', onPress: () => handleDeleteGroup(group.id) },
       ],
     );
-  }, [t, showDialog, openEditGroup, handleDeleteGroup]);
+  }, [showDialog, t, handleDeleteGroup]);
+
+  const handleLongPressGroup = useCallback((group, index, listLength, onMove, layout) => {
+    setActionMenu({ type: 'group', group, index, listLength, onMove, layout });
+  }, []);
 
   /* ── Rendering ───────────────────────────────────────────────────────────── */
 
@@ -961,6 +922,185 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
     handleMarkExecuted, handleUndoExecuted]);
 
   const hasAnyLines = lines.length > 0;
+
+  /* ── Long-press action menu ──────────────────────────────────────────────── */
+
+  // Which envelope (if any) each row belongs to, by colour. The render loop below
+  // assigns a hue per group position; the lifted copy of a row has to be handed
+  // the same one, or a child row would lose the rail that says which envelope it
+  // is in the moment it is picked up.
+  const envelopeHues = useMemo(() => {
+    const byGroup = new Map();
+    const byLine = new Map();
+    groupViews.forEach((view, groupIndex) => {
+      const hue = envelopeHue(groupIndex);
+      byGroup.set(view.group.id, hue);
+      for (const child of view.children) byLine.set(child.id, hue);
+    });
+    return { byGroup, byLine };
+  }, [groupViews]);
+
+  const closeActionMenu = useCallback(() => setActionMenu(null), []);
+
+  // The static copy of the pressed row that the menu lifts above the backdrop.
+  // Rebuilt from the current data rather than captured at press time, so a figure
+  // that lands while the menu is open shows in the copy too.
+  const menuRow = useMemo(() => {
+    if (!actionMenu) return null;
+    if (actionMenu.type === 'group') {
+      const view = groupViews.find(v => v.group.id === actionMenu.group.id);
+      if (!view) return null;
+      return (
+        // PlanGroupRow carries its own top margin — it is what separates one
+        // envelope from the row above it in the list. Inside the lifted copy
+        // there is nothing to separate from, and the margin would push the copy
+        // that far below the row it is supposed to cover.
+        <View style={styles.cloneOffset}>
+          <PlanGroupRow
+            group={view.group}
+            index={0}
+            listLength={1}
+            status={groupStatusById.get(view.group.id) || null}
+            displayAmount={view.displayAmount}
+            converting={converting}
+            childCount={view.children.length}
+            envelopeColor={envelopeHues.byGroup.get(view.group.id)}
+            planCurrency={planCurrency}
+            colors={colors}
+            t={t}
+            collapsed={!expandedGroupIds.has(view.group.id)}
+            onToggle={NOOP}
+            onLongPress={NOOP}
+            testIDPrefix="plan-group-lifted"
+          />
+        </View>
+      );
+    }
+    const { line } = actionMenu;
+    const hue = envelopeHues.byLine.get(line.id) ?? null;
+    return (
+      <PlanLineRow
+        line={line}
+        index={0}
+        listLength={1}
+        indented={!!hue}
+        envelopeColor={hue}
+        name={lineDisplayName(line)}
+        icon={lineIcon(line)}
+        status={lineStatusById.get(line.id) || null}
+        planCurrency={planCurrency}
+        displayAmount={amountById.get(line.id) ?? null}
+        converting={converting}
+        colors={colors}
+        t={t}
+        executed={line.lastExecutedMonth === month}
+        showProgress={line.kind !== 'income'}
+        // No canExecute/canUndo: the copy is not swipeable, and the actions it
+        // would carry are exactly the ones the bar above it now offers.
+        onPress={NOOP}
+        onLongPress={NOOP}
+        testIDPrefix="plan-line-lifted"
+      />
+    );
+  }, [actionMenu, groupViews, groupStatusById, envelopeHues, expandedGroupIds, lineStatusById,
+    amountById, converting, planCurrency, colors, t, month, lineDisplayName, lineIcon]);
+
+  // Stable while the menu is open (the entrance animation keys off this object),
+  // so it is rebuilt only when the pressed row or its copy actually changes.
+  const menu = useMemo(
+    () => (actionMenu ? { layout: actionMenu.layout, row: menuRow } : null),
+    [actionMenu, menuRow],
+  );
+
+  const menuActions = useMemo(() => {
+    if (!actionMenu) return [];
+    // Every action dismisses the menu first: it covers the screen, and each of
+    // these either opens an editor, moves the row or asks for a confirmation.
+    const run = (action) => () => {
+      setActionMenu(null);
+      action();
+    };
+    const { index, listLength, onMove } = actionMenu;
+    const moveActions = [];
+    if (onMove) {
+      // Offered only where the move can actually land, so the bar never shows an
+      // action that silently does nothing.
+      if (index > 0) {
+        moveActions.push({
+          key: 'move-up', icon: 'arrow-up', label: t('move_up'), onPress: run(() => onMove(index, -1)),
+        });
+      }
+      if (index < listLength - 1) {
+        moveActions.push({
+          key: 'move-down', icon: 'arrow-down', label: t('move_down'), onPress: run(() => onMove(index, 1)),
+        });
+      }
+    }
+
+    if (actionMenu.type === 'group') {
+      const { group } = actionMenu;
+      return [
+        // The bar has room for a word per button, so the buttons say what they do
+        // and the screen reader gets what they do it to.
+        {
+          key: 'edit', icon: 'pencil', label: t('edit'), a11yLabel: t('edit_group'), onPress: run(() => openEditGroup(group)),
+        },
+        ...moveActions,
+        {
+          key: 'delete',
+          icon: 'trash-can-outline',
+          label: t('delete'),
+          a11yLabel: t('delete_group'),
+          destructive: true,
+          onPress: run(() => confirmDeleteGroup(group)),
+        },
+      ];
+    }
+
+    const { line } = actionMenu;
+    const executed = line.lastExecutedMonth === month;
+    const executionActions = [];
+    if (line.hasTemplate && isCurrentMonth) {
+      if (executed) {
+        // `undo_execution` for the screen reader, not the bare `undo`: in several
+        // languages (Russian among them) "Undo" and "Cancel" collapse into
+        // near-identical words.
+        executionActions.push({
+          key: 'undo',
+          icon: 'undo',
+          label: t('undo'),
+          a11yLabel: t('undo_execution'),
+          muted: true,
+          onPress: run(() => handleUndoExecuted(line)),
+        });
+      } else {
+        executionActions.push(
+          { key: 'execute', icon: 'play', label: t('execute'), onPress: run(() => handleExecute(line)) },
+          {
+            key: 'done',
+            icon: 'check-bold',
+            label: t('done'),
+            a11yLabel: t('mark_as_executed'),
+            onPress: run(() => handleMarkExecuted(line)),
+          },
+        );
+      }
+    }
+    return [
+      ...executionActions,
+      { key: 'edit', icon: 'pencil', label: t('edit'), a11yLabel: t('edit_allocation'), onPress: run(() => openEditLine(line)) },
+      ...moveActions,
+      {
+        key: 'delete',
+        icon: 'trash-can-outline',
+        label: t('delete'),
+        a11yLabel: t('delete_allocation'),
+        destructive: true,
+        onPress: run(() => confirmDeleteLine(line)),
+      },
+    ];
+  }, [actionMenu, t, month, isCurrentMonth, openEditGroup, confirmDeleteGroup, openEditLine,
+    confirmDeleteLine, handleExecute, handleMarkExecuted, handleUndoExecuted]);
 
   // Currencies the group editor may price an override in: the same set the line
   // editor offers, for the same reason (a group belongs to no plan, so it needs
@@ -1211,6 +1351,16 @@ const MonthlyPlanSection = forwardRef(function MonthlyPlanSection({
           onClose={closeModal}
         />
 
+        {/* Long-press menu for both kinds of row. It draws into the app-wide
+            overlay layer, so it renders nothing in place here. */}
+        <RowActionMenu
+          menu={menu}
+          actions={menuActions}
+          colors={colors}
+          onClose={closeActionMenu}
+          testIDPrefix="plan-action"
+        />
+
         <BudgetLineGroupModal
           visible={groupModal.visible}
           group={groupModal.group}
@@ -1245,6 +1395,10 @@ const styles = StyleSheet.create({
     ...CARD_SURFACE,
     marginBottom: SPACING.md,
     padding: SPACING.md,
+  },
+  cloneOffset: {
+    // Cancels PlanGroupRow's own top margin inside the lifted copy — see menuRow.
+    marginTop: -SPACING.sm,
   },
   convertWarning: {
     alignItems: 'center',

--- a/app/components/budgets/PlanGroupRow.js
+++ b/app/components/budgets/PlanGroupRow.js
@@ -1,9 +1,11 @@
-import React, { memo } from 'react';
+import React, { memo, useRef } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import PlanProgressBar, { PAIR_COLUMN_WIDTH } from './PlanProgressBar';
+import { useOverlayHost } from '../../contexts/OverlayHostContext';
+import { measureAnchorRect } from '../../utils/overlayGeometry';
 import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 
 // Stands in for a figure whose exchange rate is still resolving — same em dash
@@ -53,6 +55,7 @@ const PlanGroupRow = memo(function PlanGroupRow({
   onMove = null,
   onToggle,
   onLongPress,
+  testIDPrefix = 'plan-group',
 }) {
   const isUnconvertible = status?.status === 'unconvertible';
   // A group is "tracked" once its actual is known — which only the async plan
@@ -97,11 +100,23 @@ const PlanGroupRow = memo(function PlanGroupRow({
     ? Currency.formatCompact(status.childAmount)
     : null;
 
+  // Measured on long-press so the host can lift a copy of this row above the
+  // blurred backdrop and anchor its action bar to it — see PlanLineRow for why the
+  // overlay host is the thing being measured against.
+  const rowRef = useRef(null);
+  const { hostRef } = useOverlayHost();
+  const handleLongPress = () => {
+    measureAnchorRect(rowRef.current, hostRef?.current, (layout) => {
+      onLongPress(group, index, listLength, onMove, layout);
+    });
+  };
+
   return (
     <Pressable
+      ref={rowRef}
       style={styles.groupRow}
       onPress={() => onToggle(group)}
-      onLongPress={() => onLongPress(group, index, listLength, onMove)}
+      onLongPress={handleLongPress}
       accessibilityRole="button"
       // Names the envelope and its figures; what the tap DOES is the hint, and
       // whether it is open is the state — a label that said "Edit group" was
@@ -109,14 +124,14 @@ const PlanGroupRow = memo(function PlanGroupRow({
       accessibilityLabel={`${group.label}, ${primaryText}${pairText ? `, ${pairText}` : ''}, ${childCount} ${t('allocations')}`}
       accessibilityHint={collapsed ? t('expand_group') : t('collapse_group')}
       accessibilityState={{ expanded: !collapsed }}
-      testID={`plan-group-${group.id}`}
+      testID={`${testIDPrefix}-${group.id}`}
     >
       {/* The head of the rail that runs down this envelope's children. At full
           strength here and dimmed on them: the header is the thing being
           identified, the rows below it are its parts. */}
       <View
         style={[styles.rail, { backgroundColor: envelopeColor }]}
-        testID={`plan-group-rail-${group.id}`}
+        testID={`${testIDPrefix}-rail-${group.id}`}
       />
       <View style={styles.groupInner}>
         <View style={styles.groupTop}>
@@ -134,7 +149,7 @@ const PlanGroupRow = memo(function PlanGroupRow({
             name={collapsed ? 'folder' : 'folder-open'}
             size={20}
             color={envelopeColor}
-            testID={`plan-group-folder-${group.id}`}
+            testID={`${testIDPrefix}-folder-${group.id}`}
           />
           <View style={styles.groupBody}>
             <Text style={[styles.groupName, { color: colors.text }]} numberOfLines={1}>
@@ -153,7 +168,7 @@ const PlanGroupRow = memo(function PlanGroupRow({
                 <Text
                   style={[styles.groupMeta, { color: colors.mutedText }]}
                   numberOfLines={1}
-                  testID={`plan-group-childsum-${group.id}`}
+                  testID={`${testIDPrefix}-childsum-${group.id}`}
                 >
                   · Σ {childSum}
                 </Text>
@@ -162,7 +177,7 @@ const PlanGroupRow = memo(function PlanGroupRow({
           </View>
           <Text
             style={[styles.groupAmount, { color: overspent ? colors.overspend : colors.text }]}
-            testID={`plan-group-primary-${group.id}`}
+            testID={`${testIDPrefix}-primary-${group.id}`}
           >
             {converting && target == null ? CONVERTING_PLACEHOLDER : primaryText}
           </Text>
@@ -177,14 +192,14 @@ const PlanGroupRow = memo(function PlanGroupRow({
                 fillColor={`${colors.mutedText}${FILL_ALPHA}`}
                 overspendColor={colors.overspend}
                 height={5}
-                testID={`plan-group-bar-${group.id}`}
+                testID={`${testIDPrefix}-bar-${group.id}`}
               />
             </View>
             {pairText && (
               <Text
                 style={[styles.groupPair, { color: colors.mutedText }]}
                 numberOfLines={1}
-                testID={`plan-group-pair-${group.id}`}
+                testID={`${testIDPrefix}-pair-${group.id}`}
               >
                 {pairText}
               </Text>
@@ -196,7 +211,7 @@ const PlanGroupRow = memo(function PlanGroupRow({
           // The group's own budget is in a currency with no rate to the screen's,
           // so the figure above fell back to its children's sum — say why rather
           // than quietly printing a different number than the user typed.
-          <View style={styles.noteRow} testID={`plan-group-unconvertible-${group.id}`}>
+          <View style={styles.noteRow} testID={`${testIDPrefix}-unconvertible-${group.id}`}>
             <Icon name="alert-circle-outline" size={14} color={colors.mutedText} />
             <Text style={[styles.noteText, { color: colors.mutedText }]} numberOfLines={1}>
               {t('graphs_currencies_not_converted')}
@@ -230,6 +245,8 @@ PlanGroupRow.propTypes = {
   onMove: PropTypes.func,
   onToggle: PropTypes.func.isRequired,
   onLongPress: PropTypes.func.isRequired,
+  // See PlanLineRow: the lifted copy renders under its own testID namespace.
+  testIDPrefix: PropTypes.string,
 };
 
 export default PlanGroupRow;

--- a/app/components/budgets/PlanGroupRow.js
+++ b/app/components/budgets/PlanGroupRow.js
@@ -1,12 +1,13 @@
-import React, { memo, useRef } from 'react';
+import React, { memo } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import PlanProgressBar, { PAIR_COLUMN_WIDTH } from './PlanProgressBar';
-import { useOverlayHost } from '../../contexts/OverlayHostContext';
-import { measureAnchorRect } from '../../utils/overlayGeometry';
+import useAnchoredLongPress from '../../hooks/useAnchoredLongPress';
 import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
+
+const NOOP = () => {};
 
 // Stands in for a figure whose exchange rate is still resolving — same em dash
 // PlanLineRow uses, for the same reason.
@@ -53,10 +54,13 @@ const PlanGroupRow = memo(function PlanGroupRow({
   listLength,
   collapsed = true,
   onMove = null,
-  onToggle,
-  onLongPress,
-  testIDPrefix = 'plan-group',
+  onToggle = NOOP,
+  onLongPress = NOOP,
+  lifted = false,
 }) {
+  // See PlanLineRow: the copy the action menu lifts over this row needs testIDs
+  // of its own, or a query naming the row matches both.
+  const testIDPrefix = lifted ? 'plan-group-lifted' : 'plan-group';
   const isUnconvertible = status?.status === 'unconvertible';
   // A group is "tracked" once its actual is known — which only the async plan
   // status can supply (per-line actuals are not computed on the client). Until
@@ -101,20 +105,18 @@ const PlanGroupRow = memo(function PlanGroupRow({
     : null;
 
   // Measured on long-press so the host can lift a copy of this row above the
-  // blurred backdrop and anchor its action bar to it — see PlanLineRow for why the
-  // overlay host is the thing being measured against.
-  const rowRef = useRef(null);
-  const { hostRef } = useOverlayHost();
-  const handleLongPress = () => {
-    measureAnchorRect(rowRef.current, hostRef?.current, (layout) => {
-      onLongPress(group, index, listLength, onMove, layout);
-    });
-  };
+  // blurred backdrop and anchor its action bar to it.
+  const [rowRef, handleLongPress] = useAnchoredLongPress(
+    (layout) => onLongPress(group, index, listLength, onMove, layout),
+  );
 
   return (
     <Pressable
       ref={rowRef}
-      style={styles.groupRow}
+      // The row's top margin is what separates one envelope from whatever is
+      // above it in the list; the lifted copy has nothing to separate from, and
+      // the margin would push it that far below the row it covers.
+      style={[styles.groupRow, lifted && styles.groupRowLifted]}
       onPress={() => onToggle(group)}
       onLongPress={handleLongPress}
       accessibilityRole="button"
@@ -243,10 +245,10 @@ PlanGroupRow.propTypes = {
   t: PropTypes.func.isRequired,
   collapsed: PropTypes.bool,
   onMove: PropTypes.func,
-  onToggle: PropTypes.func.isRequired,
-  onLongPress: PropTypes.func.isRequired,
-  // See PlanLineRow: the lifted copy renders under its own testID namespace.
-  testIDPrefix: PropTypes.string,
+  onToggle: PropTypes.func,
+  onLongPress: PropTypes.func,
+  // See PlanLineRow: renders the static copy the action menu lifts over the row.
+  lifted: PropTypes.bool,
 };
 
 export default PlanGroupRow;
@@ -295,6 +297,9 @@ const styles = StyleSheet.create({
     marginTop: SPACING.sm,
     overflow: 'hidden',
     paddingVertical: 7,
+  },
+  groupRowLifted: {
+    marginTop: 0,
   },
   groupTop: {
     alignItems: 'center',

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -6,11 +6,12 @@ import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import PlanProgressBar, { PAIR_COLUMN_WIDTH } from './PlanProgressBar';
-import { useOverlayHost } from '../../contexts/OverlayHostContext';
-import { measureAnchorRect } from '../../utils/overlayGeometry';
+import useAnchoredLongPress from '../../hooks/useAnchoredLongPress';
 import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 import { ENVELOPE_RAIL_CHILD_ALPHA } from '../../styles/envelopePalette';
 import { SPRING_BADGE_POP } from '../../utils/motion';
+
+const NOOP = () => {};
 
 // Where the badge springs from when its state flips. Not 0: a glyph growing out
 // of nothing reads as an element arriving, and this one was already there — it
@@ -68,13 +69,17 @@ const PlanLineRow = memo(function PlanLineRow({
   envelopeColor = null,
   listLength,
   onMove = null,
-  onPress,
-  onLongPress,
+  onPress = NOOP,
+  onLongPress = NOOP,
   onExecute = null,
   onMarkExecuted = null,
   onUndo = null,
-  testIDPrefix = 'plan-line',
+  lifted = false,
 }) {
+  // The lifted copy answers to its own testIDs: it is drawn on top of the row it
+  // copies, and two nodes under one testID is a query that can no longer name
+  // either of them.
+  const testIDPrefix = lifted ? 'plan-line-lifted' : 'plan-line';
   const lineCurrency = line.currency || planCurrency;
   const isBroken = line.isBroken || status?.broken;
   // The screen shows exactly one currency, so a row prints a bare number in it —
@@ -204,16 +209,10 @@ const PlanLineRow = memo(function PlanLineRow({
   ].filter(Boolean).join(', ');
 
   // Measured on long-press so the host can lift a copy of this exact row above the
-  // blurred backdrop and float its action bar over it (see RowActionMenu). Measured
-  // against the overlay host — the shared ancestor of this row and of the layer the
-  // copy is drawn in — so the two coordinate spaces cannot disagree.
-  const rowRef = useRef(null);
-  const { hostRef } = useOverlayHost();
-  const handleLongPress = () => {
-    measureAnchorRect(rowRef.current, hostRef?.current, (layout) => {
-      onLongPress(line, index, listLength, onMove, layout);
-    });
-  };
+  // blurred backdrop and float its action bar over it (see RowActionMenu).
+  const [rowRef, handleLongPress] = useAnchoredLongPress(
+    (layout) => onLongPress(line, index, listLength, onMove, layout),
+  );
 
   const content = (
     <Pressable
@@ -451,15 +450,14 @@ PlanLineRow.propTypes = {
   indented: PropTypes.bool,
   envelopeColor: PropTypes.string,
   onMove: PropTypes.func,
-  onPress: PropTypes.func.isRequired,
-  onLongPress: PropTypes.func.isRequired,
+  onPress: PropTypes.func,
+  onLongPress: PropTypes.func,
   onExecute: PropTypes.func,
   onMarkExecuted: PropTypes.func,
   onUndo: PropTypes.func,
-  // Namespaces every testID the row renders. The host overrides it for the static
-  // copy it lifts into the action menu, so the copy and the row it covers don't
-  // answer to the same testID.
-  testIDPrefix: PropTypes.string,
+  // Renders the static copy the action menu lifts over the row: its own testID
+  // namespace, and no handlers to wire.
+  lifted: PropTypes.bool,
 };
 
 export default PlanLineRow;

--- a/app/components/budgets/PlanLineRow.js
+++ b/app/components/budgets/PlanLineRow.js
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import * as Currency from '../../services/currency';
 import PlanProgressBar, { PAIR_COLUMN_WIDTH } from './PlanProgressBar';
+import { useOverlayHost } from '../../contexts/OverlayHostContext';
+import { measureAnchorRect } from '../../utils/overlayGeometry';
 import { BORDER_RADIUS, FONT_SIZE, SPACING } from '../../styles/designTokens';
 import { ENVELOPE_RAIL_CHILD_ALPHA } from '../../styles/envelopePalette';
 import { SPRING_BADGE_POP } from '../../utils/motion';
@@ -71,6 +73,7 @@ const PlanLineRow = memo(function PlanLineRow({
   onExecute = null,
   onMarkExecuted = null,
   onUndo = null,
+  testIDPrefix = 'plan-line',
 }) {
   const lineCurrency = line.currency || planCurrency;
   const isBroken = line.isBroken || status?.broken;
@@ -200,8 +203,21 @@ const PlanLineRow = memo(function PlanLineRow({
     line.hasTemplate ? (executed ? t('done') : t('pending_execution')) : null,
   ].filter(Boolean).join(', ');
 
+  // Measured on long-press so the host can lift a copy of this exact row above the
+  // blurred backdrop and float its action bar over it (see RowActionMenu). Measured
+  // against the overlay host — the shared ancestor of this row and of the layer the
+  // copy is drawn in — so the two coordinate spaces cannot disagree.
+  const rowRef = useRef(null);
+  const { hostRef } = useOverlayHost();
+  const handleLongPress = () => {
+    measureAnchorRect(rowRef.current, hostRef?.current, (layout) => {
+      onLongPress(line, index, listLength, onMove, layout);
+    });
+  };
+
   const content = (
     <Pressable
+      ref={rowRef}
       style={styles.lineRow}
       onPress={() => onPress(line)}
       // The row renders nothing from `listLength`/`onMove` — it forwards them so
@@ -209,10 +225,10 @@ const PlanLineRow = memo(function PlanLineRow({
       // having the host close over them in an inline callback) is what lets
       // `onLongPress` stay a stable reference, and therefore what keeps this
       // component's memo() from being defeated on every parent render.
-      onLongPress={() => onLongPress(line, index, listLength, onMove)}
+      onLongPress={handleLongPress}
       accessibilityRole="button"
       accessibilityLabel={`${t('edit_allocation')}: ${name}, ${primaryText}, ${stateWords}`}
-      testID={`plan-line-${line.id}`}
+      testID={`${testIDPrefix}-${line.id}`}
     >
       {/* The envelope's rail, continued down past its header through every one
           of its children — one bracket down the side of the group rather than a
@@ -224,7 +240,7 @@ const PlanLineRow = memo(function PlanLineRow({
       {indented && envelopeColor && (
         <View
           style={[styles.rail, { backgroundColor: `${envelopeColor}${ENVELOPE_RAIL_CHILD_ALPHA}` }]}
-          testID={`plan-line-rail-${line.id}`}
+          testID={`${testIDPrefix}-rail-${line.id}`}
         />
       )}
       <View style={[styles.lineInner, indented && styles.lineInnerIndented]}>
@@ -237,14 +253,14 @@ const PlanLineRow = memo(function PlanLineRow({
                 between states. */}
             {executed ? (
               <Animated.View
-                testID={`plan-line-check-${line.id}`}
+                testID={`${testIDPrefix}-check-${line.id}`}
                 style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.income }, badgeStyle]}
               >
                 <Icon name="check" size={7} color="white" />
               </Animated.View>
             ) : line.hasTemplate ? (
               <Animated.View
-                testID={`plan-line-pending-${line.id}`}
+                testID={`${testIDPrefix}-pending-${line.id}`}
                 style={[styles.checkBadge, { borderColor: colors.surface, backgroundColor: colors.primary }, badgeStyle]}
               >
                 <Icon name="play" size={7} color="white" />
@@ -270,7 +286,7 @@ const PlanLineRow = memo(function PlanLineRow({
                   name="numeric-1-circle-outline"
                   size={13}
                   color={colors.mutedText}
-                  testID={`plan-line-one-time-${line.id}`}
+                  testID={`${testIDPrefix}-one-time-${line.id}`}
                 />
               )}
             </View>
@@ -285,7 +301,7 @@ const PlanLineRow = memo(function PlanLineRow({
           </View>
           <Text
             style={[styles.lineAmount, { color: primaryColor }]}
-            testID={`plan-line-primary-${line.id}`}
+            testID={`${testIDPrefix}-primary-${line.id}`}
           >
             {primaryText}
           </Text>
@@ -304,14 +320,14 @@ const PlanLineRow = memo(function PlanLineRow({
                 trackColor={`${colors.mutedText}${TRACK_ALPHA}`}
                 fillColor={`${colors.mutedText}${FILL_ALPHA}`}
                 overspendColor={colors.overspend}
-                testID={`plan-line-bar-${line.id}`}
+                testID={`${testIDPrefix}-bar-${line.id}`}
               />
             </View>
             {pairText && (
               <Text
                 style={[styles.linePair, { color: colors.mutedText }]}
                 numberOfLines={1}
-                testID={`plan-line-pair-${line.id}`}
+                testID={`${testIDPrefix}-pair-${line.id}`}
               >
                 {pairText}
               </Text>
@@ -320,7 +336,7 @@ const PlanLineRow = memo(function PlanLineRow({
         )}
 
         {isBroken ? (
-          <View style={styles.brokenRow} testID={`plan-line-broken-${line.id}`}>
+          <View style={styles.brokenRow} testID={`${testIDPrefix}-broken-${line.id}`}>
             <Icon name="alert-circle-outline" size={14} color={colors.danger} />
             <Text style={[styles.brokenText, { color: colors.danger }]} numberOfLines={1}>
               {t('relink_target')}
@@ -332,7 +348,7 @@ const PlanLineRow = memo(function PlanLineRow({
           // row explains why it is the one number on screen in a foreign unit.
           // There is deliberately no bar: comparing it against actuals in another
           // currency is exactly the mismatch this branch exists to avoid.
-          <View style={styles.brokenRow} testID={`plan-line-unconvertible-${line.id}`}>
+          <View style={styles.brokenRow} testID={`${testIDPrefix}-unconvertible-${line.id}`}>
             <Icon name="alert-circle-outline" size={14} color={colors.mutedText} />
             <Text style={[styles.brokenText, { color: colors.mutedText }]} numberOfLines={1}>
               {t('graphs_currencies_not_converted')}
@@ -362,7 +378,7 @@ const PlanLineRow = memo(function PlanLineRow({
 
   const rightActions = executed
     ? () => swipeButton({
-      testID: `plan-line-undo-${line.id}`,
+      testID: `${testIDPrefix}-undo-${line.id}`,
       background: colors.mutedText,
       icon: 'undo',
       caption: t('undo'),
@@ -372,7 +388,7 @@ const PlanLineRow = memo(function PlanLineRow({
     : () => (
       <View style={styles.swipeActionsRow}>
         {swipeButton({
-          testID: `plan-line-execute-${line.id}`,
+          testID: `${testIDPrefix}-execute-${line.id}`,
           background: colors.primary,
           icon: 'play',
           caption: t('execute'),
@@ -380,7 +396,7 @@ const PlanLineRow = memo(function PlanLineRow({
           handler: onExecute,
         })}
         {swipeButton({
-          testID: `plan-line-done-${line.id}`,
+          testID: `${testIDPrefix}-done-${line.id}`,
           background: colors.income,
           icon: 'check-bold',
           caption: t('done'),
@@ -440,6 +456,10 @@ PlanLineRow.propTypes = {
   onExecute: PropTypes.func,
   onMarkExecuted: PropTypes.func,
   onUndo: PropTypes.func,
+  // Namespaces every testID the row renders. The host overrides it for the static
+  // copy it lifts into the action menu, so the copy and the row it covers don't
+  // answer to the same testID.
+  testIDPrefix: PropTypes.string,
 };
 
 export default PlanLineRow;

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -1,264 +1,50 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { BackHandler, View, Text, Pressable, StyleSheet, Animated, Dimensions } from 'react-native';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import Icon from '@expo/vector-icons/MaterialCommunityIcons';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import ModalBlurOverlay from '../ModalBlurOverlay';
-import { OverlayPortal } from '../../contexts/OverlayHostContext';
-import { SPACING, BORDER_RADIUS, FONT_SIZE, ICON_SIZE } from '../../styles/designTokens';
-import { isReduceMotionEnabled } from '../../utils/reducedMotion';
-
-// Height reserved for the floating action bar; used to decide whether it fits
-// above the pressed row or has to sit below it.
-const PANEL_HEIGHT = 68;
-const GAP = 10;
+import RowActionMenu from '../RowActionMenu';
 
 /**
  * Context action menu shown on long-pressing an operation row.
  *
- * Instead of a plain "choose action" dialog, the pressed row is lifted above a
- * blurred backdrop (a static clone rendered at its measured position) and a compact
- * icon bar floats just above (or below) it. Tapping the backdrop or pressing back
- * dismisses it.
- *
- * The clone is drawn in the app-wide overlay layer (OverlayPortal), NOT in a core
- * `<Modal>`. That is the whole trick: a Modal is a separate native window, so a row
- * measured in the app's coordinates and re-drawn inside that window drifts by
- * whatever the two origins disagree on — a status bar's worth of offset on
- * edge-to-edge Android, which is exactly what made the row visibly jump on long
- * press. The overlay shares a parent with the content it covers, so `layout.y` means
- * the same thing on both sides and the clone always lands on the row.
- *
- * Actions: edit, repeat, hide-from-charts (expense/income only — see below) and
- * delete.
+ * The lift-and-blur presentation lives in RowActionMenu, which every long-press
+ * menu in the app shares; this component is the operation-specific action list:
+ * edit, repeat, hide-from-charts (expense/income only — see below) and delete.
  *
  * The parent owns visibility: pass a `menu` object to open, `null` to close.
- * Entrance is animated; closing unmounts immediately (a snappy dismiss is the
- * expected feel for a context menu, and keeping no internal open/close state
- * avoids setState-in-effect churn).
  */
 export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, onRepeat, onToggleCharts, onDelete }) {
-  const insets = useSafeAreaInsets();
-  const progress = useRef(new Animated.Value(0)).current;
-  // Height of the overlay layer itself, not of the screen: the layer is the box the
-  // panel is being placed in, so clamping against anything else re-introduces the
-  // guesswork this component just got rid of. Seeded from window height for the
-  // first frame, corrected by the first onLayout.
-  const [layerHeight, setLayerHeight] = useState(() => Dimensions.get('window').height);
-
-  const handleLayerLayout = useCallback((e) => {
-    const { height } = e.nativeEvent.layout;
-    setLayerHeight((prev) => (height > 0 && height !== prev ? height : prev));
-  }, []);
-
-  // The overlay is not a native window, so the hardware back button is ours to handle.
-  useEffect(() => {
-    if (!menu) return undefined;
-    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
-      onClose();
-      return true;
-    });
-    return () => sub.remove();
-  }, [menu, onClose]);
-
-  useEffect(() => {
-    if (menu) {
-      // Under the OS "Remove animations" setting the menu is simply present: the
-      // lift is what carries the meaning here, and there is no fade left to keep
-      // once it is gone (`progress` drives the backdrop and the clone together).
-      if (isReduceMotionEnabled()) {
-        progress.setValue(1);
-        return;
-      }
-      progress.setValue(0);
-      Animated.spring(progress, {
-        toValue: 1,
-        useNativeDriver: true,
-        speed: 18,
-        bounciness: 6,
-      }).start();
-    }
-  }, [menu, progress]);
-
-  if (!menu) return null;
-
-  const { layout, row } = menu;
-
-  // Where the floating icon bar goes. Prefer above the row; fall back to below.
-  // Both edges are bounded so the bar never lands under the status bar / notch
-  // or under the bottom inset (tab bar / gesture area) for a near-edge row.
-  let panelTop;
-  let panelPlacedAbove = true;
-  if (layout) {
-    const topLimit = insets.top + SPACING.sm;
-    const bottomLimit = layerHeight - insets.bottom - SPACING.sm - PANEL_HEIGHT;
-    const above = layout.y - GAP - PANEL_HEIGHT;
-    const below = layout.y + layout.height + GAP;
-    if (above >= topLimit) {
-      panelTop = above;
-    } else if (below <= bottomLimit) {
-      panelTop = below;
-      panelPlacedAbove = false;
-    } else {
-      // Neither side fully clears an inset — clamp into the visible area.
-      panelTop = Math.max(topLimit, Math.min(above, bottomLimit));
-    }
-  } else {
-    // No measurement (rare): center the bar on screen.
-    panelTop = layerHeight / 2 - PANEL_HEIGHT / 2;
-    panelPlacedAbove = false;
-  }
-
-  const backdropStyle = { opacity: progress };
-  const cloneStyle = {
-    opacity: progress,
-    transform: [
-      { scale: progress.interpolate({ inputRange: [0, 1], outputRange: [0.97, 1] }) },
-    ],
-  };
-  const panelStyle = {
-    opacity: progress,
-    transform: [
-      {
-        translateY: progress.interpolate({
-          inputRange: [0, 1],
-          outputRange: [panelPlacedAbove ? SPACING.sm : -SPACING.sm, 0],
-        }),
-      },
-    ],
-  };
-
-  const deleteColor = colors.destructive;
-
   // Transfers feed no chart, so the hide/show action would be a no-op for them.
   // Balance adjustments DO get it: they have no editable form, which makes this
   // menu their only way to leave the charts.
-  const operationType = menu.operation?.type;
+  const operationType = menu?.operation?.type;
   const showChartsAction = operationType === 'expense' || operationType === 'income';
-  const hiddenFromCharts = !!menu.operation?.excludeFromCharts;
+  const hiddenFromCharts = !!menu?.operation?.excludeFromCharts;
+
+  const actions = useMemo(() => [
+    { key: 'edit', icon: 'pencil', label: t('edit'), onPress: onEdit },
+    { key: 'repeat', icon: 'repeat', label: t('repeat'), onPress: onRepeat },
+    ...(showChartsAction ? [{
+      key: 'charts',
+      icon: hiddenFromCharts ? 'eye-outline' : 'eye-off-outline',
+      // Short label — four buttons share the row width. The full phrase goes to
+      // the accessibility label.
+      label: hiddenFromCharts ? t('show_in_charts') : t('hide_from_charts'),
+      a11yLabel: hiddenFromCharts ? t('include_in_charts') : t('exclude_from_charts'),
+      muted: hiddenFromCharts,
+      onPress: onToggleCharts,
+    }] : []),
+    { key: 'delete', icon: 'trash-can-outline', label: t('delete'), destructive: true, onPress: onDelete },
+  ], [t, onEdit, onRepeat, onToggleCharts, onDelete, showChartsAction, hiddenFromCharts]);
 
   return (
-    <>
-      <ModalBlurOverlay />
-      <OverlayPortal>
-        <Pressable
-          testID="operation-action-menu-backdrop"
-          style={styles.fill}
-          onPress={onClose}
-          onLayout={handleLayerLayout}
-        >
-          <Animated.View style={[styles.backdrop, backdropStyle]} pointerEvents="none" />
-
-          {/* Lifted clone of the pressed row */}
-          {layout && row && (
-            <Animated.View
-              pointerEvents="none"
-              style={[
-                styles.clone,
-                cloneStyle,
-                {
-                  top: layout.y,
-                  left: layout.x,
-                  width: layout.width,
-                  backgroundColor: colors.surface,
-                  borderColor: colors.border,
-                },
-              ]}
-            >
-              {row}
-            </Animated.View>
-          )}
-
-          {/* Floating icon action bar. Wrapped in a non-press-through Pressable so
-              taps on the bar don't fall through to the dismiss backdrop. */}
-          <Animated.View
-            style={[
-              styles.panel,
-              panelStyle,
-              {
-                top: panelTop,
-                backgroundColor: colors.surface,
-                borderColor: colors.border,
-              },
-              // Anchored to the row when it was measured; otherwise inset from both
-              // edges of the layer, which needs no width arithmetic at all.
-              layout
-                ? { left: layout.x, width: layout.width }
-                : { left: SPACING.lg, right: SPACING.lg },
-            ]}
-          >
-            <Pressable style={styles.panelRow} onPress={() => {}}>
-              <ActionButton
-                testID="operation-action-edit"
-                icon="pencil"
-                label={t('edit')}
-                color={colors.primary}
-                textColor={colors.text}
-                onPress={onEdit}
-              />
-              <ActionButton
-                testID="operation-action-repeat"
-                icon="repeat"
-                label={t('repeat')}
-                color={colors.primary}
-                textColor={colors.text}
-                onPress={onRepeat}
-              />
-              {showChartsAction && (
-                <ActionButton
-                  testID="operation-action-charts"
-                  icon={hiddenFromCharts ? 'eye-outline' : 'eye-off-outline'}
-                  // Short label — four buttons share the row width. The full
-                  // phrase goes to the accessibility label.
-                  label={hiddenFromCharts ? t('show_in_charts') : t('hide_from_charts')}
-                  a11yLabel={hiddenFromCharts ? t('include_in_charts') : t('exclude_from_charts')}
-                  color={hiddenFromCharts ? colors.mutedText : colors.primary}
-                  textColor={colors.text}
-                  onPress={onToggleCharts}
-                />
-              )}
-              <ActionButton
-                testID="operation-action-delete"
-                icon="trash-can-outline"
-                label={t('delete')}
-                color={deleteColor}
-                textColor={deleteColor}
-                onPress={onDelete}
-              />
-            </Pressable>
-          </Animated.View>
-        </Pressable>
-      </OverlayPortal>
-    </>
+    <RowActionMenu
+      menu={menu}
+      actions={actions}
+      colors={colors}
+      onClose={onClose}
+      testIDPrefix="operation-action"
+    />
   );
 }
-
-function ActionButton({ testID, icon, label, a11yLabel, color, textColor, onPress }) {
-  return (
-    <Pressable
-      testID={testID}
-      onPress={onPress}
-      style={({ pressed }) => [styles.actionButton, pressed && styles.actionButtonPressed]}
-      accessibilityRole="button"
-      accessibilityLabel={a11yLabel || label}
-    >
-      <Icon name={icon} size={ICON_SIZE.md} color={color} />
-      <Text style={[styles.actionLabel, { color: textColor }]} numberOfLines={1}>
-        {label}
-      </Text>
-    </Pressable>
-  );
-}
-
-ActionButton.propTypes = {
-  testID: PropTypes.string,
-  icon: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-  a11yLabel: PropTypes.string,
-  color: PropTypes.string.isRequired,
-  textColor: PropTypes.string.isRequired,
-  onPress: PropTypes.func.isRequired,
-};
 
 OperationActionMenu.propTypes = {
   menu: PropTypes.shape({
@@ -281,61 +67,3 @@ OperationActionMenu.propTypes = {
   onToggleCharts: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
 };
-
-const styles = StyleSheet.create({
-  actionButton: {
-    alignItems: 'center',
-    borderRadius: BORDER_RADIUS.md,
-    flex: 1,
-    gap: SPACING.xs,
-    paddingHorizontal: SPACING.xs,
-    paddingVertical: SPACING.sm,
-  },
-  actionButtonPressed: {
-    opacity: 0.55,
-  },
-  actionLabel: {
-    fontSize: FONT_SIZE.sm,
-    fontWeight: '600',
-  },
-  backdrop: {
-    backgroundColor: 'rgba(0, 0, 0, 0.35)',
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
-  clone: {
-    borderRadius: BORDER_RADIUS.md,
-    borderWidth: 1,
-    elevation: 8,
-    overflow: 'hidden',
-    position: 'absolute',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 10,
-  },
-  fill: {
-    flex: 1,
-  },
-  panel: {
-    borderRadius: BORDER_RADIUS.lg,
-    borderWidth: 1,
-    elevation: 10,
-    height: PANEL_HEIGHT,
-    position: 'absolute',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 12,
-  },
-  panelRow: {
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-evenly',
-    paddingHorizontal: SPACING.sm,
-  },
-});

--- a/app/components/operations/OperationActionMenu.js
+++ b/app/components/operations/OperationActionMenu.js
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import RowActionMenu from '../RowActionMenu';
+import RowActionMenu, { NO_ACTIONS } from '../RowActionMenu';
 
 /**
  * Context action menu shown on long-pressing an operation row.
@@ -19,7 +19,9 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
   const showChartsAction = operationType === 'expense' || operationType === 'income';
   const hiddenFromCharts = !!menu?.operation?.excludeFromCharts;
 
-  const actions = useMemo(() => [
+  // Memoized (and NO_ACTIONS while closed) because RowActionMenu is memoized: a
+  // fresh array per render of the screen would miss its compare every time.
+  const actions = useMemo(() => (menu ? [
     { key: 'edit', icon: 'pencil', label: t('edit'), onPress: onEdit },
     { key: 'repeat', icon: 'repeat', label: t('repeat'), onPress: onRepeat },
     ...(showChartsAction ? [{
@@ -29,11 +31,11 @@ export default function OperationActionMenu({ menu, colors, t, onClose, onEdit, 
       // the accessibility label.
       label: hiddenFromCharts ? t('show_in_charts') : t('hide_from_charts'),
       a11yLabel: hiddenFromCharts ? t('include_in_charts') : t('exclude_from_charts'),
-      muted: hiddenFromCharts,
+      tone: hiddenFromCharts ? 'muted' : undefined,
       onPress: onToggleCharts,
     }] : []),
-    { key: 'delete', icon: 'trash-can-outline', label: t('delete'), destructive: true, onPress: onDelete },
-  ], [t, onEdit, onRepeat, onToggleCharts, onDelete, showChartsAction, hiddenFromCharts]);
+    { key: 'delete', icon: 'trash-can-outline', label: t('delete'), tone: 'destructive', onPress: onDelete },
+  ] : NO_ACTIONS), [menu, t, onEdit, onRepeat, onToggleCharts, onDelete, showChartsAction, hiddenFromCharts]);
 
   return (
     <RowActionMenu

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -5,7 +5,7 @@ import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
-import { anchorRectInHost } from '../../utils/overlayGeometry';
+import { measureAnchorRect } from '../../utils/overlayGeometry';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
 import { useOverlayHost } from '../../contexts/OverlayHostContext';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
@@ -51,27 +51,13 @@ const OperationListItem = ({
     onEdit(operation);
   }, [onEdit, operation]);
   const handleLongPress = useCallback(() => {
-    const node = rowRef.current;
-    const host = hostRef?.current;
-    // No host (or no measurement support, as under test): the menu still opens, just
-    // centred instead of anchored.
-    if (!node || !host
-      || typeof node.measureInWindow !== 'function'
-      || typeof host.measureInWindow !== 'function') {
-      onLongPress(operation, null);
-      return;
-    }
     // Both ends are measured in WINDOW coordinates and then subtracted (see
-    // anchorRectInHost) rather than measuring the row against the host directly —
+    // measureAnchorRect) rather than measuring the row against the host directly —
     // `measureLayout` ignores the list's scroll translation, which put the lifted
-    // clone a whole scroll offset below the row it was copying.
-    host.measureInWindow((hostX, hostY) => {
-      node.measureInWindow((x, y, width, height) => {
-        onLongPress(
-          operation,
-          anchorRectInHost({ x, y, width, height }, { x: hostX, y: hostY }),
-        );
-      });
+    // clone a whole scroll offset below the row it was copying. With no host to
+    // measure against the menu still opens, just centred instead of anchored.
+    measureAnchorRect(rowRef.current, hostRef?.current, (layout) => {
+      onLongPress(operation, layout);
     });
   }, [onLongPress, operation, hostRef]);
   const isExpense = operation.type === 'expense';

--- a/app/components/operations/OperationListItem.js
+++ b/app/components/operations/OperationListItem.js
@@ -1,13 +1,12 @@
-import React, { memo, useMemo, useRef, useCallback } from 'react';
+import React, { memo, useMemo, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { TouchableRipple } from 'react-native-paper';
 import Icon from '@expo/vector-icons/MaterialCommunityIcons';
 import PropTypes from 'prop-types';
 import { getCategoryNames } from '../../utils/categoryUtils';
 import { parseLabels, visibleListLabels, displayLabel } from '../../utils/labelUtils';
-import { measureAnchorRect } from '../../utils/overlayGeometry';
 import DescriptionSuggestionRow from './DescriptionSuggestionRow';
-import { useOverlayHost } from '../../contexts/OverlayHostContext';
+import useAnchoredLongPress from '../../hooks/useAnchoredLongPress';
 import { SPACING, FONT_SIZE, FONT_WEIGHT, ICON_SIZE, HEIGHTS } from '../../styles/designTokens';
 import currencies from '../../../assets/currencies.json';
 
@@ -36,13 +35,6 @@ const OperationListItem = ({
   onApplySuggestion = () => {},
   onDismissSuggestion = () => {},
 }) => {
-  // Measure the row on long-press so the caller can float an action menu / lifted
-  // clone exactly over it (see OperationActionMenu). Measured against the overlay
-  // host — the shared ancestor of this row and of the layer the clone is drawn in —
-  // rather than the window: same origin on both ends, so the clone cannot land
-  // anywhere but on top of the row it copies.
-  const rowRef = useRef(null);
-  const { hostRef } = useOverlayHost();
   // Bind the operation to the edit handler INSIDE the row so the stable `onEdit`
   // prop can flow down unchanged. This keeps OperationListItem's React.memo
   // compare stable — the list no longer hands each row a fresh inline
@@ -50,16 +42,13 @@ const OperationListItem = ({
   const handlePress = useCallback(() => {
     onEdit(operation);
   }, [onEdit, operation]);
-  const handleLongPress = useCallback(() => {
-    // Both ends are measured in WINDOW coordinates and then subtracted (see
-    // measureAnchorRect) rather than measuring the row against the host directly —
-    // `measureLayout` ignores the list's scroll translation, which put the lifted
-    // clone a whole scroll offset below the row it was copying. With no host to
-    // measure against the menu still opens, just centred instead of anchored.
-    measureAnchorRect(rowRef.current, hostRef?.current, (layout) => {
-      onLongPress(operation, layout);
-    });
-  }, [onLongPress, operation, hostRef]);
+  // Measure the row on long-press so the caller can float an action menu / lifted
+  // clone exactly over it (see RowActionMenu). The callback is memoized for the
+  // same reason `handlePress` is: a fresh one per render would hand the Pressable
+  // a new prop on every parent render of a memoized row.
+  const [rowRef, handleLongPress] = useAnchoredLongPress(
+    useCallback((layout) => onLongPress(operation, layout), [onLongPress, operation]),
+  );
   const isExpense = operation.type === 'expense';
   const isIncome = operation.type === 'income';
   const isTransfer = operation.type === 'transfer';

--- a/app/hooks/useAnchoredLongPress.js
+++ b/app/hooks/useAnchoredLongPress.js
@@ -1,0 +1,34 @@
+import { useCallback, useRef } from 'react';
+import { useOverlayHost } from '../contexts/OverlayHostContext';
+import { measureAnchorRect } from '../utils/overlayGeometry';
+
+/**
+ * Wiring for a row that lifts itself into an action menu on long press.
+ *
+ * A row that wants RowActionMenu to float over it has to report where it is,
+ * measured against the overlay host — the shared ancestor of the row and of the
+ * layer the lifted copy is drawn in. Doing that by hand is a ref, a context read
+ * and a measure call in a specific order, restated identically by every such row;
+ * this keeps the correct wiring in one place, so a new liftable row cannot
+ * rediscover the version that measures against the window (or with
+ * `measureLayout`, which ignores a list's scroll offset) instead.
+ *
+ *   const [rowRef, handleLongPress] = useAnchoredLongPress(
+ *     (layout) => onLongPress(item, layout),
+ *   );
+ *   return <Pressable ref={rowRef} onLongPress={handleLongPress} … />;
+ *
+ * `onMeasured` receives the row's rect in the host's coordinates, or null when
+ * there is nothing to measure against (no host mounted, or the test renderer) —
+ * the menu still opens then, just centred instead of anchored.
+ */
+export default function useAnchoredLongPress(onMeasured) {
+  const rowRef = useRef(null);
+  const { hostRef } = useOverlayHost();
+
+  const handleLongPress = useCallback(() => {
+    measureAnchorRect(rowRef.current, hostRef?.current, onMeasured);
+  }, [hostRef, onMeasured]);
+
+  return [rowRef, handleLongPress];
+}

--- a/app/screens/OperationsScreen.js
+++ b/app/screens/OperationsScreen.js
@@ -565,18 +565,16 @@ const OperationsScreen = () => {
 
   const closeActionMenu = useCallback(() => setActionMenu(null), []);
 
-  // Read the current menu from state (fresh via deps) and run the side effect
-  // outside setState — a state updater must stay pure (StrictMode double-invokes
-  // it, which would fire the action twice).
+  // The menu dismisses itself before running an action (see RowActionMenu), so
+  // these only have to act. They read the pressed operation from the menu state
+  // this render closed over, which is still the open menu's.
   const handleMenuEdit = useCallback(() => {
     const op = actionMenu?.operation;
-    setActionMenu(null);
     if (op) handleEditOperation(op);
   }, [actionMenu, handleEditOperation]);
 
   const handleMenuRepeat = useCallback(() => {
     const op = actionMenu?.operation;
-    setActionMenu(null);
     if (op) handleRepeatOperation(op);
   }, [actionMenu, handleRepeatOperation]);
 
@@ -586,7 +584,6 @@ const OperationsScreen = () => {
   // keep a correction out of the donut and the spending trend.
   const handleMenuToggleCharts = useCallback(async () => {
     const op = actionMenu?.operation;
-    setActionMenu(null);
     if (!op) return;
     // updateOperation surfaces its own failures via dialog (OperationsActionsContext).
     await updateOperation(op.id, { excludeFromCharts: !op.excludeFromCharts });
@@ -594,7 +591,6 @@ const OperationsScreen = () => {
 
   const handleMenuDelete = useCallback(() => {
     const op = actionMenu?.operation;
-    setActionMenu(null);
     if (op) handleDeleteOperation(op);
   }, [actionMenu, handleDeleteOperation]);
 

--- a/app/utils/overlayGeometry.js
+++ b/app/utils/overlayGeometry.js
@@ -29,3 +29,30 @@ export const anchorRectInHost = (rowRect, hostOrigin) => {
     height: rowRect.height,
   };
 };
+
+/**
+ * Measure a row against the overlay host and hand the resulting rect to `callback`.
+ *
+ * Every long-pressable row that lifts itself into an action menu needs the same
+ * three steps — measure the host, measure the row, subtract — and the same
+ * fallback when either end cannot be measured (no host mounted, or a test
+ * renderer whose nodes have no measure methods). The callback is invoked with
+ * `null` in that case: the menu still opens, just centred instead of anchored.
+ *
+ * @param {object|null} node - the row's native node (a ref's current value)
+ * @param {object|null} host - the overlay host's native node
+ * @param {(rect: {x: number, y: number, width: number, height: number}|null) => void} callback
+ */
+export const measureAnchorRect = (node, host, callback) => {
+  if (!node || !host
+    || typeof node.measureInWindow !== 'function'
+    || typeof host.measureInWindow !== 'function') {
+    callback(null);
+    return;
+  }
+  host.measureInWindow((hostX, hostY) => {
+    node.measureInWindow((x, y, width, height) => {
+      callback(anchorRectInHost({ x, y, width, height }, { x: hostX, y: hostY }));
+    });
+  });
+};


### PR DESCRIPTION
## Summary

Long-pressing a budget line or envelope opened a "Select an action" dialog that named the row in its message line — the same actions the operations list already offers, one step removed from the thing they act on. Budget rows now get the presentation operations already had: the pressed row is lifted above a blurred backdrop and a compact icon bar floats over it, so the actions stay attached to a budget the user can still see.

## Changes

- **app/components/RowActionMenu.js** (new) — the lift-and-blur frame extracted from `OperationActionMenu`, taking an arbitrary action list. Buttons stack into a second row when a row offers more than four (a template line offers six: execute, done, edit, up, down, delete), and the panel's height and placement follow the row count. It dismisses itself before running the chosen action, so no host has to remember to; memoized, since it draws through the overlay portal.
- **app/components/operations/OperationActionMenu.js** — reduced to the operation-specific action list (edit / repeat / hide-from-charts / delete) over the shared menu. Same props, same testIDs.
- **app/screens/OperationsScreen.js** — its four menu handlers no longer close the menu by hand.
- **app/components/budgets/MonthlyPlanSection.js** — long press opens the menu instead of `showDialog`, for both lines and envelopes; builds the action list, and renders the lifted copy through the same `renderLine` / `renderGroupRow` the list uses so the copy cannot drift from the row it covers. An envelope's colour is now assigned once, on its view. Deleting still asks for confirmation.
- **app/components/budgets/PlanLineRow.js**, **PlanGroupRow.js** — measure themselves against the overlay host on long press and forward the rect; a `lifted` prop renders the static copy (own testID namespace, no handlers, no top margin to offset).
- **app/hooks/useAnchoredLongPress.js** (new) + **app/utils/overlayGeometry.js** — the measure-host / measure-row / subtract wiring, shared by all three liftable rows; **OperationListItem.js** now uses it instead of its own copy.
- **\_\_tests\_\_/components/RowActionMenu.test.js** (new) — the generic frame: action list, lifted copy, one-row vs two-row layout, tone, dismissal (including dismiss-before-act), overlay mounting, hardware back. The operations suite keeps its action list and loses the duplicated frame tests.
- **\_\_tests\_\_/components/budgets/MonthlyPlanSection.test.js** — drives the action bar instead of the dialog, plus new coverage for the line and group menus (execute/undo, edit, delete confirmation, no move actions for a lone row, screen-reader labels).

No new translation keys — the bar reuses `execute`, `done`, `undo`, `edit`, `move_up`, `move_down`, `delete`, with the longer phrases (`mark_as_executed`, `undo_execution`, `edit_group`, `delete_group`, `edit_allocation`, `delete_allocation`) kept as accessibility labels.

## Testing

- `npx jest --testPathIgnorePatterns=/node_modules/` — 190 suites / 5453 tests pass.
- `npx eslint app __tests__ --ext .js --max-warnings 0` — clean.

## Checklist

- [x] Title follows Conventional Commits (`type(scope): subject`)
- [x] `npm test` is green (all suites pass)
- [x] User-facing strings updated in **all 11** `assets/i18n/*.json` files — n/a, no new keys
- [x] Linked the related issue with `Closes #NNN` below — n/a